### PR TITLE
resize vector before using its data pointer (and debugging removed)

### DIFF
--- a/Frame.cc
+++ b/Frame.cc
@@ -801,12 +801,10 @@ bool Frame::fillSpectralProfileData(int regionId, CARTA::SpectralProfileData& pr
                 // fill SpectralProfiles for this config
                 if (region->isPoint()) {  // values
                     std::vector<float> spectralData;
-                    getSpectralData(spectralData, sublattice, 100);
-                    std::cerr << "normal spectral data (first 5): " << spectralData[0] << " " << spectralData[1] << " " << spectralData[2] << " " << spectralData[3] << " " << spectralData[4] << std::endl;
-                    std::vector<float> spectralData2;
                     auto cursorPos = region->getControlPoints()[0];
-                    if (loader->getCursorSpectralData(spectralData2, profileStokes, cursorPos.x(), cursorPos.y())) {
-                        std::cerr << "swizzled spectral data (first 5): " << spectralData2[0] << " " << spectralData2[1] << " " << spectralData2[2] << " " << spectralData2[3] << " " << spectralData2[4] << std::endl;
+                    // try use the loader's optimized cursor profile reader first
+                    if (!loader->getCursorSpectralData(spectralData, profileStokes, cursorPos.x(), cursorPos.y())) {
+                        getSpectralData(spectralData, sublattice, 100);
                     }
                     guard.unlock();
                     region->fillSpectralProfileData(profileData, i, spectralData);

--- a/ImageData/HDF5Loader.h
+++ b/ImageData/HDF5Loader.h
@@ -327,9 +327,6 @@ void HDF5Loader::findCoords(int& spectralAxis, int& stokesAxis) {
 }
 bool HDF5Loader::getCursorSpectralData(std::vector<float>& data, int stokes, int cursorX, int cursorY) {
     bool dataOK(false);
-    
-    std::cerr << "stokes " << stokes << "; x " << cursorX << "; y " << cursorY << std::endl;
-    
     if (hasData(FileInfo::Data::Swizzled)) {
         casacore::Slicer slicer;
         if (ndims == 4) {
@@ -337,10 +334,8 @@ bool HDF5Loader::getCursorSpectralData(std::vector<float>& data, int stokes, int
         } else if (ndims == 3) {
             slicer = casacore::Slicer(ipos(3, 0, cursorY, cursorX), ipos(3, nchannels, 1, 1));
         }
-        
-        std::cerr << "slicer length " << slicer.length() << std::endl;
-        std::cerr << "dataset shape " << loadData(FileInfo::Data::Swizzled).shape() << std::endl;
-        
+
+        data.resize(nchannels);
         casacore::Array<float> tmp(slicer.length(), data.data(), casacore::StorageInitPolicy::SHARE);
         try {
             loadData(FileInfo::Data::Swizzled).doGetSlice(tmp, slicer);


### PR DESCRIPTION
Delicious 10 fps profiles :+1: 

@confluence you were 99% of the way there. Just forgot to resize the `std::vector` before using its `data()` pointer. 

![z_profiles](https://user-images.githubusercontent.com/592504/55910066-c60ab000-5bdd-11e9-8751-18124bacf5c4.gif)

(I won't submit the frontend PR to update profiles at 10 fps for HDF5 files until this has made its way to `dev` eventually)