### PR TITLE
Send histogram with raster data only during animation

### DIFF
--- a/Session.cc
+++ b/Session.cc
@@ -851,15 +851,17 @@ bool Session::SendRegionStatsData(int file_id, int region_id) {
     return data_sent;
 }
 
-void Session::UpdateRegionData(int file_id, bool channel_changed, bool stokes_changed) {
-    // Send updated data for all regions with requirements
+void Session::UpdateRegionData(int file_id, bool channel_changed, bool stokes_changed, bool send_image_histogram) {
+    // Send updated data for all regions with requirements; do not send image histogram if sent with raster data
     if (_frames.count(file_id)) {
         std::vector<int> regions(_frames.at(file_id)->GetRegionIds());
         for (auto region_id : regions) {
             // CHECK FOR CANCEL HERE ??
             if (channel_changed) {
                 SendSpatialProfileData(file_id, region_id);
-                SendRegionHistogramData(file_id, region_id, channel_changed); // if using current channel
+                if ((region_id == IMAGE_REGION_ID) && send_image_histogram) {
+                    SendRegionHistogramData(file_id, region_id, channel_changed); // if using current channel
+                }
                 SendRegionStatsData(file_id, region_id);
             }
             if (stokes_changed) {
@@ -867,7 +869,9 @@ void Session::UpdateRegionData(int file_id, bool channel_changed, bool stokes_ch
                 SendSpatialProfileData(file_id, region_id, stokes_changed);  // if using current stokes
                 SendSpectralProfileData(file_id, region_id, stokes_changed); // if using current stokes
                 SendRegionStatsData(file_id, region_id);
-                SendRegionHistogramData(file_id, region_id);
+                if ((region_id == IMAGE_REGION_ID) && send_image_histogram) {
+                    SendRegionHistogramData(file_id, region_id);
+                }
                 _frames.at(file_id)->DecreaseZProfileCount();
             }
         }
@@ -975,9 +979,10 @@ void Session::ExecuteAnimationFrameInner(bool stopped) {
 
             if (_frames.at(file_id)->SetImageChannels(channel, stokes, err_message)) {
                 // RESPONSE: updated image raster/histogram
-                SendRasterImageData(file_id, true); // true = send histogram
-                // RESPONSE: region data (includes image, cursor, and set regions)
-                UpdateRegionData(file_id, channel_changed, stokes_changed);
+                bool send_histogram(true);
+                SendRasterImageData(file_id, send_histogram);
+                // RESPONSE: region data (includes image, cursor, and any regions set)
+                UpdateRegionData(file_id, channel_changed, stokes_changed, !send_histogram); // already sent
             } else {
                 if (!err_message.empty())
                     SendLogEvent(err_message, {"animation"}, CARTA::ErrorSeverity::ERROR);

--- a/Session.h
+++ b/Session.h
@@ -170,7 +170,7 @@ private:
     bool SendSpectralProfileData(int file_id, int region_id, bool check_current_stokes = false);
     bool SendRegionHistogramData(int file_id, int region_id, bool check_current_channel = false);
     bool SendRegionStatsData(int file_id, int region_id);
-    void UpdateRegionData(int file_id, bool channel_changed, bool stokes_changed);
+    void UpdateRegionData(int file_id, bool channel_changed, bool stokes_changed, bool send_image_histogram=true);
 
     // Send protobuf messages
     void SendEvent(CARTA::EventType event_type, u_int32_t event_id, google::protobuf::MessageLite& message);


### PR DESCRIPTION
Issue #219 
Add parameter whether to send histogram message when updating region data streams. Not needed for image region when histogram sent in RASTER_IMAGE_DATA during animation.  When not animating, data is sent in RASTER_TILE_DATA with no histogram, so histogram is sent when required.