### PR TITLE
Avoid the copy of channelCache if it is not necessary

### DIFF
--- a/Frame.cc
+++ b/Frame.cc
@@ -812,6 +812,8 @@ bool Frame::fillRegionHistogramData(int regionId, CARTA::RegionHistogramData* hi
                     region->fillHistogram(newHistogram, data, configChannel, currStokes, configNumBins, minval, maxval);
                 } else { // requested channel (current or specified)
                     if (configChannel == currentChannel()) {  // use channel cache
+                        bool writeLock(false);
+                        tbb::queuing_rw_mutex::scoped_lock cacheLock(cacheMutex, writeLock);
                         region->getMinMax(minval, maxval, channelCache);
                         region->fillHistogram(newHistogram, channelCache, configChannel, currStokes, configNumBins, minval, maxval);
                     } else {


### PR DESCRIPTION
The original code in `Frame.cc` line 813: `data = channelCache`, which copies the channelCache to a new `std::vector<float> data`. It makes the memory doubled and spends a significant time if channelCache is very large. It can be avoided if the copy is not necessary. 

Another part makes the memory doubled is in the function `Frame::setChannelCache(size_t channel, size_t stokes)`. It is the issue about how to convert `casacore::Array` to `std::vector` in a proper way. I will deal with it in another branch.