### PR TITLE
Rwjs/fix session count log

### DIFF
--- a/OnMessageTask.h
+++ b/OnMessageTask.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include "AnimationQueue.h"
 #include "FileSettings.h"
 #include "Session.h"
 

--- a/Session.cc
+++ b/Session.cc
@@ -38,6 +38,7 @@ Session::Session(uWS::WebSocket<uWS::SERVER>* ws,
       newFrame(false),
       fsettings(this) {
   _ref_count= 0;
+  _connected= true;
 
   ++__num_sessions;
 }
@@ -802,8 +803,10 @@ void Session::sendPendingMessages() {
     // Do not parallelize: this must be done serially
     // due to the constraints of uWS.
     std::vector<char> msg;
-    while(out_msgs.try_pop(msg)) {
+    if( _connected ) {
+      while(out_msgs.try_pop(msg)) {
         socket->send(msg.data(), msg.size(), uWS::BINARY);
+      }
     }
 }
 

--- a/Session.cc
+++ b/Session.cc
@@ -15,7 +15,11 @@
 using namespace std;
 
 
-int __num_sessions= 0;
+#define DEBUG( _DB_TEXT_ ) { }
+
+int Session::_num_sessions= 0;
+
+
 // Default constructor. Associates a websocket with a UUID and sets the root and base folders for all files
 Session::Session(uWS::WebSocket<uWS::SERVER>* ws,
 		 std::string uuid,
@@ -41,7 +45,8 @@ Session::Session(uWS::WebSocket<uWS::SERVER>* ws,
   _ref_count= 0;
   _connected= true;
 
-  ++__num_sessions;
+  ++_num_sessions;
+  DEBUG(fprintf(stderr,"%p ::Session (%d)\n", this, _num_sessions ));
 }
 
 Session::~Session() {
@@ -51,7 +56,11 @@ Session::~Session() {
     }
     frames.clear();
     outgoing->close();
-    --__num_sessions;
+    
+    --_num_sessions;
+    DEBUG(fprintf(stderr,"%p  ~Session (%d)\n", this, _num_sessions ));
+    if( !_num_sessions )
+      std::cout << "No remaining sessions." << endl;
 }
 
 // ********************************************************************************

--- a/Session.h
+++ b/Session.h
@@ -46,6 +46,8 @@ class Session {
     uWS::WebSocket<uWS::SERVER>* socket;
     std::vector<char> binaryPayloadCache;
 
+    bool _connected;
+    
     // permissions
     std::string apiKey;
 
@@ -125,6 +127,8 @@ public:
     }
     int increase_ref_count() { return ++_ref_count; }
     int decrease_ref_count() { return --_ref_count; }
+    void disconnect_called() { _connected= false; }
+
     
     // CARTA ICD
     void onRegisterViewer(const CARTA::RegisterViewer& message, uint32_t requestId);

--- a/Session.h
+++ b/Session.h
@@ -81,6 +81,8 @@ class Session {
     // Reference counter
     int _ref_count;
 
+    static int _num_sessions;
+    
     // file list handler
     FileListHandler *fileListHandler;
     
@@ -127,7 +129,7 @@ public:
     int increase_ref_count() { return ++_ref_count; }
     int decrease_ref_count() { return --_ref_count; }
     void disconnect_called() { _connected= false; }
-
+    static int number_of_sessions() { return _num_sessions; }
     
     // CARTA ICD
     void onRegisterViewer(const CARTA::RegisterViewer& message, uint32_t requestId);

--- a/main.cc
+++ b/main.cc
@@ -42,9 +42,6 @@ FileListHandler* fileListHandler;
 int sessionNumber;
 uWS::Hub wsHub;
 
-// Number of active sessions
-int _num_sessions= 0;
-
 // Map from string uuids to 32 bit ints.
 unordered_map<std::string,uint8_t> _event_name_map;
 
@@ -188,7 +185,8 @@ void onConnect(uWS::WebSocket<uWS::SERVER>* ws, uWS::HttpRequest httpRequest) {
     session->increase_ref_count();
     outgoing->setData(session);
 
-    log(uuid, "Client {} [{}] Connected. Clients: {}", uuid, ws->getAddress().address, ++_num_sessions);
+    log(uuid, "Client {} [{}] Connected. Num sessions: {}",
+	uuid, ws->getAddress().address, Session::number_of_sessions());
 }
 
 
@@ -201,13 +199,12 @@ void onDisconnect(uWS::WebSocket<uWS::SERVER>* ws, int code,
   if( session ) {
     auto uuid= session->uuid;
     session->disconnect_called();
+    log(uuid, "Client {} [{}] Disconnected. Remaining sessions: {}",
+	uuid, ws->getAddress().address, Session::number_of_sessions());
     if ( ! session->decrease_ref_count() ) {
       delete session;
       ws->setUserData(nullptr);
-      --_num_sessions;   
     }
-    log(uuid, "Client {} [{}] Disconnected. Remaining clients: {}",
-	uuid, ws->getAddress().address, _num_sessions);
   }
   else {
     std::cerr <<

--- a/main.cc
+++ b/main.cc
@@ -179,6 +179,7 @@ void onConnect(uWS::WebSocket<uWS::SERVER>* ws, uWS::HttpRequest httpRequest) {
 	  sess->sendPendingMessages();
         });
 
+
     session= new Session(ws, uuid, permissionsMap, usePermissions,
 			 rootFolder, baseFolder, outgoing,
 			 fileListHandler, verbose);
@@ -199,6 +200,7 @@ void onDisconnect(uWS::WebSocket<uWS::SERVER>* ws, int code,
   
   if( session ) {
     auto uuid= session->uuid;
+    session->disconnect_called();
     if ( ! session->decrease_ref_count() ) {
       delete session;
       ws->setUserData(nullptr);


### PR DESCRIPTION
Fixes output of the number of active sessions. Also adds a message that says when the reference counting has determined that all sessions have been deleted, that I have found useful in understanding when all the tasks have completed.