### PR TITLE
Send NaN stats when region outside image

### DIFF
--- a/Frame.cc
+++ b/Frame.cc
@@ -1048,7 +1048,7 @@ bool Frame::FillRegionStatsData(int region_id, CARTA::RegionStatsData& stats_dat
                 region->FillStatsData(stats_data, sub_image, _channel_index, _stokes_index);
             } else {
                 guard.unlock(); // not using ImageStatistics
-                region->FillStatsDataNaN(stats_data);
+                region->FillNaNStatsData(stats_data);
             }
             stats_ok = true;
         }

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -670,6 +670,24 @@ void Region::FillStatsData(CARTA::RegionStatsData& stats_data, std::map<CARTA::S
     }
 }
 
+void Region::FillStatsDataNaN(CARTA::RegionStatsData& stats_data) {
+    // set stats 0-9 with NaN values when no subimage (region is outside image)
+    for (int i = CARTA::StatsType::NumPixels; i < CARTA::StatsType::Blc; ++i) {
+        auto carta_stats_type = static_cast<CARTA::StatsType>(i);
+        double nan_value = std::numeric_limits<double>::quiet_NaN();
+	if (carta_stats_type == CARTA::StatsType::NanCount) { // not implemented
+            continue;
+        }
+	if (carta_stats_type == CARTA::StatsType::NumPixels) {
+            nan_value = 0.0;
+        }
+	auto stats_value = stats_data.add_statistics();
+        stats_value->set_stats_type(carta_stats_type);
+        stats_value->set_value(nan_value);
+    }
+}
+
+
 // ***********************************
 // RegionProfiler
 

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -670,7 +670,7 @@ void Region::FillStatsData(CARTA::RegionStatsData& stats_data, std::map<CARTA::S
     }
 }
 
-void Region::FillStatsDataNaN(CARTA::RegionStatsData& stats_data) {
+void Region::FillNaNStatsData(CARTA::RegionStatsData& stats_data) {
     // set stats 0-9 with NaN values when no subimage (region is outside image)
     for (int i = CARTA::StatsType::NumPixels; i < CARTA::StatsType::Blc; ++i) {
         auto carta_stats_type = static_cast<CARTA::StatsType>(i);

--- a/Region/Region.h
+++ b/Region/Region.h
@@ -105,6 +105,7 @@ public:
     size_t NumStats();
     void FillStatsData(CARTA::RegionStatsData& stats_data, const casacore::ImageInterface<float>& image, int channel, int stokes);
     void FillStatsData(CARTA::RegionStatsData& stats_data, std::map<CARTA::StatsType, double>& stats_values);
+    void FillStatsDataNaN(CARTA::RegionStatsData& stats_data);
 
     RegionState GetRegionState();
 

--- a/Region/Region.h
+++ b/Region/Region.h
@@ -105,7 +105,7 @@ public:
     size_t NumStats();
     void FillStatsData(CARTA::RegionStatsData& stats_data, const casacore::ImageInterface<float>& image, int channel, int stokes);
     void FillStatsData(CARTA::RegionStatsData& stats_data, std::map<CARTA::StatsType, double>& stats_values);
-    void FillStatsDataNaN(CARTA::RegionStatsData& stats_data);
+    void FillNaNStatsData(CARTA::RegionStatsData& stats_data);
 
     RegionState GetRegionState();
 


### PR DESCRIPTION
Issue found while testing, stats are not updated when region is outside image.  Fixed by sending stats data message with 0 NumPixels and NaN for other stats.