### PR TITLE
Patches to fix z profile bugs

### DIFF
--- a/Frame.cc
+++ b/Frame.cc
@@ -244,6 +244,7 @@ bool Frame::setImageView(const CARTA::ImageBounds& newBounds, int newMip,
 }
 
 bool Frame::setImageChannels(int newChannel, int newStokes, std::string& message) {
+    increase_job_count_();
     bool updated(false);
     if (!valid || (regions.count(IMAGE_REGION_ID)==0)) {
         message = "No file loaded";
@@ -263,6 +264,7 @@ bool Frame::setImageChannels(int newChannel, int newStokes, std::string& message
             }
         }
     }
+    decrease_job_count_();
     return updated;
 }
 
@@ -454,6 +456,7 @@ bool Frame::setRegionStatsRequirements(int regionId, const std::vector<int> stat
 
 bool Frame::fillRasterImageData(CARTA::RasterImageData& rasterImageData, std::string& message) {
     // fill data message with compressed channel cache data
+    increase_job_count_();
     bool rasterDataOK(false);
     std::vector<float> imageData;
     if (getImageData(imageData)) {
@@ -512,6 +515,7 @@ bool Frame::fillRasterImageData(CARTA::RasterImageData& rasterImageData, std::st
     } else {
         message = "Raster image data failed to load";
     }
+    decrease_job_count_();
     return rasterDataOK;
 }
 

--- a/Frame.cc
+++ b/Frame.cc
@@ -852,18 +852,13 @@ bool Frame::fillSpectralProfileData(int regionId, CARTA::SpectralProfileData& pr
 bool Frame::fillRegionStatsData(int regionId, CARTA::RegionStatsData& statsData) {
     // fill stats data message with requested statistics for the region with
     // current channel and stokes
-    increase_job_count_();
     bool statsOK(false);
     if (regions.count(regionId)) {
         auto& region = regions[regionId];
-        if (!region->isValid()) {
-            decrease_job_count_();
+        if (!region->isValid())
             return false;
-        }
-        if (region->numStats() == 0) {
-            decrease_job_count_();
+        if (region->numStats() == 0)
             return false; // not requested
-        }
 
         statsData.set_channel(channelIndex);
         statsData.set_stokes(stokesIndex);
@@ -875,7 +870,6 @@ bool Frame::fillRegionStatsData(int regionId, CARTA::RegionStatsData& statsData)
         region->fillStatsData(statsData, sublattice, channelIndex, stokesIndex);
         statsOK = true;
     }
-    decrease_job_count_();
     return statsOK;
 }
 

--- a/Frame.cc
+++ b/Frame.cc
@@ -684,19 +684,14 @@ bool Frame::fillRegionHistogramData(int regionId, CARTA::RegionHistogramData* hi
 bool Frame::fillSpatialProfileData(int regionId, CARTA::SpatialProfileData& profileData,
         bool checkCurrentStokes) {
     // fill spatial profile message with requested x/y profiles (for a point region)
-    increase_job_count_();
     bool profileOK(false);
     if (regions.count(regionId)) {
         auto& region = regions[regionId];
-        if (!region->isValid() || !region->isPoint()) {
-            decrease_job_count_();
+        if (!region->isValid() || !region->isPoint())
             return profileOK;
-        }
         size_t numProfiles(region->numSpatialProfiles());
-        if (numProfiles==0) {
-            decrease_job_count_();
+        if (numProfiles==0)
             return profileOK; // not requested
-        }
 
         // set spatial profile fields
         std::vector<CARTA::Point> ctrlPts = region->getControlPoints();
@@ -724,10 +719,8 @@ bool Frame::fillSpatialProfileData(int regionId, CARTA::SpatialProfileData& prof
                 // get <axis, stokes> for slicing image data
                 std::pair<int,int> axisStokes = region->getSpatialProfileReq(i);
                 // only send if using current stokes, which changed
-                if (checkCurrentStokes && (axisStokes.second != CURRENT_STOKES)) {
-                    decrease_job_count_();
+                if (checkCurrentStokes && (axisStokes.second != CURRENT_STOKES))
                     return false;
-                }
 
                 int profileStokes = (axisStokes.second < 0 ? stokesIndex : axisStokes.second);
                 std::vector<float> profile;
@@ -790,7 +783,6 @@ bool Frame::fillSpatialProfileData(int regionId, CARTA::SpatialProfileData& prof
             profileOK = true;
         }
     }
-    decrease_job_count_();
     return profileOK;
 }
 

--- a/Frame.cc
+++ b/Frame.cc
@@ -244,7 +244,6 @@ bool Frame::setImageView(const CARTA::ImageBounds& newBounds, int newMip,
 }
 
 bool Frame::setImageChannels(int newChannel, int newStokes, std::string& message) {
-    increase_job_count_();
     bool updated(false);
     if (!valid || (regions.count(IMAGE_REGION_ID)==0)) {
         message = "No file loaded";
@@ -264,7 +263,6 @@ bool Frame::setImageChannels(int newChannel, int newStokes, std::string& message
             }
         }
     }
-    decrease_job_count_();
     return updated;
 }
 
@@ -456,7 +454,6 @@ bool Frame::setRegionStatsRequirements(int regionId, const std::vector<int> stat
 
 bool Frame::fillRasterImageData(CARTA::RasterImageData& rasterImageData, std::string& message) {
     // fill data message with compressed channel cache data
-    increase_job_count_();
     bool rasterDataOK(false);
     std::vector<float> imageData;
     if (getImageData(imageData)) {
@@ -515,7 +512,6 @@ bool Frame::fillRasterImageData(CARTA::RasterImageData& rasterImageData, std::st
     } else {
         message = "Raster image data failed to load";
     }
-    decrease_job_count_();
     return rasterDataOK;
 }
 

--- a/Frame.cc
+++ b/Frame.cc
@@ -1012,20 +1012,20 @@ bool Frame::getSublatticeXY(casacore::SubLattice<float>& sublattice, std::pair<i
 bool Frame::getSpectralData(std::vector<float>& data, casacore::SubLattice<float>& sublattice, int checkPerChannels) {
     bool dataOK(false);
     casacore::IPosition sublattShape = sublattice.shape();
+    casacore::IPosition count(sublattShape);
+    int profileAxis = -1; // profile axis index
+    size_t profileSize; // profile vector size
+    // get profile axis index and its vector size
+    for (int i=0; i<sublattShape.size(); ++i) {
+        if (count(i)>1) {
+            profileAxis = i;
+            profileSize = count(i);
+        }
+    }
     data.resize(sublattShape.product());
-    if (checkPerChannels > 0 && sublattShape.size() > 2 && sublattShape > 1) { // stoppable spectral profile process
+    if (checkPerChannels > 0 && sublattShape.size() > 2 && profileAxis > 0) { // stoppable spectral profile process
         try {
             casacore::IPosition start(sublattShape.size(), 0);
-            casacore::IPosition count(sublattShape);
-            int profileAxis; // profile axis index
-            size_t profileSize; // profile vector size
-            // get profile axis index and its vector size
-            for (int i=0; i<sublattShape.size(); ++i) {
-                if (count(i)>1) {
-                    profileAxis = i;
-                    profileSize = count(i);
-                }
-            }
             size_t begin = 0; // the begin index of profile vector in each copy
             size_t upperBound = (profileSize%checkPerChannels == 0 ? profileSize/checkPerChannels : profileSize/checkPerChannels + 1);
             // get cursor's x-y coordinate from sub-lattice

--- a/Frame.cc
+++ b/Frame.cc
@@ -959,21 +959,19 @@ bool Frame::getImageHistogram(int channel, int stokes, int nbins, CARTA::Histogr
             haveHistogram = true;
         }
     }
-
+    
     return haveHistogram;
 }
 
 bool Frame::getRegionHistogram(int regionId, int channel, int stokes, int nbins,
     CARTA::Histogram& histogram) {
     // Return stored histogram in histogram parameter
-    increase_job_count_();
     bool haveHistogram(false);
     if (regions.count(regionId)) {
         auto& region = regions[regionId];
         nbins = (nbins==AUTO_BIN_SIZE ? calcAutoNumBins(regionId) : nbins);
         haveHistogram = region->getHistogram(channel, stokes, nbins, histogram);
     }
-    decrease_job_count_();
     return haveHistogram;
 }
 

--- a/Frame.cc
+++ b/Frame.cc
@@ -12,7 +12,7 @@ using namespace std;
 Frame::Frame(const string& uuidString, const string& filename, const string& hdu, int defaultChannel)
     : uuid(uuidString),
       valid(true),
-      connected(true),
+      connected_(true),
       cursorSet(false),
       filename(filename),
       loader(FileLoader::getLoader(filename)),
@@ -72,8 +72,8 @@ bool Frame::isValid() {
     return valid;
 }
 
-void Frame::disconnect_called() {
-    connected = false;
+void Frame::DisconnectCalled() {
+    connected_ = false;
 }
 
 std::vector<int> Frame::getRegionIds() {
@@ -1033,7 +1033,7 @@ bool Frame::getSpectralData(std::vector<float>& data, casacore::SubLattice<float
             // get profile data section by section with a specific length (i.e., checkPerChannels)
             for (size_t i=0; i<upperBound; ++i) {
                 // check if cursor's position changed during this loop, if so, stop the profile process
-                if (tmpXY != cursorXY || !connected)
+                if (tmpXY != cursorXY || !connected_)
                     return false;
                 // modify the start position for slicer
                 start(spectralAxis) = i*checkPerChannels;

--- a/Frame.cc
+++ b/Frame.cc
@@ -684,14 +684,19 @@ bool Frame::fillRegionHistogramData(int regionId, CARTA::RegionHistogramData* hi
 bool Frame::fillSpatialProfileData(int regionId, CARTA::SpatialProfileData& profileData,
         bool checkCurrentStokes) {
     // fill spatial profile message with requested x/y profiles (for a point region)
+    increase_job_count_();
     bool profileOK(false);
     if (regions.count(regionId)) {
         auto& region = regions[regionId];
-        if (!region->isValid() || !region->isPoint())
+        if (!region->isValid() || !region->isPoint()) {
+            decrease_job_count_();
             return profileOK;
+        }
         size_t numProfiles(region->numSpatialProfiles());
-        if (numProfiles==0)
+        if (numProfiles==0) {
+            decrease_job_count_();
             return profileOK; // not requested
+        }
 
         // set spatial profile fields
         std::vector<CARTA::Point> ctrlPts = region->getControlPoints();
@@ -719,8 +724,10 @@ bool Frame::fillSpatialProfileData(int regionId, CARTA::SpatialProfileData& prof
                 // get <axis, stokes> for slicing image data
                 std::pair<int,int> axisStokes = region->getSpatialProfileReq(i);
                 // only send if using current stokes, which changed
-                if (checkCurrentStokes && (axisStokes.second != CURRENT_STOKES))
+                if (checkCurrentStokes && (axisStokes.second != CURRENT_STOKES)) {
+                    decrease_job_count_();
                     return false;
+                }
 
                 int profileStokes = (axisStokes.second < 0 ? stokesIndex : axisStokes.second);
                 std::vector<float> profile;
@@ -783,6 +790,7 @@ bool Frame::fillSpatialProfileData(int regionId, CARTA::SpatialProfileData& prof
             profileOK = true;
         }
     }
+    decrease_job_count_();
     return profileOK;
 }
 

--- a/Frame.cc
+++ b/Frame.cc
@@ -897,12 +897,13 @@ bool Frame::getRegionMinMax(int regionId, int channel, int stokes, float& minval
     if (regions.count(regionId)) {
         auto& region = regions[regionId];
         haveMinMax = region->getMinMax(channel, stokes, minval, maxval);
-    } 
+    }
     return haveMinMax;
 }
 
 bool Frame::calcRegionMinMax(int regionId, int channel, int stokes, float& minval, float& maxval) {
     // Calculate min/max for region data; primarily for cube histogram
+    increase_job_count_();
     bool minmaxOK(false);
     if (regions.count(regionId)) {
         auto& region = regions[regionId];
@@ -930,18 +931,19 @@ bool Frame::calcRegionMinMax(int regionId, int channel, int stokes, float& minva
             minmaxOK = hasData;
         }
     }
+    decrease_job_count_();
     return minmaxOK;
-}  
+}
 
 bool Frame::getImageHistogram(int channel, int stokes, int nbins, CARTA::Histogram& histogram) {
     // Return image histogram in histogram parameter
     bool haveHistogram(false);
-    
+
     auto& currentStats = loader->getImageStats(stokes, channel);
 
     if (currentStats.valid) {
         int imageNbins(currentStats.histogramBins.size());
-        
+
         if ((nbins == AUTO_BIN_SIZE) || (nbins == imageNbins)) {
             histogram.set_num_bins(imageNbins);
             histogram.set_bin_width((currentStats.maxVal - currentStats.minVal) / imageNbins);

--- a/Frame.cc
+++ b/Frame.cc
@@ -74,7 +74,8 @@ bool Frame::isValid() {
 }
 
 void Frame::DisconnectCalled() {
-    connected_ = false;
+    connected_ = false; // set a false flag to interrupt the running jobs
+    while (job_count_) {} // wait for the jobs finished
 }
 
 std::vector<int> Frame::getRegionIds() {

--- a/Frame.cc
+++ b/Frame.cc
@@ -972,7 +972,6 @@ bool Frame::getRegionHistogram(int regionId, int channel, int stokes, int nbins,
 bool Frame::calcRegionHistogram(int regionId, int channel, int stokes, int nbins,
     float minval, float maxval, CARTA::Histogram& histogram) {
     // Return calculated histogram in histogram parameter; primarily for cube histogram
-    increase_job_count_();
     bool histogramOK(false);
     if (regions.count(regionId)) {
         auto& region = regions[regionId];
@@ -1001,7 +1000,6 @@ bool Frame::calcRegionHistogram(int regionId, int channel, int stokes, int nbins
             histogramOK = hasData;
         }
     }
-    decrease_job_count_();
     return histogramOK;
 }
 

--- a/Frame.cc
+++ b/Frame.cc
@@ -808,14 +808,12 @@ bool Frame::fillSpectralProfileData(int regionId, CARTA::SpectralProfileData& pr
                     std::vector<float> spectralData;
                     auto cursorPos = region->getControlPoints()[0];
                     // try use the loader's optimized cursor profile reader first
-                    bool complete(false); // whether the spectral profile is complete (for all image channels)
                     if (!loader->getCursorSpectralData(spectralData, profileStokes, cursorPos.x(), cursorPos.y())) {
-                        complete = getSpectralData(spectralData, sublattice, 100);
+                        // only send spectral profile data to frontend while it is complete
+                        if (getSpectralData(spectralData, sublattice, 100))
+                            region->fillSpectralProfileData(profileData, i, spectralData);
                     }
                     guard.unlock();
-                    // only send spectral profile data to frontend while it is complete
-                    if (complete)
-                        region->fillSpectralProfileData(profileData, i, spectralData);
                 } else {  // statistics
                     if (!sublattice.shape().empty())
                         setPixelMask(sublattice);

--- a/Frame.cc
+++ b/Frame.cc
@@ -599,15 +599,12 @@ bool Frame::getImageData(std::vector<float>& imageData, bool meanFilter) {
 bool Frame::fillRegionHistogramData(int regionId, CARTA::RegionHistogramData* histogramData,
         bool checkCurrentChannel) {
     // fill histogram message with histograms for requested channel/num bins
-    increase_job_count_();
     bool histogramOK(false);
     if (regions.count(regionId)) {
         auto& region = regions[regionId];
         size_t numHistograms(region->numHistogramConfigs());
-        if (numHistograms==0) {
-            decrease_job_count_();
+        if (numHistograms==0)
             return false; // not requested
-        }
 
         int currStokes(currentStokes());
         histogramData->set_stokes(currStokes);
@@ -617,24 +614,22 @@ bool Frame::fillRegionHistogramData(int regionId, CARTA::RegionHistogramData* hi
             CARTA::SetHistogramRequirements_HistogramConfig config = region->getHistogramConfig(i);
             int configChannel(config.channel()), configNumBins(config.num_bins());
             // only send if using current channel, which changed
-            if (checkCurrentChannel && (configChannel != CURRENT_CHANNEL)) {
-                decrease_job_count_();
+            if (checkCurrentChannel && (configChannel != CURRENT_CHANNEL))
                 return false;
-            }
             if (configChannel == CURRENT_CHANNEL) {
                 configChannel = channelIndex;
             }
             auto newHistogram = histogramData->add_histograms();
             newHistogram->set_channel(configChannel);
             // get stored histograms or fill new histograms
-
+            
             bool haveHistogram(false);
 
             // Check if read from image file (HDF5 only)
             if (regionId == IMAGE_REGION_ID || regionId == CUBE_REGION_ID) {
                 haveHistogram = getImageHistogram(configChannel, currStokes, configNumBins, *newHistogram);
             }
-
+            
             if (!haveHistogram) {
                 // Retrieve histogram if stored
                 if (!getRegionHistogram(regionId, configChannel, currStokes, configNumBins, *newHistogram)) {
@@ -677,7 +672,6 @@ bool Frame::fillRegionHistogramData(int regionId, CARTA::RegionHistogramData* hi
         }
         histogramOK = true;
     }
-    decrease_job_count_();
     return histogramOK;
 }
 

--- a/Frame.cc
+++ b/Frame.cc
@@ -959,19 +959,21 @@ bool Frame::getImageHistogram(int channel, int stokes, int nbins, CARTA::Histogr
             haveHistogram = true;
         }
     }
-    
+
     return haveHistogram;
 }
 
 bool Frame::getRegionHistogram(int regionId, int channel, int stokes, int nbins,
     CARTA::Histogram& histogram) {
     // Return stored histogram in histogram parameter
+    increase_job_count_();
     bool haveHistogram(false);
     if (regions.count(regionId)) {
         auto& region = regions[regionId];
         nbins = (nbins==AUTO_BIN_SIZE ? calcAutoNumBins(regionId) : nbins);
         haveHistogram = region->getHistogram(channel, stokes, nbins, histogram);
     }
+    decrease_job_count_();
     return haveHistogram;
 }
 

--- a/Frame.cc
+++ b/Frame.cc
@@ -1026,7 +1026,6 @@ bool Frame::getSpectralData(std::vector<float>& data, casacore::SubLattice<float
             casacore::IPosition start(sublattShape.size(), 0);
             casacore::IPosition count(sublattShape);
             size_t profileSize = nchannels(); // profile vector size
-            size_t begin = 0; // the begin index of profile vector in each copy
             size_t upperBound = (profileSize%checkPerChannels == 0 ? profileSize/checkPerChannels : profileSize/checkPerChannels + 1);
             // get cursor's x-y coordinate from sub-lattice
             std::pair<int, int> tmpXY;
@@ -1043,8 +1042,7 @@ bool Frame::getSpectralData(std::vector<float>& data, casacore::SubLattice<float
                 casacore::Slicer slicer(start, count);
                 casacore::Array<float> buffer;
                 sublattice.doGetSlice(buffer, slicer);
-                memcpy(&data[begin], buffer.data(), count(spectralAxis)*sizeof(float));
-                begin += count(spectralAxis);
+                memcpy(&data[i*checkPerChannels], buffer.data(), count(spectralAxis)*sizeof(float));
             }
             dataOK = true;
         } catch (casacore::AipsError& err) {

--- a/Frame.cc
+++ b/Frame.cc
@@ -897,13 +897,12 @@ bool Frame::getRegionMinMax(int regionId, int channel, int stokes, float& minval
     if (regions.count(regionId)) {
         auto& region = regions[regionId];
         haveMinMax = region->getMinMax(channel, stokes, minval, maxval);
-    }
+    } 
     return haveMinMax;
 }
 
 bool Frame::calcRegionMinMax(int regionId, int channel, int stokes, float& minval, float& maxval) {
     // Calculate min/max for region data; primarily for cube histogram
-    increase_job_count_();
     bool minmaxOK(false);
     if (regions.count(regionId)) {
         auto& region = regions[regionId];
@@ -931,19 +930,18 @@ bool Frame::calcRegionMinMax(int regionId, int channel, int stokes, float& minva
             minmaxOK = hasData;
         }
     }
-    decrease_job_count_();
     return minmaxOK;
-}
+}  
 
 bool Frame::getImageHistogram(int channel, int stokes, int nbins, CARTA::Histogram& histogram) {
     // Return image histogram in histogram parameter
     bool haveHistogram(false);
-
+    
     auto& currentStats = loader->getImageStats(stokes, channel);
 
     if (currentStats.valid) {
         int imageNbins(currentStats.histogramBins.size());
-
+        
         if ((nbins == AUTO_BIN_SIZE) || (nbins == imageNbins)) {
             histogram.set_num_bins(imageNbins);
             histogram.set_bin_width((currentStats.maxVal - currentStats.minVal) / imageNbins);

--- a/Frame.cc
+++ b/Frame.cc
@@ -809,11 +809,13 @@ bool Frame::fillSpectralProfileData(int regionId, CARTA::SpectralProfileData& pr
                     auto cursorPos = region->getControlPoints()[0];
                     // try use the loader's optimized cursor profile reader first
                     if (!loader->getCursorSpectralData(spectralData, profileStokes, cursorPos.x(), cursorPos.y())) {
+                        // get spectral profile data
+                        bool complete = getSpectralData(spectralData, sublattice, 100);
+                        guard.unlock();
                         // only send spectral profile data to frontend while it is complete
-                        if (getSpectralData(spectralData, sublattice, 100))
+                        if (complete)
                             region->fillSpectralProfileData(profileData, i, spectralData);
                     }
-                    guard.unlock();
                 } else {  // statistics
                     if (!sublattice.shape().empty())
                         setPixelMask(sublattice);

--- a/Frame.cc
+++ b/Frame.cc
@@ -972,6 +972,7 @@ bool Frame::getRegionHistogram(int regionId, int channel, int stokes, int nbins,
 bool Frame::calcRegionHistogram(int regionId, int channel, int stokes, int nbins,
     float minval, float maxval, CARTA::Histogram& histogram) {
     // Return calculated histogram in histogram parameter; primarily for cube histogram
+    increase_job_count_();
     bool histogramOK(false);
     if (regions.count(regionId)) {
         auto& region = regions[regionId];
@@ -1000,6 +1001,7 @@ bool Frame::calcRegionHistogram(int regionId, int channel, int stokes, int nbins
             histogramOK = hasData;
         }
     }
+    decrease_job_count_();
     return histogramOK;
 }
 

--- a/Frame.cc
+++ b/Frame.cc
@@ -1020,20 +1020,12 @@ bool Frame::getSublatticeXY(casacore::SubLattice<float>& sublattice, std::pair<i
 bool Frame::getSpectralData(std::vector<float>& data, casacore::SubLattice<float>& sublattice, int checkPerChannels) {
     bool dataOK(false);
     casacore::IPosition sublattShape = sublattice.shape();
-    casacore::IPosition count(sublattShape);
-    int profileAxis = -1; // profile axis index
-    size_t profileSize; // profile vector size
-    // get profile axis index and its vector size
-    for (int i=0; i<sublattShape.size(); ++i) {
-        if (count(i)>1) {
-            profileAxis = i;
-            profileSize = count(i);
-        }
-    }
     data.resize(sublattShape.product());
-    if (checkPerChannels > 0 && sublattShape.size() > 2 && profileAxis > -1) { // stoppable spectral profile process
+    if (checkPerChannels > 0 && sublattShape.size() > 2 && spectralAxis >= 0) { // stoppable spectral profile process
         try {
             casacore::IPosition start(sublattShape.size(), 0);
+            casacore::IPosition count(sublattShape);
+            size_t profileSize = nchannels(); // profile vector size
             size_t begin = 0; // the begin index of profile vector in each copy
             size_t upperBound = (profileSize%checkPerChannels == 0 ? profileSize/checkPerChannels : profileSize/checkPerChannels + 1);
             // get cursor's x-y coordinate from sub-lattice
@@ -1045,14 +1037,14 @@ bool Frame::getSpectralData(std::vector<float>& data, casacore::SubLattice<float
                 if (tmpXY != cursorXY || !connected)
                     return false;
                 // modify the start position for slicer
-                start(profileAxis) = i*checkPerChannels;
+                start(spectralAxis) = i*checkPerChannels;
                 // modify the count for slicer
-                count(profileAxis) = (checkPerChannels*(i+1) < profileSize ? checkPerChannels : profileSize - i*checkPerChannels);
+                count(spectralAxis) = (checkPerChannels*(i+1) < profileSize ? checkPerChannels : profileSize - i*checkPerChannels);
                 casacore::Slicer slicer(start, count);
                 casacore::Array<float> buffer;
                 sublattice.doGetSlice(buffer, slicer);
-                memcpy(&data[begin], buffer.data(), count(profileAxis)*sizeof(float));
-                begin += count(profileAxis);
+                memcpy(&data[begin], buffer.data(), count(spectralAxis)*sizeof(float));
+                begin += count(spectralAxis);
             }
             dataOK = true;
         } catch (casacore::AipsError& err) {

--- a/Frame.cc
+++ b/Frame.cc
@@ -852,13 +852,18 @@ bool Frame::fillSpectralProfileData(int regionId, CARTA::SpectralProfileData& pr
 bool Frame::fillRegionStatsData(int regionId, CARTA::RegionStatsData& statsData) {
     // fill stats data message with requested statistics for the region with
     // current channel and stokes
+    increase_job_count_();
     bool statsOK(false);
     if (regions.count(regionId)) {
         auto& region = regions[regionId];
-        if (!region->isValid())
+        if (!region->isValid()) {
+            decrease_job_count_();
             return false;
-        if (region->numStats() == 0)
+        }
+        if (region->numStats() == 0) {
+            decrease_job_count_();
             return false; // not requested
+        }
 
         statsData.set_channel(channelIndex);
         statsData.set_stokes(stokesIndex);
@@ -870,6 +875,7 @@ bool Frame::fillRegionStatsData(int regionId, CARTA::RegionStatsData& statsData)
         region->fillStatsData(statsData, sublattice, channelIndex, stokesIndex);
         statsOK = true;
     }
+    decrease_job_count_();
     return statsOK;
 }
 

--- a/Frame.h
+++ b/Frame.h
@@ -23,6 +23,9 @@ private:
     std::string uuid;
     bool valid;
 
+    // communication
+    bool connected;
+
     // image loader, stats from image file
     std::string filename;
     std::unique_ptr<carta::FileLoader> loader;
@@ -147,4 +150,7 @@ public:
         float maxval, CARTA::Histogram& histogram);
     void setRegionMinMax(int regionId, int channel, int stokes, float minval, float maxval);
     void setRegionHistogram(int regionId, int channel, int stokes, CARTA::Histogram& histogram);
+
+    // set the flag connected = false, in order to stop the job
+    void disconnect_called();
 };

--- a/Frame.h
+++ b/Frame.h
@@ -7,6 +7,7 @@
 #include <mutex>
 #include <algorithm>
 #include <tbb/queuing_rw_mutex.h>
+#include <tbb/atomic.h>
 
 #include <carta-protobuf/raster_image.pb.h>
 #include <carta-protobuf/region_histogram.pb.h>
@@ -25,6 +26,9 @@ private:
 
     // communication
     bool connected_;
+
+    // Reference counter
+    tbb::atomic<int> job_count_;
 
     // image loader, stats from image file
     std::string filename;
@@ -93,6 +97,8 @@ private:
     // get spectral profile data from sub-lattice
     bool getSpectralData(std::vector<float>& data, casacore::SubLattice<float>& sublattice, int checkPerChannels=ALL_CHANNELS);
 
+    void increase_job_count_() { ++job_count_; }
+    void decrease_job_count_() { --job_count_; }
 
 public:
     Frame(const std::string& uuidString, const std::string& filename, const std::string& hdu,
@@ -153,4 +159,5 @@ public:
 
     // set the flag connected_ = false, in order to stop the job
     void DisconnectCalled();
+    int get_job_count_() { return job_count_; }
 };

--- a/Frame.h
+++ b/Frame.h
@@ -24,7 +24,7 @@ private:
     bool valid;
 
     // communication
-    bool connected;
+    bool connected_;
 
     // image loader, stats from image file
     std::string filename;
@@ -151,6 +151,6 @@ public:
     void setRegionMinMax(int regionId, int channel, int stokes, float minval, float maxval);
     void setRegionHistogram(int regionId, int channel, int stokes, CARTA::Histogram& histogram);
 
-    // set the flag connected = false, in order to stop the job
-    void disconnect_called();
+    // set the flag connected_ = false, in order to stop the job
+    void DisconnectCalled();
 };

--- a/Frame.h
+++ b/Frame.h
@@ -25,10 +25,10 @@ private:
     bool valid;
 
     // communication
-    bool connected_;
+    bool connected;
 
-    // Reference counter
-    tbb::atomic<int> job_count_;
+    // spectral profile counter
+    tbb::atomic<int> zProfileCount;
 
     // image loader, stats from image file
     std::string filename;
@@ -97,8 +97,8 @@ private:
     // get spectral profile data from sub-lattice
     bool getSpectralData(std::vector<float>& data, casacore::SubLattice<float>& sublattice, int checkPerChannels=ALL_CHANNELS);
 
-    void increase_job_count_() { ++job_count_; }
-    void decrease_job_count_() { --job_count_; }
+    void increaseZProfileCount() { ++zProfileCount; }
+    void decreaseZProfileCount() { --zProfileCount; }
 
 public:
     Frame(const std::string& uuidString, const std::string& filename, const std::string& hdu,
@@ -157,6 +157,6 @@ public:
     void setRegionMinMax(int regionId, int channel, int stokes, float minval, float maxval);
     void setRegionHistogram(int regionId, int channel, int stokes, CARTA::Histogram& histogram);
 
-    // set the flag connected_ = false, in order to stop the jobs and wait for jobs finished
-    void DisconnectCalled();
+    // set the flag connected = false, in order to stop the jobs and wait for jobs finished
+    void disconnectCalled();
 };

--- a/Frame.h
+++ b/Frame.h
@@ -157,7 +157,6 @@ public:
     void setRegionMinMax(int regionId, int channel, int stokes, float minval, float maxval);
     void setRegionHistogram(int regionId, int channel, int stokes, CARTA::Histogram& histogram);
 
-    // set the flag connected_ = false, in order to stop the job
+    // set the flag connected_ = false, in order to stop the jobs and wait for jobs finished
     void DisconnectCalled();
-    int get_job_count_() { return job_count_; }
 };

--- a/Session.cc
+++ b/Session.cc
@@ -62,7 +62,7 @@ Session::~Session() {
 void Session::disconnect_called() {
     _connected= false;
     for (auto& frame : frames) {
-        frame.second->disconnect_called();  // call to stop the frame process
+        frame.second->DisconnectCalled();  // call to stop the frame process
     }
 }
 
@@ -236,12 +236,12 @@ void Session::onCloseFile(const CARTA::CloseFile& message, uint32_t requestId) {
     std::unique_lock<std::mutex> lock(frameMutex);
     if (fileId == ALL_FILES) {
         for (auto& frame : frames) {
-            frame.second->disconnect_called();
+            frame.second->DisconnectCalled();
             frame.second.reset();  // delete Frame
         }
         frames.clear();
     } else if (frames.count(fileId)) {
-        frames[fileId]->disconnect_called();
+        frames[fileId]->DisconnectCalled();
         frames[fileId].reset();
         frames.erase(fileId);
     }

--- a/Session.cc
+++ b/Session.cc
@@ -236,10 +236,12 @@ void Session::onCloseFile(const CARTA::CloseFile& message, uint32_t requestId) {
     std::unique_lock<std::mutex> lock(frameMutex);
     if (fileId == ALL_FILES) {
         for (auto& frame : frames) {
+            frame.second->disconnect_called();
             frame.second.reset();  // delete Frame
         }
         frames.clear();
     } else if (frames.count(fileId)) {
+        frames[fileId]->disconnect_called();
         frames[fileId].reset();
         frames.erase(fileId);
     }

--- a/Session.cc
+++ b/Session.cc
@@ -62,7 +62,7 @@ Session::~Session() {
 void Session::disconnect_called() {
     _connected= false;
     for (auto& frame : frames) {
-        frame.second->DisconnectCalled(); // call to stop Frame's jobs
+        frame.second->DisconnectCalled(); // call to stop Frame's jobs and wait for jobs finished
     }
 }
 
@@ -236,12 +236,12 @@ void Session::onCloseFile(const CARTA::CloseFile& message, uint32_t requestId) {
     std::unique_lock<std::mutex> lock(frameMutex);
     if (fileId == ALL_FILES) {
         for (auto& frame : frames) {
-            frame.second->DisconnectCalled(); // call to stop Frame's jobs
+            frame.second->DisconnectCalled(); // call to stop Frame's jobs and wait for jobs finished
             frame.second.reset();  // delete Frame
         }
         frames.clear();
     } else if (frames.count(fileId)) {
-        frames[fileId]->DisconnectCalled(); // call to stop Frame's jobs
+        frames[fileId]->DisconnectCalled(); // call to stop Frame's jobs and wait for jobs finished
         frames[fileId].reset();
         frames.erase(fileId);
     }

--- a/Session.cc
+++ b/Session.cc
@@ -52,11 +52,18 @@ Session::~Session() {
     }
     frames.clear();
     outgoing->close();
-    
+
     --_num_sessions;
     DEBUG(fprintf(stderr,"%p  ~Session (%d)\n", this, _num_sessions ));
     if( !_num_sessions )
       std::cout << "No remaining sessions." << endl;
+}
+
+void Session::disconnect_called() {
+    _connected= false;
+    for (auto& frame : frames) {
+        frame.second->disconnect_called();  // call to stop the frame process
+    }
 }
 
 // ********************************************************************************

--- a/Session.cc
+++ b/Session.cc
@@ -62,7 +62,7 @@ Session::~Session() {
 void Session::disconnect_called() {
     _connected= false;
     for (auto& frame : frames) {
-        frame.second->DisconnectCalled(); // call to stop Frame's jobs and wait for jobs finished
+        frame.second->disconnectCalled(); // call to stop Frame's jobs and wait for jobs finished
     }
 }
 
@@ -236,12 +236,12 @@ void Session::onCloseFile(const CARTA::CloseFile& message, uint32_t requestId) {
     std::unique_lock<std::mutex> lock(frameMutex);
     if (fileId == ALL_FILES) {
         for (auto& frame : frames) {
-            frame.second->DisconnectCalled(); // call to stop Frame's jobs and wait for jobs finished
+            frame.second->disconnectCalled(); // call to stop Frame's jobs and wait for jobs finished
             frame.second.reset();  // delete Frame
         }
         frames.clear();
     } else if (frames.count(fileId)) {
-        frames[fileId]->DisconnectCalled(); // call to stop Frame's jobs and wait for jobs finished
+        frames[fileId]->disconnectCalled(); // call to stop Frame's jobs and wait for jobs finished
         frames[fileId].reset();
         frames.erase(fileId);
     }

--- a/Session.cc
+++ b/Session.cc
@@ -48,7 +48,6 @@ Session::Session(uWS::WebSocket<uWS::SERVER>* ws,
 Session::~Session() {
     std::unique_lock<std::mutex> lock(frameMutex);
     for (auto& frame : frames) {
-        while (frame.second->get_job_count_()) {} // wait for Frame's jobs finished
         frame.second.reset();  // delete Frame
     }
     frames.clear();
@@ -238,13 +237,11 @@ void Session::onCloseFile(const CARTA::CloseFile& message, uint32_t requestId) {
     if (fileId == ALL_FILES) {
         for (auto& frame : frames) {
             frame.second->DisconnectCalled(); // call to stop Frame's jobs
-            while (frame.second->get_job_count_()) {} // wait for Frame's jobs finished
             frame.second.reset();  // delete Frame
         }
         frames.clear();
     } else if (frames.count(fileId)) {
         frames[fileId]->DisconnectCalled(); // call to stop Frame's jobs
-        while (frames[fileId]->get_job_count_()) {} // wait for Frame's jobs finished
         frames[fileId].reset();
         frames.erase(fileId);
     }

--- a/Session.h
+++ b/Session.h
@@ -123,9 +123,9 @@ public:
     }
     int increase_ref_count() { return ++_ref_count; }
     int decrease_ref_count() { return --_ref_count; }
-    void disconnect_called() { _connected= false; }
+    void disconnect_called();
     static int number_of_sessions() { return _num_sessions; }
-    
+
     // CARTA ICD
     void onRegisterViewer(const CARTA::RegisterViewer& message, uint32_t requestId);
     void onFileListRequest(const CARTA::FileListRequest& request, uint32_t requestId);


### PR DESCRIPTION
* Last time in order to fix the z profile problem for a single channel image. I set the `sublattShape > 1` as a necessary condition for executing the stoppable process. However, it is not correct, which leads to all z profile processes for the multi-channel images are non-stoppable. Now I correct it.
* Add a private bool variable `connected` in the `Frame`. If Session is closed or the image file under Session is closed, Session fires a signal to Frame and set `connected=false`. So the z profile process belongs to such Frame will be stopped.
* If the stopped process is called, the Frame will not continue the next process `region->fillSpectralProfileData(...)` and will also not send z profile data to the frontend. This could avoid the crash.

This is for issue #179.