### PR TITLE
Cache region stats data

### DIFF
--- a/Frame.cc
+++ b/Frame.cc
@@ -822,7 +822,7 @@ bool Frame::fillRegionStatsData(int regionId, CARTA::RegionStatsData& statsData)
         // current channel only
         std::lock_guard<std::mutex> guard(latticeMutex);
         getRegionSubLattice(regionId, sublattice, stokesIndex, channelIndex);
-        region->fillStatsData(statsData, sublattice);
+        region->fillStatsData(statsData, sublattice, channelIndex, stokesIndex);
         statsOK = true;
     }
     return statsOK;

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -440,8 +440,9 @@ size_t Region::numStats() {
     return m_stats->numStats();
 }
 
-void Region::fillStatsData(CARTA::RegionStatsData& statsData, const casacore::SubLattice<float>& subLattice) {
-    m_stats->fillStatsData(statsData, subLattice);
+void Region::fillStatsData(CARTA::RegionStatsData& statsData, const casacore::SubLattice<float>& subLattice,
+        int channel, int stokes) {
+    m_stats->fillStatsData(statsData, subLattice, channel, stokes);
 }
 
 // ***********************************
@@ -510,7 +511,7 @@ void Region::fillSpectralProfileData(CARTA::SpectralProfileData& profileData, in
         size_t nstats = requestedStats.size();
         std::vector<std::vector<double>> statsValues;
         // get values from RegionStats
-        bool haveStats(m_stats->getStatsValues(statsValues, requestedStats, sublattice));
+        bool haveStats(m_stats->calcStatsValues(statsValues, requestedStats, sublattice));
         for (size_t i=0; i<nstats; ++i) {
             // one SpectralProfile per stats type
             auto newProfile = profileData.add_profiles();

--- a/Region/Region.h
+++ b/Region/Region.h
@@ -72,7 +72,8 @@ public:
     // Stats: pass through to RegionStats
     void setStatsRequirements(const std::vector<int>& statsTypes);
     size_t numStats();
-    void fillStatsData(CARTA::RegionStatsData& statsData, const casacore::SubLattice<float>& subLattice);
+    void fillStatsData(CARTA::RegionStatsData& statsData, const casacore::SubLattice<float>& subLattice,
+        int channel, int stokes);
 
 private:
 

--- a/Region/RegionStats.cc
+++ b/Region/RegionStats.cc
@@ -19,22 +19,36 @@
 using namespace carta;
 using namespace std;
 
+RegionStats::RegionStats() {
+    clearStats();
+}
+
+RegionStats::~RegionStats() {
+}
+
+// ***** Cache *****
+
+void RegionStats::clearStats() {
+    m_histogramsValid = false;
+    m_statsValid = false;    
+}
+
 // ***** Histograms *****
 
 // config
 bool RegionStats::setHistogramRequirements(const std::vector<CARTA::SetHistogramRequirements_HistogramConfig>& histogramReqs) {
-    m_configs = histogramReqs;
+    m_histogramReqs = histogramReqs;
     return true;
 }
 
 size_t RegionStats::numHistogramConfigs() {
-    return m_configs.size();
+    return m_histogramReqs.size();
 }
 
 CARTA::SetHistogramRequirements_HistogramConfig RegionStats::getHistogramConfig(int histogramIndex) {
     CARTA::SetHistogramRequirements_HistogramConfig config;
-    if (histogramIndex < m_configs.size())
-        config = m_configs[histogramIndex];
+    if (histogramIndex < m_histogramReqs.size())
+        config = m_histogramReqs[histogramIndex];
     return config;
 }
 
@@ -93,6 +107,8 @@ bool RegionStats::getHistogram(int channel, int stokes, int nbins, CARTA::Histog
 
 void RegionStats::setHistogram(int channel, int stokes, CARTA::Histogram& histogram) {
     // Store histogram for given channel and stokes
+    if (!m_histogramsValid)
+        m_histograms.clear();
     if (channel == ALL_CHANNELS) { // all channels(cube); don't save intermediate channel histograms
         m_histograms[stokes].clear();
     }
@@ -127,51 +143,78 @@ void RegionStats::calcHistogram(int channel, int stokes, int nBins, float minVal
 
     // save for next time
     setHistogram(channel, stokes, histogramMsg);
-    m_histogramsValid = true;
 }
 
 // ***** Statistics *****
 
 void RegionStats::setStatsRequirements(const std::vector<int>& statsTypes) {
-    m_regionStats = statsTypes;
+    m_statsReqs = statsTypes;
 }
 
 size_t RegionStats::numStats() {
-   return m_regionStats.size();
+   return m_statsReqs.size();
 }
 
-void RegionStats::fillStatsData(CARTA::RegionStatsData& statsData, const casacore::SubLattice<float>& subLattice) {
+void RegionStats::fillStatsData(CARTA::RegionStatsData& statsData,
+        const casacore::SubLattice<float>& subLattice, int channel, int stokes) {
     // Fill RegionStatsData with statistics types set in requirements.
-    // Sublattice shape may be empty because of no xyregion (outside image or 0 pixels selected),
-    // or lattice mask removed all NaN values
-    if (m_regionStats.empty()) {  // no requirements set, add empty StatisticsValue
+    if (m_statsReqs.empty()) {  // no requirements set, add empty StatisticsValue
         auto statsValue = statsData.add_statistics();
         statsValue->set_stats_type(CARTA::StatsType::None);
-        return;
     } else {
         std::vector<std::vector<double>> results;
-        // stats for entire region, not per channel
-        bool haveStats(getStatsValues(results, m_regionStats, subLattice, false));
-        // update message whether have stats or not
-        for (size_t i=0; i<m_regionStats.size(); ++i) {
-            // add StatisticsValue to message
-            auto statsValue = statsData.add_statistics();
-            auto statType = static_cast<CARTA::StatsType>(m_regionStats[i]);
-            statsValue->set_stats_type(statType);
-            if (!haveStats || results[i].empty()) { // region outside image or NaNs
-                if (statType==CARTA::NumPixels) {
-                    statsValue->set_value(0.0);
-                } else {
-                    statsValue->set_value(std::numeric_limits<double>::quiet_NaN());
+        if (m_statsValid && (m_statsData.count(stokes)) && (m_statsData.at(stokes).count(channel))) {
+            // used stored stats
+            try {
+                std::vector<double> storedStats(m_statsData.at(stokes).at(channel));
+                for (size_t i=0; i<m_statsReqs.size(); ++i) {
+                    // add StatisticsValue to message
+                    auto statsValue = statsData.add_statistics();
+                    auto cartaStatType = static_cast<CARTA::StatsType>(m_statsReqs[i]);
+                    statsValue->set_stats_type(cartaStatType);
+                    statsValue->set_value(storedStats[cartaStatType-13]);
                 }
-            } else {
-                statsValue->set_value(results[i][0]);
+            } catch (std::out_of_range& rangeError) {
+                // stats cleared
+                auto statsValue = statsData.add_statistics();
+                statsValue->set_stats_type(CARTA::StatsType::None);
             }
+        } else {
+            // calculate stats
+            if (!m_statsValid)
+                m_statsData.clear();
+            // per channel = false, stats for entire region
+            bool haveStats(calcStatsValues(results, m_statsReqs, subLattice, false));
+            // update message whether have stats or not
+            for (size_t i=0; i<m_statsReqs.size(); ++i) {
+                // add StatisticsValue to message
+                auto statsValue = statsData.add_statistics();
+                auto cartaStatType = static_cast<CARTA::StatsType>(m_statsReqs[i]);
+                statsValue->set_stats_type(cartaStatType);
+                double value(0.0);
+                if (!haveStats || results[i].empty()) { // region outside image or NaNs
+                    if (cartaStatType != CARTA::NumPixels) {
+                        value = std::numeric_limits<double>::quiet_NaN();
+                    }
+                } else {
+                    value = results[i][0];
+                }
+                statsValue->set_value(value);
+
+                // cache stats values
+                if (m_statsData[stokes][channel].empty()) { // resize vector, set to NaN
+                    m_statsData[stokes][channel].resize(CARTA::StatsType_MAX-13, // 13 is the first stat
+                        std::numeric_limits<double>::quiet_NaN());
+                }
+                // first type enum is 13; make 0-based
+                m_statsData[stokes][channel][cartaStatType-13] = value;
+            }
+            m_statsValid = true;
         }
     }
 }
 
-bool RegionStats::getStatsValues(std::vector<std::vector<double>>& statsValues,
+bool RegionStats::calcStatsValues(std::vector<std::vector<double>>& statsValues,
     const std::vector<int>& requestedStats, const casacore::SubLattice<float>& subLattice,
     bool perChannel) {
     // Fill statsValues vector for requested stats; one vector<float> per stat if per channel,

--- a/Region/RegionStats.h
+++ b/Region/RegionStats.h
@@ -17,8 +17,10 @@ namespace carta {
 
 class RegionStats {
 
-
 public:
+    RegionStats();
+    ~RegionStats();
+
     // Histograms
     // config
     bool setHistogramRequirements(const std::vector<CARTA::SetHistogramRequirements_HistogramConfig>& histogramReqs);
@@ -38,29 +40,32 @@ public:
     // Stats
     void setStatsRequirements(const std::vector<int>& statsTypes);
     size_t numStats();
-    void fillStatsData(CARTA::RegionStatsData& statsData, const casacore::SubLattice<float>& subLattice);
-    bool getStatsValues(std::vector<std::vector<double>>& statsValues,
+    void fillStatsData(CARTA::RegionStatsData& statsData, const casacore::SubLattice<float>& subLattice,
+        int channel, int stokes);
+    bool calcStatsValues(std::vector<std::vector<double>>& statsValues,
         const std::vector<int>& requestedStats, const casacore::SubLattice<float>& lattice,
         bool perChannel=true);
 
-    // invalidate stored calculations (only histograms for now) for new region
-    inline void clearStats() { m_histogramsValid = false; };
+    // invalidate stored calculations for previous region settings
+    void clearStats();
 
 private:
 
-    bool m_histogramsValid; // for current region
+    // Valid calculations
+    bool m_histogramsValid, m_statsValid;
 
     // Histogram config
-    std::vector<CARTA::SetHistogramRequirements_HistogramConfig> m_configs;
-
+    std::vector<CARTA::SetHistogramRequirements_HistogramConfig> m_histogramReqs;
     // Statistics config
-    std::vector<int> m_regionStats; // CARTA::StatsType requirements for this region
+    std::vector<int> m_statsReqs; // CARTA::StatsType requirements for this region
 
-    // MinMax, histogram maps to store calculations
-    // first key is stokes, second is channel number (-2 all channels for cube)
+    // Cache calculations
+    // MinMax: first key is stokes, second is channel number (-2 all channels for cube)
     std::unordered_map<int, std::unordered_map<int, minmax_t>> m_minmax;
+    // Histogram: first key is stokes, second is channel number (-2 all channels for cube)
     std::unordered_map<int, std::unordered_map<int, CARTA::Histogram>> m_histograms;
-
+    // Region stats: first key is stokes, second is channel number
+    std::unordered_map<int, std::unordered_map<int, std::vector<double>>> m_statsData;
 };
 
 }


### PR DESCRIPTION
Issue #113 , store per-channel, per-stokes region stats.  Will help performance during animation when region stats are requested.  When the region is changed (control points and rotation), the stats and histograms are invalidated.  When they are recalculated for the new region, the old stats are cleared, the new stats are stored, and the valid flag is set again.

Not required for release 1.1, wait to merge for 1.2--?