### PR TITLE
Send a NaN spectral profile if a region is outside the lattice

### DIFF
--- a/Frame.cc
+++ b/Frame.cc
@@ -924,7 +924,7 @@ bool Frame::FillSpectralProfileData(std::function<void(CARTA::SpectralProfileDat
                         CARTA::SpectralProfileData profile_data;
                         profile_data.set_stokes(curr_stokes);
                         profile_data.set_progress(1.0);
-                        region->FillEmptySpectralProfileData(profile_data, i);
+                        region->FillSpectralProfileData(profile_data, i);
                         // send empty (NaN) result to Session
                         cb(profile_data);
                         profile_ok = true;
@@ -943,7 +943,7 @@ bool Frame::FillSpectralProfileData(std::function<void(CARTA::SpectralProfileDat
                         CARTA::SpectralProfileData profile_data;
                         profile_data.set_stokes(curr_stokes);
                         profile_data.set_progress(1.0);
-                        region->FillEmptySpectralProfileData(profile_data, i);
+                        region->FillSpectralProfileData(profile_data, i);
                         // send empty (NaN) result to Session
                         cb(profile_data);
                         profile_ok = true;

--- a/Frame.cc
+++ b/Frame.cc
@@ -921,20 +921,34 @@ bool Frame::FillSpectralProfileData(std::function<void(CARTA::SpectralProfileDat
                 } else { // statistics
                     // do calculations for the image dimensions >= 3 
                     if (_image_shape.size() < 3) {
-                        return profile_ok; // false
+                        CARTA::SpectralProfileData profile_data;
+                        profile_data.set_stokes(curr_stokes);
+                        profile_data.set_progress(1.0);
+                        region->FillEmptySpectralProfileData(profile_data, i);
+                        // send empty (NaN) result to Session
+                        cb(profile_data);
+                        profile_ok = true;
+                        return profile_ok;
                     }
                     bool use_swizzled_data(false);
-                    std::unique_lock<std::mutex> guard(_image_mutex);
                     try {
                         // check is the region mask valid (outside the lattice or not)
                         region->XyMask();
                         // if region mask is valid, then check is swizzled data available
+                        std::unique_lock<std::mutex> guard(_image_mutex);
                         use_swizzled_data = _loader->UseRegionSpectralData(region->XyMask());
+                        guard.unlock();
                     } catch (casacore::AipsError& err) {
                         std::cerr << err.getMesg() << std::endl;
-                        return profile_ok; // false
+                        CARTA::SpectralProfileData profile_data;
+                        profile_data.set_stokes(curr_stokes);
+                        profile_data.set_progress(1.0);
+                        region->FillEmptySpectralProfileData(profile_data, i);
+                        // send empty (NaN) result to Session
+                        cb(profile_data);
+                        profile_ok = true;
+                        return profile_ok;
                     }
-                    guard.unlock();
                     if (use_swizzled_data) {
                         std::unique_lock<std::mutex> guard(_image_mutex);
                         _loader->GetRegionSpectralData(profile_stokes, region_id, region->XyMask(), region->XyOrigin(),

--- a/Frame.cc
+++ b/Frame.cc
@@ -924,7 +924,7 @@ bool Frame::FillSpectralProfileData(std::function<void(CARTA::SpectralProfileDat
                         CARTA::SpectralProfileData profile_data;
                         profile_data.set_stokes(curr_stokes);
                         profile_data.set_progress(1.0);
-                        region->FillSpectralProfileData(profile_data, i);
+                        region->FillNaNSpectralProfileData(profile_data, i);
                         // send empty (NaN) result to Session
                         cb(profile_data);
                         profile_ok = true;
@@ -943,7 +943,7 @@ bool Frame::FillSpectralProfileData(std::function<void(CARTA::SpectralProfileDat
                         CARTA::SpectralProfileData profile_data;
                         profile_data.set_stokes(curr_stokes);
                         profile_data.set_progress(1.0);
-                        region->FillSpectralProfileData(profile_data, i);
+                        region->FillNaNSpectralProfileData(profile_data, i);
                         // send empty (NaN) result to Session
                         cb(profile_data);
                         profile_ok = true;

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -721,8 +721,6 @@ void Region::FillSpectralProfileData(
             new_profile->set_coordinate(profile_coord);
             auto stat_type = static_cast<CARTA::StatsType>(requested_stats[i]);
             new_profile->set_stats_type(stat_type);
-            // convert to float for spectral profile
-            std::vector<float> values;
             if (stats_values.find(stat_type) == stats_values.end()) { // stat not provided
                 double nan_value = std::numeric_limits<double>::quiet_NaN();
                 new_profile->set_raw_values_fp64(&nan_value, sizeof(double));
@@ -748,14 +746,31 @@ void Region::FillSpectralProfileData(
             new_profile->set_coordinate(profile_coord);
             auto stat_type = static_cast<CARTA::StatsType>(requested_stats[i]);
             new_profile->set_stats_type(stat_type);
-            // convert to float for spectral profile
-            std::vector<float> values;
             if (stats_values[i].empty()) { // region outside image or NaNs
                 double nan_value = std::numeric_limits<double>::quiet_NaN();
                 new_profile->set_raw_values_fp64(&nan_value, sizeof(double));
             } else {
                 new_profile->set_raw_values_fp64(stats_values[i].data(), stats_values[i].size() * sizeof(double));
             }
+        }
+    }
+}
+
+void Region::FillEmptySpectralProfileData(CARTA::SpectralProfileData& profile_data, int profile_index) {
+    CARTA::SetSpectralRequirements_SpectralConfig config;
+    if (_profiler->GetSpectralConfig(config, profile_index)) {
+        std::string profile_coord(config.coordinate());
+        std::vector<int> requested_stats(config.stats_types().begin(), config.stats_types().end());
+        size_t nstats = requested_stats.size();
+        for (size_t i = 0; i < nstats; ++i) {
+            // one SpectralProfile per stats type
+            auto new_profile = profile_data.add_profiles();
+            new_profile->set_coordinate(profile_coord);
+            auto stat_type = static_cast<CARTA::StatsType>(requested_stats[i]);
+            new_profile->set_stats_type(stat_type);
+            // region outside image or NaNs
+            double nan_value = std::numeric_limits<double>::quiet_NaN();
+            new_profile->set_raw_values_fp64(&nan_value, sizeof(double));
         }
     }
 }

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -756,7 +756,7 @@ void Region::FillSpectralProfileData(
     }
 }
 
-void Region::FillSpectralProfileData(CARTA::SpectralProfileData& profile_data, int profile_index) {
+void Region::FillNaNSpectralProfileData(CARTA::SpectralProfileData& profile_data, int profile_index) {
     // Fill spectral profile with NaN statistics values according to config stored in RegionProfiler
     CARTA::SetSpectralRequirements_SpectralConfig config;
     if (_profiler->GetSpectralConfig(config, profile_index)) {

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -756,7 +756,8 @@ void Region::FillSpectralProfileData(
     }
 }
 
-void Region::FillEmptySpectralProfileData(CARTA::SpectralProfileData& profile_data, int profile_index) {
+void Region::FillSpectralProfileData(CARTA::SpectralProfileData& profile_data, int profile_index) {
+    // Fill spectral profile with NaN statistics values according to config stored in RegionProfiler
     CARTA::SetSpectralRequirements_SpectralConfig config;
     if (_profiler->GetSpectralConfig(config, profile_index)) {
         std::string profile_coord(config.coordinate());

--- a/Region/Region.h
+++ b/Region/Region.h
@@ -91,7 +91,7 @@ public:
     bool GetSpectralProfileData(std::vector<std::vector<double>>& stats_values, int profile_index, casacore::ImageInterface<float>& image);
     void FillSpectralProfileData(
         CARTA::SpectralProfileData& profile_data, int profile_index, const std::vector<std::vector<double>>& stats_values);
-    void FillSpectralProfileData(CARTA::SpectralProfileData& profile_data, int profile_index);
+    void FillNaNSpectralProfileData(CARTA::SpectralProfileData& profile_data, int profile_index);
 
     // Stats: pass through to RegionStats
     void SetStatsRequirements(const std::vector<int>& stats_types);

--- a/Region/Region.h
+++ b/Region/Region.h
@@ -91,7 +91,7 @@ public:
     bool GetSpectralProfileData(std::vector<std::vector<double>>& stats_values, int profile_index, casacore::ImageInterface<float>& image);
     void FillSpectralProfileData(
         CARTA::SpectralProfileData& profile_data, int profile_index, const std::vector<std::vector<double>>& stats_values);
-    void FillEmptySpectralProfileData(CARTA::SpectralProfileData& profile_data, int profile_index);
+    void FillSpectralProfileData(CARTA::SpectralProfileData& profile_data, int profile_index);
 
     // Stats: pass through to RegionStats
     void SetStatsRequirements(const std::vector<int>& stats_types);

--- a/Region/Region.h
+++ b/Region/Region.h
@@ -91,6 +91,7 @@ public:
     bool GetSpectralProfileData(std::vector<std::vector<double>>& stats_values, int profile_index, casacore::ImageInterface<float>& image);
     void FillSpectralProfileData(
         CARTA::SpectralProfileData& profile_data, int profile_index, const std::vector<std::vector<double>>& stats_values);
+    void FillEmptySpectralProfileData(CARTA::SpectralProfileData& profile_data, int profile_index);
 
     // Stats: pass through to RegionStats
     void SetStatsRequirements(const std::vector<int>& stats_types);


### PR DESCRIPTION
This is related to issue #264. The backend sends a NaN spectral profile to the frontend if a region is outside the lattice.