### PR TITLE
Fix reading of fixed size null-terminated string attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,5 @@ fabric.properties
 
 # End of https://www.gitignore.io/api/clion
 permissions.txt
+
+build

--- a/.gitignore
+++ b/.gitignore
@@ -65,5 +65,3 @@ fabric.properties
 
 # End of https://www.gitignore.io/api/clion
 permissions.txt
-
-build

--- a/ImageData/HDF5Attributes.cc
+++ b/ImageData/HDF5Attributes.cc
@@ -54,11 +54,20 @@ void HDF5Attributes::readScalar (hid_t attrId, hid_t dtid, const casacore::Strin
             }
             break;
         case H5T_STRING: {
-            casacore::String value;
-            value.resize(sz+1);
-            casacore::HDF5DataType dtype(value);
-            H5Aread(attrId, dtype.getHidMem(), const_cast<char*>(value.c_str()));
-            value.resize(sz);
+            std::cout << "ATTR NAME: " << name << " ATTR SIZE: " << sz << "\n" << "PADDING TYPE: " << H5Tget_strpad(dtid) << "\n";
+            char * buf;
+            if (H5Tget_strpad(dtid) == 0) { // null-terminated
+                buf = new char[sz];
+                H5Aread(attrId, H5Tget_native_type(dtid, H5T_DIR_ASCEND), buf);
+            } else { // zero-padded (1) or space-padded (2)
+                buf = new char[sz + 1];
+                H5Aread(attrId, H5Tget_native_type(dtid, H5T_DIR_ASCEND), buf);
+                buf[sz] = '\0';
+            }
+            std::cout << "BUF IS: " << buf << "\n";
+            casacore::String value(buf);
+            delete [] buf;
+            std::cout << "MY VALUE IS: " << value << "\n";
             rec.define(name, value);
             }
             break;

--- a/ImageData/HDF5Attributes.cc
+++ b/ImageData/HDF5Attributes.cc
@@ -56,24 +56,28 @@ void HDF5Attributes::readScalar (hid_t attrId, hid_t dtid, const casacore::Strin
         case H5T_STRING: {
             casacore::String value;
             char * buf;
+            hid_t nativeType = H5Tget_native_type(dtid, H5T_DIR_ASCEND);
             
             if (H5Tis_variable_str(dtid)) { // variable-length string
-                if (H5Aread(attrId, dtid, &buf) >= 0) {
+                if (H5Aread(attrId, nativeType, &buf) >= 0) {
                     value = buf;
-                     H5free_memory(buf); // only free if the read didn't fail.
+                    H5free_memory(buf); // only free if the read didn't fail.
                 }
             } else { // fixed-length string
                 if (H5Tget_strpad(dtid) == 0) { // null-terminated
                     buf = new char[sz];
-                    H5Aread(attrId, dtid, buf);
+                    H5Aread(attrId, nativeType, buf);
                 } else { // zero-padded (1) or space-padded (2)
                     buf = new char[sz + 1];
-                    H5Aread(attrId, dtid, buf);
+                    H5Aread(attrId, nativeType, buf);
                     buf[sz] = '\0';
                 }
                 value = buf;
                 delete [] buf; // always delete, because we always allocate
             }
+            
+            H5Tclose(nativeType);
+            
             rec.define(name, value);
             }
             break;


### PR DESCRIPTION
Fixes #86.

One of our FITS-to-HDF5 converters (the C implementation) writes string attributes as 256-character fields which are null-terminated (unlike the Python implementation, which writes them as zero-padded fields which are truncated to different sizes). Our schema does not specify a particular storage mechanism for fixed strings, so both these options should be legal and supported.

Overwriting the internal c-string buffer of a `casacore::String` object does not change the size property of the string, and the subsequent resize which uses the size obtained from the attribute doesn't help, because that's the fixed maximum size of the field. So for these null-terminated fields we currently produce 256-character strings with embedded nulls followed by (as far as I can make out) a repeated padding character (which does not trigger any protocol buffer errors). Firefox seems to treat the nulls in these characters as terminators, and displays the strings truncated, but Chromium/Chrome and Edge display the full strings including padding characters, which causes the long lines of unicode boxes documented in the bug.

We can calculate the correct length of the string (in both cases) by calling `strlen` on the modified c-string buffer, and resizing the string object to this length solves the problem.