### PR TITLE
Fix a bug for HDF5 region definition

### DIFF
--- a/ImageData/Hdf5Loader.h
+++ b/ImageData/Hdf5Loader.h
@@ -334,8 +334,8 @@ bool Hdf5Loader::GetRegionSpectralData(
         return false;
     }
 
-    int num_y = mask->shape()(0);
-    int num_x = mask->shape()(1);
+    int num_x = mask->shape()(0);
+    int num_y = mask->shape()(1);
     int num_z = _num_channels;
 
     bool recalculate(false);


### PR DESCRIPTION
I think this is the reason why @kswang1029 saw the broken spectral profile for a range in the HDF5 image. 