### PR TITLE
Use lattice iterator to generate pixel mask

### DIFF
--- a/Frame.h
+++ b/Frame.h
@@ -77,8 +77,9 @@ private:
     // make Lattice sublattice from Region given channel and stokes
     bool getRegionSubLattice(int regionId, casacore::SubLattice<float>& sublattice, int stokes,
         int channel=ALL_CHANNELS);
-    // add pixel mask to sublattice for NaN values
-    void generatePixelMask(casacore::Array<bool>& maskArray, casacore::SubLattice<float>& sublattice);
+    // add pixel mask to sublattice for stats
+    void setPixelMask(casacore::SubLattice<float>& sublattice);
+    void generatePixelMask(casacore::ArrayLattice<bool>& pixelMask, casacore::SubLattice<float>& sublattice);
 
     // histogram helpers
     int calcAutoNumBins(int regionId); // calculate automatic bin size for region


### PR DESCRIPTION
Use casacore::LatticeIterator for pixel mask rather than reading entire SubLattice for better memory usage.  Set SubLattice pixel mask for statistics only (region spectral profile and stats data).  If SubLattice has no tile shape, make one with TiledFileAccess for iterator cursor shape; after casacore PR 892 is merged, this will be done in HDF5Lattice automatically and this code will not be used (should be removed later).

Response to issue #137 