### PR TITLE
optimisations to down-sampling implementation

### DIFF
--- a/Frame.cc
+++ b/Frame.cc
@@ -107,21 +107,23 @@ std::vector<float> Frame::getImageData(CARTA::ImageBounds& bounds, int mip, bool
     if (meanFilter) {
         // Perform down-sampling by calculating the mean for each MIPxMIP block
         auto range = tbb::blocked_range2d<size_t>(0, numRowsRegion, 0, rowLengthRegion);
-        auto loop = [&](const tbb::blocked_range2d<size_t> &r) {
-            for(size_t j = r.rows().begin(); j != r.rows().end(); ++j) {
-                for(size_t i = r.cols().begin(); i != r.cols().end(); ++i) {
+        auto loop = [&](const tbb::blocked_range2d<size_t>& r) {
+            for (size_t j = r.rows().begin(); j != r.rows().end(); ++j) {
+                for (size_t i = r.cols().begin(); i != r.cols().end(); ++i) {
                     float pixelSum = 0;
                     int pixelCount = 0;
-                    for (auto pixelX = 0; pixelX < mip; pixelX++) {
-                        for (auto pixelY = 0; pixelY < mip; pixelY++) {
-                            auto imageRow = y + j * mip + pixelY;
-                            auto imageCol = x + i * mip + pixelX;
+                    size_t imageRow = y + j * mip;
+                    for (size_t pixelY = 0; pixelY < mip; pixelY++) {
+                        size_t imageCol = x + i * mip;
+                        for (size_t pixelX = 0; pixelX < mip; pixelX++) {
                             float pixVal = channelCache[(imageRow * nImgCol) + imageCol];
-                            if (!isnan(pixVal) && !isinf(pixVal)) {
+                            if (isfinite(pixVal)) {
                                 pixelCount++;
                                 pixelSum += pixVal;
                             }
+                            imageCol++;
                         }
+                        imageRow++;
                     }
                     regionData[j * rowLengthRegion + i] = pixelCount ? pixelSum / pixelCount : NAN;
                 }


### PR DESCRIPTION
While implementing similar downsampling code in another project, I realised that we should be accessing the channel cache along the contiguous axis (x) in the inner loop, so that memory reads are more efficient. At the same time, I've switched from using a combination of `isnan` and `isinf` to simply using `std::isfinite` (introduced in c++11). 

These may seem like micro-optimisations, but I've tested and found a significant performance improvement when viewing large files. See below for two tests. Each point is the average of three test runs on the same file with the same zoom actions to trigger them. 

![Cropping and downsampling 10K x 10K image by various factors ](https://user-images.githubusercontent.com/592504/54068508-1e086c80-4256-11e9-8f84-d170d0549e16.png)
![Cropping and downsampling 48K x 48K image by various factors ](https://user-images.githubusercontent.com/592504/54068509-206ac680-4256-11e9-9d8c-14dd7d003dd2.png)

