### PR TITLE
Remove quotes in hdf5 FileInfoExtended entries

### DIFF
--- a/ImageData/CartaHdf5Image.cc
+++ b/ImageData/CartaHdf5Image.cc
@@ -214,7 +214,9 @@ casacore::Record CartaHdf5Image::ConvertInfoToCasacoreRecord(const CARTA::FileIn
 
         switch (header_entry.entry_type()) {
             case CARTA::EntryType::STRING: {
-                header_record.define(entry_name, header_entry.value());
+                casacore::String entry_value = header_entry.value();
+                entry_value.gsub("'", ""); // remove quote : error converting to FITS card if final quote removed
+                header_record.define(entry_name, entry_value);
             } break;
             case CARTA::EntryType::INT: {
                 if (entry_name == "SIMPLE") { // FITSKeywordUtil adds this


### PR DESCRIPTION
Bug found when testing fix for #212 .

Error in ubuntu when converting FileInfoExtended -> casacore::Record -> FITS cards in CartaHdf5Image.  HeaderEntry::value() can add single quotes around string, problem when final quote removed for FITS 80-char limit.