### PR TITLE
hdu.h before fitsio.h with a blank line

### DIFF
--- a/FileInfoLoader.h
+++ b/FileInfoLoader.h
@@ -5,10 +5,11 @@
 
 #include <string>
 
+#include <casacore/fits/FITS/hdu.h> // hdu.h must come before fitsio.h
+
 #include <casacore/casa/Arrays/IPosition.h>
 #include <casacore/fits/FITS/FITSError.h>
 #include <casacore/fits/FITS/fitsio.h>
-#include <casacore/fits/FITS/hdu.h> // hdu.h must come before fitsio.h
 #include <casacore/images/Images/ImageOpener.h>
 #include <casacore/measures/Measures/MDirection.h>
 #include <casacore/measures/Measures/MFrequency.h>


### PR DESCRIPTION
Fixing the problem where autoformating arranged the includes in alphabetical order, but it is necessary for hdu.h to come before fitsio.h in order to build successfully on MacOS for some reason.