### PR TITLE
reuse vector memory when creating large temporary casacore::array containers.

### DIFF
--- a/Frame.cc
+++ b/Frame.cc
@@ -476,11 +476,11 @@ void Frame::setChannelCache(size_t channel, size_t stokes) {
     if (channel != currentChannel() || stokes != currentStokes()) {
         bool writeLock(true);
         tbb::queuing_rw_mutex::scoped_lock cacheLock(cacheMutex, writeLock);
+        channelCache.resize(imageShape(0) * imageShape(1));
         casacore::Slicer section = getChannelMatrixSlicer(channel, stokes);
-        casacore::Array<float> tmp;
+        casacore::Array<float>tmp(section.length(), channelCache.data(), casacore::StorageInitPolicy::SHARE);
         std::lock_guard<std::mutex> guard(latticeMutex);
         loader->loadData(FileInfo::Data::XYZW).getSlice(tmp, section, true);
-        channelCache = tmp.tovector();
     }
 }
 

--- a/Frame.cc
+++ b/Frame.cc
@@ -476,7 +476,7 @@ void Frame::setChannelCache(size_t channel, size_t stokes) {
         tbb::queuing_rw_mutex::scoped_lock cacheLock(cacheMutex, writeLock);
         channelCache.resize(imageShape(0) * imageShape(1));
         casacore::Slicer section = getChannelMatrixSlicer(channel, stokes);
-        casacore::Array<float>tmp(section.length(), channelCache.data(), casacore::StorageInitPolicy::SHARE);
+        casacore::Array<float> tmp(section.length(), channelCache.data(), casacore::StorageInitPolicy::SHARE);
         std::lock_guard<std::mutex> guard(latticeMutex);
         loader->loadData(FileInfo::Data::XYZW).getSlice(tmp, section, true);
     }
@@ -485,11 +485,11 @@ void Frame::setChannelCache(size_t channel, size_t stokes) {
 void Frame::getChannelMatrix(std::vector<float>& chanMatrix, size_t channel, size_t stokes) {
     // fill matrix for given channel and stokes
     casacore::Slicer section = getChannelMatrixSlicer(channel, stokes);
-    casacore::Array<float> tmp;
+	chanMatrix.resize(imageShape(0) * imageShape(1));
+	casacore::Array<float> tmp(section.length(), chanMatrix.data(), casacore::StorageInitPolicy::SHARE);
     // slice image data
     std::unique_lock<std::mutex> guard(latticeMutex);
     loader->loadData(FileInfo::Data::XYZW).getSlice(tmp, section, true);
-    tmp.tovector(chanMatrix);
 }
 
 casacore::Slicer Frame::getChannelMatrixSlicer(size_t channel, size_t stokes) {
@@ -988,10 +988,10 @@ bool Frame::fillSpatialProfileData(int regionId, CARTA::SpatialProfileData& prof
                         break;
                     }
                 }
-                casacore::Array<float> tmp;
+                profile.resize(end);
+                casacore::Array<float> tmp(section.length(), profile.data(), casacore::StorageInitPolicy::SHARE);
                 std::unique_lock<std::mutex> guard(latticeMutex);
                 loader->loadData(FileInfo::Data::XYZW).getSlice(tmp, section, true);
-                tmp.tovector(profile);
             }
             newProfile->set_coordinate(region->getSpatialProfileStr(i));
             newProfile->set_start(0);

--- a/Frame.cc
+++ b/Frame.cc
@@ -485,8 +485,8 @@ void Frame::setChannelCache(size_t channel, size_t stokes) {
 void Frame::getChannelMatrix(std::vector<float>& chanMatrix, size_t channel, size_t stokes) {
     // fill matrix for given channel and stokes
     casacore::Slicer section = getChannelMatrixSlicer(channel, stokes);
-	chanMatrix.resize(imageShape(0) * imageShape(1));
-	casacore::Array<float> tmp(section.length(), chanMatrix.data(), casacore::StorageInitPolicy::SHARE);
+    chanMatrix.resize(imageShape(0) * imageShape(1));
+    casacore::Array<float> tmp(section.length(), chanMatrix.data(), casacore::StorageInitPolicy::SHARE);
     // slice image data
     std::unique_lock<std::mutex> guard(latticeMutex);
     loader->loadData(FileInfo::Data::XYZW).getSlice(tmp, section, true);


### PR DESCRIPTION
This PR changes the construction of three large temporary `casacore::array` containers to re-use memory already defined by a `std::vector`, thus solving the 2x memory usage issue and speeding up reading a bit by avoiding unnecessary memory allocations and copies.

Going forward, we should probably consider the following:
- Switching back to `casacore::Matrix` and `casacore::Vector` containers, as they allow us to specify a no-initialisation policy. This will require some careful checking of the thread safety issues that are apparently fixed
- Whether we can directly utilise memory in the protocol buffer objects. At the moment, we're allocating some memory, getting a profile, then copy to a protocol buffer object. Probably a minor optimisation, but might help in future for large allocations of a fixed size.

Those two are less urgent than the 2x memory issue though. 