### PR TITLE
Fix ellipse angle

### DIFF
--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -287,10 +287,10 @@ casacore::LCRegion* Region::makeEllipseRegion(const std::vector<CARTA::Point>& p
     if (points.size()==2) {
         float cx(points[0].x()), cy(points[0].y());
         float bmaj(points[1].x()), bmin(points[1].y());
-	// rotation is in degrees from y-axis
+        // rotation is in degrees from y-axis
         // ellipse rotation angle is in radians from x-axis
-	casacore::Quantity theta((rotation+90.0), "deg");
-	theta.convert("rad");
+        casacore::Quantity theta((rotation+90.0), "deg");
+        theta.convert("rad");
         ellipse = new casacore::LCEllipsoid(cx, cy, bmaj, bmin, theta.getValue(), m_latticeShape.keepAxes(m_xyAxes));
     }
     return ellipse;

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -5,7 +5,6 @@
 #include <casacore/lattices/LRegions/LCExtension.h>
 #include <casacore/lattices/LRegions/LCEllipsoid.h>
 #include <casacore/lattices/LRegions/LCPolygon.h>
-#include <casacore/casa/Quanta/Quantum.h>
 #include <algorithm> // max
 #include <cmath>  // round
 
@@ -289,9 +288,8 @@ casacore::LCRegion* Region::makeEllipseRegion(const std::vector<CARTA::Point>& p
         float bmaj(points[1].x()), bmin(points[1].y());
         // rotation is in degrees from y-axis
         // ellipse rotation angle is in radians from x-axis
-        casacore::Quantity theta((rotation+90.0), "deg");
-        theta.convert("rad");
-        ellipse = new casacore::LCEllipsoid(cx, cy, bmaj, bmin, theta.getValue(), m_latticeShape.keepAxes(m_xyAxes));
+        float theta = (rotation + 90.0) * (M_PI / 180.0f);
+        ellipse = new casacore::LCEllipsoid(cx, cy, bmaj, bmin, theta, m_latticeShape.keepAxes(m_xyAxes));
     }
     return ellipse;
 }

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -5,7 +5,7 @@
 #include <casacore/lattices/LRegions/LCExtension.h>
 #include <casacore/lattices/LRegions/LCEllipsoid.h>
 #include <casacore/lattices/LRegions/LCPolygon.h>
-#include <casacore/casa/BasicSL/Constants.h> // pi
+#include <casacore/casa/Quanta/Quantum.h>
 #include <algorithm> // max
 #include <cmath>  // round
 
@@ -287,9 +287,11 @@ casacore::LCRegion* Region::makeEllipseRegion(const std::vector<CARTA::Point>& p
     if (points.size()==2) {
         float cx(points[0].x()), cy(points[0].y());
         float bmaj(points[1].x()), bmin(points[1].y());
-        // ellipse rotation angle is from x-axis, not north-south axis
-        rotation -= casacore::C::pi_2;
-        ellipse = new casacore::LCEllipsoid(cx, cy, bmaj, bmin, rotation, m_latticeShape.keepAxes(m_xyAxes));
+	// rotation is in degrees from y-axis
+        // ellipse rotation angle is in radians from x-axis
+	casacore::Quantity theta((rotation+90.0), "deg");
+	theta.convert("rad");
+        ellipse = new casacore::LCEllipsoid(cx, cy, bmaj, bmin, theta.getValue(), m_latticeShape.keepAxes(m_xyAxes));
     }
     return ellipse;
 }

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -5,6 +5,7 @@
 #include <casacore/lattices/LRegions/LCExtension.h>
 #include <casacore/lattices/LRegions/LCEllipsoid.h>
 #include <casacore/lattices/LRegions/LCPolygon.h>
+#include <casacore/casa/BasicSL/Constants.h> // pi
 #include <algorithm> // max
 #include <cmath>  // round
 
@@ -248,6 +249,8 @@ casacore::LCRegion* Region::makeEllipseRegion(const std::vector<CARTA::Point>& p
     if (points.size()==2) {
         float cx(points[0].x()), cy(points[0].y());
         float bmaj(points[1].x()), bmin(points[1].y());
+        // ellipse rotation angle is from x-axis, not north-south axis
+        rotation -= casacore::C::pi_2;
         ellipse = new casacore::LCEllipsoid(cx, cy, bmaj, bmin, rotation, m_latticeShape.keepAxes(m_xyAxes));
     }
     return ellipse;


### PR DESCRIPTION
Fix for test feedback in Issue #80 .
Region rotation field is measured from north-south axis but LCEllipsoid theta is from east (x-axis)