### PR TITLE
added explicit ping/ping handling in order to measure latency

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -212,6 +212,10 @@ void onMessage(uWS::WebSocket<uWS::SERVER>* ws, char* rawMessage, size_t length,
             }
             tbb::task::enqueue(*omt);
         }
+    } else if (opCode == uWS::OpCode::TEXT) {
+        if (std::strncmp(rawMessage, "PING", 4) == 0) {
+            ws->send("PONG");
+        }
     }
 };
 
@@ -281,7 +285,6 @@ int main(int argc, const char* argv[]) {
         wsHub.onConnection(&onConnect);
         wsHub.onDisconnection(&onDisconnect);
         if (wsHub.listen(port)) {
-            wsHub.getDefaultGroup<uWS::SERVER>().startAutoPing(5000);
             fmt::print("Listening on port {} with root folder {}, base folder {}, and {} threads in thread pool\n", port, rootFolder, baseFolder, threadCount);
             wsHub.run();
         } else {


### PR DESCRIPTION
The frontend needs to display server-client latency (https://github.com/CARTAvis/carta-frontend/issues/164). 

Currently, we let the underlying websocket connection handle the heartbeat automatically. However, this prevents us from keeping track of latency. The frontend has been updated to send a manual ping to the backend. This PR simply responds to a ping event with a pong. 

Since all events are sent through the main thread anyway, I don't think there's a need to place any guards around this response, is there?

