### PR TITLE
prevents querying existence of empty dataset name

### DIFF
--- a/ImageData/HDF5Loader.h
+++ b/ImageData/HDF5Loader.h
@@ -54,6 +54,9 @@ bool HDF5Loader::hasData(FileInfo::Data ds) const {
     default:
         auto group_ptr = image.group();
         std::string data = dataSetToString(ds);
+        if (data.empty()) {
+            return false;
+        }
         return casacore::HDF5Group::exists(*group_ptr, data);
     }
 }


### PR DESCRIPTION
There's an issue with HDF5 files at the moment, because calling `loader->hasData(FileInfo::Data::Mask)` results in an exception being thrown, and it goes on to cause odd behaviour until the file is reloaded. 

The reason is that the HDF5 loader's `dataSetToString` function returns empty strings if it doesn't know what the dataset name should be, based on the type. I've fixed this by simply returning false when the data set string is empty.