### PR TITLE
changing to new Docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.0
 jobs:
   "ubuntu":
     docker:
-      - image: ajmasiaa/carta-backend-builder-ubuntu
+      - image: ajmasiaa/carta-backend-builder-ubuntu-may2019
     steps:
       - checkout
       - run:
@@ -28,7 +28,7 @@ jobs:
             echo "Finished !!!"
   "centos6":
     docker:
-      - image: ajmasiaa/carta-backend-builder-centos6
+      - image: ajmasiaa/carta-backend-builder-centos6-may2019
     steps:
       - checkout
       - run:


### PR DESCRIPTION
I thought it would be better to create new Docker images from scratch rather than adding extra layers on the old ones 
(Circle-CI pulls the ready made Docker images from Docker hub. It doesn't build from Dockerfile each time)
I tested locally with the new centos6 Docker image. The HDF file reading ICD test now passes on the christy/WCregions branch.