### PR TITLE
histogram memory leak bugfix

### DIFF
--- a/Session.cc
+++ b/Session.cc
@@ -824,7 +824,7 @@ bool Session::SendSpectralProfileData(int file_id, int region_id, bool check_cur
 bool Session::SendRegionHistogramData(int file_id, int region_id, bool check_current_channel) {
     // return true if data sent
     bool data_sent(false);
-    CARTA::RegionHistogramData* histogram_data = GetRegionHistogramData(file_id, region_id, check_current_channel);
+    std::unique_ptr<CARTA::RegionHistogramData> histogram_data(GetRegionHistogramData(file_id, region_id, check_current_channel));
     if (histogram_data != nullptr) { // RESPONSE
         SendFileEvent(file_id, CARTA::EventType::REGION_HISTOGRAM_DATA, 0, *histogram_data);
         data_sent = true;


### PR DESCRIPTION
Closes #255.

See #255 for memory behaviour without bugfix. Minor change, just use a `std::unique_ptr` instead of a raw pointer, to ensure cleanup when it goes out of scope. 

supermosaic.10 at 10 fps:
![output_bugfix](https://user-images.githubusercontent.com/592504/60916782-95471f00-a28f-11e9-97ab-ee5d6515c6ca.png)

