### PR TITLE
updated to latest protocol buffer definitions and enabled numPixels stats type

### DIFF
--- a/Region/RegionStats.cc
+++ b/Region/RegionStats.cc
@@ -193,6 +193,9 @@ bool RegionStats::getStatsValues(std::vector<std::vector<float>>& statsValues,
         switch (statType) {
             case CARTA::StatsType::None:
                 break;
+			case CARTA::StatsType::NumPixels:
+				lattStatsType = casacore::LatticeStatsBase::NPTS;
+				break;
             case CARTA::StatsType::Sum:
                 lattStatsType = casacore::LatticeStatsBase::SUM;
                 break;

--- a/Region/RegionStats.cc
+++ b/Region/RegionStats.cc
@@ -193,9 +193,9 @@ bool RegionStats::getStatsValues(std::vector<std::vector<float>>& statsValues,
         switch (statType) {
             case CARTA::StatsType::None:
                 break;
-			case CARTA::StatsType::NumPixels:
-				lattStatsType = casacore::LatticeStatsBase::NPTS;
-				break;
+            case CARTA::StatsType::NumPixels:
+                lattStatsType = casacore::LatticeStatsBase::NPTS;
+                break;
             case CARTA::StatsType::Sum:
                 lattStatsType = casacore::LatticeStatsBase::SUM;
                 break;


### PR DESCRIPTION
This very minor PR just updates the protocol buffer definition commit, and links up the CARTA `NumPixels` stats type to casacore's `NPTS` type.