### PR TITLE
copy event buffer memory when enqueueing a task.

### DIFF
--- a/Main.cc
+++ b/Main.cc
@@ -48,7 +48,7 @@ void OnConnect(uWS::WebSocket<uWS::SERVER>* ws, uWS::HttpRequest http_request) {
     Session* session;
 
     outgoing->start([](uS::Async* async) -> void {
-        Session* current_session = ((Session*)async->getData());
+        Session* current_session = ((Session*) async->getData());
         current_session->SendPendingMessages();
     });
 
@@ -64,7 +64,7 @@ void OnConnect(uWS::WebSocket<uWS::SERVER>* ws, uWS::HttpRequest http_request) {
 
 // Called on disconnect. Cleans up sessions. In future, we may want to delay this (in case of unintentional disconnects)
 void OnDisconnect(uWS::WebSocket<uWS::SERVER>* ws, int code, char* message, size_t length) {
-    Session* session = (Session*)ws->getUserData();
+    Session* session = (Session*) ws->getUserData();
 
     if (session) {
         auto uuid = session->_id;
@@ -81,7 +81,7 @@ void OnDisconnect(uWS::WebSocket<uWS::SERVER>* ws, int code, char* message, size
 
 // Forward message requests to session callbacks after parsing message into relevant ProtoBuf message
 void OnMessage(uWS::WebSocket<uWS::SERVER>* ws, char* raw_message, size_t length, uWS::OpCode op_code) {
-    Session* session = (Session*)ws->getUserData();
+    Session* session = (Session*) ws->getUserData();
     if (!session) {
         fmt::print("Missing session!\n");
         return;
@@ -99,45 +99,59 @@ void OnMessage(uWS::WebSocket<uWS::SERVER>* ws, char* raw_message, size_t length
                     CARTA::RegisterViewer message;
                     if (message.ParseFromArray(event_buf, event_length)) {
                         session->OnRegisterViewer(message, head.icd_version, head.request_id);
+                    } else {
+                        fmt::print("Bad REGISTER_VIEWER message!\n");
                     }
                     break;
                 }
                 case CARTA::EventType::SET_IMAGE_CHANNELS: {
                     CARTA::SetImageChannels message;
-                    message.ParseFromArray(event_buf, event_length);
-                    session->ImageChannelLock();
-                    if (!session->ImageChannelTaskTestAndSet()) {
-                        tsk = new (tbb::task::allocate_root(session->Context()))
-                            SetImageChannelsTask(session, make_pair(message, head.request_id));
+                    if (message.ParseFromArray(event_buf, event_length)) {
+                        session->ImageChannelLock();
+                        if (!session->ImageChannelTaskTestAndSet()) {
+                            tsk = new(tbb::task::allocate_root(session->Context()))
+                                SetImageChannelsTask(session, make_pair(message, head.request_id));
+                        } else {
+                            // has its own queue to keep channels in order during animation
+                            session->AddToSetChannelQueue(message, head.request_id);
+                        }
+                        session->ImageChannelUnlock();
                     } else {
-                        // has its own queue to keep channels in order during animation
-                        session->AddToSetChannelQueue(message, head.request_id);
+                        fmt::print("Bad SET_IMAGE_CHANNELS message!\n");
                     }
-                    session->ImageChannelUnlock();
                     break;
                 }
                 case CARTA::EventType::SET_IMAGE_VIEW: {
                     CARTA::SetImageView message;
-                    message.ParseFromArray(event_buf, event_length);
-                    session->OnSetImageView(message);
+                    if (message.ParseFromArray(event_buf, event_length)) {
+                        session->OnSetImageView(message);
+                    } else {
+                        fmt::print("Bad SET_IMAGE_VIEW message!\n");
+                    }
                     break;
                 }
                 case CARTA::EventType::SET_CURSOR: {
                     CARTA::SetCursor message;
-                    message.ParseFromArray(event_buf, event_length);
-                    session->AddCursorSetting(message, head.request_id);
-                    tsk = new (tbb::task::allocate_root(session->Context())) SetCursorTask(session, message.file_id());
+                    if (message.ParseFromArray(event_buf, event_length)) {
+                        session->AddCursorSetting(message, head.request_id);
+                        tsk = new(tbb::task::allocate_root(session->Context())) SetCursorTask(session, message.file_id());
+                    } else {
+                        fmt::print("Bad SET_CURSOR message!\n");
+                    }
                     break;
                 }
                 case CARTA::EventType::SET_HISTOGRAM_REQUIREMENTS: {
                     CARTA::SetHistogramRequirements message;
-                    message.ParseFromArray(event_buf, event_length);
-                    if (message.histograms_size() == 0) {
-                        session->CancelSetHistRequirements();
+                    if (message.ParseFromArray(event_buf, event_length)) {
+                        if (message.histograms_size() == 0) {
+                            session->CancelSetHistRequirements();
+                        } else {
+                            session->ResetHistContext();
+                            tsk = new(tbb::task::allocate_root(session->HistContext()))
+                                SetHistogramRequirementsTask(session, head, event_length, event_buf);
+                        }
                     } else {
-                        session->ResetHistContext();
-                        tsk = new (tbb::task::allocate_root(session->HistContext()))
-                            SetHistogramRequirementsTask(session, head, event_length, event_buf);
+                        fmt::print("Bad SET_HISTOGRAM_REQUIREMENTS message!\n");
                     }
                     break;
                 }
@@ -147,33 +161,46 @@ void OnMessage(uWS::WebSocket<uWS::SERVER>* ws, char* raw_message, size_t length
                         session->CheckCancelAnimationOnFileClose(message.file_id());
                         session->_file_settings.ClearSettings(message.file_id());
                         session->OnCloseFile(message);
+                    } else {
+                        fmt::print("Bad CLOSE_FILE message!\n");
                     }
                     break;
                 }
                 case CARTA::EventType::START_ANIMATION: {
                     CARTA::StartAnimation message;
-                    message.ParseFromArray(event_buf, event_length);
-                    session->CancelExistingAnimation();
-                    session->BuildAnimationObject(message, head.request_id);
-                    tsk = new (tbb::task::allocate_root(session->AnimationContext())) AnimationTask(session);
+                    if (message.ParseFromArray(event_buf, event_length)) {
+                        session->CancelExistingAnimation();
+                        session->BuildAnimationObject(message, head.request_id);
+                        tsk = new(tbb::task::allocate_root(session->AnimationContext())) AnimationTask(session);
+                    } else {
+                        fmt::print("Bad START_ANIMATION message!\n");
+                    }
                     break;
                 }
                 case CARTA::EventType::STOP_ANIMATION: {
                     CARTA::StopAnimation message;
-                    message.ParseFromArray(event_buf, event_length);
-                    session->StopAnimation(message.file_id(), message.end_frame());
+                    if (message.ParseFromArray(event_buf, event_length)) {
+                        session->StopAnimation(message.file_id(), message.end_frame());
+                    } else {
+                        fmt::print("Bad STOP_ANIMATION message!\n");
+                    }
                     break;
                 }
                 case CARTA::EventType::ANIMATION_FLOW_CONTROL: {
                     CARTA::AnimationFlowControl message;
-                    message.ParseFromArray(event_buf, event_length);
-                    session->HandleAnimationFlowControlEvt(message);
+                    if (message.ParseFromArray(event_buf, event_length)) {
+                        session->HandleAnimationFlowControlEvt(message);
+                    } else {
+                        fmt::print("Bad ANIMATION_FLOW_CONTROL message!\n");
+                    }
                     break;
                 }
                 case CARTA::EventType::FILE_INFO_REQUEST: {
                     CARTA::FileInfoRequest message;
                     if (message.ParseFromArray(event_buf, event_length)) {
                         session->OnFileInfoRequest(message, head.request_id);
+                    } else {
+                        fmt::print("Bad FILE_INFO_REQUEST message!\n");
                     }
                     break;
                 }
@@ -181,6 +208,8 @@ void OnMessage(uWS::WebSocket<uWS::SERVER>* ws, char* raw_message, size_t length
                     CARTA::FileListRequest message;
                     if (message.ParseFromArray(event_buf, event_length)) {
                         session->OnFileListRequest(message, head.request_id);
+                    } else {
+                        fmt::print("Bad FILE_LIST_REQUEST message!\n");
                     }
                     break;
                 }
@@ -188,11 +217,16 @@ void OnMessage(uWS::WebSocket<uWS::SERVER>* ws, char* raw_message, size_t length
                     CARTA::OpenFile message;
                     if (message.ParseFromArray(event_buf, event_length)) {
                         session->OnOpenFile(message, head.request_id);
+                    } else {
+                        fmt::print("Bad OPEN_FILE message!\n");
                     }
                     break;
                 }
                 default: {
-                    tsk = new (tbb::task::allocate_root(session->Context())) MultiMessageTask(session, head, event_length, event_buf);
+                    // Copy memory into new buffer to be used and disposed by MultiMessageTask::execute
+                    char* message_buffer = new char[event_length];
+                    memcpy(message_buffer, event_buf, event_length);
+                    tsk = new(tbb::task::allocate_root(session->Context())) MultiMessageTask(session, head, event_length, message_buffer);
                 }
             }
 
@@ -271,7 +305,7 @@ int main(int argc, const char* argv[]) {
         websocket_hub.onDisconnection(&OnDisconnect);
         if (websocket_hub.listen(port)) {
             fmt::print("Listening on port {} with root folder {}, base folder {}, and {} threads in thread pool\n", port, root_folder,
-                base_folder, thread_count);
+                       base_folder, thread_count);
             websocket_hub.run();
         } else {
             fmt::print("Error listening on port {}\n", port);

--- a/OnMessageTask.cc
+++ b/OnMessageTask.cc
@@ -15,6 +15,8 @@ tbb::task* MultiMessageTask::execute() {
             CARTA::SetSpatialRequirements message;
             if (message.ParseFromArray(_event_buffer, _event_length)) {
                 _session->OnSetSpatialRequirements(message);
+            } else {
+                fmt::print("Bad SET_SPATIAL_REQUIREMENTS message!\n");
             }
             break;
         }
@@ -22,13 +24,17 @@ tbb::task* MultiMessageTask::execute() {
             CARTA::SetSpectralRequirements message;
             if (message.ParseFromArray(_event_buffer, _event_length)) {
                 _session->OnSetSpectralRequirements(message);
+            } else {
+                fmt::print("Bad SET_SPECTRAL_REQUIREMENTS message!\n");
             }
             break;
         }
         case CARTA::EventType::ADD_REQUIRED_TILES: {
             CARTA::AddRequiredTiles message;
-            if (message.ParseFromArray(_event_buffer, _event_length)) {
+            if (message.ParseFromArray(_event_buffer, _event_length) && message.tiles_size()) {
                 _session->OnAddRequiredTiles(message);
+            } else {
+                fmt::print("Bad ADD_REQUIRED_TILES message!\n");
             }
             break;
         }
@@ -36,6 +42,8 @@ tbb::task* MultiMessageTask::execute() {
             CARTA::SetStatsRequirements message;
             if (message.ParseFromArray(_event_buffer, _event_length)) {
                 _session->OnSetStatsRequirements(message);
+            } else {
+                fmt::print("Bad SET_STATS_REQUIREMENTS message!\n");
             }
             break;
         }
@@ -43,6 +51,8 @@ tbb::task* MultiMessageTask::execute() {
             CARTA::SetRegion message;
             if (message.ParseFromArray(_event_buffer, _event_length)) {
                 _session->OnSetRegion(message, _header.request_id);
+            } else {
+                fmt::print("Bad SET_REGION message!\n");
             }
             break;
         }
@@ -50,6 +60,8 @@ tbb::task* MultiMessageTask::execute() {
             CARTA::RemoveRegion message;
             if (message.ParseFromArray(_event_buffer, _event_length)) {
                 _session->OnRemoveRegion(message);
+            } else {
+                fmt::print("Bad REMOVE_REGION message!\n");
             }
             break;
         }
@@ -68,8 +80,9 @@ tbb::task* SetImageChannelsTask::execute() {
     _session->ExecuteSetChannelEvt(_request_pair);
     _session->ImageChannelLock();
 
-    if (!(tester = _session->_set_channel_queue.try_pop(_request_pair)))
+    if (!(tester = _session->_set_channel_queue.try_pop(_request_pair))) {
         _session->ImageChannelTaskSetIdle();
+    }
     _session->ImageChannelUnlock();
 
     if (tester) {

--- a/OnMessageTask.h
+++ b/OnMessageTask.h
@@ -43,7 +43,9 @@ public:
         _event_length = evt_len;
         _event_buffer = event_buf;
     }
-    ~MultiMessageTask() = default;
+    ~MultiMessageTask() {
+        delete [] _event_buffer;
+    };
 };
 
 class SetImageChannelsTask : public OnMessageTask {


### PR DESCRIPTION
This PR modifies the handling of event buffers when handing events via a TBB task. Previously, we were re-using the uWebSockets message buffer, which was getting overwritten (See #258). I've changed this to now use a separate buffer which is then cleaned up by the `MultiMessageTask` destructor. 

I've also added more consistent handling of protocol buffer message decode errors. Now, if a message fails to decode, it will be ignored, and an error message will be printed. 