### PR TITLE
Remove conditional behaviour of function which populates histogram messages

### DIFF
--- a/Session.cc
+++ b/Session.cc
@@ -647,14 +647,12 @@ bool Session::sendCubeHistogramData(const CARTA::SetHistogramRequirements& messa
 }
 
 void Session::createCubeHistogramMessage(CARTA::RegionHistogramData& message, int fileId, int stokes, float progress) {
-    // check for cancel then update progress and make new message
-    if (histogramProgress != HISTOGRAM_CANCEL) {
-        histogramProgress.fetch_and_store(progress);
-        message.set_file_id(fileId);
-        message.set_region_id(CUBE_REGION_ID);
-        message.set_stokes(stokes);
-        message.set_progress(progress);
-    }
+    // update progress and make new message
+    histogramProgress.fetch_and_store(progress);
+    message.set_file_id(fileId);
+    message.set_region_id(CUBE_REGION_ID);
+    message.set_stokes(stokes);
+    message.set_progress(progress);
 }
 
 bool Session::sendRasterImageData(int fileId, bool sendHistogram) {


### PR DESCRIPTION
The `createCubeHistogramMessage` function is used to populate cube histogram messages. It previously failed silently if the global histogram progress variable in the session was set to `HISTOGRAM_CANCEL`. This was causing a hang in the frontend if a cube histogram was requested after a region histogram had been requested. The check is unnecessary within the cube histogram calculation, because it is already being performed in the calling function wherever this function is used.

This fixes #189.