### PR TITLE
Jenkinsfile2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,23 +11,20 @@ void setBuildStatus(String message, String state) {
 pipeline {
     agent any
     stages {
-        stage('Build backend') {
+        stage('MacOS build backend') {
             steps {
                 sh "export PATH=/usr/local/bin:$PATH"
                 sh "git submodule init && git submodule update"
                 dir ('build') {
-                 sh "pwd"
                  sh "cp ../../cmake-command.sh ."
-                 sh "pwd"
                  sh "./cmake-command.sh"
                  sh "make"
                 }
             }
         }
-        stage('ICD tests') {
+        stage('MacOS run ICD tests') {
             steps {
                     sh "export PATH=/usr/local/bin:$PATH"
-                    sh "pwd && ls -sort"
                     dir ('build') {
                       sh "cp ../../carta-backend-ICD-test-travis.tar.gz . && tar -xvf carta-backend-ICD-test-travis.tar.gz && cp ../../run.sh ."
                       sh "./run.sh # run carta_backend in the background"
@@ -36,10 +33,10 @@ pipeline {
                         dir ('protobuf') {
                           sh "source ~/emsdk/emsdk_env.sh && git submodule init && git submodule update && git checkout master && npm install && ./build_proto.sh # prepare the tests"
                         }
-                          sh "source ~/emsdk/emsdk_env.sh && ./run-travis.sh # run the tests"
+                        sh "source ~/emsdk/emsdk_env.sh && ./run-travis.sh # run the tests"
                       }
-                   }
-                 echo "Finished !!"
+                    }
+                    echo "Finished !!"
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,16 +29,14 @@ pipeline {
                     sh "export PATH=/usr/local/bin:$PATH"
                     sh "pwd && ls -sort"
                     dir ('build') {
-                      sh "pwd && ls -sort"
                       sh "cp ../../carta-backend-ICD-test-travis.tar.gz . && tar -xvf carta-backend-ICD-test-travis.tar.gz && cp ../../run.sh ."
                       sh "./run.sh # run carta_backend in the background"
                       sh "lsof -i :3002 # check backend is running"
                       dir ('carta-backend-ICD-test-travis') {
                         dir ('protobuf') {
-                        sh "pwd && ls -sort"
-                        sh "source ~/emsdk/emsdk_env.sh && git submodule init && git submodule update && git checkout master && npm install && ./build_proto.sh # prepare the tests"
+                          sh "source ~/emsdk/emsdk_env.sh && git submodule init && git submodule update && git checkout master && npm install && ./build_proto.sh # prepare the tests"
                         }
-                        sh "source ~/emsdk/emsdk_env.sh && ./run-travis.sh # run the tests"
+                          sh "source ~/emsdk/emsdk_env.sh && ./run-travis.sh # run the tests"
                       }
                    }
                  echo "Finished !!"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,56 @@
+void setBuildStatus(String message, String state) {
+  step([
+      $class: "GitHubCommitStatusSetter",
+      reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/CARTAvis/carta-backend"],
+      contextSource: [$class: "ManuallyEnteredCommitContextSource", context: "ci/jenkins/build-status"],
+      errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
+      statusResultSource: [ $class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: message, state: state]] ]
+  ]);
+}
+
+pipeline {
+    agent any
+    stages {
+        stage('Build backend') {
+            steps {
+                sh "export PATH=/usr/local/bin:$PATH"
+                sh "git submodule init && git submodule update"
+                dir ('build') {
+                 sh "pwd"
+                 sh "cp ../../cmake-command.sh ."
+                 sh "pwd"
+                 sh "./cmake-command.sh"
+                 sh "make"
+                }
+            }
+        }
+        stage('ICD tests') {
+            steps {
+                    sh "export PATH=/usr/local/bin:$PATH"
+                    sh "pwd && ls -sort"
+                    dir ('build') {
+                      sh "pwd && ls -sort"
+                      sh "cp ../../carta-backend-ICD-test-travis.tar.gz . && tar -xvf carta-backend-ICD-test-travis.tar.gz && cp ../../run.sh ."
+                      sh "./run.sh # run carta_backend in the background"
+                      sh "lsof -i :3002 # check backend is running"
+                      dir ('carta-backend-ICD-test-travis') {
+                        dir ('protobuf') {
+                        sh "pwd && ls -sort"
+                        sh "source ~/emsdk/emsdk_env.sh && git submodule init && git submodule update && git checkout master && npm install && ./build_proto.sh # prepare the tests"
+                        }
+                        sh "source ~/emsdk/emsdk_env.sh && ./run-travis.sh # run the tests"
+                      }
+                   }
+                 echo "Finished !!"
+            }
+        }
+    }
+  post {
+    success {
+        setBuildStatus("Build succeeded", "SUCCESS");
+    }
+    failure {
+        setBuildStatus("Build failed", "FAILURE");
+    }
+  }
+}


### PR DESCRIPTION
Working Jenkinsfile to build the carta-backend, run the ICD tests in Jenkins, and report the status back to Github (currently set up in a MacOS environment).

The developer can log in directly to see the Jenkins build logs;
The Mac is running 'ngrok' to enable external access to Jenkins through the Institute's firewall. 
Jenkins is set up to integrate with Github credentials so any CARTAvis Github members can log in with their Github username and ID.
Jenkins is using the 'Blue Ocean' plugin for a  modern user friendly interface.