### PR TITLE
Refactor histogram for reuse

### DIFF
--- a/Frame.cc
+++ b/Frame.cc
@@ -848,10 +848,8 @@ bool Frame::fillRegionHistogramData(int regionId, CARTA::RegionHistogramData* hi
             // get histogram requirements for this index
             CARTA::SetHistogramRequirements_HistogramConfig config = region->getHistogramConfig(i);
             int configChannel(config.channel()), configNumBins(config.num_bins());
-            bool useCurrentChannel(false);
             if (configChannel == CURRENT_CHANNEL) {
                 configChannel = currentChannel();
-                useCurrentChannel = true;
             }
             auto newHistogram = histogramData->add_histograms();
             newHistogram->set_channel(configChannel);

--- a/Frame.cc
+++ b/Frame.cc
@@ -148,9 +148,7 @@ std::vector<float> Frame::getImageData(CARTA::ImageBounds& bounds, int mip, bool
 std::vector<float> Frame::getImageChanData(size_t chan) {
     // get data for given chan, current stokes
     std::vector<float> data;
-    casacore::Matrix<float> chanMatrix;
-    getChannelMatrix(chanMatrix, chan, currentStokes());
-    data = chanMatrix.tovector();
+    getChannelMatrix(data, chan, currentStokes());
     return data;
 }
 
@@ -484,14 +482,14 @@ void Frame::setChannelCache(size_t channel, size_t stokes) {
     }
 }
 
-void Frame::getChannelMatrix(casacore::Matrix<float>& chanMatrix, size_t channel, size_t stokes) {
+void Frame::getChannelMatrix(std::vector<float>& chanMatrix, size_t channel, size_t stokes) {
     // fill matrix for given channel and stokes
     casacore::Slicer section = getChannelMatrixSlicer(channel, stokes);
     casacore::Array<float> tmp;
     // slice image data
     std::unique_lock<std::mutex> guard(latticeMutex);
     loader->loadData(FileInfo::Data::XYZW).getSlice(tmp, section, true);
-    chanMatrix.reference(tmp);
+    chanMatrix = tmp.tovector();
 }
 
 casacore::Slicer Frame::getChannelMatrixSlicer(size_t channel, size_t stokes) {
@@ -639,7 +637,7 @@ void Frame::setImageRegion(int regionId) {
     setRegion(regionId, name, CARTA::RECTANGLE, minchan, maxchan, allStokes, points,
         rotation, message);
     if (regionId == IMAGE_REGION_ID) { 
-        // histogram requirements: use current channel, for now
+        // histogram requirements: use current channel
         std::vector<CARTA::SetHistogramRequirements_HistogramConfig> configs;
         setRegionHistogramRequirements(IMAGE_REGION_ID, configs);
         // frontend sets region requirements for cursor before cursor set
@@ -765,6 +763,73 @@ bool Frame::setRegionStatsRequirements(int regionId, const std::vector<int> stat
 
 // ***** histograms *****
 
+// helpers
+int Frame::calcAutoNumBins() {
+    // automatic bin size for histogram when num_bins = -1
+    return int(max(sqrt(imageShape(0) * imageShape(1)), 2.0));
+}
+
+bool Frame::getRegionMinMax(int regionId, int channel, int stokes, float& minval, float& maxval) {
+    // Return stored min and max value; false if not stored
+    bool haveMinMax(false);
+    if (regions.count(regionId)) {
+        auto& region = regions[regionId];
+        haveMinMax = region->getMinMax(channel, stokes, minval, maxval);
+    } 
+    return haveMinMax;
+}
+
+bool Frame::calcRegionMinMax(int regionId, int channel, int stokes, float& minval, float& maxval) {
+    // Calculate and store min/max for region data
+    bool minmaxOK(false);
+    if (regions.count(regionId)) {
+        auto& region = regions[regionId];
+        if (channel == currentChannel()) {
+            bool writeLock(false);
+            tbb::queuing_rw_mutex::scoped_lock cacheLock(cacheMutex, writeLock);
+            region->calcMinMax(channel, stokes, channelCache, minval, maxval);
+        } else {
+            std::vector<float> data;
+            getChannelMatrix(data, channel, stokes);
+            region->calcMinMax(channel, stokes, data, minval, maxval);
+        }
+        minmaxOK = true;
+    }
+    return minmaxOK;
+} 
+
+bool Frame::getRegionHistogram(int regionId, int channel, int stokes, int nbins, CARTA::Histogram& histogram) {
+    // Return stored histogram in histogram parameter
+    bool haveHistogram(false);
+    if (regions.count(regionId)) {
+        auto& region = regions[regionId];
+        nbins = (nbins==AUTO_BIN_SIZE ? calcAutoNumBins() : nbins);
+        haveHistogram = region->getHistogram(channel, stokes, nbins, histogram);
+    }
+    return haveHistogram;
+}
+
+bool Frame::calcRegionHistogram(int regionId, int channel, int stokes, int nbins, float minval, float maxval,
+    CARTA::Histogram& histogram) {
+    // Return calculated histogram in histogram parameter
+    bool histogramOK(false);
+    if (regions.count(regionId)) {
+        auto& region = regions[regionId];
+        nbins = (nbins==AUTO_BIN_SIZE ? calcAutoNumBins() : nbins);
+        if (channel == currentChannel()) {
+            bool writeLock(false);
+            tbb::queuing_rw_mutex::scoped_lock cacheLock(cacheMutex, writeLock);
+            region->calcHistogram(channel, stokes, nbins, minval, maxval, channelCache, histogram);
+        } else {
+            std::vector<float> data;
+            getChannelMatrix(data, channel, stokes);
+            region->calcHistogram(channel, stokes, nbins, minval, maxval, data, histogram);
+        }
+        histogramOK = true;
+    }
+    return histogramOK;
+}
+
 bool Frame::fillRegionHistogramData(int regionId, CARTA::RegionHistogramData* histogramData) {
     bool histogramOK(false);
     if (regions.count(regionId)) {
@@ -773,94 +838,72 @@ bool Frame::fillRegionHistogramData(int regionId, CARTA::RegionHistogramData* hi
         histogramData->set_stokes(currStokes);
         histogramData->set_progress(1.0); // send entire histogram
         for (int i=0; i<region->numHistogramConfigs(); ++i) {
+            // get histogram requirements for this index
             CARTA::SetHistogramRequirements_HistogramConfig config = region->getHistogramConfig(i);
             int configChannel(config.channel()), configNumBins(config.num_bins());
-            if (configChannel == CURRENT_CHANNEL) configChannel = currentChannel();
-            // fill Histograms
+            bool useCurrentChannel(false);
+            if (configChannel == CURRENT_CHANNEL) {
+                configChannel = currentChannel();
+                useCurrentChannel = true;
+            }
             auto newHistogram = histogramData->add_histograms();
             newHistogram->set_channel(configChannel);
+            // get stored histograms or fill new histograms
+            auto& currentStats = channelStats[currStokes][configChannel];
             bool haveHistogram(false);
-            if (configChannel >= 0) {
-                // use histogram from image file if correct channel, stokes, and numBins
-                auto& currentStats = channelStats[currStokes][configChannel];
-                if (!channelStats[currStokes][configChannel].histogramBins.empty()) {
-                    int nbins(currentStats.histogramBins.size());
-                    if ((configNumBins == AUTO_BIN_SIZE) || (configNumBins == nbins)) {
-                        newHistogram->set_num_bins(nbins);
-                        newHistogram->set_bin_width((currentStats.maxVal - currentStats.minVal) / nbins);
-                        newHistogram->set_first_bin_center(currentStats.minVal + (newHistogram->bin_width()/2.0));
-                        *newHistogram->mutable_bins() = {currentStats.histogramBins.begin(),
-                            currentStats.histogramBins.end()};
-                        haveHistogram = true;
-                    }
+            // Check if read from image file (HDF5 only)
+            if (!channelStats[currStokes][configChannel].histogramBins.empty()) {
+                int nbins(currentStats.histogramBins.size());
+                if ((configNumBins == AUTO_BIN_SIZE) || (configNumBins == nbins)) {
+                    newHistogram->set_num_bins(nbins);
+                    newHistogram->set_bin_width((currentStats.maxVal - currentStats.minVal) / nbins);
+                    newHistogram->set_first_bin_center(currentStats.minVal + (newHistogram->bin_width()/2.0));
+                    *newHistogram->mutable_bins() = {currentStats.histogramBins.begin(),
+                        currentStats.histogramBins.end()};
+                    haveHistogram = true;
                 }
             }
-            if (!haveHistogram) { 
-                // get histogram from Region
-                std::vector<float> data;
-                if (configChannel == ALL_CHANNELS ) { // all channels in region: cube!
-                    casacore::Slicer latticeSlicer;
-                    getLatticeSlicer(latticeSlicer, -1, -1, -1, currStokes);
-                    std::unique_lock<std::mutex> guard(latticeMutex);
-                    casacore::Array<float> tmp;
-                    loader->loadData(FileInfo::Data::XYZW).getSlice(tmp, latticeSlicer, true);
-                    guard.unlock();
-                    data = tmp.tovector();
-                } else { // requested channel (current or specified)
-                    if (configChannel == currentChannel()) {  // use channel cache
-                        bool writeLock(false);
-                        tbb::queuing_rw_mutex::scoped_lock cacheLock(cacheMutex, writeLock);
-                        data = channelCache;
-                    } else {
-                        casacore::Matrix<float> chanMatrix;
-                        getChannelMatrix(chanMatrix, configChannel, currStokes);
-                        data = chanMatrix.tovector();
+            if (!haveHistogram) {
+                // Retrieve histogram if stored
+                if (!getRegionHistogram(regionId, configChannel, currStokes, configNumBins, *newHistogram)) {
+                    // Calculate histogram
+                    float minval, maxval;
+                    if (!getRegionMinMax(regionId, configChannel, currStokes, minval, maxval)) {
+                        calcRegionMinMax(regionId, configChannel, currStokes, minval, maxval);
                     }
+                    calcRegionHistogram(regionId, configChannel, currStokes, configNumBins, minval, maxval,
+                        *newHistogram);
                 }
-                configNumBins = (configNumBins==AUTO_BIN_SIZE ? calcAutoNumBins() : configNumBins);
-                float minval, maxval;
-                region->getMinMax(minval, maxval, data);
-                region->fillHistogram(newHistogram, data, configChannel, currStokes, configNumBins, minval, maxval);
             }
         }
         histogramOK = true;
-    } 
+    }
     return histogramOK;
 }
 
-bool Frame::getChannelHistogramData(CARTA::RegionHistogramData& histogramData, int chan, int stokes, int numbins) {
-    // Get existing channel histogram for given channel and stokes; return false if does not exist.
-    // Note: probably no longer needed as frontend hides cube histogram for 2d images
-    numbins = (numbins == AUTO_BIN_SIZE ? calcAutoNumBins() : numbins);
-    auto newHistogram = histogramData.mutable_histograms(0);
-    return regions[IMAGE_REGION_ID]->getChannelHistogram(newHistogram, chan, stokes, numbins);
-}
-
-bool Frame::fillChannelHistogramData(CARTA::RegionHistogramData& histogramData, std::vector<float>& data,
-        size_t channel, int numBins, float minval, float maxval) {
-    // Frame completes message with CARTA::Histogram
-    int numbins = (numBins == AUTO_BIN_SIZE ? calcAutoNumBins() : numBins);
-    auto newHistogram = histogramData.add_histograms();
-    if (!regions.count(CUBE_REGION_ID))
+// store cube histogram calculations
+void Frame::setRegionMinMax(int regionId, int channel, int stokes, float minval, float maxval) {
+    // Store cube min/max calculated in Session
+    if (!regions.count(regionId) && (regionId==CUBE_REGION_ID))
         setImageRegion(CUBE_REGION_ID);
-    auto& region = regions[CUBE_REGION_ID];
-    region->fillHistogram(newHistogram, data, channel, currentStokes(), numbins, minval, maxval);
-    return true;
+
+    if (regions.count(regionId)) {
+        auto& region = regions[regionId];
+        region->setMinMax(channel, stokes, minval, maxval);
+    }
 }
 
-void Frame::getMinMax(float& minval, float& maxval, std::vector<float>& data) {
-    // determine min and max value in cube data
-    if (!regions.count(CUBE_REGION_ID))
+void Frame::setRegionHistogram(int regionId, int channel, int stokes, CARTA::Histogram& histogram) {
+    // Store cube histogram calculated in Session
+    if (!regions.count(regionId) && (regionId==CUBE_REGION_ID))
         setImageRegion(CUBE_REGION_ID);
-    auto& region = regions[CUBE_REGION_ID];
-    region->getMinMax(minval, maxval, data);
-}
 
-int Frame::calcAutoNumBins() {
-    // automatic bin size for histogram when num_bins = -1
-    return int(max(sqrt(imageShape(0) * imageShape(1)), 2.0));
+    if (regions.count(regionId)) {
+        auto& region = regions[regionId];
+        region->setHistogram(channel, stokes, histogram);
+    }
 }
-
+    
 // ***** profiles *****
 
 bool Frame::fillSpatialProfileData(int regionId, CARTA::SpatialProfileData& profileData) {

--- a/Frame.cc
+++ b/Frame.cc
@@ -489,7 +489,7 @@ void Frame::getChannelMatrix(std::vector<float>& chanMatrix, size_t channel, siz
     // slice image data
     std::unique_lock<std::mutex> guard(latticeMutex);
     loader->loadData(FileInfo::Data::XYZW).getSlice(tmp, section, true);
-    chanMatrix = tmp.tovector();
+    tmp.tovector(chanMatrix);
 }
 
 casacore::Slicer Frame::getChannelMatrixSlicer(size_t channel, size_t stokes) {

--- a/Frame.h
+++ b/Frame.h
@@ -12,17 +12,9 @@
 #include <carta-protobuf/region_histogram.pb.h>
 #include <carta-protobuf/spatial_profile.pb.h>
 #include <carta-protobuf/spectral_profile.pb.h>
+#include "InterfaceConstants.h"
 #include "ImageData/FileLoader.h"
 #include "Region/Region.h"
-
-#define CUBE_REGION_ID -2
-#define IMAGE_REGION_ID -1
-#define CURSOR_REGION_ID 0
-
-#define CURRENT_CHANNEL -1
-#define ALL_CHANNELS -2
-
-#define AUTO_BIN_SIZE -1
 
 struct ChannelStats {
     float minVal;

--- a/InterfaceConstants.h
+++ b/InterfaceConstants.h
@@ -1,0 +1,19 @@
+//# InterfaceConstants.h: definitions used in the Interface Control Document
+
+// region ids
+#define CUBE_REGION_ID -2
+#define IMAGE_REGION_ID -1
+#define CURSOR_REGION_ID 0
+
+// channels
+#define CURRENT_CHANNEL -1
+#define ALL_CHANNELS -2
+
+// raster image data
+#define MAX_SUBSETS 8
+
+// histograms
+#define AUTO_BIN_SIZE -1
+#define HISTOGRAM_COMPLETE 1.0
+#define HISTOGRAM_CANCEL -1.0
+

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -52,17 +52,30 @@ size_t Region::numHistogramConfigs() {
     return m_stats->numHistogramConfigs();
 }
 
-void Region::getMinMax(float& minVal, float& maxVal, const std::vector<float>& data) {
-    m_stats->getMinMax(minVal, maxVal, data);
+bool Region::getMinMax(int channel, int stokes, float& minVal, float& maxVal) {
+    return m_stats->getMinMax(channel, stokes, minVal, maxVal);
 }
 
-void Region::fillHistogram(CARTA::Histogram* histogram, const std::vector<float>& data,
-        const size_t chanIndex, const size_t stokesIndex, const int numBins, const float minVal, const float maxVal) {
-    return m_stats->fillHistogram(histogram, data, chanIndex, stokesIndex, numBins, minVal, maxVal);
+void Region::setMinMax(int channel, int stokes, float minVal, float maxVal) {
+    std::pair<float, float> vals = std::make_pair(minVal, maxVal);
+    m_stats->setMinMax(channel, stokes, vals);
 }
 
-bool Region::getChannelHistogram(CARTA::Histogram* histogram, int channel, int stokes, int numBins) {
-    return m_stats->getChannelHistogram(histogram, channel, stokes, numBins);
+void Region::calcMinMax(int channel, int stokes, const std::vector<float>& data, float& minVal, float& maxVal) {
+    m_stats->calcMinMax(channel, stokes, data, minVal, maxVal);
+}
+
+bool Region::getHistogram(int channel, int stokes, int nbins, CARTA::Histogram& histogram) {
+    return m_stats->getHistogram(channel, stokes, nbins, histogram);
+}
+
+void Region::setHistogram(int channel, int stokes, CARTA::Histogram& histogram) {
+    m_stats->setHistogram(channel, stokes, histogram);
+}
+
+void Region::calcHistogram(int channel, int stokes, int nBins, float minVal, float maxVal,
+        const std::vector<float>& data, CARTA::Histogram& histogramMsg) {
+    m_stats->calcHistogram(channel, stokes, nBins, minVal, maxVal, data, histogramMsg);
 }
 
 // stats

--- a/Region/Region.h
+++ b/Region/Region.h
@@ -29,10 +29,13 @@ public:
     bool setHistogramRequirements(const std::vector<CARTA::SetHistogramRequirements_HistogramConfig>& histogramReqs);
     CARTA::SetHistogramRequirements_HistogramConfig getHistogramConfig(int histogramIndex);
     size_t numHistogramConfigs();
-    void getMinMax(float& minVal, float& maxVal, const std::vector<float>& data);
-    void fillHistogram(CARTA::Histogram* histogram, const std::vector<float>& data, const size_t chanIndex,
-        const size_t stokesIndex, const int numBins, const float minVal, const float maxVal);
-    bool getChannelHistogram(CARTA::Histogram* histogram, int channel, int stokes, int numBins);
+    bool getMinMax(int channel, int stokes, float& minVal, float& maxVal);
+    void setMinMax(int channel, int stokes, float minVal, float maxVal);
+    void calcMinMax(int channel, int stokes, const std::vector<float>& data, float& minVal, float& maxVal);
+    bool getHistogram(int channel, int stokes, int nbins, CARTA::Histogram& histogram);
+    void setHistogram(int channel, int stokes, CARTA::Histogram& histogram);
+    void calcHistogram(int channel, int stokes, int nBins, float minVal, float maxVal,
+        const std::vector<float>& data, CARTA::Histogram& histogramMsg);
 
     // Spatial: pass through to RegionProfiler
     bool setSpatialRequirements(const std::vector<std::string>& profiles, const int nstokes);

--- a/Region/RegionStats.cc
+++ b/Region/RegionStats.cc
@@ -1,6 +1,7 @@
 //# RegionStats.cc: implementation of class for calculating region statistics and histograms
 
 #include "RegionStats.h"
+#include "../InterfaceConstants.h"
 #include "Histogram.h"
 #include "MinMax.h"
 
@@ -54,7 +55,7 @@ bool RegionStats::getMinMax(int channel, int stokes, float& minVal, float& maxVa
 
 void RegionStats::setMinMax(int channel, int stokes, minmax_t minmaxVals) {
     // Save min, max for given channel and stokes
-    if (channel == -2) { // all channels (cube); don't save intermediate channel min/max
+    if (channel == ALL_CHANNELS) { // all channels (cube); don't save intermediate channel min/max
         m_minmax[stokes].clear();
     }
     m_minmax[stokes][channel] = minmaxVals;
@@ -88,7 +89,7 @@ bool RegionStats::getHistogram(int channel, int stokes, int nbins, CARTA::Histog
 
 void RegionStats::setHistogram(int channel, int stokes, CARTA::Histogram& histogram) {
     // Store histogram for given channel and stokes
-    if (channel == -2) { // all channels(cube); don't save intermediate channel histograms
+    if (channel == ALL_CHANNELS) { // all channels(cube); don't save intermediate channel histograms
         m_histograms[stokes].clear();
     }
     m_histograms[stokes][channel] = histogram;

--- a/Region/RegionStats.cc
+++ b/Region/RegionStats.cc
@@ -20,6 +20,7 @@ using namespace std;
 
 // ***** Histograms *****
 
+// config
 bool RegionStats::setHistogramRequirements(const std::vector<CARTA::SetHistogramRequirements_HistogramConfig>& histogramReqs) {
     m_configs = histogramReqs;
     return true;
@@ -36,51 +37,81 @@ CARTA::SetHistogramRequirements_HistogramConfig RegionStats::getHistogramConfig(
     return config;
 }
 
-void RegionStats::getMinMax(float& minVal, float& maxVal, const std::vector<float>& data) {
-    // get min and max values in data
+// min max
+bool RegionStats::getMinMax(int channel, int stokes, float& minVal, float& maxVal) {
+    // Get stored min,max for given channel and stokes; return value indicates status
+    bool haveMinMax(false);
+    try {
+        minmax_t vals = m_minmax.at(stokes).at(channel);
+        minVal = vals.first;
+        maxVal = vals.second;
+        haveMinMax = true;
+    } catch (std::out_of_range) {
+        // not stored
+    }
+    return haveMinMax;
+}
+
+void RegionStats::setMinMax(int channel, int stokes, minmax_t minmaxVals) {
+    // Save min, max for given channel and stokes
+    if (channel == -2) { // all channels (cube); don't save intermediate channel min/max
+        m_minmax[stokes].clear();
+    }
+    m_minmax[stokes][channel] = minmaxVals;
+}
+
+void RegionStats::calcMinMax(int channel, int stokes, const std::vector<float>& data, float& minval, float& maxval) {
+    // Calculate and store min, max values in data; return minval and maxval
     tbb::blocked_range<size_t> range(0, data.size());
     MinMax<float> mm(data);
     tbb::parallel_reduce(range, mm);
-    std::tie(minVal, maxVal) = mm.getMinMax();
+    minmax_t minmaxVals(mm.getMinMax());
+    setMinMax(channel, stokes, minmaxVals);
+    minval = minmaxVals.first;
+    maxval = minmaxVals.second;
 }
 
-void RegionStats::fillHistogram(CARTA::Histogram* histogram, const std::vector<float>& data,
-        const size_t chanIndex, const size_t stokesIndex, const int nBins, const float minVal,
-        const float maxVal) {
-    // stored?
-    if (m_channelHistograms.count(chanIndex) && m_stokes==stokesIndex && m_bins==nBins) {
-        *histogram = m_channelHistograms[chanIndex];
-    } else {
-        // find histogram for input array
-        tbb::blocked_range<size_t> range(0, data.size());
-        Histogram hist(nBins, minVal, maxVal, data);
-        tbb::parallel_reduce(range, hist);
-        std::vector<int> histogramBins = hist.getHistogram();
-        float binWidth = hist.getBinWidth();
-
-        // fill histogram
-        histogram->set_channel(chanIndex);
-        histogram->set_num_bins(nBins);
-        histogram->set_bin_width(binWidth);
-        histogram->set_first_bin_center(minVal + (binWidth / 2.0));
-        *histogram->mutable_bins() = {histogramBins.begin(), histogramBins.end()};
-
-        // save for next time
-        m_channelHistograms[chanIndex] = *histogram;
-        m_stokes = stokesIndex;
-        m_bins = nBins;
-    }
-}
-
-bool RegionStats::getChannelHistogram(CARTA::Histogram* histogram, int channel, int stokes, int numBins) {
+bool RegionStats::getHistogram(int channel, int stokes, int nbins, CARTA::Histogram& histogram) {
+    // Get stored histogram for given channel and stokes; return value indicates status
     bool haveHistogram(false);
-    if (m_channelHistograms.count(channel) && m_stokes==stokes && m_bins==numBins) {
-        *histogram = m_channelHistograms[channel];
-        haveHistogram = true;
-    } else {
-        histogram = nullptr;
+    try {
+        CARTA::Histogram storedHistogram = m_histograms.at(stokes).at(channel);
+        if (storedHistogram.num_bins() == nbins) {
+            histogram = storedHistogram;
+            haveHistogram = true;
+        }
+    } catch (std::out_of_range) {
+        // not stored
     }
     return haveHistogram;
+}
+
+void RegionStats::setHistogram(int channel, int stokes, CARTA::Histogram& histogram) {
+    // Store histogram for given channel and stokes
+    if (channel == -2) { // all channels(cube); don't save intermediate channel histograms
+        m_histograms[stokes].clear();
+    }
+    m_histograms[stokes][channel] = histogram;
+}
+
+void RegionStats::calcHistogram(int channel, int stokes, int nBins, float minVal, float maxVal,
+        const std::vector<float>& data, CARTA::Histogram& histogramMsg) {
+    // Calculate and store histogram for given channel, stokes, nbins; return histogram
+    tbb::blocked_range<size_t> range(0, data.size());
+    Histogram hist(nBins, minVal, maxVal, data);
+    tbb::parallel_reduce(range, hist);
+    std::vector<int> histogramBins(hist.getHistogram());
+    float binWidth(hist.getBinWidth());
+
+    // fill histogram message
+    histogramMsg.set_channel(channel);
+    histogramMsg.set_num_bins(nBins);
+    histogramMsg.set_bin_width(binWidth);
+    histogramMsg.set_first_bin_center(minVal + (binWidth / 2.0));
+    *histogramMsg.mutable_bins() = {histogramBins.begin(), histogramBins.end()};
+
+    // save for next time
+    setHistogram(channel, stokes, histogramMsg);
 }
 
 // ***** Statistics *****

--- a/Region/RegionStats.h
+++ b/Region/RegionStats.h
@@ -17,15 +17,23 @@ namespace carta {
 
 class RegionStats {
 
+
 public:
     // Histograms
+    // config
     bool setHistogramRequirements(const std::vector<CARTA::SetHistogramRequirements_HistogramConfig>& histogramReqs);
     size_t numHistogramConfigs();
     CARTA::SetHistogramRequirements_HistogramConfig getHistogramConfig(int histogramIndex);
-    void getMinMax(float& minVal, float& maxVal, const std::vector<float>& data);
-    void fillHistogram(CARTA::Histogram* histogram, const std::vector<float>& data,
-        const size_t chanIndex, const size_t stokesIndex, const int nBins, const float minVal, const float maxVal);
-    bool getChannelHistogram(CARTA::Histogram* histogram, int channel, int stokes, int numBins);
+    // min max
+    using minmax_t = std::pair<float, float>; // <min, max>
+    bool getMinMax(int channel, int stokes, float& minVal, float& maxVal);
+    void setMinMax(int channel, int stokes, minmax_t minmaxVals);
+    void calcMinMax(int channel, int stokes, const std::vector<float>& data, float& minVal, float& maxVal);
+    // CARTA::Histogram
+    bool getHistogram(int channel, int stokes, int nbins, CARTA::Histogram& histogram);
+    void setHistogram(int channel, int stokes, CARTA::Histogram& histogram);
+    void calcHistogram(int channel, int stokes, int nBins, float minVal, float maxVal,
+        const std::vector<float>& data, CARTA::Histogram& histogramMsg);
 
     // Stats
     void setStatsRequirements(const std::vector<int>& statsTypes);
@@ -35,13 +43,16 @@ public:
         const std::vector<int>& requestedStats, const casacore::SubLattice<float>& lattice);
 
 private:
-    // Histograms
-    size_t m_stokes, m_bins;
-    std::unordered_map<int, CARTA::Histogram> m_channelHistograms;
+    // Histogram config
     std::vector<CARTA::SetHistogramRequirements_HistogramConfig> m_configs;
 
-    // Statistics
-    std::vector<int> m_regionStats; // CARTA::StatsType requirements
+    // MinMax, histogram maps
+    // first key is stokes, second is channel number (-2 all channels for cube)
+    std::unordered_map<int, std::unordered_map<int, minmax_t>> m_minmax;
+    std::unordered_map<int, std::unordered_map<int, CARTA::Histogram>> m_histograms;
+
+    // Statistics config
+    std::vector<int> m_regionStats; // CARTA::StatsType requirements for this region
 };
 
 }

--- a/Session.cc
+++ b/Session.cc
@@ -758,7 +758,7 @@ void Session::sendCubeHistogramData(const CARTA::SetHistogramRequirements& messa
                             float progress = thischan / allchans;
                             CARTA::RegionHistogramData histogramProgressMsg;
                             createCubeHistogramMessage(histogramProgressMsg, fileId, stokes, progress);
-                            CARTA::Histogram* histogram = histogramMessage.add_histograms();  // blank
+                            CARTA::Histogram* histogram = histogramProgressMsg.add_histograms();  // blank
                             sendFileEvent(fileId, "REGION_HISTOGRAM_DATA", requestId, histogramProgressMsg);
                             tStart = tEnd;
                         }

--- a/Session.cc
+++ b/Session.cc
@@ -1,4 +1,5 @@
 #include "Session.h"
+#include "InterfaceConstants.h"
 #include "FileInfoLoader.h"
 #include "compression.h"
 #include "util.h"
@@ -780,12 +781,11 @@ void Session::sendCubeHistogramData(const CARTA::SetHistogramRequirements& messa
                             frames.at(fileId)->calcRegionHistogram(regionId, chan, stokes, numbins, cubemin,
                                 cubemax, chanHistogram);
                             // add channel bins to cube bins
-                            std::vector<int> channelBins = {chanHistogram.bins().begin(), chanHistogram.bins().end()};
                             if (chan==0) {
-                                cubeBins = channelBins;
-                            } else {
-                                for (std::size_t i=0; i < channelBins.size(); ++i)
-                                    cubeBins[i] += channelBins[i];
+                                cubeBins = {chanHistogram.bins().begin(), chanHistogram.bins().end()};
+                            } else { // add chan histogram bins to cube histogram bins
+                                std::transform(chanHistogram.bins().begin(), chanHistogram.bins().end(), cubeBins.begin(),
+                                    cubeBins.begin(), std::plus<int>());
                             }
 
                             // check for cancel

--- a/Session.h
+++ b/Session.h
@@ -29,10 +29,6 @@
 #include "compression.h"
 #include "Frame.h"
 
-#define MAX_SUBSETS 8
-#define HISTOGRAM_COMPLETE 1.0
-#define HISTOGRAM_CANCEL -1.0
-
 class Session {
 public:
     std::string uuid;

--- a/main.cc
+++ b/main.cc
@@ -19,8 +19,6 @@
 #include <vector>
 #include <signal.h>
 
-#define MAX_THREADS 4
-
 using namespace std;
 
 // key is uuid:


### PR DESCRIPTION
Issue #65 .  Separated min/max calculation from histogram calculation, useful for cube histogram.  Both are saved in RegionStats by channel and stokes; previously only saved current stokes and started over when stokes changed.  Created functions in Frame (calls Region calls RegionStats) to _get_ min/max (retrieve if stored) and _calc_ min/max (calculate and store), as well as to _get_ histogram (retrieve if stored) and _calc_ histogram (calculate and store).

This may speed up the histograms for the cube or animation (whichever is requested second) as the min/max for each channel are stored in the image region and can be retrieved.  When the final cube histograms are calculated, the functions setMinMax and setHistogram are used to store them for retrieval later.  Since the finalhistogram is the only one needed for later retrieval, the interim per-channel histograms are destroyed.