### PR TITLE
Create pixel mask which is false for NaN values in sublattice

### DIFF
--- a/Frame.h
+++ b/Frame.h
@@ -77,6 +77,8 @@ private:
     // make Lattice sublattice from Region given channel and stokes
     bool getRegionSubLattice(int regionId, casacore::SubLattice<float>& sublattice, int stokes,
         int channel=ALL_CHANNELS);
+    // add pixel mask to sublattice for NaN values
+    void generatePixelMask(casacore::Array<bool>& maskArray, casacore::SubLattice<float>& sublattice);
 
     // histogram helpers
     int calcAutoNumBins(int regionId); // calculate automatic bin size for region


### PR DESCRIPTION
Issue #131. For issue #137 , fixes the bug reported by Angus that NaNs are not ignored when calculating region stats.