### PR TITLE
minor changes to permission checking

### DIFF
--- a/Session.cc
+++ b/Session.cc
@@ -61,6 +61,11 @@ bool Session::checkPermissionForDirectory(std::string prefix) {
     if (!permissionsEnabled) {
         return true;
     }
+
+    // trim leading dot
+    if (prefix.length() && prefix[0] == '.') {
+        prefix.erase(0, 1);
+    }
     // Check for root folder permissions
     if (!prefix.length() || prefix == "/") {
         if (permissionsMap.count("/")) {
@@ -154,7 +159,7 @@ void Session::getFileList(CARTA::FileListResponse& fileList, string folder) {
                             else if (imType==casacore::ImageOpener::UNKNOWN) {
                                 // Check if it is a directory and the user has permission to access it
                                 casacore::String dirname(ccfile.path().baseName());
-                                string pathNameRelative = (folder.length() && folder != "/") ? folder.append("/" + dirname) : dirname;
+                                string pathNameRelative = (folder.length() && folder != "/") ? folder + "/" + string(dirname): dirname;
                                 if (checkPermissionForDirectory(pathNameRelative))
                                    fileList.add_subdirectories(dirname);
                             } else {
@@ -295,6 +300,7 @@ void Session::onRegisterViewer(const CARTA::RegisterViewer& message, uint32_t re
             success = true;
         }
     }
+    apiKey = message.api_key();
     // response
     CARTA::RegisterViewerAck ackMessage;
     ackMessage.set_session_id(sessionId);


### PR DESCRIPTION
In order for IDIA's beta testers for 1.1 to access their files securely, and ensure that unauthenticated users can only access to publicly available files, we need to enable API key authentication. While this is is not a fully fledged authentication scheme, it's sufficient for users to manage basic file permissions. 
(See https://github.com/CARTAvis/carta-frontend/issues/186 for the frontend issues and PR)

Most of this was already implemented, but I've just made three minor changes to get it working:
- Store the api key from `REGISTER_VIEWER` messages. Previously we were just ignoring it
- Trim leading dots when checking permissions
- Fixed a bug in the folder path construction (we were using `std::string::append` previously, which modifies the string in place, ending up with wacky combinations of directory names).

As we head toward 1.2, I'd imagine this will need to be fleshed out and carefully tested, but for 1.1, it should be sufficient. 