### PR TITLE
Adding e2e tests to Jenkinsfile 1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,9 +36,19 @@ pipeline {
                         sh "source ~/emsdk/emsdk_env.sh && ./run-travis.sh # run the tests"
                       }
                     }
+            }
+        }
+        stage('MacOS run e2e tests') {
+            steps {
+                    sh "export PATH=/usr/local/bin:$PATH"
+                    dir ('build') {
+                      sh "cp ../../permissions.txt . && cp ../../e2e.sh . && ./e2e.sh"
+                    }
                     echo "Finished !!"
             }
         }
+
+
     }
   post {
     success {


### PR DESCRIPTION
Adding an extra stage to the Jenkinsfile to run Kuo-Song's e2e tests. 
Here it simply copies a script called e2e.sh that would be placed in the Jenkins workspace directory. 
The e2e.sh script simply starts up the carta_backend with the correct image library path, clones the latest e2e repository, customises the timing for some tests, and finally runs the tests.
The idea is that the Jenkinsfile would not need any further GitHub commits to keep it up to date. We only need to maintain/modify the e2e.sh script held locally on the server. 
Plus, an e2e.sh script can be appropriately customised for other machines running Jenkins e.g. adjusted for longer timings if running on a slower machine.