### PR TITLE
Fix animation hanging

### DIFF
--- a/Session.cc
+++ b/Session.cc
@@ -35,6 +35,7 @@ Session::Session(uWS::WebSocket<uWS::SERVER>* ws,
       outgoing(outgoing_),
       fileListHandler(fileListHandler),
       newFrame(false),
+      _image_channel_task_active(false),
       fsettings(this) {
   histogramProgress.fetch_and_store(HISTOGRAM_COMPLETE);
   _ref_count= 0;


### PR DESCRIPTION
`Session::_image_channel_task_active` had an undefined default value. When its value starts as `true`, the animation hangs (#168). Modifying unrelated parts of the code (or changing build flags) causes the default value to change between `true` and `false`, making this a tricky bug to track down.

This PR initialises `_image_channel_task_active` to `false` explicitly, preventing the animation bug.