### PR TITLE
Update data streams correctly

### DIFF
--- a/Frame.cc
+++ b/Frame.cc
@@ -673,8 +673,9 @@ bool Frame::GetRasterTileData(std::vector<float>& tile_data, const Tile& tile, i
 // ****************************************************
 // Region histograms, profiles, stats
 
-bool Frame::FillRegionHistogramData(int region_id, CARTA::RegionHistogramData* histogram_data, bool check_current_chan) {
-    // fill histogram message with histograms for requested channel/num bins
+bool Frame::FillRegionHistogramData(int region_id, CARTA::RegionHistogramData* histogram_data, bool channel_changed) {
+    // Fill histogram message with histograms for requested channel/num bins.
+    // Do not send cube histogram if channel changed.
     bool histogram_ok(false);
     if (_regions.count(region_id)) {
         auto& region = _regions[region_id];
@@ -690,13 +691,14 @@ bool Frame::FillRegionHistogramData(int region_id, CARTA::RegionHistogramData* h
             // get histogram requirements for this index
             CARTA::SetHistogramRequirements_HistogramConfig config = region->GetHistogramConfig(i);
             int config_channel(config.channel()), config_num_bins(config.num_bins());
-            // only send if using current channel, which changed
-            if (check_current_chan && (config_channel != CURRENT_CHANNEL)) {
-                return false;
+
+            if ((config_channel == ALL_CHANNELS) && channel_changed) {
+                continue; // do not send
             }
             if (config_channel == CURRENT_CHANNEL) {
                 config_channel = _channel_index;
             }
+
             auto new_histogram = histogram_data->add_histograms();
             new_histogram->set_channel(config_channel);
             // get stored histograms or fill new histograms
@@ -749,8 +751,9 @@ bool Frame::FillRegionHistogramData(int region_id, CARTA::RegionHistogramData* h
     return histogram_ok;
 }
 
-bool Frame::FillSpatialProfileData(int region_id, CARTA::SpatialProfileData& profile_data, bool check_current_stokes) {
-    // fill spatial profile message with requested x/y profiles (for a point region)
+bool Frame::FillSpatialProfileData(int region_id, CARTA::SpatialProfileData& profile_data, bool stokes_changed) {
+    // Fill spatial profile message with requested x/y profiles (for a point region).
+    // Do not send spatial profile for fixed stokes when stokes changed.
     bool profile_ok(false);
     if (_regions.count(region_id)) {
         auto& region = _regions[region_id];
@@ -786,12 +789,12 @@ bool Frame::FillSpatialProfileData(int region_id, CARTA::SpatialProfileData& pro
             for (size_t i = 0; i < num_profiles; ++i) {
                 // get <axis, stokes> for slicing image data
                 std::pair<int, int> axis_stokes = region->GetSpatialProfileReq(i);
-                // only send if using current stokes, which changed
-                if (check_current_stokes && (axis_stokes.second != CURRENT_STOKES)) {
-                    return false;
-                }
 
+                if (stokes_changed && (axis_stokes.second != CURRENT_STOKES)) {
+                    continue; // do not send fixed stokes profile when stokes changes
+                }
                 int profile_stokes = (axis_stokes.second < 0 ? _stokes_index : axis_stokes.second);
+
                 std::vector<float> profile;
                 int end(0);
                 if ((profile_stokes == _stokes_index) && !_image_cache.empty()) {
@@ -855,8 +858,8 @@ bool Frame::FillSpatialProfileData(int region_id, CARTA::SpatialProfileData& pro
     return profile_ok;
 }
 
-bool Frame::FillSpectralProfileData(
-    std::function<void(CARTA::SpectralProfileData profile_data)> cb, int region_id, bool check_current_stokes) {
+bool Frame::FillSpectralProfileData(std::function<void(CARTA::SpectralProfileData profile_data)> cb,
+    int region_id, bool channel_changed, bool stokes_changed) {
     // fill spectral profile message with requested statistics (or values for a point region)
     bool profile_ok(false);
     if (_regions.count(region_id)) {
@@ -875,13 +878,14 @@ bool Frame::FillSpectralProfileData(
         for (size_t i = 0; i < num_profiles; ++i) {
             int profile_stokes;
             if (region->GetSpectralConfigStokes(profile_stokes, i)) {
-                // only send if using current stokes, which changed
-                if (check_current_stokes && (profile_stokes != CURRENT_STOKES)) {
-                    return false;
+                if ((channel_changed || stokes_changed) && (profile_stokes != CURRENT_STOKES)) {
+                    continue; // do not send fixed stokes profile when channel or stokes changes
                 }
-                if (profile_stokes == CURRENT_STOKES) {
-                    profile_stokes = curr_stokes;
+                if ((profile_stokes == CURRENT_STOKES) && (channel_changed && !stokes_changed)) {
+                    continue; // do not send current stokes profile when only channel changes
                 }
+                profile_stokes = curr_stokes;
+
                 // fill SpectralProfiles for this config
                 if (region->IsPoint()) { // values
                     std::vector<float> spectral_data;
@@ -951,8 +955,7 @@ bool Frame::FillSpectralProfileData(
 }
 
 bool Frame::FillRegionStatsData(int region_id, CARTA::RegionStatsData& stats_data) {
-    // fill stats data message with requested statistics for the region with
-    // current channel and stokes
+    // fill stats data message with requested statistics for the region with current channel and stokes
     bool stats_ok(false);
     if (_regions.count(region_id)) {
         auto& region = _regions[region_id];

--- a/Frame.h
+++ b/Frame.h
@@ -71,14 +71,17 @@ public:
     bool SetRegionStatsRequirements(int region_id, const std::vector<int>& stats_types);
 
     // fill data, profiles, stats messages
-    // For some messages, only fill if requirements are for current channel/stokes
+    // For some messages, prevent sending data when current channel/stokes changes
     bool FillRasterImageData(CARTA::RasterImageData& raster_image_data, std::string& message);
     bool FillRasterTileData(CARTA::RasterTileData& raster_tile_data, const Tile& tile, int channel, int stokes,
         CARTA::CompressionType compression_type, float compression_quality);
-    bool FillSpatialProfileData(int region_id, CARTA::SpatialProfileData& profile_data, bool check_current_stokes = false);
+    bool FillSpatialProfileData(int region_id, CARTA::SpatialProfileData& profile_data, bool stokes_changed = false);
     bool FillSpectralProfileData(
-        std::function<void(CARTA::SpectralProfileData profile_data)> cb, int region_id, bool check_current_stokes = false);
-    bool FillRegionHistogramData(int region_id, CARTA::RegionHistogramData* histogram_data, bool check_current_chan = false);
+        std::function<void(CARTA::SpectralProfileData profile_data)> cb,
+        int region_id,
+        bool channel_changed = false,
+        bool stokes_changed = false);
+    bool FillRegionHistogramData(int region_id, CARTA::RegionHistogramData* histogram_data, bool channel_changed = false);
     bool FillRegionStatsData(int region_id, CARTA::RegionStatsData& stats_data);
 
     // histogram only (not full data message) : get if stored, else can calculate

--- a/Session.cc
+++ b/Session.cc
@@ -304,7 +304,7 @@ void Session::OnOpenFile(const CARTA::OpenFile& message, uint32_t request_id) {
     ack.set_success(success);
     ack.set_message(err_message);
     SendEvent(CARTA::EventType::OPEN_FILE_ACK, request_id, ack);
-    UpdateRegionData(file_id, true, false);
+    UpdateRegionData(file_id);
 }
 
 void Session::OnCloseFile(const CARTA::CloseFile& message) {
@@ -436,10 +436,7 @@ void Session::OnSetRegion(const CARTA::SetRegion& message, uint32_t request_id) 
     // update data streams if requirements set
     if (success && _frames.at(file_id)->RegionChanged(region_id)) {
         _frames.at(file_id)->IncreaseZProfileCount();
-        SendSpatialProfileData(file_id, region_id);
-        SendSpectralProfileData(file_id, region_id);
-        SendRegionHistogramData(file_id, region_id);
-        SendRegionStatsData(file_id, region_id);
+	UpdateRegionData(file_id, region_id);
         _frames.at(file_id)->DecreaseZProfileCount();
     }
 }
@@ -772,7 +769,7 @@ bool Session::SendRasterImageData(int file_id, bool send_histogram) {
     return data_sent;
 }
 
-bool Session::SendSpatialProfileData(int file_id, int region_id, bool check_current_stokes) {
+bool Session::SendSpatialProfileData(int file_id, int region_id, bool stokes_changed) {
     // return true if data sent
     bool data_sent(false);
     if (_frames.count(file_id)) {
@@ -781,7 +778,7 @@ bool Session::SendSpatialProfileData(int file_id, int region_id, bool check_curr
                 return data_sent; // do not send profile unless frontend set cursor
             }
             CARTA::SpatialProfileData spatial_profile_data;
-            if (_frames.at(file_id)->FillSpatialProfileData(region_id, spatial_profile_data, check_current_stokes)) {
+            if (_frames.at(file_id)->FillSpatialProfileData(region_id, spatial_profile_data, stokes_changed)) {
                 spatial_profile_data.set_file_id(file_id);
                 spatial_profile_data.set_region_id(region_id);
                 SendFileEvent(file_id, CARTA::EventType::SPATIAL_PROFILE_DATA, 0, spatial_profile_data);
@@ -798,7 +795,7 @@ bool Session::SendSpatialProfileData(int file_id, int region_id, bool check_curr
     return data_sent;
 }
 
-bool Session::SendSpectralProfileData(int file_id, int region_id, bool check_current_stokes) {
+bool Session::SendSpectralProfileData(int file_id, int region_id, bool channel_changed, bool stokes_changed) {
     // return true if data sent
     bool data_sent(false);
     if (_frames.count(file_id)) {
@@ -814,7 +811,7 @@ bool Session::SendSpectralProfileData(int file_id, int region_id, bool check_cur
                     // send (partial) profile data to the frontend
                     SendFileEvent(file_id, CARTA::EventType::SPECTRAL_PROFILE_DATA, 0, profile_data);
                 },
-                region_id, check_current_stokes);
+                region_id, channel_changed, stokes_changed);
             _frames.at(file_id)->DecreaseZProfileCount();
             if (profile_ok) {
                 data_sent = true;
@@ -830,10 +827,10 @@ bool Session::SendSpectralProfileData(int file_id, int region_id, bool check_cur
     return data_sent;
 }
 
-bool Session::SendRegionHistogramData(int file_id, int region_id, bool check_current_channel) {
+bool Session::SendRegionHistogramData(int file_id, int region_id, bool channel_changed) {
     // return true if data sent
     bool data_sent(false);
-    std::unique_ptr<CARTA::RegionHistogramData> histogram_data(GetRegionHistogramData(file_id, region_id, check_current_channel));
+    std::unique_ptr<CARTA::RegionHistogramData> histogram_data(GetRegionHistogramData(file_id, region_id, channel_changed));
     if (histogram_data != nullptr) { // RESPONSE
         SendFileEvent(file_id, CARTA::EventType::REGION_HISTOGRAM_DATA, 0, *histogram_data);
         data_sent = true;
@@ -861,29 +858,22 @@ bool Session::SendRegionStatsData(int file_id, int region_id) {
     return data_sent;
 }
 
-void Session::UpdateRegionData(int file_id, bool channel_changed, bool stokes_changed, bool send_image_histogram) {
-    // Send updated data for all regions with requirements; do not send image histogram if sent with raster data
+void Session::UpdateRegionData(int file_id, bool send_image_histogram, bool channel_changed, bool stokes_changed) {
+    // Send updated data for all regions with requirements; do not send image histogram if sent with raster data.
+    // Only set channel_changed and stokes_changed if they are the only trigger for new data,
+    // to prevent sending unneeded data streams.
     if (_frames.count(file_id)) {
         std::vector<int> regions(_frames.at(file_id)->GetRegionIds());
         for (auto region_id : regions) {
+            SendRegionStatsData(file_id, region_id);
+            SendSpatialProfileData(file_id, region_id, stokes_changed);
+            if ((region_id == IMAGE_REGION_ID) && send_image_histogram) {
+                SendRegionHistogramData(file_id, region_id, channel_changed);
+            }
             // CHECK FOR CANCEL HERE ??
-            if (channel_changed) {
-                SendSpatialProfileData(file_id, region_id);
-                if ((region_id == IMAGE_REGION_ID) && send_image_histogram) {
-                    SendRegionHistogramData(file_id, region_id, channel_changed); // if using current channel
-                }
-                SendRegionStatsData(file_id, region_id);
-            }
-            if (stokes_changed) {
-                _frames.at(file_id)->IncreaseZProfileCount();
-                SendSpatialProfileData(file_id, region_id, stokes_changed);  // if using current stokes
-                SendSpectralProfileData(file_id, region_id, stokes_changed); // if using current stokes
-                SendRegionStatsData(file_id, region_id);
-                if ((region_id == IMAGE_REGION_ID) && send_image_histogram) {
-                    SendRegionHistogramData(file_id, region_id);
-                }
-                _frames.at(file_id)->DecreaseZProfileCount();
-            }
+            _frames.at(file_id)->IncreaseZProfileCount();
+            SendSpectralProfileData(file_id, region_id, stokes_changed);
+            _frames.at(file_id)->DecreaseZProfileCount();
         }
     }
 }
@@ -991,8 +981,8 @@ void Session::ExecuteAnimationFrameInner(bool stopped) {
                 // RESPONSE: updated image raster/histogram
                 bool send_histogram(true);
                 SendRasterImageData(file_id, send_histogram);
-                // RESPONSE: region data (includes image, cursor, and any regions set)
-                UpdateRegionData(file_id, channel_changed, stokes_changed, !send_histogram); // already sent
+                // RESPONSE: data for all regions
+                UpdateRegionData(file_id, !send_histogram, channel_changed, stokes_changed);
             } else {
                 if (!err_message.empty())
                     SendLogEvent(err_message, {"animation"}, CARTA::ErrorSeverity::ERROR);

--- a/Session.h
+++ b/Session.h
@@ -167,11 +167,13 @@ private:
 
     // Send data streams
     bool SendRasterImageData(int file_id, bool send_histogram = false);
-    bool SendSpatialProfileData(int file_id, int region_id, bool check_current_stokes = false);
-    bool SendSpectralProfileData(int file_id, int region_id, bool check_current_stokes = false);
-    bool SendRegionHistogramData(int file_id, int region_id, bool check_current_channel = false);
-    bool SendRegionStatsData(int file_id, int region_id);
-    void UpdateRegionData(int file_id, bool channel_changed, bool stokes_changed, bool send_image_histogram = true);
+    // Only set channel_changed and stokes_changed if they are the only trigger for new data
+    // (i.e. result of SET_IMAGE_CHANNELS) to prevent sending unneeded data streams.
+    bool SendSpatialProfileData(int file_id, int region_id, bool stokes_changed = false);
+    bool SendSpectralProfileData(int file_id, int region_id, bool channel_changed = false, bool stokes_changed = false);
+    bool SendRegionHistogramData(int file_id, int region_id, bool channel_changed = false);
+    bool SendRegionStatsData(int file_id, int region_id); // update stats in all cases
+    void UpdateRegionData(int file_id, bool send_image_histogram = true, bool channel_changed = false, bool stokes_changed = false);
 
     // Send protobuf messages
     void SendEvent(CARTA::EventType event_type, u_int32_t event_id, google::protobuf::MessageLite& message);


### PR DESCRIPTION
Issue #252

When requirements, a region, channel, or stokes change, the backend sends new data streams in response.  This PR ensures that the correct data streams are updated.  In certain cases, data is not sent: (1) when only the channel changes, a cube histogram is not sent and spectral profiles are not sent; (2) when the stokes changes, profiles with a fixed stokes are not sent.

Also sends the spatial profile message with no profiles when not in requirements to update the cursor value.