### PR TITLE
Diff new profile requirements and only send new ones.

### DIFF
--- a/Frame.cc
+++ b/Frame.cc
@@ -30,9 +30,9 @@ Frame::Frame(
         Log(session_id, "Problem loading file {}: loader not implemented", filename);
         _valid = false;
         return;
-    } else {
-        _loader->SetFramePtr(this);
     }
+
+    _loader->SetFramePtr(this);
 
     try {
         _loader->OpenFile(hdu, info);
@@ -300,7 +300,7 @@ bool Frame::SetImageChannels(int new_channel, int new_stokes, std::string& messa
                 SetImageCache();
                 updated = true;
                 for (auto& region : _regions) {
-		    // force sending new profiles for new chan/stokes
+                    // force sending new profiles for new chan/stokes
                     region.second->SetAllProfilesUnsent();
                 }
             } else {
@@ -797,14 +797,14 @@ bool Frame::FillSpatialProfileData(int region_id, CARTA::SpatialProfileData& pro
                 if (!region->GetSpatialProfileSent(i)) {
                     // get <axis, stokes> for slicing image data
                     std::pair<int, int> axis_stokes = region->GetSpatialProfileAxes(i);
-                    if (axis_stokes.first < 0) {  // invalid index
+                    if (axis_stokes.first < 0) { // invalid index
                         return profile_ok;
                     }
 
                     if (stokes_changed && (axis_stokes.second != CURRENT_STOKES)) {
-			// Do not send fixed stokes profile when stokes changes.
+                        // Do not send fixed stokes profile when stokes changes.
                         // When chan/stokes changes, all messages are set to unsent to force new profiles;
-			// put fixed stokes profile back to sent
+                        // put fixed stokes profile back to sent
                         region->SetSpatialProfileSent(i, true);
                         continue;
                     }
@@ -880,8 +880,8 @@ bool Frame::FillSpatialProfileData(int region_id, CARTA::SpatialProfileData& pro
     return profile_ok;
 }
 
-bool Frame::FillSpectralProfileData(std::function<void(CARTA::SpectralProfileData profile_data)> cb,
-    int region_id, bool channel_changed, bool stokes_changed) {
+bool Frame::FillSpectralProfileData(
+    std::function<void(CARTA::SpectralProfileData profile_data)> cb, int region_id, bool channel_changed, bool stokes_changed) {
     // fill spectral profile message with requested statistics (or values for a point region)
     bool profile_ok(false);
     if (_regions.count(region_id)) {
@@ -950,7 +950,7 @@ bool Frame::FillSpectralProfileData(std::function<void(CARTA::SpectralProfileDat
                         guard.unlock();
                     }
                 } else { // statistics
-                    // do calculations for the image dimensions >= 3 
+                    // do calculations for the image dimensions >= 3
                     if (_image_shape.size() < 3) {
                         CARTA::SpectralProfileData profile_data;
                         profile_data.set_stokes(curr_stokes);
@@ -1324,8 +1324,8 @@ bool Frame::GetRegionSpectralData(std::vector<std::vector<double>>& stats_values
                     memcpy(&results[j][start], &buffer[j][0], buffer[j].size() * sizeof(double));
                 }
             } else {
-                std::cerr << "Can not get zprofile (statistics), region id: " << region_id
-                    << ", channel range: [" << start << "," << end << "]" << std::endl;
+                std::cerr << "Can not get zprofile (statistics), region id: " << region_id << ", channel range: [" << start << "," << end
+                          << "]" << std::endl;
                 return false;
             }
         }

--- a/Frame.h
+++ b/Frame.h
@@ -76,11 +76,8 @@ public:
     bool FillRasterTileData(CARTA::RasterTileData& raster_tile_data, const Tile& tile, int channel, int stokes,
         CARTA::CompressionType compression_type, float compression_quality);
     bool FillSpatialProfileData(int region_id, CARTA::SpatialProfileData& profile_data, bool stokes_changed = false);
-    bool FillSpectralProfileData(
-        std::function<void(CARTA::SpectralProfileData profile_data)> cb,
-        int region_id,
-        bool channel_changed = false,
-        bool stokes_changed = false);
+    bool FillSpectralProfileData(std::function<void(CARTA::SpectralProfileData profile_data)> cb, int region_id,
+        bool channel_changed = false, bool stokes_changed = false);
     bool FillRegionHistogramData(int region_id, CARTA::RegionHistogramData* histogram_data, bool channel_changed = false);
     bool FillRegionStatsData(int region_id, CARTA::RegionStatsData& stats_data);
 

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -784,7 +784,7 @@ int Region::GetSpectralConfigStokes(int profile_index) {
     if (_region_profiler) {
         return _region_profiler->GetSpectralConfigStokes(profile_index);
     }
-    return CURRENT_STOKES - 1;  // invalid
+    return CURRENT_STOKES - 1; // invalid
 }
 
 std::string Region::GetSpectralCoordinate(int profile_index) {

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -641,19 +641,52 @@ void Region::FillStatsData(CARTA::RegionStatsData& stats_data, std::map<CARTA::S
 // spatial
 
 bool Region::SetSpatialRequirements(const std::vector<std::string>& profiles, const int num_stokes) {
+    if (_profiler == nullptr) {
+        return false;
+    }
     return _profiler->SetSpatialRequirements(profiles, num_stokes);
 }
 
 size_t Region::NumSpatialProfiles() {
+    if (_profiler == nullptr) {
+        return 0;
+    }
     return _profiler->NumSpatialProfiles();
 }
 
-std::pair<int, int> Region::GetSpatialProfileReq(int profile_index) {
-    return _profiler->GetSpatialProfileReq(profile_index);
+std::pair<int, int> Region::GetSpatialProfileAxes(int profile_index) {
+    if (_profiler == nullptr) {
+        return {};
+    }
+    return _profiler->GetSpatialProfileAxes(profile_index);
 }
 
 std::string Region::GetSpatialCoordinate(int profile_index) {
+    if (_profiler == nullptr) {
+        return "";
+    }
     return _profiler->GetSpatialCoordinate(profile_index);
+}
+
+bool Region::GetSpatialProfileSent(int profile_index) {
+    if (_profiler == nullptr) {
+        return false;
+    }
+    return _profiler->GetSpatialProfileSent(profile_index);
+}
+
+void Region::SetSpatialProfileSent(int profile_index, bool sent) {
+    if (_profiler == nullptr) {
+        return;
+    }
+    _profiler->SetSpatialProfileSent(profile_index, sent);
+}
+
+void Region::SetAllSpatialProfilesUnsent() {
+    if (_profiler == nullptr) {
+        return;
+    }
+    _profiler->SetAllSpatialProfilesUnsent();
 }
 
 // spectral

--- a/Region/Region.h
+++ b/Region/Region.h
@@ -76,8 +76,11 @@ public:
     // Spatial: pass through to RegionProfiler
     bool SetSpatialRequirements(const std::vector<std::string>& profiles, const int num_stokes);
     size_t NumSpatialProfiles();
-    std::pair<int, int> GetSpatialProfileReq(int profile_index);
+    std::pair<int, int> GetSpatialProfileAxes(int profile_index);
     std::string GetSpatialCoordinate(int profile_index);
+    bool GetSpatialProfileSent(int profile_index);
+    void SetSpatialProfileSent(int profile_index, bool sent);
+    void SetAllSpatialProfilesUnsent();
 
     // Spectral: pass through to RegionProfiler
     bool SetSpectralRequirements(const std::vector<CARTA::SetSpectralRequirements_SpectralConfig>& profiles, const int num_stokes);

--- a/Region/Region.h
+++ b/Region/Region.h
@@ -73,25 +73,29 @@ public:
     void CalcHistogram(int channel, int stokes, int num_bins, float min_val, float max_val, const std::vector<float>& data,
         CARTA::Histogram& histogram_msg);
 
+    void SetAllProfilesUnsent(); // enable sending new spatial and spectral profiles
+
     // Spatial: pass through to RegionProfiler
     bool SetSpatialRequirements(const std::vector<std::string>& profiles, const int num_stokes);
     size_t NumSpatialProfiles();
-    std::pair<int, int> GetSpatialProfileAxes(int profile_index);
     std::string GetSpatialCoordinate(int profile_index);
+    std::pair<int, int> GetSpatialProfileAxes(int profile_index);
     bool GetSpatialProfileSent(int profile_index);
     void SetSpatialProfileSent(int profile_index, bool sent);
-    void SetAllSpatialProfilesUnsent();
 
     // Spectral: pass through to RegionProfiler
     bool SetSpectralRequirements(const std::vector<CARTA::SetSpectralRequirements_SpectralConfig>& profiles, const int num_stokes);
     size_t NumSpectralProfiles();
-    bool GetSpectralConfigStokes(int& stokes, int profile_index);
-    std::string GetSpectralCoordinate(int profile_index);
-    bool GetSpectralConfig(CARTA::SetSpectralRequirements_SpectralConfig& config, int profile_index);
-    void FillSpectralProfileData(CARTA::SpectralProfileData& profile_data, int profile_index, std::vector<float>& spectral_data);
+    int NumStatsToLoad(int profile_index);
+    void SetSpectralProfileStatSent(int profile_index, int stats_type, bool sent);
+    void SetSpectralProfileAllStatsSent(int profile_index, bool sent);
+    void SetAllSpectralProfileStatsUnsent(); // enable sending new profiles
+    int GetSpectralConfigStokes(int profile_index);
+    bool GetSpectralConfigStats(int profile_index, std::vector<int>& stats);
+    bool GetSpectralProfileData(std::vector<std::vector<double>>& stats_values, int profile_index, casacore::ImageInterface<float>& image);
+    void FillPointSpectralProfileData(CARTA::SpectralProfileData& profile_data, int profile_index, std::vector<float>& spectral_data);
     void FillSpectralProfileData(
         CARTA::SpectralProfileData& profile_data, int profile_index, std::map<CARTA::StatsType, std::vector<double>>& stats_values);
-    bool GetSpectralProfileData(std::vector<std::vector<double>>& stats_values, int profile_index, casacore::ImageInterface<float>& image);
     void FillSpectralProfileData(
         CARTA::SpectralProfileData& profile_data, int profile_index, const std::vector<std::vector<double>>& stats_values);
     void FillNaNSpectralProfileData(CARTA::SpectralProfileData& profile_data, int profile_index);
@@ -125,6 +129,11 @@ private:
     bool MakeExtensionBox(casacore::WCBox& extend_box, int stokes, ChannelRange channel_range); // for extended region
     casacore::WCRegion* MakeExtendedRegion(int stokes, ChannelRange channel_range);             // x/y region extended chan/stokes
 
+    // internal for spectral profile message
+    std::string GetSpectralCoordinate(int profile_index);
+    bool GetSpectralStatsToLoad(int profile_index, std::vector<int>& stats);
+    bool GetSpectralProfileStatSent(int profile_index, int stats_type);
+
     // region definition (ICD SET_REGION parameters)
     std::string _name;
     CARTA::RegionType _type;
@@ -149,8 +158,8 @@ private:
     casacore::CoordinateSystem _coord_sys;
 
     // classes for requirements, calculations
-    std::unique_ptr<carta::RegionStats> _stats;
-    std::unique_ptr<carta::RegionProfiler> _profiler;
+    std::unique_ptr<carta::RegionStats> _region_stats;
+    std::unique_ptr<carta::RegionProfiler> _region_profiler;
 };
 
 } // namespace carta

--- a/Region/RegionProfiler.cc
+++ b/Region/RegionProfiler.cc
@@ -1,48 +1,15 @@
 // RegionProfiler.cc: implementation of RegionProfiler class to create x, y, z region profiles
 
 #include "RegionProfiler.h"
+#include "../InterfaceConstants.h"
 
 using namespace carta;
 
-// ***** spatial *****
-
-bool RegionProfiler::SetSpatialRequirements(const std::vector<std::string>& profiles, const int num_stokes) {
-    // Set new spatial requirements for this region
-    // process profile strings into pairs <axis, stokes>
-    std::vector<SpatialProfile> last_profiles = _spatial_profiles; // for diff
-    // Replace spatial profiles with requested profiles
-    _spatial_profiles.clear();
-    for (const auto& profile : profiles) {
-        if (profile.empty() || profile.size() > 2) // ignore invalid profile string
-            continue;
-        // convert string to pair<axisIndex, stokesIndex>;
-        std::pair<int, int> axis_stokes_index = GetAxisStokes(profile);
-        if ((axis_stokes_index.first < 0) || (axis_stokes_index.first > 1)) { // invalid axis
-            continue;
-        }
-        if (axis_stokes_index.second > (num_stokes - 1)) { // invalid stokes
-            continue;
-        }
-	SpatialProfile new_spatial_profile;
-	new_spatial_profile.profile = profile;
-	new_spatial_profile.profile_axes = axis_stokes_index;
-	new_spatial_profile.profile_sent = false;
-        _spatial_profiles.push_back(new_spatial_profile);
-    }
-    bool valid(false);
-    if (profiles.size() == _spatial_profiles.size()) {
-        // Determine diff for required data streams
-        DiffSpatialRequirements(last_profiles);
-	valid = true;
-    }
-    return valid;
-}
-
-std::pair<int, int> RegionProfiler::GetAxisStokes(std::string profile) {
+std::pair<int, int> RegionProfiler::CoordinateToAxisStokes(std::string coordinate) {
     // converts profile string into <axis, stokes> pair
-    int axis_index(-1), stokes_index(-1);
+    int axis_index(-1), stokes_index(CURRENT_STOKES);
     // axis
-    char axis_char(profile.back());
+    char axis_char(coordinate.back());
     if (axis_char == 'x')
         axis_index = 0;
     else if (axis_char == 'y')
@@ -50,8 +17,8 @@ std::pair<int, int> RegionProfiler::GetAxisStokes(std::string profile) {
     else if (axis_char == 'z')
         axis_index = 2;
     // stokes
-    if (profile.size() == 2) {
-        char stokes_char(profile.front());
+    if (coordinate.size() == 2) {
+        char stokes_char(coordinate.front());
         if (stokes_char == 'I')
             stokes_index = 0;
         else if (stokes_char == 'Q')
@@ -64,14 +31,54 @@ std::pair<int, int> RegionProfiler::GetAxisStokes(std::string profile) {
     return std::make_pair(axis_index, stokes_index);
 }
 
+// ***** spatial *****
+
+bool RegionProfiler::SetSpatialRequirements(const std::vector<std::string>& profiles, const int num_stokes) {
+    // Validate and set new spatial requirements for this region
+    std::vector<SpatialProfile> last_profiles = _spatial_profiles; // for diff
+
+    // Set spatial profiles to requested profiles
+    _spatial_profiles.clear();
+    for (const auto& profile : profiles) {
+        // validate profile string
+        if (profile.empty() || profile.size() > 2) {
+            continue;
+        }
+
+        // validate and convert string to pair<axisIndex, stokesIndex>;
+        std::pair<int, int> axis_stokes_index = CoordinateToAxisStokes(profile);
+        if ((axis_stokes_index.first < 0) || (axis_stokes_index.first > 1)) { // invalid axis
+            continue;
+        }
+        if (axis_stokes_index.second > (num_stokes - 1)) { // invalid stokes
+            continue;
+        }
+
+        // add to spatial profiles
+        SpatialProfile new_spatial_profile;
+        new_spatial_profile.coordinate = profile;
+        new_spatial_profile.profile_axes = axis_stokes_index;
+        new_spatial_profile.profile_sent = false;
+        _spatial_profiles.push_back(new_spatial_profile);
+    }
+
+    bool valid(false);
+    if (profiles.size() == _spatial_profiles.size()) {
+        // Determine diff for required data streams
+        DiffSpatialRequirements(last_profiles);
+        valid = true;
+    }
+    return valid;
+}
+
 void RegionProfiler::DiffSpatialRequirements(std::vector<SpatialProfile>& last_profiles) {
     // Determine which current profiles are new (have unsent data streams)
     for (size_t i = 0; i < NumSpatialProfiles(); ++i) {
         bool found(false);
         for (size_t j = 0; j < last_profiles.size(); ++j) {
-            if (_spatial_profiles[i].profile == last_profiles[j].profile) {
+            if (_spatial_profiles[i].coordinate == last_profiles[j].coordinate) {
                 found = true;
-		break;
+                break;
             }
         }
         _spatial_profiles[i].profile_sent = found;
@@ -85,34 +92,33 @@ size_t RegionProfiler::NumSpatialProfiles() {
 std::pair<int, int> RegionProfiler::GetSpatialProfileAxes(int profile_index) {
     if (profile_index < _spatial_profiles.size()) {
         return _spatial_profiles[profile_index].profile_axes;
-    } else {
-        return {};
     }
+    return std::make_pair(-1, -1);
 }
 
 std::string RegionProfiler::GetSpatialCoordinate(int profile_index) {
     if (profile_index < _spatial_profiles.size()) {
-        return _spatial_profiles[profile_index].profile;
-    } else {
-        return std::string();
+        return _spatial_profiles[profile_index].coordinate;
     }
+    return std::string();
 }
 
 bool RegionProfiler::GetSpatialProfileSent(int profile_index) {
     if (profile_index < _spatial_profiles.size()) {
         return _spatial_profiles[profile_index].profile_sent;
-    } else {
-        return false;
     }
+    return false;
 }
 
 void RegionProfiler::SetSpatialProfileSent(int profile_index, bool sent) {
-    _spatial_profiles[profile_index].profile_sent = sent;
+    if (profile_index < _spatial_profiles.size()) {
+        _spatial_profiles[profile_index].profile_sent = sent;
+    }
 }
 
 void RegionProfiler::SetAllSpatialProfilesUnsent() {
-    for (size_t i=0; i<NumSpatialProfiles(); ++i) {
-        _spatial_profiles[i].profile_sent = false;
+    for (auto& profile : _spatial_profiles) {
+        profile.profile_sent = false;
     }
 }
         
@@ -120,51 +126,152 @@ void RegionProfiler::SetAllSpatialProfilesUnsent() {
 
 bool RegionProfiler::SetSpectralRequirements(
     const std::vector<CARTA::SetSpectralRequirements_SpectralConfig>& configs, const int num_stokes) {
-    // parse stokes into index
-    _spectral_configs.clear();
-    _spectral_stokes.clear();
+    // Validate and set new spectral requirements for this region
+    std::vector<SpectralProfile> last_profiles = _spectral_profiles; // for diff
+
+    // Set spectral profiles to requested profiles
+    std::vector<SpectralProfile> new_profiles;
     for (const auto& config : configs) {
         std::string coordinate(config.coordinate());
+
+        // validate coordinate string, axis, stokes
         if (coordinate.empty() || coordinate.size() > 2) // ignore invalid profile string
             continue;
-        std::pair<int, int> axis_stokes = GetAxisStokes(coordinate);
+        std::pair<int, int> axis_stokes = CoordinateToAxisStokes(coordinate);
         if (axis_stokes.first != 2) // invalid axis
             continue;
         if (axis_stokes.second > (num_stokes - 1)) // invalid stokes
             continue;
-        _spectral_configs.push_back(config);
-        _spectral_stokes.push_back(axis_stokes.second);
+
+        // add to spectral profiles
+        SpectralProfile new_spectral_profile;
+        new_spectral_profile.coordinate = coordinate;
+        new_spectral_profile.stokes_index = axis_stokes.second;
+        new_spectral_profile.stats_types = {config.stats_types().begin(), config.stats_types().end()};
+        new_spectral_profile.profiles_sent = std::vector<bool>(config.stats_types_size(), false);
+        new_profiles.push_back(new_spectral_profile);
     }
-    return (configs.size() == _spectral_configs.size());
+    bool valid(false);
+    _spectral_profiles = new_profiles;
+    if (configs.size() == _spectral_profiles.size()) {
+        // Determine diff for required data streams
+        DiffSpectralRequirements(last_profiles);
+        valid = true;
+    }
+    return valid;
+}
+
+void RegionProfiler::DiffSpectralRequirements(std::vector<SpectralProfile>& last_profiles) {
+    // Determine which current profiles are new (have unsent data streams)
+    for (size_t i = 0; i < NumSpectralProfiles(); ++i) {
+        for (size_t j = 0; j < last_profiles.size(); ++j) {
+            if (_spectral_profiles[i].coordinate == last_profiles[j].coordinate) {
+                // search for each stats_type
+                for (size_t k = 0; k < _spectral_profiles[i].stats_types.size(); ++k) {
+                    for (size_t l = 0; l < last_profiles[j].stats_types.size(); ++l) {
+                        if (_spectral_profiles[i].stats_types[k] == last_profiles[j].stats_types[l]) {
+                            _spectral_profiles[i].profiles_sent[k] = last_profiles[j].profiles_sent[l];
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 size_t RegionProfiler::NumSpectralProfiles() {
-    return _spectral_configs.size();
+    return _spectral_profiles.size();
 }
 
-bool RegionProfiler::GetSpectralConfigStokes(int& stokes, int profile_index) {
-    // return Stokes int value at given index; return false if index out of range
-    bool index_ok(false);
-    if (profile_index < _spectral_stokes.size()) {
-        stokes = _spectral_stokes[profile_index];
-        index_ok = true;
+int RegionProfiler::NumStatsToLoad(int profile_index) {
+    int num_unsent(0);
+    if (profile_index < _spectral_profiles.size()) {
+        SpectralProfile profile = _spectral_profiles[profile_index];
+        for (auto sent : profile.profiles_sent) {
+            if (!sent) {
+                ++num_unsent;
+            }
+        }
     }
-    return index_ok;
+    return num_unsent;
+}
+
+int RegionProfiler::GetSpectralConfigStokes(int profile_index) {
+    // return Stokes int value at given index; return false if index out of range
+    if (profile_index < _spectral_profiles.size()) {
+        return _spectral_profiles[profile_index].stokes_index;
+    }
+    return CURRENT_STOKES - 1; // invalid
 }
 
 std::string RegionProfiler::GetSpectralCoordinate(int profile_index) {
-    if (profile_index < _spectral_configs.size())
-        return _spectral_configs[profile_index].coordinate();
-    else
+    if (profile_index < _spectral_profiles.size()) {
+        return _spectral_profiles[profile_index].coordinate;
+    } else {
         return std::string();
+    }
 }
 
-bool RegionProfiler::GetSpectralConfig(CARTA::SetSpectralRequirements_SpectralConfig& config, int profile_index) {
-    // return SpectralConfig at given index; return false if index out of range
-    bool index_ok(false);
-    if (profile_index < _spectral_configs.size()) {
-        config = _spectral_configs[profile_index];
-        index_ok = true;
+bool RegionProfiler::GetSpectralConfigStats(int profile_index, std::vector<int>& stats) {
+    // return stats_types at given index; return false if index out of range
+    if (profile_index < _spectral_profiles.size()) {
+        stats = _spectral_profiles[profile_index].stats_types;
+        return true;
     }
-    return index_ok;
+    return false;
+}
+
+bool RegionProfiler::GetSpectralStatsToLoad(int profile_index, std::vector<int>& stats) {
+    // Return vector of stats that were not sent
+    if (profile_index < _spectral_profiles.size()) {
+        stats.clear();
+        for (size_t i = 0; i < _spectral_profiles[profile_index].profiles_sent.size(); ++i) {
+            if (!_spectral_profiles[profile_index].profiles_sent[i]) {
+                stats.push_back(_spectral_profiles[profile_index].stats_types[i]);
+            }
+        }
+        return true;
+    }
+    return false;
+}
+
+bool RegionProfiler::GetSpectralProfileStatSent(int profile_index, int stats_type) {
+    bool stat_sent(false);
+    if (profile_index < _spectral_profiles.size()) {
+        SpectralProfile profile = _spectral_profiles[profile_index];
+        for (size_t i = 0; i < profile.stats_types.size(); ++i) {
+            if (profile.stats_types[i] == stats_type) {
+                stat_sent = profile.profiles_sent[i];
+                break;
+            }
+        }
+    }
+    return stat_sent;
+}
+
+void RegionProfiler::SetSpectralProfileStatSent(int profile_index, int stats_type, bool sent) {
+    if (profile_index < _spectral_profiles.size()) {
+        for (size_t i = 0; i < _spectral_profiles[profile_index].stats_types.size(); ++i) {
+            if (_spectral_profiles[profile_index].stats_types[i] == stats_type) {
+                _spectral_profiles[profile_index].profiles_sent[i] = sent;
+                break;
+            }
+        }
+    }
+}
+
+void RegionProfiler::SetSpectralProfileAllStatsSent(int profile_index, bool sent) {
+    if (profile_index < _spectral_profiles.size()) {
+        for (size_t i = 0; i < _spectral_profiles[profile_index].profiles_sent.size(); ++i) {
+            _spectral_profiles[profile_index].profiles_sent[i] = sent;
+        }
+    }
+}
+
+void RegionProfiler::SetAllSpectralProfilesUnsent() {
+    for (size_t i = 0; i < _spectral_profiles.size(); ++i) {
+        for (size_t j = 0; j < _spectral_profiles[i].profiles_sent.size(); ++j) {
+            _spectral_profiles[i].profiles_sent[j] = false;
+        }
+    }
 }

--- a/Region/RegionProfiler.cc
+++ b/Region/RegionProfiler.cc
@@ -121,7 +121,7 @@ void RegionProfiler::SetAllSpatialProfilesUnsent() {
         profile.profile_sent = false;
     }
 }
-        
+
 // ***** spectral *****
 
 bool RegionProfiler::SetSpectralRequirements(

--- a/Region/RegionProfiler.h
+++ b/Region/RegionProfiler.h
@@ -12,9 +12,16 @@
 namespace carta {
 
 struct SpatialProfile {
-    std::string profile;
+    std::string coordinate;
     std::pair<int, int> profile_axes; // <axis index, stokes index>
     bool profile_sent;
+};
+
+struct SpectralProfile {
+    std::string coordinate;
+    int stokes_index;
+    std::vector<int> stats_types;
+    std::vector<bool> profiles_sent;
 };
 
 class RegionProfiler {
@@ -31,23 +38,27 @@ public:
     // spectral
     bool SetSpectralRequirements(const std::vector<CARTA::SetSpectralRequirements_SpectralConfig>& profiles, const int num_stokes);
     size_t NumSpectralProfiles();
-    // return false if profileIndex out of range:
-    bool GetSpectralConfigStokes(int& stokes, int profile_index);
+    int NumStatsToLoad(int profile_index);
+    int GetSpectralConfigStokes(int profile_index);
     std::string GetSpectralCoordinate(int profile_index);
-    bool GetSpectralConfig(CARTA::SetSpectralRequirements_SpectralConfig& config, int profile_index);
+    bool GetSpectralConfigStats(int profile_index, std::vector<int>& stats); // all requested
+    bool GetSpectralStatsToLoad(int profile_index, std::vector<int>& stats); // diff of requested and already sent
+    bool GetSpectralProfileStatSent(int profile_index, int stats_type);
+    void SetSpectralProfileStatSent(int profile_index, int stats_type, bool sent);
+    void SetSpectralProfileAllStatsSent(int profile_index, bool sent);
+    void SetAllSpectralProfilesUnsent(); // enable sending new profiles
 
 private:
-    // parse spatial/coordinate strings into <axisIndex, stokesIndex> pairs
-    std::pair<int, int> GetAxisStokes(std::string profile);
+    // parse coordinate strings into <axisIndex, stokesIndex> pairs
+    std::pair<int, int> CoordinateToAxisStokes(std::string coordinate);
+
     // determine unsent profiles by diffing current profiles with last profiles
     void DiffSpatialRequirements(std::vector<SpatialProfile>& last_profiles);
+    void DiffSpectralRequirements(std::vector<SpectralProfile>& last_profiles);
 
-    // spatial profile: map coordinate string to <axis, stokes> pair and whether data has been sent 
+    // profiles
     std::vector<SpatialProfile> _spatial_profiles;
-
-    // spectral
-    std::vector<int> _spectral_stokes;
-    std::vector<CARTA::SetSpectralRequirements_SpectralConfig> _spectral_configs;
+    std::vector<SpectralProfile> _spectral_profiles;
 };
 
 } // namespace carta

--- a/Region/RegionProfiler.h
+++ b/Region/RegionProfiler.h
@@ -1,4 +1,4 @@
-// RegionProfiler.h: class for creating requested profiles for and axis (x, y, z) and stokes
+// RegionProfiler.h: class for handling requested profiles for an axis (x, y, z) and stokes
 
 #ifndef CARTA_BACKEND_REGION_REGIONPROFILER_H_
 #define CARTA_BACKEND_REGION_REGIONPROFILER_H_
@@ -11,13 +11,22 @@
 
 namespace carta {
 
+struct SpatialProfile {
+    std::string profile;
+    std::pair<int, int> profile_axes; // <axis index, stokes index>
+    bool profile_sent;
+};
+
 class RegionProfiler {
 public:
     // spatial
     bool SetSpatialRequirements(const std::vector<std::string>& profiles, const int num_stokes);
     size_t NumSpatialProfiles();
-    std::pair<int, int> GetSpatialProfileReq(int profile_index);
     std::string GetSpatialCoordinate(int profile_index);
+    std::pair<int, int> GetSpatialProfileAxes(int profile_index);
+    bool GetSpatialProfileSent(int profile_index);
+    void SetSpatialProfileSent(int profile_index, bool sent);
+    void SetAllSpatialProfilesUnsent(); // enable sending new profiles
 
     // spectral
     bool SetSpectralRequirements(const std::vector<CARTA::SetSpectralRequirements_SpectralConfig>& profiles, const int num_stokes);
@@ -30,10 +39,11 @@ public:
 private:
     // parse spatial/coordinate strings into <axisIndex, stokesIndex> pairs
     std::pair<int, int> GetAxisStokes(std::string profile);
+    // determine unsent profiles by diffing current profiles with last profiles
+    void DiffSpatialRequirements(std::vector<SpatialProfile>& last_profiles);
 
-    // spatial
-    std::vector<std::string> _spatial_profiles;
-    std::vector<std::pair<int, int>> _profile_pairs;
+    // spatial profile: map coordinate string to <axis, stokes> pair and whether data has been sent 
+    std::vector<SpatialProfile> _spatial_profiles;
 
     // spectral
     std::vector<int> _spectral_stokes;


### PR DESCRIPTION
Issue #273

RegionProfiler tracks when spatial and spectral profiles are sent so they are not re-sent unnecessarily, such as when a profile is added or removed from requirements.  The Frame can reset all profiles' status to unsent when e.g. the region changes and they must all be regenerated.  It also handles fixed-stokes profiles so that these profiles are not sent when the stokes changes.

Some unrelated changes in Session.cc for checkformat and checkstyle.