### PR TITLE
Rwjs/task cancel

### DIFF
--- a/AnimationObject.h
+++ b/AnimationObject.h
@@ -2,6 +2,7 @@
 #define CARTA_BACKEND__ANIMATIONOBJECT_H_
 
 #include <chrono>
+#include <tbb/task.h>
 
 #include <carta-protobuf/animation.pb.h>
 #include <carta-protobuf/set_image_channels.pb.h>
@@ -32,7 +33,8 @@ class AnimationObject {
     volatile int _file_open;
     volatile bool _waiting_flow_event;
     tbb::task* _waiting_task;
-
+    tbb::task_group_context _tbb_context;
+    
 public:
     AnimationObject(int file_id, CARTA::AnimationFrame& start_frame, CARTA::AnimationFrame& first_frame, CARTA::AnimationFrame& last_frame,
         CARTA::AnimationFrame& delta_frame, int frame_rate, bool looping, bool reverse_at_end, CARTA::CompressionType compression_type,
@@ -63,6 +65,9 @@ public:
     }
     void set_waiting_task_ptr(tbb::task* tsk) {
         _waiting_task = tsk;
+    }
+    void cancel_execution() {
+      _tbb_context.cancel_group_execution();
     }
 };
 

--- a/AnimationObject.h
+++ b/AnimationObject.h
@@ -1,8 +1,8 @@
 #ifndef CARTA_BACKEND__ANIMATIONOBJECT_H_
 #define CARTA_BACKEND__ANIMATIONOBJECT_H_
 
-#include <chrono>
 #include <tbb/task.h>
+#include <chrono>
 
 #include <carta-protobuf/animation.pb.h>
 #include <carta-protobuf/set_image_channels.pb.h>
@@ -34,7 +34,7 @@ class AnimationObject {
     volatile bool _waiting_flow_event;
     tbb::task* _waiting_task;
     tbb::task_group_context _tbb_context;
-    
+
 public:
     AnimationObject(int file_id, CARTA::AnimationFrame& start_frame, CARTA::AnimationFrame& first_frame, CARTA::AnimationFrame& last_frame,
         CARTA::AnimationFrame& delta_frame, int frame_rate, bool looping, bool reverse_at_end, CARTA::CompressionType compression_type,
@@ -67,7 +67,7 @@ public:
         _waiting_task = tsk;
     }
     void cancel_execution() {
-      _tbb_context.cancel_group_execution();
+        _tbb_context.cancel_group_execution();
     }
 };
 

--- a/Main.cc
+++ b/Main.cc
@@ -141,10 +141,21 @@ void OnMessage(uWS::WebSocket<uWS::SERVER>* ws, char* raw_message, size_t length
                     }
                     break;
                 }
+                case CARTA::EventType::CLOSE_FILE: {
+                    CARTA::CloseFile message;
+                    if (message.ParseFromArray(event_buf, event_length)) {
+                        session->CheckCancelAnimationOnFileClose(message.file_id());
+                        session->_file_settings.ClearSettings(message.file_id());
+                        session->OnCloseFile(message);
+                    }
+                    break;
+                }
                 case CARTA::EventType::START_ANIMATION: {
                     CARTA::StartAnimation message;
                     message.ParseFromArray(event_buf, event_length);
-                    tsk = new (tbb::task::allocate_root(session->AnimationContext())) AnimationTask(session, head.request_id, message);
+                    session->cancelExistingAnimation();
+                    session->BuildAnimationObject(message, head.request_id);
+                    tsk = new (tbb::task::allocate_root(session->AnimationContext())) AnimationTask(session);
                     break;
                 }
                 case CARTA::EventType::STOP_ANIMATION: {

--- a/Main.cc
+++ b/Main.cc
@@ -28,15 +28,15 @@ using namespace std;
 unordered_map<string, vector<string>> permissions_map;
 
 // file list handler for the file browser
-FileListHandler* file_list_handler;
+static FileListHandler* file_list_handler;
 
-uint32_t session_number;
-uWS::Hub websocket_hub;
+static uint32_t session_number;
+static uWS::Hub websocket_hub;
 
 // command-line arguments
-string root_folder("/"), base_folder("."), version_id("1.1");
-bool verbose, use_permissions;
-int wait_at_exit= -1;
+static string root_folder("/"), base_folder("."), version_id("1.1");
+static bool verbose, use_permissions;
+static int wait_at_exit= -1;
 
 // Called on connection. Creates session objects and assigns UUID and API keys to it
 void OnConnect(uWS::WebSocket<uWS::SERVER>* ws, uWS::HttpRequest http_request) {

--- a/Main.cc
+++ b/Main.cc
@@ -137,7 +137,7 @@ void OnMessage(uWS::WebSocket<uWS::SERVER>* ws, char* raw_message, size_t length
                     if (message.histograms_size() == 0) {
                         session->CancelSetHistRequirements();
                     } else {
-                        tsk = new (tbb::task::allocate_root(session->HistoContext()))
+                        tsk = new (tbb::task::allocate_root(session->HistContext()))
                             SetHistogramRequirementsTask(session, head, event_length, event_buf);
                     }
                     break;

--- a/Main.cc
+++ b/Main.cc
@@ -219,7 +219,10 @@ int main(int argc, const char* argv[]) {
             base_folder = inp.getString("base");
             root_folder = inp.getString("root");
 
-            Session::SetExitTimeout(inp.getInt("exit_after"));
+            if (inp.getInt("exit_after")) {
+                tmp = inp.getInt("exit_after");
+                Session::SetExitTimeout(tmp);
+            }
         }
 
         if (!CheckRootBaseFolders(root_folder, base_folder)) {

--- a/Main.cc
+++ b/Main.cc
@@ -137,6 +137,7 @@ void OnMessage(uWS::WebSocket<uWS::SERVER>* ws, char* raw_message, size_t length
                     if (message.histograms_size() == 0) {
                         session->CancelSetHistRequirements();
                     } else {
+		        session->resetHistContext();
                         tsk = new (tbb::task::allocate_root(session->HistContext()))
                             SetHistogramRequirementsTask(session, head, event_length, event_buf);
                     }

--- a/Main.cc
+++ b/Main.cc
@@ -177,6 +177,20 @@ void OnMessage(uWS::WebSocket<uWS::SERVER>* ws, char* raw_message, size_t length
                     }
                     break;
                 }
+                case CARTA::EventType::FILE_LIST_REQUEST: {
+                    CARTA::FileListRequest message;
+                    if (message.ParseFromArray(event_buf, event_length)) {
+                        session->OnFileListRequest(message, head.request_id);
+                    }
+                    break;
+                }
+                case CARTA::EventType::OPEN_FILE: {
+                    CARTA::OpenFile message;
+                    if (message.ParseFromArray(event_buf, event_length)) {
+                        session->OnOpenFile(message, head.request_id);
+                    }
+                    break;
+                }
                 default: {
                     tsk = new (tbb::task::allocate_root(session->context())) MultiMessageTask(session, head, event_length, event_buf);
                 }

--- a/Main.cc
+++ b/Main.cc
@@ -136,7 +136,7 @@ void OnMessage(uWS::WebSocket<uWS::SERVER>* ws, char* raw_message, size_t length
                     if (message.histograms_size() == 0) {
                         session->CancelSetHistRequirements();
                     } else {
-                        tsk = new (tbb::task::allocate_root(session->context()))
+		      tsk = new (tbb::task::allocate_root(session->HistoContext()))
                             SetHistogramRequirementsTask(session, head, event_length, event_buf);
                     }
                     break;
@@ -144,7 +144,7 @@ void OnMessage(uWS::WebSocket<uWS::SERVER>* ws, char* raw_message, size_t length
                 case CARTA::EventType::START_ANIMATION: {
                     CARTA::StartAnimation message;
                     message.ParseFromArray(event_buf, event_length);
-                    tsk = new (tbb::task::allocate_root(session->context())) AnimationTask(session, head.request_id, message);
+                    tsk = new (tbb::task::allocate_root(session->AnimationContext())) AnimationTask(session, head.request_id, message);
                     break;
                 }
                 case CARTA::EventType::STOP_ANIMATION: {

--- a/Main.cc
+++ b/Main.cc
@@ -136,7 +136,7 @@ void OnMessage(uWS::WebSocket<uWS::SERVER>* ws, char* raw_message, size_t length
                     if (message.histograms_size() == 0) {
                         session->CancelSetHistRequirements();
                     } else {
-		      tsk = new (tbb::task::allocate_root(session->HistoContext()))
+                        tsk = new (tbb::task::allocate_root(session->HistoContext()))
                             SetHistogramRequirementsTask(session, head, event_length, event_buf);
                     }
                     break;
@@ -201,6 +201,7 @@ int main(int argc, const char* argv[]) {
         int thread_count(tbb::task_scheduler_init::default_num_threads());
         { // get values then let Input go out of scope
             casacore::Input inp;
+            int tmp;
             inp.version(version_id);
             inp.create("verbose", "False", "display verbose logging", "Bool");
             inp.create("permissions", "False", "use a permissions file for determining access", "Bool");
@@ -208,6 +209,7 @@ int main(int argc, const char* argv[]) {
             inp.create("threads", to_string(thread_count), "set thread pool count", "Int");
             inp.create("base", base_folder, "set folder for data files", "String");
             inp.create("root", root_folder, "set top-level folder for data files", "String");
+            inp.create("exit_after", to_string(tmp), "number of seconds to stay alive afer last sessions exists", "Int");
             inp.readArguments(argc, argv);
 
             verbose = inp.getBool("verbose");
@@ -216,6 +218,8 @@ int main(int argc, const char* argv[]) {
             thread_count = inp.getInt("threads");
             base_folder = inp.getString("base");
             root_folder = inp.getString("root");
+
+            Session::SetExitTimeout(inp.getInt("exit_after"));
         }
 
         if (!CheckRootBaseFolders(root_folder, base_folder)) {

--- a/Main.cc
+++ b/Main.cc
@@ -36,6 +36,7 @@ uWS::Hub websocket_hub;
 // command-line arguments
 string root_folder("/"), base_folder("."), version_id("1.1");
 bool verbose, use_permissions;
+int wait_at_exit= -1;
 
 // Called on connection. Creates session objects and assigns UUID and API keys to it
 void OnConnect(uWS::WebSocket<uWS::SERVER>* ws, uWS::HttpRequest http_request) {
@@ -244,7 +245,8 @@ int main(int argc, const char* argv[]) {
             base_folder = inp.getString("base");
             root_folder = inp.getString("root");
 
-            if (inp.getInt("exit_after")) {
+            wait_at_exit = inp.getInt("exit_after");
+	    if ( wait_at_exit > -1 ) {
                 tmp = inp.getInt("exit_after");
                 Session::SetExitTimeout(tmp);
             }

--- a/OnMessageTask.cc
+++ b/OnMessageTask.cc
@@ -96,8 +96,8 @@ tbb::task* SetImageChannelsTask::execute() {
     _session->ImageChannelUnlock();
 
     if (tester) {
-        tbb::increment_ref_count();
-        tbb::recycle_as_safe_continuation();
+        increment_ref_count();
+        recycle_as_safe_continuation();
     }
 
     return nullptr;
@@ -124,8 +124,8 @@ tbb::task* SetHistogramRequirementsTask::execute() {
 
 tbb::task* AnimationTask::execute() {
     if (_session->ExecuteAnimationFrame()) {
-        tbb::increment_ref_count();
-        tbb::recycle_as_safe_continuation();
+        increment_ref_count();
+        recycle_as_safe_continuation();
     } else {
         if (_session->waitingFlowEvent()) {
             _session->setWaitingTask_ptr(this);

--- a/OnMessageTask.cc
+++ b/OnMessageTask.cc
@@ -127,11 +127,11 @@ tbb::task* AnimationTask::execute() {
         increment_ref_count();
         recycle_as_safe_continuation();
     } else {
-        if (_session->waiting_flow_event()) {
+        if (_session->waitingFlowEvent()) {
             _session->setWaitingTask_ptr(this);
         } else {
-	  _session->CancelAnimation();
-	}
+            _session->CancelAnimation();
+        }
     }
 
     return nullptr;

--- a/OnMessageTask.cc
+++ b/OnMessageTask.cc
@@ -96,8 +96,8 @@ tbb::task* SetImageChannelsTask::execute() {
     _session->ImageChannelUnlock();
 
     if (tester) {
-        increment_ref_count();
-        recycle_as_safe_continuation();
+        tbb::increment_ref_count();
+        tbb::recycle_as_safe_continuation();
     }
 
     return nullptr;
@@ -124,8 +124,8 @@ tbb::task* SetHistogramRequirementsTask::execute() {
 
 tbb::task* AnimationTask::execute() {
     if (_session->ExecuteAnimationFrame()) {
-        increment_ref_count();
-        recycle_as_safe_continuation();
+        tbb::increment_ref_count();
+        tbb::recycle_as_safe_continuation();
     } else {
         if (_session->waitingFlowEvent()) {
             _session->setWaitingTask_ptr(this);

--- a/OnMessageTask.cc
+++ b/OnMessageTask.cc
@@ -11,27 +11,6 @@
 
 tbb::task* MultiMessageTask::execute() {
     switch (_header.type) {
-        case CARTA::EventType::FILE_LIST_REQUEST: {
-            CARTA::FileListRequest message;
-            if (message.ParseFromArray(_event_buffer, _event_length)) {
-                _session->OnFileListRequest(message, _header.request_id);
-            }
-            break;
-        }
-        case CARTA::EventType::FILE_INFO_REQUEST: {
-            CARTA::FileInfoRequest message;
-            if (message.ParseFromArray(_event_buffer, _event_length)) {
-                _session->OnFileInfoRequest(message, _header.request_id);
-            }
-            break;
-        }
-        case CARTA::EventType::OPEN_FILE: {
-            CARTA::OpenFile message;
-            if (message.ParseFromArray(_event_buffer, _event_length)) {
-                _session->OnOpenFile(message, _header.request_id);
-            }
-            break;
-        }
         case CARTA::EventType::SET_SPATIAL_REQUIREMENTS: {
             CARTA::SetSpatialRequirements message;
             if (message.ParseFromArray(_event_buffer, _event_length)) {

--- a/OnMessageTask.cc
+++ b/OnMessageTask.cc
@@ -66,15 +66,7 @@ tbb::task* MultiMessageTask::execute() {
             }
             break;
         }
-        case CARTA::EventType::CLOSE_FILE: {
-            CARTA::CloseFile message;
-            if (message.ParseFromArray(_event_buffer, _event_length)) {
-                _session->CheckCancelAnimationOnFileClose(message.file_id());
-                _session->_file_settings.ClearSettings(message.file_id());
-                _session->OnCloseFile(message);
-            }
-            break;
-        }
+       
         default: {
             std::cerr << " Bad event type in MultiMessageType:execute : (" << this << ") ";
             std::fprintf(stderr, "(%u)\n", _header.type);

--- a/OnMessageTask.cc
+++ b/OnMessageTask.cc
@@ -4,6 +4,7 @@
 #include <cstring>
 
 #include <fmt/format.h>
+#include <fmt/ostream.h>
 
 #include "EventHeader.h"
 #include "Util.h"
@@ -66,10 +67,8 @@ tbb::task* MultiMessageTask::execute() {
             }
             break;
         }
-       
         default: {
-            std::cerr << " Bad event type in MultiMessageType:execute : (" << this << ") ";
-            std::fprintf(stderr, "(%u)\n", _header.type);
+            fmt::print("Bad event type in MultiMessageType:execute : ({})", _header.type);
             break;
         }
     }

--- a/OnMessageTask.cc
+++ b/OnMessageTask.cc
@@ -90,6 +90,7 @@ tbb::task* SetImageChannelsTask::execute() {
 
     _session->ExecuteSetChannelEvt(_request_pair);
     _session->ImageChannelLock();
+
     if (!(tester = _session->_set_channel_queue.try_pop(_request_pair)))
         _session->ImageChannelTaskSetIdle();
     _session->ImageChannelUnlock();
@@ -128,7 +129,9 @@ tbb::task* AnimationTask::execute() {
     } else {
         if (_session->waiting_flow_event()) {
             _session->setWaitingTask_ptr(this);
-        }
+        } else {
+	  _session->CancelAnimation();
+	}
     }
 
     return nullptr;

--- a/OnMessageTask.h
+++ b/OnMessageTask.h
@@ -98,9 +98,7 @@ class AnimationTask : public OnMessageTask {
     tbb::task* execute() override;
 
 public:
-    AnimationTask(Session* session, uint32_t request_id, CARTA::StartAnimation msg) : OnMessageTask(session) {
-        session->BuildAnimationObject(msg, request_id);
-    }
+    AnimationTask(Session* session) : OnMessageTask(session) {}
     ~AnimationTask() = default;
 };
 

--- a/Session.cc
+++ b/Session.cc
@@ -834,6 +834,7 @@ void Session::UpdateRegionData(int file_id, bool channel_changed, bool stokes_ch
     if (_frames.count(file_id)) {
         std::vector<int> regions(_frames.at(file_id)->GetRegionIds());
         for (auto region_id : regions) {
+	  // CHECK FOR CHANCEL HERE ??
             if (channel_changed) {
                 SendSpatialProfileData(file_id, region_id);
                 SendRegionHistogramData(file_id, region_id, channel_changed); // if using current channel
@@ -1094,10 +1095,8 @@ void Session::HandleAnimationFlowControlEvt(CARTA::AnimationFlowControl& message
 }
 
 void Session::CheckCancelAnimationOnFileClose(int file_id) {
-    std::cerr << "Cancelling animation ??\n";
     if (!_animation_object)
         return;
-    std::cerr << "Cancelling animation\n";
     _animation_object->_file_open = false;
     _animation_object->cancel_execution();
 }

--- a/Session.cc
+++ b/Session.cc
@@ -40,7 +40,7 @@ Session::Session(uWS::WebSocket<uWS::SERVER>* ws, uint32_t id, std::string root,
       _new_frame(false),
       _image_channel_task_active(false),
       _file_settings(this) {
-    _histogram_progress.fetch_and_store(HISTOGRAM_COMPLETE);
+    _histogram_progress = HISTOGRAM_COMPLETE;
     _ref_count = 0;
     _animation_object = nullptr;
     _connected = true;
@@ -557,7 +557,7 @@ bool Session::SendCubeHistogramData(const CARTA::SetHistogramRequirements& messa
     if (_frames.count(file_id)) {
         try {
             if (message.histograms_size() == 0) { // cancel!
-                _histogram_progress.fetch_and_store(HISTOGRAM_CANCEL);
+                _histogram_progress = HISTOGRAM_CANCEL;
                 _histo_context.cancel_group_execution();
                 SendLogEvent("Histogram cancelled", {"histogram"}, CARTA::ErrorSeverity::INFO);
                 return data_sent;
@@ -598,7 +598,7 @@ bool Session::SendCubeHistogramData(const CARTA::SetHistogramRequirements& messa
                         data_sent = true;
                     }
                 } else { // calculate cube histogram
-                    _histogram_progress.fetch_and_store(HISTOGRAM_START);
+                    _histogram_progress = HISTOGRAM_START;
                     auto t_start = std::chrono::high_resolution_clock::now();
                     // determine cube min and max values
                     float cube_min(FLT_MAX), cube_max(FLT_MIN);
@@ -692,10 +692,10 @@ bool Session::SendCubeHistogramData(const CARTA::SetHistogramRequirements& messa
                             // send completed histogram message
                             SendFileEvent(file_id, CARTA::EventType::REGION_HISTOGRAM_DATA, request_id, final_histogram_message);
                             data_sent = true;
-                            _histogram_progress.fetch_and_store(HISTOGRAM_COMPLETE);
+                            _histogram_progress = HISTOGRAM_COMPLETE;
                         }
                     }
-                    _histogram_progress.fetch_and_store(HISTOGRAM_COMPLETE);
+                    _histogram_progress = HISTOGRAM_COMPLETE;
                 }
             }
         } catch (std::out_of_range& range_error) {
@@ -711,7 +711,7 @@ bool Session::SendCubeHistogramData(const CARTA::SetHistogramRequirements& messa
 
 void Session::CreateCubeHistogramMessage(CARTA::RegionHistogramData& msg, int file_id, int stokes, float progress) {
     // update progress and make new message
-    _histogram_progress.fetch_and_store(progress);
+    _histogram_progress = progress;
     msg.set_file_id(file_id);
     msg.set_region_id(CUBE_REGION_ID);
     msg.set_stokes(stokes);

--- a/Session.cc
+++ b/Session.cc
@@ -834,7 +834,7 @@ void Session::UpdateRegionData(int file_id, bool channel_changed, bool stokes_ch
     if (_frames.count(file_id)) {
         std::vector<int> regions(_frames.at(file_id)->GetRegionIds());
         for (auto region_id : regions) {
-	  // CHECK FOR CHANCEL HERE ??
+            // CHECK FOR CHANCEL HERE ??
             if (channel_changed) {
                 SendSpatialProfileData(file_id, region_id);
                 SendRegionHistogramData(file_id, region_id, channel_changed); // if using current channel

--- a/Session.cc
+++ b/Session.cc
@@ -834,7 +834,7 @@ void Session::UpdateRegionData(int file_id, bool channel_changed, bool stokes_ch
     if (_frames.count(file_id)) {
         std::vector<int> regions(_frames.at(file_id)->GetRegionIds());
         for (auto region_id : regions) {
-            // CHECK FOR CHANCEL HERE ??
+            // CHECK FOR CANCEL HERE ??
             if (channel_changed) {
                 SendSpatialProfileData(file_id, region_id);
                 SendRegionHistogramData(file_id, region_id, channel_changed); // if using current channel

--- a/Session.cc
+++ b/Session.cc
@@ -1094,8 +1094,17 @@ void Session::HandleAnimationFlowControlEvt(CARTA::AnimationFlowControl& message
 }
 
 void Session::CheckCancelAnimationOnFileClose(int file_id) {
+    std::cerr << "Cancelling animation ??\n";
     if (!_animation_object)
         return;
+    std::cerr << "Cancelling animation\n";
     _animation_object->_file_open = false;
     _animation_object->cancel_execution();
+}
+
+void Session::cancelExistingAnimation() {
+    if (_animation_object) {
+        _animation_object->cancel_execution();
+        _animation_object = nullptr;
+    }
 }

--- a/Session.h
+++ b/Session.h
@@ -86,6 +86,7 @@ public:
     void ExecuteAnimationFrame_inner(bool stopped);
     void StopAnimation(int file_id, const ::CARTA::AnimationFrame& frame);
     void HandleAnimationFlowControlEvt(CARTA::AnimationFlowControl& message);
+    void cancelExistingAnimation();
     void CheckCancelAnimationOnFileClose(int file_id);
     void AddViewSetting(CARTA::SetImageView message, uint32_t request_id) {
         _file_settings.AddViewSetting(message, request_id);

--- a/Session.h
+++ b/Session.h
@@ -72,7 +72,7 @@ public:
     void CancelSetHistRequirements() {
         _histo_context.cancel_group_execution();
     }
-    tbb::task_group_context& HistoContext() {
+    tbb::task_group_context& HistContext() {
         return _histo_context;
     }
     tbb::task_group_context& AnimationContext() {

--- a/Session.h
+++ b/Session.h
@@ -70,7 +70,16 @@ public:
         OnSetImageChannels(request.first);
     }
     void CancelSetHistRequirements() {
-        _histogram_progress.fetch_and_store(HISTOGRAM_CANCEL);
+      _histo_context.cancel_group_execution();
+    }
+    tbb::task_group_context& HistoContext() {
+      return _histo_context;
+    }
+    tbb::task_group_context& AnimationContext() {
+      return _animation_context;
+    }
+    void CancelAnimation() {
+      _animation_object->cancel_execution();
     }
     void BuildAnimationObject(CARTA::StartAnimation& msg, uint32_t request_id);
     bool ExecuteAnimationFrame();
@@ -187,6 +196,11 @@ private:
 
     // TBB context that enables all tasks associated with a session to be cancelled.
     tbb::task_group_context _base_context;
+
+    // TBB context to cancel histogram calculations.
+    tbb::task_group_context _histo_context;
+
+    tbb::task_group_context _animation_context;
 
     int _ref_count;
     bool _connected;

--- a/Session.h
+++ b/Session.h
@@ -70,16 +70,16 @@ public:
         OnSetImageChannels(request.first);
     }
     void CancelSetHistRequirements() {
-      _histo_context.cancel_group_execution();
+        _histo_context.cancel_group_execution();
     }
     tbb::task_group_context& HistoContext() {
-      return _histo_context;
+        return _histo_context;
     }
     tbb::task_group_context& AnimationContext() {
-      return _animation_context;
+        return _animation_context;
     }
     void CancelAnimation() {
-      _animation_object->cancel_execution();
+        _animation_object->cancel_execution();
     }
     void BuildAnimationObject(CARTA::StartAnimation& msg, uint32_t request_id);
     bool ExecuteAnimationFrame();
@@ -129,8 +129,12 @@ public:
     tbb::task* getWaitingTask_ptr() {
         return _animation_object->_waiting_task;
     }
-    bool waiting_flow_event() {
+    bool waitingFlowEvent() {
         return _animation_object->_waiting_flow_event;
+    }
+    static void SetExitTimeout(int secs) {
+        _exit_after_num_seconds = secs;
+        _exit_when_all_sessions_closed = true;
     }
 
     // TODO: should these be public? NO!!!!!!!!
@@ -205,6 +209,8 @@ private:
     int _ref_count;
     bool _connected;
     static int _num_sessions;
+    static int _exit_after_num_seconds;
+    static bool _exit_when_all_sessions_closed;
 };
 
 #endif // CARTA_BACKEND__SESSION_H_

--- a/Session.h
+++ b/Session.h
@@ -72,6 +72,9 @@ public:
     void CancelSetHistRequirements() {
         _histo_context.cancel_group_execution();
     }
+    void restetHistContext() {
+      _histo_context.reset();
+    }
     tbb::task_group_context& HistContext() {
         return _histo_context;
     }

--- a/Session.h
+++ b/Session.h
@@ -191,8 +191,8 @@ private:
     std::mutex _image_channel_mutex;
     bool _image_channel_task_active;
 
-    // Cube histogram progress: 0.0 to 1.0 (complete), -1 (cancel)
-    tbb::atomic<float> _histogram_progress;
+    // Cube histogram progress: 0.0 to 1.0 (complete)
+    float _histogram_progress;
 
     // Outgoing messages
     uS::Async* _outgoing_async;                         // Notification mechanism when messages are ready


### PR DESCRIPTION
This adds additional TBB contexts for more fine grain task cancellation.
Also moved more event processing to main thread, mainly to reduce the delay before cancellation starts.
Added a few more checks for when animation should be cancelled.
Added -exit_after arg that if set causes the backend to exist after the number of seconds set when there are no sessions left. This is needed for the apache2 based AuthN/AuthZ scheme I have been working on.