### PR TITLE
Take stokes into account when caching spectral profile stats on the HDF5 loader.

### DIFF
--- a/ImageData/FileLoader.h
+++ b/ImageData/FileLoader.h
@@ -24,6 +24,19 @@ struct ImageStats {
     bool valid;
 };
 
+struct RegionStatsId {
+    int region_id;
+    int stokes;
+
+    RegionStatsId() {}
+
+    RegionStatsId(int region_id, int stokes) : region_id(region_id), stokes(stokes) {}
+
+    bool operator<(const RegionStatsId& rhs) const {
+        return (region_id < rhs.region_id) || ((region_id == rhs.region_id) && (stokes < rhs.stokes));
+    }
+};
+
 struct RegionSpectralStats {
     casacore::IPosition origin;
     casacore::IPosition shape;


### PR DESCRIPTION
This fixes #247 by adding the stokes value to the key used in the map of cached stats on the HDF5 loader. It also fixes an unrelated bug: when the stats were recalculated after a change in the region, the region properties were not updated on the stats object, so we kept recalculating unnecessarily.