### PR TITLE
Get cursor region z-profile from swizzled dataset if it exists

### DIFF
--- a/Frame.cc
+++ b/Frame.cc
@@ -339,8 +339,6 @@ bool Frame::getRegionSubLattice(int regionId, casacore::SubLattice<float>& subla
     bool sublatticeOK(false);
     if (checkStokes(stokes) && (regions.count(regionId))) {
         auto& region = regions[regionId];
-        std::cout << "Region X: " << region->getControlPoints()[0].x() << std::endl;
-        std::cout << "Region Y: " << region->getControlPoints()[0].y() << std::endl;
         if (region->isValid()) {
             casacore::LatticeRegion lattRegion;
             if (region->getRegion(lattRegion, stokes, channel)) {
@@ -804,11 +802,11 @@ bool Frame::fillSpectralProfileData(int regionId, CARTA::SpectralProfileData& pr
                 if (region->isPoint()) {  // values
                     std::vector<float> spectralData;
                     getSpectralData(spectralData, sublattice, 100);
-                    std::cout << "normal spectral data (first 5): " << spectralData[0] << " " << spectralData[1] << " " << spectralData[2] << " " << spectralData[3] << " " << spectralData[4] << std::endl;
+                    std::cerr << "normal spectral data (first 5): " << spectralData[0] << " " << spectralData[1] << " " << spectralData[2] << " " << spectralData[3] << " " << spectralData[4] << std::endl;
                     std::vector<float> spectralData2;
                     auto cursorPos = region->getControlPoints()[0];
                     if (loader->getCursorSpectralData(spectralData2, profileStokes, cursorPos.x(), cursorPos.y())) {
-                        std::cout << "swizzled spectral data (first 5): " << spectralData2[0] << " " << spectralData2[1] << " " << spectralData2[2] << " " << spectralData2[3] << " " << spectralData2[4] << std::endl;
+                        std::cerr << "swizzled spectral data (first 5): " << spectralData2[0] << " " << spectralData2[1] << " " << spectralData2[2] << " " << spectralData2[3] << " " << spectralData2[4] << std::endl;
                     }
                     guard.unlock();
                     region->fillSpectralProfileData(profileData, i, spectralData);

--- a/ImageData/CasaLoader.h
+++ b/ImageData/CasaLoader.h
@@ -31,20 +31,23 @@ void CasaLoader::openFile(const std::string &filename, const std::string& /*hdu*
 
 bool CasaLoader::hasData(FileInfo::Data dl) const {
     switch(dl) {
-    case FileInfo::Data::XY:
-        return image.shape().size() >= 2;
-    case FileInfo::Data::XYZ:
-        return image.shape().size() >= 3;
-    case FileInfo::Data::XYZW:
-        return image.shape().size() >= 4;
-    case FileInfo::Data::Mask:
-        return image.hasPixelMask();
-    default:
-        break;
+        case FileInfo::Data::Image:
+            return true;
+        case FileInfo::Data::XY:
+            return ndims >= 2;
+        case FileInfo::Data::XYZ:
+            return ndims >= 3;
+        case FileInfo::Data::XYZW:
+            return ndims >= 4;
+        case FileInfo::Data::Mask:
+            return image.hasPixelMask();
+        default:
+            break;
     }
     return false;
 }
 
+// TODO: should this check the parameter and fail if it's not the image dataset?
 typename CasaLoader::image_ref CasaLoader::loadData(FileInfo::Data ds) {
     return image;
 }

--- a/ImageData/FITSLoader.h
+++ b/ImageData/FITSLoader.h
@@ -40,20 +40,25 @@ void FITSLoader::openFile(const std::string &filename, const std::string &hdu) {
 
 bool FITSLoader::hasData(FileInfo::Data dl) const {
     switch(dl) {
-    case FileInfo::Data::XY:
-        return image->shape().size() >= 2;
-    case FileInfo::Data::XYZ:
-        return image->shape().size() >= 3;
-    case FileInfo::Data::XYZW:
-        return image->shape().size() >= 4;
-    case FileInfo::Data::Mask:
-        return image->hasPixelMask();
-    default:
-        break;
+        case FileInfo::Data::Image:
+            return true;
+        case FileInfo::Data::XY:
+            return ndims >= 2;
+        case FileInfo::Data::XYZ:
+            return ndims >= 3;
+        case FileInfo::Data::XYZW:
+            return ndims >= 4;
+        case FileInfo::Data::Mask:
+            return image->hasPixelMask();
+        default:
+            break;
     }
     return false;
 }
 
+// TODO: should this check the parameter and fail if it's not the image dataset?
+// TODO: other loaders don't have this fallback; we should either consistently assume that openFile has been run, or not.
+// TODO: in other loaders this is also not an optional property which could be a null pointer.
 typename FITSLoader::image_ref FITSLoader::loadData(FileInfo::Data) {
     if (image==nullptr)
         openFile(file, fitsHdu);

--- a/ImageData/FileLoader.cc
+++ b/ImageData/FileLoader.cc
@@ -77,7 +77,7 @@ void FileLoader::findCoords(int& spectralAxis, int& stokesAxis) {
 }
 
 bool FileLoader::findShape(ipos& shape, size_t& nchannels, size_t& nstokes, int& spectralAxis, int& stokesAxis) {
-    auto &image = loadData(FileInfo::Data::XYZW);
+    auto &image = loadData(FileInfo::Data::Image);
     
     shape = image.shape();
     size_t ndims = shape.size();
@@ -398,4 +398,9 @@ void FileLoader::loadImageStats(bool loadPercentiles) {
 
 FileInfo::ImageStats& FileLoader::getImageStats(int stokes, int channel) {
     return (channel >= 0 ? channelStats[stokes][channel] : cubeStats[stokes]);
+}
+
+bool FileLoader::getCursorSpectralData(std::vector<float>& data, int stokes, int cursorX, int cursorY) {
+    // Must be implemented in subclasses
+    return false;
 }

--- a/ImageData/FileLoader.h
+++ b/ImageData/FileLoader.h
@@ -22,12 +22,17 @@ struct ImageStats {
 
 enum class Data : uint32_t
 {
-     // Standard layouts
+    // Main dataset
+    Image,
+    // Possible aliases to main dataset
     XY, XYZ, XYZW,
-     // Swizzled layouts
+    // Possible swizzled datasets
     YX, ZYX, ZYXW,
+    // Alias to swizzled dataset
+    Swizzled,
     // Statistics tables
-    Stats, Stats2D, S2DMin, S2DMax, S2DMean, S2DNans, S2DHist, S2DPercent, Ranks,
+    Stats, Ranks,
+    Stats2D, S2DMin, S2DMax, S2DMean, S2DNans, S2DHist, S2DPercent,
     Stats3D, S3DMin, S3DMax, S3DMean, S3DNans, S3DHist, S3DPercent,
     // Mask
     Mask
@@ -76,6 +81,7 @@ public:
     // specified HDU/group/table/etc.
     virtual image_ref loadData(FileInfo::Data ds) = 0;
     virtual bool getPixelMaskSlice(casacore::Array<bool>& mask, const casacore::Slicer& slicer) = 0;
+    virtual bool getCursorSpectralData(std::vector<float>& data, int stokes, int cursorX, int cursorY);
 protected:
     virtual const casacore::CoordinateSystem& getCoordSystem() = 0;
     

--- a/ImageData/HDF5Loader.h
+++ b/ImageData/HDF5Loader.h
@@ -328,22 +328,25 @@ void HDF5Loader::findCoords(int& spectralAxis, int& stokesAxis) {
 bool HDF5Loader::getCursorSpectralData(std::vector<float>& data, int stokes, int cursorX, int cursorY) {
     bool dataOK(false);
     
-    std::cout << "stokes " << stokes << "; x " << cursorX << "; y " << cursorY << std::endl;
+    std::cerr << "stokes " << stokes << "; x " << cursorX << "; y " << cursorY << std::endl;
     
     if (hasData(FileInfo::Data::Swizzled)) {
         casacore::Slicer slicer;
         if (ndims == 4) {
-            slicer = casacore::Slicer(ipos(4, stokes, cursorX, cursorY, 0), ipos(4, 1, 1, 1, nchannels));
+            slicer = casacore::Slicer(ipos(4, 0, cursorY, cursorX, stokes), ipos(4, nchannels, 1, 1, 1));
         } else if (ndims == 3) {
-            slicer = casacore::Slicer(ipos(3, cursorX, cursorY, 0), ipos(3, 1, 1, nchannels));
+            slicer = casacore::Slicer(ipos(3, 0, cursorY, cursorX), ipos(3, nchannels, 1, 1));
         }
+        
+        std::cerr << "slicer length " << slicer.length() << std::endl;
+        std::cerr << "dataset shape " << loadData(FileInfo::Data::Swizzled).shape() << std::endl;
         
         casacore::Array<float> tmp(slicer.length(), data.data(), casacore::StorageInitPolicy::SHARE);
         try {
             loadData(FileInfo::Data::Swizzled).doGetSlice(tmp, slicer);
             dataOK = true;
         } catch (casacore::AipsError& err) {
-            std::cout << "AIPS ERROR: " << err.getMesg() << std::endl;
+            std::cerr << "AIPS ERROR: " << err.getMesg() << std::endl;
         }
     }
     

--- a/ImageData/HDF5Loader.h
+++ b/ImageData/HDF5Loader.h
@@ -327,13 +327,15 @@ void HDF5Loader::findCoords(int& spectralAxis, int& stokesAxis) {
 }
 bool HDF5Loader::getCursorSpectralData(std::vector<float>& data, int stokes, int cursorX, int cursorY) {
     bool dataOK(false);
-        
+    
+    std::cout << "stokes " << stokes << "; x " << cursorX << "; y " << cursorY << std::endl;
+    
     if (hasData(FileInfo::Data::Swizzled)) {
         casacore::Slicer slicer;
         if (ndims == 4) {
-            slicer = casacore::Slicer(ipos(4, stokes, cursorX, cursorY, 0), ipos(4, stokes, cursorX, cursorY, nchannels));
+            slicer = casacore::Slicer(ipos(4, stokes, cursorX, cursorY, 0), ipos(4, 1, 1, 1, nchannels));
         } else if (ndims == 3) {
-            slicer = casacore::Slicer(ipos(3, cursorX, cursorY, 0), ipos(3, cursorX, cursorY, nchannels));
+            slicer = casacore::Slicer(ipos(3, cursorX, cursorY, 0), ipos(3, 1, 1, nchannels));
         }
         
         casacore::Array<float> tmp(slicer.length(), data.data(), casacore::StorageInitPolicy::SHARE);

--- a/ImageData/MIRIADLoader.h
+++ b/ImageData/MIRIADLoader.h
@@ -31,18 +31,21 @@ void MIRIADLoader::openFile(const std::string &filename, const std::string& /*hd
 
 bool MIRIADLoader::hasData(FileInfo::Data dl) const {
     switch(dl) {
-    case FileInfo::Data::XY:
-        return image.shape().size() >= 2;
-    case FileInfo::Data::XYZ:
-        return image.shape().size() >= 3;
-    case FileInfo::Data::XYZW:
-        return image.shape().size() >= 4;
-    default:
-        break;
+        case FileInfo::Data::Image:
+            return true;
+        case FileInfo::Data::XY:
+            return ndims >= 2;
+        case FileInfo::Data::XYZ:
+            return ndims >= 3;
+        case FileInfo::Data::XYZW:
+            return ndims >= 4;
+        default:
+            break;
     }
     return false;
 }
 
+// TODO: should this check the parameter and fail if it's not the image dataset? 
 typename MIRIADLoader::image_ref MIRIADLoader::loadData(FileInfo::Data) {
     return image;
 }


### PR DESCRIPTION
This reads z-profiles from the swizzled dataset, currently only for point regions. Apart from that, I have removed some confusing and inconsistent usage of dataset names, as follows:

* `Data::Image` is always `DATA`; dimensions are not checked
* *Only one of* `Data::XYZW`, `Data::XYZ` and `Data:XY` is an alias for `Data::Image`, depending on the actual shape of the image.
* *Only one of* `Data::ZYXW`, etc., is the swizzled dataset, depending on the shape of the image and therefore the actual name of the dataset in the file
* `Data::Swizzled` is always an alias to the swizzled dataset.
* To make all this possible, the function for mapping these enums to strings is no longer static, since it needs to be aware of instance state.

In summary, `Data::Image` and `Data::Swizzled` are generic names for the main dataset and swizzled dataset, while enums that name specific axes refer *only* to datasets with those exact corresponding axes, and may no longer be used as generic names.

The HDF5 functions for loading data and checking for the existence of datasets have also been adjusted.

Edit: fixes #90.