### PR TITLE
Rwjs/prevent closed ws send

### DIFF
--- a/OnMessageTask.h
+++ b/OnMessageTask.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include "AnimationQueue.h"
 #include "FileSettings.h"
 #include "Session.h"
 

--- a/Session.cc
+++ b/Session.cc
@@ -38,6 +38,7 @@ Session::Session(uWS::WebSocket<uWS::SERVER>* ws,
       newFrame(false),
       fsettings(this) {
   _ref_count= 0;
+  _connected= true;
 
   ++__num_sessions;
 }
@@ -802,8 +803,10 @@ void Session::sendPendingMessages() {
     // Do not parallelize: this must be done serially
     // due to the constraints of uWS.
     std::vector<char> msg;
-    while(out_msgs.try_pop(msg)) {
+    if( _connected ) {
+      while(out_msgs.try_pop(msg)) {
         socket->send(msg.data(), msg.size(), uWS::BINARY);
+      }
     }
 }
 

--- a/Session.h
+++ b/Session.h
@@ -46,6 +46,8 @@ class Session {
     uWS::WebSocket<uWS::SERVER>* socket;
     std::vector<char> binaryPayloadCache;
 
+    bool _connected;
+    
     // permissions
     std::string apiKey;
 
@@ -125,6 +127,8 @@ public:
     }
     int increase_ref_count() { return ++_ref_count; }
     int decrease_ref_count() { return --_ref_count; }
+    void disconnect_called() { _connected= false; }
+
     
     // CARTA ICD
     void onRegisterViewer(const CARTA::RegisterViewer& message, uint32_t requestId);

--- a/main.cc
+++ b/main.cc
@@ -179,6 +179,7 @@ void onConnect(uWS::WebSocket<uWS::SERVER>* ws, uWS::HttpRequest httpRequest) {
 	  sess->sendPendingMessages();
         });
 
+
     session= new Session(ws, uuid, permissionsMap, usePermissions,
 			 rootFolder, baseFolder, outgoing,
 			 fileListHandler, verbose);
@@ -199,6 +200,7 @@ void onDisconnect(uWS::WebSocket<uWS::SERVER>* ws, int code,
   
   if( session ) {
     auto uuid= session->uuid;
+    session->disconnect_called();
     if ( ! session->decrease_ref_count() ) {
       delete session;
       ws->setUserData(nullptr);


### PR DESCRIPTION
Stop any attempts to send to websocket after a child has disconnected. Hopefully this will 
put an end to a few seg faults that I am still seeing.