### PR TITLE
switches spatial and spectral profiles to bytes instead of repeated fields

### DIFF
--- a/EventHeader.h
+++ b/EventHeader.h
@@ -2,7 +2,7 @@
 #define CARTA_BACKEND__EVENTHEADER_H_
 
 namespace carta {
-const uint16_t ICD_VERSION = 4;
+const uint16_t ICD_VERSION = 5;
 struct EventHeader {
     uint16_t type;
     uint16_t icd_version;

--- a/Frame.cc
+++ b/Frame.cc
@@ -840,7 +840,7 @@ bool Frame::FillSpatialProfileData(int region_id, CARTA::SpatialProfileData& pro
                 new_profile->set_coordinate(region->GetSpatialCoordinate(i));
                 new_profile->set_start(0);
                 new_profile->set_end(end);
-                *new_profile->mutable_values() = {profile.begin(), profile.end()};
+                new_profile->set_raw_values_fp32(profile.data(), profile.size() * sizeof(float));
             }
             profile_ok = true;
         }

--- a/Main.cc
+++ b/Main.cc
@@ -48,7 +48,7 @@ void OnConnect(uWS::WebSocket<uWS::SERVER>* ws, uWS::HttpRequest http_request) {
     Session* session;
 
     outgoing->start([](uS::Async* async) -> void {
-        Session* current_session = ((Session*) async->getData());
+        Session* current_session = ((Session*)async->getData());
         current_session->SendPendingMessages();
     });
 
@@ -64,7 +64,7 @@ void OnConnect(uWS::WebSocket<uWS::SERVER>* ws, uWS::HttpRequest http_request) {
 
 // Called on disconnect. Cleans up sessions. In future, we may want to delay this (in case of unintentional disconnects)
 void OnDisconnect(uWS::WebSocket<uWS::SERVER>* ws, int code, char* message, size_t length) {
-    Session* session = (Session*) ws->getUserData();
+    Session* session = (Session*)ws->getUserData();
 
     if (session) {
         auto uuid = session->_id;
@@ -81,7 +81,7 @@ void OnDisconnect(uWS::WebSocket<uWS::SERVER>* ws, int code, char* message, size
 
 // Forward message requests to session callbacks after parsing message into relevant ProtoBuf message
 void OnMessage(uWS::WebSocket<uWS::SERVER>* ws, char* raw_message, size_t length, uWS::OpCode op_code) {
-    Session* session = (Session*) ws->getUserData();
+    Session* session = (Session*)ws->getUserData();
     if (!session) {
         fmt::print("Missing session!\n");
         return;
@@ -109,7 +109,7 @@ void OnMessage(uWS::WebSocket<uWS::SERVER>* ws, char* raw_message, size_t length
                     if (message.ParseFromArray(event_buf, event_length)) {
                         session->ImageChannelLock();
                         if (!session->ImageChannelTaskTestAndSet()) {
-                            tsk = new(tbb::task::allocate_root(session->Context()))
+                            tsk = new (tbb::task::allocate_root(session->Context()))
                                 SetImageChannelsTask(session, make_pair(message, head.request_id));
                         } else {
                             // has its own queue to keep channels in order during animation
@@ -134,7 +134,7 @@ void OnMessage(uWS::WebSocket<uWS::SERVER>* ws, char* raw_message, size_t length
                     CARTA::SetCursor message;
                     if (message.ParseFromArray(event_buf, event_length)) {
                         session->AddCursorSetting(message, head.request_id);
-                        tsk = new(tbb::task::allocate_root(session->Context())) SetCursorTask(session, message.file_id());
+                        tsk = new (tbb::task::allocate_root(session->Context())) SetCursorTask(session, message.file_id());
                     } else {
                         fmt::print("Bad SET_CURSOR message!\n");
                     }
@@ -147,7 +147,7 @@ void OnMessage(uWS::WebSocket<uWS::SERVER>* ws, char* raw_message, size_t length
                             session->CancelSetHistRequirements();
                         } else {
                             session->ResetHistContext();
-                            tsk = new(tbb::task::allocate_root(session->HistContext()))
+                            tsk = new (tbb::task::allocate_root(session->HistContext()))
                                 SetHistogramRequirementsTask(session, head, event_length, event_buf);
                         }
                     } else {
@@ -171,7 +171,7 @@ void OnMessage(uWS::WebSocket<uWS::SERVER>* ws, char* raw_message, size_t length
                     if (message.ParseFromArray(event_buf, event_length)) {
                         session->CancelExistingAnimation();
                         session->BuildAnimationObject(message, head.request_id);
-                        tsk = new(tbb::task::allocate_root(session->AnimationContext())) AnimationTask(session);
+                        tsk = new (tbb::task::allocate_root(session->AnimationContext())) AnimationTask(session);
                     } else {
                         fmt::print("Bad START_ANIMATION message!\n");
                     }
@@ -226,7 +226,7 @@ void OnMessage(uWS::WebSocket<uWS::SERVER>* ws, char* raw_message, size_t length
                     // Copy memory into new buffer to be used and disposed by MultiMessageTask::execute
                     char* message_buffer = new char[event_length];
                     memcpy(message_buffer, event_buf, event_length);
-                    tsk = new(tbb::task::allocate_root(session->Context())) MultiMessageTask(session, head, event_length, message_buffer);
+                    tsk = new (tbb::task::allocate_root(session->Context())) MultiMessageTask(session, head, event_length, message_buffer);
                 }
             }
 
@@ -305,7 +305,7 @@ int main(int argc, const char* argv[]) {
         websocket_hub.onDisconnection(&OnDisconnect);
         if (websocket_hub.listen(port)) {
             fmt::print("Listening on port {} with root folder {}, base folder {}, and {} threads in thread pool\n", port, root_folder,
-                       base_folder, thread_count);
+                base_folder, thread_count);
             websocket_hub.run();
         } else {
             fmt::print("Error listening on port {}\n", port);

--- a/OnMessageTask.h
+++ b/OnMessageTask.h
@@ -44,7 +44,7 @@ public:
         _event_buffer = event_buf;
     }
     ~MultiMessageTask() {
-        delete [] _event_buffer;
+        delete[] _event_buffer;
     };
 };
 

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -671,7 +671,7 @@ void Region::FillSpectralProfileData(CARTA::SpectralProfileData& profile_data, i
             auto new_profile = profile_data.add_profiles();
             new_profile->set_coordinate(profile_coord);
             new_profile->set_stats_type(CARTA::StatsType::Sum);
-            *new_profile->mutable_vals() = {spectral_data.begin(), spectral_data.end()};
+            new_profile->set_raw_values_fp32(spectral_data.data(), spectral_data.size() * sizeof(float));
         }
     }
 }
@@ -694,9 +694,10 @@ void Region::FillSpectralProfileData(
             // convert to float for spectral profile
             std::vector<float> values;
             if (stats_values.find(stat_type) == stats_values.end()) { // stat not provided
-                new_profile->add_double_vals(std::numeric_limits<float>::quiet_NaN());
+                double nan_value = std::numeric_limits<double>::quiet_NaN();
+                new_profile->set_raw_values_fp64(&nan_value, sizeof(double));
             } else {
-                *new_profile->mutable_double_vals() = {stats_values[stat_type].begin(), stats_values[stat_type].end()};
+                new_profile->set_raw_values_fp64(stats_values[stat_type].data(), stats_values[stat_type].size() * sizeof(double));
             }
         }
     }
@@ -722,9 +723,10 @@ void Region::FillSpectralProfileData(CARTA::SpectralProfileData& profile_data, i
             // convert to float for spectral profile
             std::vector<float> values;
             if (!have_stats || stats_values[i].empty()) { // region outside image or NaNs
-                new_profile->add_double_vals(std::numeric_limits<float>::quiet_NaN());
+                double nan_value = std::numeric_limits<double>::quiet_NaN();
+                new_profile->set_raw_values_fp64(&nan_value, sizeof(double));
             } else {
-                *new_profile->mutable_double_vals() = {stats_values[i].begin(), stats_values[i].end()};
+                new_profile->set_raw_values_fp64(stats_values[i].data(), stats_values[i].size() * sizeof(double));
             }
         }
     }

--- a/Session.cc
+++ b/Session.cc
@@ -178,8 +178,7 @@ void Session::OnRegisterViewer(const CARTA::RegisterViewer& message, uint16_t ic
     } else {
         type = CARTA::SessionType::RESUMED;
         if (session_id != _id) { // invalid session id
-            error = fmt::format("Cannot resume session id {}"
-                , session_id);
+            error = fmt::format("Cannot resume session id {}", session_id);
         } else {
             success = true;
         }


### PR DESCRIPTION
Note: Companion PR of [#379](https://github.com/CARTAvis/carta-frontend/pull/379). This PR should not be merged until the companion PR is approved.

This PR adapts the backend to the changes in ICD version 5.0.0 (described in the google doc). Specifically, it makes use of `bytes` fields instead of `repeated float` and `repeated double` for spatial and spectral profiles. This is done to avoid the overhead incurred when decoding these messages, particularly in the case when the profiles are very large. 

This approach is already used for `RASTER_IMAGE_DATA` and `RASTER_TILE_DATA`. See [here](https://github.com/CARTAvis/carta-protobuf/issues/8) for details. 