### PR TITLE
Reserve memory for vectors before pushing data of known total size to avoid reallocation

### DIFF
--- a/Frame.cc
+++ b/Frame.cc
@@ -888,7 +888,6 @@ bool Frame::fillSpatialProfileData(int regionId, CARTA::SpatialProfileData& prof
             // get <axis, stokes> for slicing image data
             std::pair<int,int> axisStokes = region->getSpatialProfileReq(i);
             std::vector<float> profile;
-            profile.reserve(imageShape(0));
             int end;
             if ((axisStokes.second == -1) || (axisStokes.second == stokes)) {
                 // use stored channel cache 
@@ -896,6 +895,7 @@ bool Frame::fillSpatialProfileData(int regionId, CARTA::SpatialProfileData& prof
                     case 0: { // x
                         tbb::queuing_rw_mutex::scoped_lock cacheLock(cacheMutex, writeLock);
                         auto xStart = y * nImageCol;
+                        profile.reserve(imageShape(0));
                         for (unsigned int i=0; i<imageShape(0); ++i) {
                             auto idx = xStart + i;
                             profile.push_back(channelCache[idx]);
@@ -906,6 +906,7 @@ bool Frame::fillSpatialProfileData(int regionId, CARTA::SpatialProfileData& prof
                     }
                     case 1: { // y
                         tbb::queuing_rw_mutex::scoped_lock cacheLock(cacheMutex, writeLock);
+                        profile.reserve(imageShape(1));
                         for (unsigned int i=0; i<imageShape(1); ++i) {
                             auto idx = (i * nImageCol) + x;
                             profile.push_back(channelCache[idx]);

--- a/Frame.cc
+++ b/Frame.cc
@@ -888,6 +888,7 @@ bool Frame::fillSpatialProfileData(int regionId, CARTA::SpatialProfileData& prof
             // get <axis, stokes> for slicing image data
             std::pair<int,int> axisStokes = region->getSpatialProfileReq(i);
             std::vector<float> profile;
+            profile.reserve(imageShape(0));
             int end;
             if ((axisStokes.second == -1) || (axisStokes.second == stokes)) {
                 // use stored channel cache 

--- a/Region/RegionStats.cc
+++ b/Region/RegionStats.cc
@@ -179,6 +179,7 @@ bool RegionStats::getStatsValues(std::vector<std::vector<float>>& statsValues,
                         result = (blc + maxPos).asStdVector();
                     }
                 }
+                values.reserve(result.size());
                 for (unsigned int i=0; i<result.size(); ++i)  // convert to float
                     values.push_back(static_cast<float>(result[i]));
                 }
@@ -192,6 +193,7 @@ bool RegionStats::getStatsValues(std::vector<std::vector<float>>& statsValues,
             latticeStats.getStatistic(result, lattStatsType);
             if (!result.empty()) {
                 std::vector<double> dblResult(result.tovector());
+                values.reserve(dblResult.size());
                 for (unsigned int i=0; i<dblResult.size(); ++i)  // convert to float
                     values.push_back(static_cast<float>(dblResult[i]));
             }


### PR DESCRIPTION
This fixes #84 and also fixes a similar issue in `RegionStats.cc`.