### PR TITLE
Rwjs/animation start

### DIFF
--- a/AnimationObject.h
+++ b/AnimationObject.h
@@ -34,16 +34,18 @@ class AnimationObject {
 		 bool l,
 		 bool rae,
 		 uint8_t ct,
-		 uint8_t cq,
+		 float cq,
 		 bool aw) :
-  _file_id(fid), _start_frame(sf), _curr_frame(sf),
+  _file_id(fid), _start_frame(sf), 
     _end_frame(ef), _delta_frame(df),
     _looping(l), _reverse_at_end(rae),
-    _compression_type(ct), _compression_quality(cq),
     _always_wait(aw) {
-    _frame_interval= std::chrono::microseconds(1000)*fi;
-    _going_forward= true;
-    _waitms= 100;
+      _compression_type= ct;
+      _compression_quality= cq;
+      _curr_frame= sf,
+	_frame_interval= std::chrono::microseconds(1000)*fi;
+      _going_forward= true;
+      _waitms= 100;
   }
   ~AnimationObject() {
   }

--- a/AnimationObject.h
+++ b/AnimationObject.h
@@ -1,0 +1,43 @@
+
+#pragma once
+
+
+#include <carta-protobuf/animation.pb.h>
+#include <carta-protobuf/set_image_channels.pb.h>
+
+class AnimationObject {
+  friend class Session;
+
+  int _file_id;
+  ::CARTA::AnimationFrame _start_frame;
+  ::CARTA::AnimationFrame _end_frame;
+  ::CARTA::AnimationFrame _delta_frame;
+  ::CARTA::AnimationFrame _curr_frame;
+  ::CARTA::AnimationFrame _stop_frame;
+  std::chrono::milliseconds _frame_interval;
+  bool _looping;
+  bool _reverse_at_end;
+  bool _going_forward;
+  uint8_t _compression_type;
+  float _compression_quality;
+  volatile bool _stop_called;
+ public:
+ AnimationObject(int fid,
+		 ::CARTA::AnimationFrame &sf,
+		 ::CARTA::AnimationFrame &ef,
+		 ::CARTA::AnimationFrame &df,
+		 int fi,
+		 bool l,
+		 bool rae,
+		 uint8_t ct,
+		 uint8_t cq) :
+  _file_id(fid), _start_frame(sf), _curr_frame(sf),
+    _end_frame(ef), _delta_frame(df),
+    _looping(l), _reverse_at_end(rae),
+    _compression_type(ct), _compression_quality(cq) {
+    _frame_interval= std::chrono::milliseconds(1)*fi;
+    _going_forward= true;
+  }
+  ~AnimationObject() {
+  }
+};

--- a/AnimationObject.h
+++ b/AnimationObject.h
@@ -14,13 +14,17 @@ class AnimationObject {
   ::CARTA::AnimationFrame _delta_frame;
   ::CARTA::AnimationFrame _curr_frame;
   ::CARTA::AnimationFrame _stop_frame;
-  std::chrono::milliseconds _frame_interval;
+  std::chrono::microseconds _frame_interval;
+  std::chrono::time_point<std::chrono::high_resolution_clock> _tStart;
+  std::chrono::time_point<std::chrono::high_resolution_clock> _tLast;
   bool _looping;
   bool _reverse_at_end;
   bool _going_forward;
+  bool _always_wait;
   uint8_t _compression_type;
   float _compression_quality;
   volatile bool _stop_called;
+  int _waitms;
  public:
  AnimationObject(int fid,
 		 ::CARTA::AnimationFrame &sf,
@@ -35,8 +39,10 @@ class AnimationObject {
     _end_frame(ef), _delta_frame(df),
     _looping(l), _reverse_at_end(rae),
     _compression_type(ct), _compression_quality(cq) {
-    _frame_interval= std::chrono::milliseconds(1)*fi;
+    _frame_interval= std::chrono::microseconds(1000)*fi;
     _going_forward= true;
+    _always_wait= false;
+    _waitms= 100;
   }
   ~AnimationObject() {
   }

--- a/AnimationObject.h
+++ b/AnimationObject.h
@@ -34,14 +34,15 @@ class AnimationObject {
 		 bool l,
 		 bool rae,
 		 uint8_t ct,
-		 uint8_t cq) :
+		 uint8_t cq,
+		 bool aw) :
   _file_id(fid), _start_frame(sf), _curr_frame(sf),
     _end_frame(ef), _delta_frame(df),
     _looping(l), _reverse_at_end(rae),
-    _compression_type(ct), _compression_quality(cq) {
+    _compression_type(ct), _compression_quality(cq),
+    _always_wait(aw) {
     _frame_interval= std::chrono::microseconds(1000)*fi;
     _going_forward= true;
-    _always_wait= false;
     _waitms= 100;
   }
   ~AnimationObject() {

--- a/EventMappings.h
+++ b/EventMappings.h
@@ -14,3 +14,6 @@ const uint8_t SET_REGION_ID= 11;
 const uint8_t REMOVE_REGION_ID= 12;
 const uint8_t CLOSE_FILE_ID= 13;
 const uint8_t SET_SPECTRAL_REQUIREMENTS_ID= 14;
+const uint8_t START_ANIMATION_ID= 15;
+const uint8_t START_ANIMATION_ACK_ID= 16;
+const uint8_t STOP_ANIMATION_ID= 17;

--- a/OnMessageTask.cc
+++ b/OnMessageTask.cc
@@ -113,14 +113,17 @@ SetImageChannelsTask::execute()
 {
   bool tester;
 
-  do {
-    session->executeSetChanEvt(_req);
-    session->image_channel_lock();
-    if( ! (tester= session->setchanq.try_pop(_req)) )
-      session->image_channal_task_set_idle();
-    session->image_channel_unlock();
-  } while( tester );
-  
+  session->executeSetChanEvt(_req);
+  session->image_channel_lock();
+  if( ! (tester= session->setchanq.try_pop(_req)) )
+    session->image_channal_task_set_idle();
+  session->image_channel_unlock();
+
+  if( tester ) {
+    increment_ref_count();
+    recycle_as_safe_continuation();
+  }
+    
   return nullptr;
 }
 

--- a/OnMessageTask.cc
+++ b/OnMessageTask.cc
@@ -155,3 +155,16 @@ SetHistogramReqsTask::execute()
 
    return nullptr;
 }
+
+tbb::task*
+AnimationTask::execute()
+{
+  if( session->execute_animation_frame() ) {
+    increment_ref_count();
+    recycle_as_safe_continuation();
+  }
+  
+  return nullptr;
+}
+
+  

--- a/OnMessageTask.cc
+++ b/OnMessageTask.cc
@@ -114,9 +114,9 @@ SetImageChannelsTask::execute()
   bool tester;
 
   do {
-    session->executeAniEvt(_req);
+    session->executeSetChanEvt(_req);
     session->image_channel_lock();
-    if( ! (tester= session->aniq.try_pop(_req)) )
+    if( ! (tester= session->setchanq.try_pop(_req)) )
       session->image_channal_task_set_idle();
     session->image_channel_unlock();
   } while( tester );

--- a/OnMessageTask.h
+++ b/OnMessageTask.h
@@ -3,6 +3,8 @@
 #pragma once
 
 #include "Session.h"
+#include "AnimationObject.h"
+
 
 #include <tbb/concurrent_queue.h>
 #include <tbb/task.h>
@@ -86,6 +88,20 @@ public:
     _msg= msg;
   }
   ~SetHistogramReqsTask() {
+  }
+};
+
+class AnimationTask : public OnMessageTask {
+  std::tuple<uint8_t,uint32_t,std::vector<char>> _msg;
+  tbb::task* execute();
+  
+ public:
+ AnimationTask(Session *session_, uint32_t req_id,
+	       CARTA::StartAnimation msg)
+   : OnMessageTask( session_ ) {
+    session_->build_animation_object( msg, req_id );
+  }
+  ~AnimationTask() {
   }
 };
 

--- a/Session.cc
+++ b/Session.cc
@@ -837,8 +837,7 @@ void Session::sendLogEvent(std::string message, std::vector<std::string> tags, C
 }
 
 
-void
-Session::build_animation_object(::CARTA::StartAnimation &msg, uint32_t requestID)
+void Session::build_animation_object(::CARTA::StartAnimation &msg, uint32_t requestID)
 {
   ::CARTA::AnimationFrame startF, endF, deltaF;
   int file_id;
@@ -868,8 +867,7 @@ Session::build_animation_object(::CARTA::StartAnimation &msg, uint32_t requestID
   sendEvent("START_ANIMATION_ACK", requestID, ackMessage);
 }
 
-bool
-Session::execute_animation_frame( void )
+bool Session::execute_animation_frame( void )
 {
   if( !_ani_obj ) {
     std::fprintf(stderr,
@@ -973,8 +971,7 @@ Session::execute_animation_frame( void )
 }
 
 
-void
-Session::stop_animation( int fid, CARTA::AnimationFrame stop_frame )
+void Session::stop_animation( int fid, CARTA::AnimationFrame stop_frame )
 {
   if( !_ani_obj ) {
     std::fprintf(stderr,

--- a/Session.cc
+++ b/Session.cc
@@ -12,8 +12,8 @@
 #include <thread>
 #include <chrono>
 #include <limits>
+#include <memory>
 
-using namespace std;
 
 
 #define DEBUG( _DB_TEXT_ ) { }
@@ -55,10 +55,6 @@ Session::~Session() {
     }
     frames.clear();
     outgoing->close();
-    if( _ani_obj ) {
-      delete _ani_obj;
-      _ani_obj= nullptr;
-    }
     --_num_sessions;
     DEBUG(fprintf(stderr,"%p  ~Session (%d)\n", this, _num_sessions ));
     if( !_num_sessions )
@@ -861,9 +857,10 @@ Session::build_animation_object(::CARTA::StartAnimation &msg, uint32_t requestID
   compQual= msg.compression_quality();
   always_wait= false;
 
-  _ani_obj= new AnimationObject( file_id, startF, endF, deltaF,
-				 millisec, looping, reverse_at_end,
-				 compType, compQual, always_wait );
+  _ani_obj= std::unique_ptr<AnimationObject>
+    (new AnimationObject(file_id, startF, endF, deltaF,
+			 millisec, looping, reverse_at_end,
+			 compType, compQual, always_wait));
 
   CARTA::StartAnimationAck ackMessage;
   ackMessage.set_success(true);

--- a/Session.cc
+++ b/Session.cc
@@ -849,7 +849,7 @@ Session::build_animation_object(::CARTA::StartAnimation &msg, uint32_t requestID
   startF= msg.start_frame();
   endF= msg.end_frame();
   deltaF= msg.delta_frame();
-
+  file_id= msg.file_id();
   millisec= msg.frame_interval();
   looping= msg.looping();
   reverse_at_end= msg.reverse();

--- a/Session.cc
+++ b/Session.cc
@@ -847,7 +847,7 @@ Session::build_animation_object(::CARTA::StartAnimation &msg, uint32_t requestID
   ::CARTA::AnimationFrame startF, endF, deltaF;
   int file_id;
   uint32_t millisec;
-  bool looping, reverse_at_end;
+  bool looping, reverse_at_end, always_wait;
   uint8_t compType, compQual;
 
   startF= msg.start_frame();
@@ -859,10 +859,11 @@ Session::build_animation_object(::CARTA::StartAnimation &msg, uint32_t requestID
   reverse_at_end= msg.reverse();
   compType= msg.compression_type();
   compQual= msg.compression_quality();
-    
+  always_wait= false;
+
   _ani_obj= new AnimationObject( file_id, startF, endF, deltaF,
 				 millisec, looping, reverse_at_end,
-				 compType, compQual );
+				 compType, compQual, always_wait );
 
   CARTA::StartAnimationAck ackMessage;
   ackMessage.set_success(true);

--- a/Session.h
+++ b/Session.h
@@ -65,7 +65,7 @@ class Session {
     bool newFrame;         // flag to send histogram with data
 
     // State for animation functions.
-    AnimationObject * _ani_obj;
+    std::unique_ptr<AnimationObject> _ani_obj;
     
     std::mutex _image_channel_mutex;
     bool _image_channel_task_active;

--- a/Session.h
+++ b/Session.h
@@ -40,7 +40,7 @@ class Session {
  public:
     std::string uuid;
     carta::FileSettings fsettings;
-    tbb::concurrent_queue<std::pair<CARTA::SetImageChannels,uint32_t>> aniq;
+    tbb::concurrent_queue<std::pair<CARTA::SetImageChannels,uint32_t>> setchanq;
  protected:
     // communication
     uWS::WebSocket<uWS::SERVER>* socket;
@@ -96,10 +96,10 @@ public:
             bool verbose = false);
     ~Session();
 
-    void addToAniQueue(CARTA::SetImageChannels message, uint32_t requestId) {
-      aniq.push(std::make_pair(message, requestId));
+    void addToSetChanQueue(CARTA::SetImageChannels message, uint32_t requestId) {
+      setchanq.push(std::make_pair(message, requestId));
     }
-    void executeAniEvt(std::pair<CARTA::SetImageChannels,uint32_t> req) {
+    void executeSetChanEvt(std::pair<CARTA::SetImageChannels,uint32_t> req) {
       onSetImageChannels(req.first, req.second);
     }
     void cancel_SetHistReqs() {

--- a/Session.h
+++ b/Session.h
@@ -5,6 +5,7 @@
 
 #include "FileListHandler.h"
 #include "FileSettings.h"
+#include "AnimationObject.h"
 #include "Frame.h"
 #include "util.h"
 
@@ -63,7 +64,9 @@ class Session {
     std::mutex frameMutex; // lock frames to create/destroy
     bool newFrame;         // flag to send histogram with data
 
-
+    // State for animation functions.
+    AnimationObject * _ani_obj;
+    
     std::mutex _image_channel_mutex;
     bool _image_channel_task_active;
 
@@ -102,7 +105,9 @@ public:
     void cancel_SetHistReqs() {
       histogramProgress.fetch_and_store(HISTOGRAM_CANCEL);
     }
-
+    void build_animation_object(::CARTA::StartAnimation &msg, uint32_t req_id);
+    bool execute_animation_frame();
+    void stop_animation(int file_id, ::CARTA::AnimationFrame frame);
     void addViewSetting(CARTA::SetImageView message, uint32_t requestId) {
       fsettings.addViewSetting(message, requestId);
     }

--- a/main.cc
+++ b/main.cc
@@ -145,7 +145,7 @@ void onMessage(uWS::WebSocket<uWS::SERVER>* ws, char* rawMessage,
 	}
 	else {
 	// has its own queue to keep channels in order during animation
-	  session->addToAniQueue(message, requestId);
+	  session->addToSetChanQueue(message, requestId);
 	}
 	session->image_channel_unlock();
 	break;

--- a/main.cc
+++ b/main.cc
@@ -38,7 +38,7 @@ FileListHandler* fileListHandler;
 int sessionNumber;
 uWS::Hub wsHub;
 
-// Map from string uuids to 32 bit ints.
+// Map from string uuids to 8 bit ints.
 unordered_map<std::string,uint8_t> _event_name_map;
 
 // command-line arguments

--- a/main.cc
+++ b/main.cc
@@ -279,6 +279,19 @@ void onMessage(uWS::WebSocket<uWS::SERVER>* ws, char* rawMessage,
         }
 	break;
       }
+      case START_ANIMATION_ID: {
+	CARTA::StartAnimation message;
+	message.ParseFromArray(eventPayload.data(), eventPayload.size());
+	tsk= new (tbb::task::allocate_root())
+	  AnimationTask(session, requestId, message );
+	break;
+      }
+      case STOP_ANIMATION_ID: {
+	CARTA::StopAnimation message;
+	message.ParseFromArray(eventPayload.data(), eventPayload.size());
+	session->stop_animation( message.file_id(), message.end_frame() );
+	break;
+      }
       default: {
 	tsk= new (tbb::task::allocate_root())
 	  MultiMessageTask(session,
@@ -296,6 +309,7 @@ void onMessage(uWS::WebSocket<uWS::SERVER>* ws, char* rawMessage,
     }
   }
 }
+
 
 
 
@@ -325,6 +339,8 @@ void populate_event_name_map(void)
   _event_name_map["SET_STATS_REQUIREMENTS"]= SET_STATS_REQUIREMENTS_ID;
   _event_name_map["SET_REGION"]= SET_REGION_ID;
   _event_name_map["REMOVE_REGION"]= REMOVE_REGION_ID;
+  _event_name_map["START_ANIMATION"]= START_ANIMATION_ID;
+  _event_name_map["STOP_ANIMATION"]= STOP_ANIMATION_ID;
 }
 
 

--- a/main.cc
+++ b/main.cc
@@ -33,10 +33,10 @@ unordered_map<string, vector<string>> permissionsMap;
 FileListHandler* fileListHandler;
 
 int sessionNumber;
-uWS::Hub
+uWS::Hub wsHub;
 
 // Map from string uuids to 8 bit ints.
-unordered_map<string,uint8_t> _event_name_map;
+unordered_map<std::string,uint8_t> _event_name_map;
 
 // command-line arguments
 string rootFolder("/"), baseFolder("."), version_id("1.1");

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,3 @@
+
+test_message_format: 
+	g++ -I .. test_message_format.cc ../build/carta-protobuf/libcarta-protobuf.a -l protobuf

--- a/test/test_message_format.cc
+++ b/test/test_message_format.cc
@@ -1,0 +1,81 @@
+#include <iostream>
+#include <string>
+
+#include "util.h"
+#include "build/carta-protobuf/defs.pb.h"
+#include "build/carta-protobuf/register_viewer.pb.h"
+
+
+typedef struct {
+  uint8_t _type; 
+  uint8_t _icd_vers;
+  uint16_t _req_id;
+} msg_header;
+
+
+const uint8_t test_TYPE= 1;
+const uint8_t ICD_VERSION= 2;
+
+void
+recv_event( char * buff, int length )
+{
+  msg_header head= *reinterpret_cast<msg_header*>(buff);
+
+  std::printf("type= %d, icd vers= %d, reqid= %d\n",
+	      head._type, head._icd_vers, head._req_id );
+  
+  switch( head._type ) {
+  case test_TYPE: {
+    CARTA::RegisterViewerAck Message;
+    Message.ParseFromArray(buff + sizeof(msg_header), length);
+    std::cout << " Got RVack for uuid " << Message.session_id() << std::endl;
+    break;
+    }
+  default:
+    std::cerr << " Bad message type : " << head._type << std::endl;
+    exit(1);
+  }
+}
+
+
+void
+send_event( uint8_t evt_type,
+	    uint32_t event_id,
+	    google::protobuf::MessageLite& Message )
+{
+  msg_header head;
+  char buffer[128]; // Would have buffer pool in production system.
+  
+  head._type= evt_type;
+  head._icd_vers= ICD_VERSION;
+  head._req_id= event_id;
+
+  std::memcpy(buffer, &head, sizeof(msg_header));
+  Message.SerializeToArray(buffer + sizeof(msg_header), Message.ByteSize());
+  
+  // Would add to the send queue here in real version, but just pass it straight
+  // to receive for this test.
+  recv_event(buffer, Message.ByteSize());
+}
+
+int main(int argc, const char* argv[])
+{
+  uint32_t req_id= 1002;
+  std::string message("Error string ...");
+  std::string uuid("123882"); // Should be uint32_t, but need to update protobuf def
+  ::CARTA::SessionType type(CARTA::SessionType::NEW);
+  
+  CARTA::RegisterViewerAck ackMessage;
+
+  ackMessage.set_session_id(uuid);
+  ackMessage.set_success(false);
+  ackMessage.set_message(message);
+  ackMessage.set_session_type(type);
+  
+  std::cout << " message type : " << ackMessage.GetTypeName() << std::endl;
+
+  send_event(test_TYPE, req_id, ackMessage);
+  
+  return 0;
+}
+  


### PR DESCRIPTION
Added support for the StartAnimation message. Note that this not get called until someone writes a client to support it.

Changed the names of the queue and the functions previously with an "ani" in them to reflect that they really are to do with setting the image channels.

Change the SetImageChannelsTask::execute() so that tasks are recycled after each execution so that this does not hold on to a TBB thread.