### PR TITLE
Change the task cancellation codes for spectral profiles

### DIFF
--- a/Frame.cc
+++ b/Frame.cc
@@ -1317,10 +1317,6 @@ bool Frame::GetRegionSpectralData(int region_id, int profile_index, int profile_
         return data_ok;
     }
 
-    if (!region->GetSpectralConfigStats(profile_index, config_stats)) { // stats in config, to see if req changed
-        return data_ok;
-    }
-
     // initialize the stats data
     std::map<CARTA::StatsType, std::vector<double>> results;
     size_t profile_size = NumChannels(); // total number of channels

--- a/Frame.cc
+++ b/Frame.cc
@@ -156,8 +156,6 @@ bool Frame::SetRegion(int region_id, const std::string& name, CARTA::RegionType 
     if (region_set) {
         if (name == "cursor" && type == CARTA::RegionType::POINT) { // update current cursor's x-y coordinate
             SetCursorXy(points[0].x(), points[0].y());
-        } else { // update current region's states
-            SetRegionState(region_id, name, type, points, rotation);
         }
     } else {
         message = fmt::format("Region parameters failed to validate for region id {}", region_id);
@@ -1422,7 +1420,10 @@ bool Frame::IsConnected() {
 }
 
 bool Frame::IsSameRegionState(int region_id, const RegionState& region_state) {
-    return (_region_states.count(region_id) && _region_states[region_id] == region_state);
+    if (_regions.count(region_id)) {
+        return (_regions[region_id]->GetRegionState() == region_state);
+    }
+    return false;
 }
 
 bool Frame::AreSameRegionSpectralRequests(int region_id, int profile_index, const std::vector<int>& requested_stats) {
@@ -1437,14 +1438,15 @@ void Frame::SetCursorXy(float x, float y) {
     _cursor_xy = CursorXy(x, y);
 }
 
-void Frame::SetRegionState(int region_id, std::string name, CARTA::RegionType type, std::vector<CARTA::Point> points, float rotation) {
-    _region_states[region_id].UpdateState(name, type, points, rotation);
-}
-
 void Frame::SetRegionSpectralRequests(int region_id, const std::vector<CARTA::SetSpectralRequirements_SpectralConfig>& profiles) {
     _region_requests[region_id].UpdateRequest(profiles);
 }
 
 RegionState Frame::GetRegionState(int region_id) {
-    return _region_states[region_id];
+    if (_regions.count(region_id)) {
+        return _regions[region_id]->GetRegionState();
+    } else {
+        std::cerr << "ERROR: region id " << region_id << " does not exist!" << std::endl;
+    }
+    return RegionState();
 }

--- a/Frame.cc
+++ b/Frame.cc
@@ -1257,7 +1257,7 @@ bool Frame::GetPointSpectralData(std::vector<float>& data, int region_id, casaco
                     if (_regions.count(region_id)) {
                         std::vector<CARTA::Point> region_points = _regions[region_id]->GetControlPoints();
                         // round the region cursor float values since subimage cursor comes from IPosition
-                        CursorXy region_cursor(round(region_points[0].x()), round(region_points[0].y())); 
+                        CursorXy region_cursor(round(region_points[0].x()), round(region_points[0].y()));
                         if (Interrupt(region_id, region_cursor, subimage_cursor)) { // point region moved
                             return false;
                         }
@@ -1416,8 +1416,8 @@ bool Frame::Interrupt(int region_id, const RegionState& region_state) {
     return interrupt;
 }
 
-bool Frame::Interrupt(int region_id, int num_profiles, int profile_index, int profile_stokes,
-    const RegionState& region_state, const std::vector<int>& config_stats) {
+bool Frame::Interrupt(int region_id, int num_profiles, int profile_index, int profile_stokes, const RegionState& region_state,
+    const std::vector<int>& config_stats) {
     bool interrupt(true);
     if (!IsConnected()) {
         std::cerr << "[Region " << region_id << "] closing image, exit zprofile (statistics) before complete" << std::endl;
@@ -1454,8 +1454,8 @@ bool Frame::IsSameRegionState(int region_id, const RegionState& region_state) {
     return false;
 }
 
-bool Frame::IsSameRegionSpectralConfig(int region_id, int num_profiles, int profile_index, int profile_stokes,
-    const std::vector<int>& config_stats) {
+bool Frame::IsSameRegionSpectralConfig(
+    int region_id, int num_profiles, int profile_index, int profile_stokes, const std::vector<int>& config_stats) {
     bool is_same(false);
     if (_regions.count(region_id)) {
         auto& region = _regions[region_id];

--- a/Frame.cc
+++ b/Frame.cc
@@ -435,6 +435,9 @@ bool Frame::SetRegionSpectralRequirements(int region_id, const std::vector<CARTA
     if (_regions.count(region_id)) {
         auto& region = _regions[region_id];
         region_ok = region->SetSpectralRequirements(profiles, NumStokes());
+        if (profiles.size() > 0) {
+            SetRegionId(region_id);
+        }
     }
     return region_ok;
 }
@@ -1244,7 +1247,7 @@ bool Frame::GetPointSpectralData(
                 // start the timer
                 auto t_start = std::chrono::high_resolution_clock::now();
                 // check if region point changed from subimage point
-                if ((region_id == CURSOR_REGION_ID) && (Interrupt(_cursor_xy, subimage_cursor))) {
+                if ((region_id == CURSOR_REGION_ID) && (Interrupt(region_id, _cursor_xy, subimage_cursor))) {
                     return false; // cursor moved
                 }
                 if (region_id > CURSOR_REGION_ID) {
@@ -1252,7 +1255,7 @@ bool Frame::GetPointSpectralData(
                         std::vector<CARTA::Point> region_points = _regions[region_id]->GetControlPoints();
                         // round the region cursor float values since subimage cursor comes from IPosition
                         CursorXy region_cursor(round(region_points[0].x()), round(region_points[0].y())); 
-                        if (Interrupt(region_cursor, subimage_cursor)) { // point region moved
+                        if (Interrupt(region_id, region_cursor, subimage_cursor)) { // point region moved
                             return false;
                         }
                     } else { // region closed
@@ -1374,49 +1377,71 @@ bool Frame::GetRegionSpectralData(std::vector<std::vector<double>>& stats_values
     return true;
 }
 
-bool Frame::Interrupt(const CursorXy& cursor1, const CursorXy& cursor2) {
+bool Frame::Interrupt(int region_id, const CursorXy& cursor1, const CursorXy& cursor2) {
+    bool interrupt(true);
     if (!IsConnected()) {
         std::cerr << "Closing image, exit zprofile before complete" << std::endl;
-        return true;
+        return interrupt;
+    }
+    if (!IsSameRegionId(region_id)) {
+        std::cerr << "[Region " << region_id << "] region changed, exit zprofile (statistics) before complete" << std::endl;
+        return interrupt;
     }
     if (!(cursor1 == cursor2)) {
         std::cerr << "Cursor/Point changed, exit zprofile before complete" << std::endl;
-        return true;
+        return interrupt;
     }
-    return false;
+    interrupt = false;
+    return interrupt;
 }
 
 bool Frame::Interrupt(int region_id, const RegionState& region_state) {
+    bool interrupt(true);
     if (!IsConnected()) {
         std::cerr << "[Region " << region_id << "] closing image, exit zprofile (statistics) before complete" << std::endl;
-        return true;
+        return interrupt;
+    }
+    if (!IsSameRegionId(region_id)) {
+        std::cerr << "[Region " << region_id << "] region changed, exit zprofile (statistics) before complete" << std::endl;
+        return interrupt;
     }
     if (!IsSameRegionState(region_id, region_state)) {
         std::cerr << "[Region " << region_id << "] region state changed, exit zprofile (statistics) before complete" << std::endl;
-        return true;
+        return interrupt;
     }
-    return false;
+    interrupt = false;
+    return interrupt;
 }
 
 bool Frame::Interrupt(int region_id, int num_profiles, int profile_index, int profile_stokes,
     const RegionState& region_state, const std::vector<int>& config_stats) {
+    bool interrupt(true);
     if (!IsConnected()) {
         std::cerr << "[Region " << region_id << "] closing image, exit zprofile (statistics) before complete" << std::endl;
-        return true;
+        return interrupt;
+    }
+    if (!IsSameRegionId(region_id)) {
+        std::cerr << "[Region " << region_id << "] region changed, exit zprofile (statistics) before complete" << std::endl;
+        return interrupt;
     }
     if (!IsSameRegionState(region_id, region_state)) {
         std::cerr << "[Region " << region_id << "] region state changed, exit zprofile (statistics) before complete" << std::endl;
-        return true;
+        return interrupt;
     }
     if (!IsSameRegionSpectralConfig(region_id, num_profiles, profile_index, profile_stokes, config_stats)) {
         std::cerr << "[Region " << region_id << "] region requirement changed, exit zprofile (statistics) before complete" << std::endl;
-        return true;
+        return interrupt;
     }
-    return false;
+    interrupt = false;
+    return interrupt;
 }
 
 bool Frame::IsConnected() {
     return _connected;
+}
+
+bool Frame::IsSameRegionId(int region_id) {
+    return (_region_id == region_id);
 }
 
 bool Frame::IsSameRegionState(int region_id, const RegionState& region_state) {
@@ -1460,6 +1485,10 @@ void Frame::SetConnectionFlag(bool connected) {
 
 void Frame::SetCursorXy(float x, float y) {
     _cursor_xy = CursorXy(x, y);
+}
+
+void Frame::SetRegionId(int region_id) {
+    _region_id = region_id;
 }
 
 RegionState Frame::GetRegionState(int region_id) {

--- a/Frame.cc
+++ b/Frame.cc
@@ -1453,22 +1453,25 @@ bool Frame::IsSameRegionState(int region_id, const RegionState& region_state) {
 
 bool Frame::IsSameRegionSpectralConfig(int region_id, int num_profiles, int profile_index, int profile_stokes,
     const std::vector<int>& config_stats) {
+    bool is_same(false);
     if (_regions.count(region_id)) {
         auto& region = _regions[region_id];
         // check is number of profiles changed
         size_t new_num_profiles(region->NumSpectralProfiles());
         if ((new_num_profiles == 0) || (new_num_profiles != num_profiles)) {
-            return false;
+            return is_same;
         }
         // check is profile stoke changed
         int new_profile_stokes = region->GetSpectralConfigStokes(profile_index);
-        if (new_profile_stokes == CURRENT_STOKES) {
-            new_profile_stokes = CurrentStokes();
+        if (new_profile_stokes >= CURRENT_STOKES) {
+            if (new_profile_stokes == CURRENT_STOKES) {
+                new_profile_stokes = CurrentStokes();
+            }
             if (new_profile_stokes != profile_stokes) {
-                return false;
+                return is_same;
             }
         } else {
-            return false;
+            return is_same;
         }
         // check are stats requirements changed
         std::vector<int> new_config_stats;
@@ -1476,7 +1479,7 @@ bool Frame::IsSameRegionSpectralConfig(int region_id, int num_profiles, int prof
             return (new_config_stats == config_stats);
         }
     }
-    return false;
+    return is_same;
 }
 
 void Frame::SetConnectionFlag(bool connected) {

--- a/Frame.cc
+++ b/Frame.cc
@@ -435,6 +435,10 @@ bool Frame::SetRegionSpectralRequirements(int region_id, const std::vector<CARTA
     if (_regions.count(region_id)) {
         auto& region = _regions[region_id];
         region_ok = region->SetSpectralRequirements(profiles, NumStokes());
+        // set the current requested region id
+        if (profiles.size() > 0) {
+            SetRegionId(region_id);
+        }
     }
     return region_ok;
 }
@@ -1245,7 +1249,7 @@ bool Frame::GetPointSpectralData(std::vector<float>& data, int region_id, casaco
                 // start the timer
                 auto t_start = std::chrono::high_resolution_clock::now();
                 // check if region point changed from subimage point
-                if ((region_id == CURSOR_REGION_ID) && (Interrupt(_cursor_xy, subimage_cursor))) {
+                if ((region_id == CURSOR_REGION_ID) && (Interrupt(region_id, _cursor_xy, subimage_cursor))) {
                     return false; // cursor moved
                 }
                 if (region_id > CURSOR_REGION_ID) {
@@ -1253,7 +1257,7 @@ bool Frame::GetPointSpectralData(std::vector<float>& data, int region_id, casaco
                         std::vector<CARTA::Point> region_points = _regions[region_id]->GetControlPoints();
                         // round the region cursor float values since subimage cursor comes from IPosition
                         CursorXy region_cursor(round(region_points[0].x()), round(region_points[0].y()));
-                        if (Interrupt(region_cursor, subimage_cursor)) { // point region moved
+                        if (Interrupt(region_id, region_cursor, subimage_cursor)) { // point region moved
                             return false;
                         }
                     } else { // region closed
@@ -1390,10 +1394,14 @@ bool Frame::GetRegionSpectralData(int region_id, int profile_index, int profile_
     return data_ok;
 }
 
-bool Frame::Interrupt(const CursorXy& cursor1, const CursorXy& cursor2) {
+bool Frame::Interrupt(int region_id, const CursorXy& cursor1, const CursorXy& cursor2) {
     bool interrupt(true);
     if (!IsConnected()) {
         std::cerr << "Closing image, exit zprofile before complete" << std::endl;
+        return interrupt;
+    }
+    if (!IsSameRegionId(region_id)) {
+        std::cerr << "[Region " << region_id << "] region changed, exit zprofile (statistics) before complete" << std::endl;
         return interrupt;
     }
     if (!(cursor1 == cursor2)) {
@@ -1410,6 +1418,10 @@ bool Frame::Interrupt(int region_id, const RegionState& region_state) {
         std::cerr << "[Region " << region_id << "] closing image, exit zprofile (statistics) before complete" << std::endl;
         return interrupt;
     }
+    if (!IsSameRegionId(region_id)) {
+        std::cerr << "[Region " << region_id << "] region changed, exit zprofile (statistics) before complete" << std::endl;
+        return interrupt;
+    }
     if (!IsSameRegionState(region_id, region_state)) {
         std::cerr << "[Region " << region_id << "] region state changed, exit zprofile (statistics) before complete" << std::endl;
         return interrupt;
@@ -1422,6 +1434,10 @@ bool Frame::Interrupt(int region_id, const RegionState& region_state, const ZPro
     bool interrupt(true);
     if (!IsConnected()) {
         std::cerr << "[Region " << region_id << "] closing image, exit zprofile (statistics) before complete" << std::endl;
+        return interrupt;
+    }
+    if (!IsSameRegionId(region_id)) {
+        std::cerr << "[Region " << region_id << "] region changed, exit zprofile (statistics) before complete" << std::endl;
         return interrupt;
     }
     if (!IsSameRegionState(region_id, region_state)) {
@@ -1438,6 +1454,10 @@ bool Frame::Interrupt(int region_id, const RegionState& region_state, const ZPro
 
 bool Frame::IsConnected() {
     return _connected;
+}
+
+bool Frame::IsSameRegionId(int region_id) {
+    return (_region_id == region_id);
 }
 
 bool Frame::IsSameRegionState(int region_id, const RegionState& region_state) {
@@ -1463,6 +1483,10 @@ void Frame::SetConnectionFlag(bool connected) {
 
 void Frame::SetCursorXy(float x, float y) {
     _cursor_xy = CursorXy(x, y);
+}
+
+void Frame::SetRegionId(int region_id) {
+    _region_id = region_id;
 }
 
 RegionState Frame::GetRegionState(int region_id) {

--- a/Frame.cc
+++ b/Frame.cc
@@ -436,10 +436,6 @@ bool Frame::SetRegionSpectralRequirements(int region_id, const std::vector<CARTA
     if (_regions.count(region_id)) {
         auto& region = _regions[region_id];
         region_ok = region->SetSpectralRequirements(profiles, NumStokes());
-        // set the current requested region id
-        if (profiles.size() > 0) {
-            SetRegionId(region_id);
-        }
     }
     return region_ok;
 }
@@ -1402,10 +1398,6 @@ bool Frame::Interrupt(int region_id, const CursorXy& cursor1, const CursorXy& cu
         std::cerr << "Closing image/region, exit zprofile before complete" << std::endl;
         return interrupt;
     }
-    if (!IsSameRegionId(region_id)) {
-        std::cerr << "[Region " << region_id << "] region changed, exit zprofile (statistics) before complete" << std::endl;
-        return interrupt;
-    }
     if (!(cursor1 == cursor2)) {
         std::cerr << "Cursor/Point changed, exit zprofile before complete" << std::endl;
         return interrupt;
@@ -1420,10 +1412,6 @@ bool Frame::Interrupt(int region_id, const RegionState& region_state) {
         std::cerr << "[Region " << region_id << "] closing image/region, exit zprofile (statistics) before complete" << std::endl;
         return interrupt;
     }
-    if (!IsSameRegionId(region_id)) {
-        std::cerr << "[Region " << region_id << "] region changed, exit zprofile (statistics) before complete" << std::endl;
-        return interrupt;
-    }
     if (!IsSameRegionState(region_id, region_state)) {
         std::cerr << "[Region " << region_id << "] region state changed, exit zprofile (statistics) before complete" << std::endl;
         return interrupt;
@@ -1436,10 +1424,6 @@ bool Frame::Interrupt(int region_id, const RegionState& region_state, const ZPro
     bool interrupt(true);
     if (!IsConnected(region_id)) {
         std::cerr << "[Region " << region_id << "] closing image/region, exit zprofile (statistics) before complete" << std::endl;
-        return interrupt;
-    }
-    if (!IsSameRegionId(region_id)) {
-        std::cerr << "[Region " << region_id << "] region changed, exit zprofile (statistics) before complete" << std::endl;
         return interrupt;
     }
     if (!IsSameRegionState(region_id, region_state)) {
@@ -1459,10 +1443,6 @@ bool Frame::IsConnected(int region_id) {
         return (_connected && _regions[region_id]->IsConnected());
     }
     return _connected;
-}
-
-bool Frame::IsSameRegionId(int region_id) {
-    return (_region_id == region_id);
 }
 
 bool Frame::IsSameRegionState(int region_id, const RegionState& region_state) {
@@ -1488,10 +1468,6 @@ void Frame::SetConnectionFlag(bool connected) {
 
 void Frame::SetCursorXy(float x, float y) {
     _cursor_xy = CursorXy(x, y);
-}
-
-void Frame::SetRegionId(int region_id) {
-    _region_id = region_id;
 }
 
 RegionState Frame::GetRegionState(int region_id) {

--- a/Frame.h
+++ b/Frame.h
@@ -105,7 +105,7 @@ public:
     RegionState GetRegionState(int region_id);
 
     // Interrupt conditions
-    bool Interrupt(int region_id, const CursorXy& cursor1, const CursorXy& cursor2); // cursor and point regions
+    bool Interrupt(const CursorXy& cursor1, const CursorXy& cursor2); // cursor and point regions
     bool Interrupt(int region_id, const RegionState& region_state);
     bool Interrupt(int region_id, int num_profiles, int profile_index, int profile_stokes, const RegionState& region_state,
         const std::vector<int>& config_stats);
@@ -159,11 +159,9 @@ private:
     // Functions used to set cursor and region states
     void SetConnectionFlag(bool connected);
     void SetCursorXy(float x, float y);
-    void SetRegionId(int region_id);
 
     // Functions used to check cursor and region states
     bool IsConnected();
-    bool IsSameRegionId(int region_id);
     bool IsSameRegionState(int region_id, const RegionState& region_state);
     bool IsSameRegionSpectralConfig(
         int region_id, int num_profiles, int profile_index, int profile_stokes, const std::vector<int>& config_stats);
@@ -203,8 +201,6 @@ private:
     volatile bool _connected = true;
     // Current cursor's x-y coordinate
     CursorXy _cursor_xy;
-    // Current region id;
-    int _region_id;
 };
 
 #endif // CARTA_BACKEND__FRAME_H_

--- a/Frame.h
+++ b/Frame.h
@@ -107,7 +107,8 @@ public:
     // Interrupt conditions
     bool Interrupt(const CursorXy& cursor1, const CursorXy& cursor2); // cursor and point regions
     bool Interrupt(int region_id, const RegionState& region_state);
-    bool Interrupt(int region_id, int profile_index, const RegionState& region_state, const std::vector<int>& requested_stats);
+    bool Interrupt(int region_id, int num_profiles, int profile_index, int profile_stokes,
+        const RegionState& region_state, const std::vector<int>& config_stats);
 
 private:
     // Internal regions: image, cursor
@@ -152,18 +153,18 @@ private:
     bool GetPointSpectralData(std::vector<float>& data, int region_id, casacore::SubImage<float>& sub_image,
         const std::function<void(std::vector<float>, float)>& partial_results_callback);
     // get regional spectral profile (statistics) data
-    bool GetRegionSpectralData(std::vector<std::vector<double>>& stats_values, int region_id, int profile_index, int profile_stokes,
-        const std::function<void(std::vector<std::vector<double>>, float)>& partial_results_callback);
+    bool GetRegionSpectralData(std::vector<std::vector<double>>& stats_values, int region_id, int num_profiles, int profile_index,
+        int profile_stokes, const std::function<void(std::vector<std::vector<double>>, float)>& partial_results_callback);
 
     // Functions used to set cursor and region states
     void SetConnectionFlag(bool connected);
     void SetCursorXy(float x, float y);
-    void SetRegionSpectralRequests(int region_id, const std::vector<CARTA::SetSpectralRequirements_SpectralConfig>& profiles);
 
     // Functions used to check cursor and region states
     bool IsConnected();
     bool IsSameRegionState(int region_id, const RegionState& region_state);
-    bool AreSameRegionSpectralRequests(int region_id, int profile_index, const std::vector<int>& requested_stats);
+    bool IsSameRegionSpectralConfig(int region_id, int num_profiles, int profile_index, int profile_stokes,
+        const std::vector<int>& config_stats);
 
     // setup
     uint32_t _session_id;
@@ -200,8 +201,6 @@ private:
     volatile bool _connected = true;
     // Current cursor's x-y coordinate
     CursorXy _cursor_xy;
-    // Current region configs
-    std::unordered_map<int, RegionRequest> _region_requests;
 };
 
 #endif // CARTA_BACKEND__FRAME_H_

--- a/Frame.h
+++ b/Frame.h
@@ -152,9 +152,9 @@ private:
     // get point spectral profile data from subimage
     bool GetPointSpectralData(std::vector<float>& data, int region_id, casacore::SubImage<float>& sub_image,
         const std::function<void(std::vector<float>, float)>& partial_results_callback);
-    // get regional spectral profile (statistics) data
-    bool GetRegionSpectralData(std::vector<std::vector<double>>& stats_values, int region_id, int num_profiles, int profile_index,
-        int profile_stokes, const std::function<void(std::vector<std::vector<double>>, float)>& partial_results_callback);
+    // get region stats data
+    bool GetRegionSpectralData(int region_id, int num_profiles, int profile_index, int profile_stokes,
+        const std::function<void(std::vector<std::vector<double>>, float)>& partial_results_callback);
 
     // Functions used to set cursor and region states
     void SetConnectionFlag(bool connected);

--- a/Frame.h
+++ b/Frame.h
@@ -164,11 +164,9 @@ private:
     // Functions used to set cursor and region states
     void SetConnectionFlag(bool connected);
     void SetCursorXy(float x, float y);
-    void SetRegionId(int region_id);
 
     // Functions used to check cursor and region states
     bool IsConnected(int region_id);
-    bool IsSameRegionId(int region_id);
     bool IsSameRegionState(int region_id, const RegionState& region_state);
     bool IsSameRegionSpectralConfig(int region_id, const ZProfileWidget& config_stats);
 
@@ -207,8 +205,6 @@ private:
     volatile bool _connected = true;
     // Current cursor's x-y coordinate
     CursorXy _cursor_xy;
-    // Current region id;
-    int _region_id;
 };
 
 #endif // CARTA_BACKEND__FRAME_H_

--- a/Frame.h
+++ b/Frame.h
@@ -107,8 +107,8 @@ public:
     // Interrupt conditions
     bool Interrupt(int region_id, const CursorXy& cursor1, const CursorXy& cursor2); // cursor and point regions
     bool Interrupt(int region_id, const RegionState& region_state);
-    bool Interrupt(int region_id, int num_profiles, int profile_index, int profile_stokes,
-        const RegionState& region_state, const std::vector<int>& config_stats);
+    bool Interrupt(int region_id, int num_profiles, int profile_index, int profile_stokes, const RegionState& region_state,
+        const std::vector<int>& config_stats);
 
 private:
     // Internal regions: image, cursor
@@ -165,8 +165,8 @@ private:
     bool IsConnected();
     bool IsSameRegionId(int region_id);
     bool IsSameRegionState(int region_id, const RegionState& region_state);
-    bool IsSameRegionSpectralConfig(int region_id, int num_profiles, int profile_index, int profile_stokes,
-        const std::vector<int>& config_stats);
+    bool IsSameRegionSpectralConfig(
+        int region_id, int num_profiles, int profile_index, int profile_stokes, const std::vector<int>& config_stats);
 
     // setup
     uint32_t _session_id;

--- a/Frame.h
+++ b/Frame.h
@@ -158,7 +158,6 @@ private:
     // Functions used to set cursor and region states
     void SetConnectionFlag(bool connected);
     void SetCursorXy(float x, float y);
-    void SetRegionState(int region_id, std::string name, CARTA::RegionType type, std::vector<CARTA::Point> points, float rotation);
     void SetRegionSpectralRequests(int region_id, const std::vector<CARTA::SetSpectralRequirements_SpectralConfig>& profiles);
 
     // Functions used to check cursor and region states
@@ -201,8 +200,6 @@ private:
     volatile bool _connected = true;
     // Current cursor's x-y coordinate
     CursorXy _cursor_xy;
-    // Current region states
-    std::unordered_map<int, RegionState> _region_states;
     // Current region configs
     std::unordered_map<int, RegionRequest> _region_requests;
 };

--- a/Frame.h
+++ b/Frame.h
@@ -107,8 +107,7 @@ public:
     // Interrupt conditions
     bool Interrupt(const CursorXy& cursor1, const CursorXy& cursor2); // cursor and point regions
     bool Interrupt(int region_id, const RegionState& region_state);
-    bool Interrupt(int region_id, int num_profiles, int profile_index, int profile_stokes, const RegionState& region_state,
-        const std::vector<int>& config_stats);
+    bool Interrupt(int region_id, const RegionState& region_state, const ZProfileWidget& config_stats);
 
 private:
     // Internal regions: image, cursor
@@ -153,7 +152,7 @@ private:
     bool GetPointSpectralData(std::vector<float>& data, int region_id, casacore::SubImage<float>& sub_image,
         const std::function<void(std::vector<float>, float)>& partial_results_callback);
     // get region stats data
-    bool GetRegionSpectralData(int region_id, int num_profiles, int profile_index, int profile_stokes,
+    bool GetRegionSpectralData(int region_id, int profile_index, int profile_stokes,
         const std::function<void(std::vector<std::vector<double>>, float)>& partial_results_callback);
 
     // Functions used to set cursor and region states
@@ -163,8 +162,7 @@ private:
     // Functions used to check cursor and region states
     bool IsConnected();
     bool IsSameRegionState(int region_id, const RegionState& region_state);
-    bool IsSameRegionSpectralConfig(
-        int region_id, int num_profiles, int profile_index, int profile_stokes, const std::vector<int>& config_stats);
+    bool IsSameRegionSpectralConfig(int region_id, const ZProfileWidget& config_stats);
 
     // setup
     uint32_t _session_id;

--- a/Frame.h
+++ b/Frame.h
@@ -108,12 +108,14 @@ public:
     }
 
     // Get current region states
-    RegionState GetRegionState(int region_id);
+    bool GetRegionState(int region_id, RegionState& region_state);
+    // Get current region configs
+    bool GetRegionConfigs(int region_id, int profile_index, ZProfileWidget& config_stats);
 
     // Interrupt conditions
     bool Interrupt(int region_id, const CursorXy& cursor1, const CursorXy& cursor2); // cursor and point regions
-    bool Interrupt(int region_id, const RegionState& region_state);
-    bool Interrupt(int region_id, int profile_stokes, const RegionState& region_state, const ZProfileWidget& config_stats);
+    bool Interrupt(
+        int region_id, int profile_stokes, const RegionState& region_state, const ZProfileWidget& config_stats, bool is_HDF5 = false);
 
 private:
     // Internal regions: image, cursor
@@ -168,7 +170,7 @@ private:
     // Functions used to check cursor and region states
     bool IsConnected(int region_id);
     bool IsSameRegionState(int region_id, const RegionState& region_state);
-    bool IsSameRegionSpectralConfig(int region_id, int profile_stokes, const ZProfileWidget& config_stats);
+    bool IsSameRegionSpectralConfig(int region_id, int profile_stokes, const ZProfileWidget& config_stats, bool is_HDF5 = false);
 
     // setup
     uint32_t _session_id;

--- a/Frame.h
+++ b/Frame.h
@@ -157,7 +157,7 @@ private:
     // get cursor's x-y coordinate from subimage
     bool GetSubImageXy(casacore::SubImage<float>& sub_image, CursorXy& cursor_xy);
     // get point spectral profile data from subimage
-    bool GetPointSpectralData(std::vector<float>& data, int region_id, casacore::SubImage<float>& sub_image,
+    bool GetPointSpectralData(int region_id, casacore::SubImage<float>& sub_image,
         const std::function<void(std::vector<float>, float)>& partial_results_callback);
     // get region stats data
     bool GetRegionSpectralData(int region_id, int profile_index, int profile_stokes,

--- a/Frame.h
+++ b/Frame.h
@@ -113,7 +113,7 @@ public:
     // Interrupt conditions
     bool Interrupt(int region_id, const CursorXy& cursor1, const CursorXy& cursor2); // cursor and point regions
     bool Interrupt(int region_id, const RegionState& region_state);
-    bool Interrupt(int region_id, const RegionState& region_state, const ZProfileWidget& config_stats);
+    bool Interrupt(int region_id, int profile_stokes, const RegionState& region_state, const ZProfileWidget& config_stats);
 
 private:
     // Internal regions: image, cursor
@@ -168,7 +168,7 @@ private:
     // Functions used to check cursor and region states
     bool IsConnected(int region_id);
     bool IsSameRegionState(int region_id, const RegionState& region_state);
-    bool IsSameRegionSpectralConfig(int region_id, const ZProfileWidget& config_stats);
+    bool IsSameRegionSpectralConfig(int region_id, int profile_stokes, const ZProfileWidget& config_stats);
 
     // setup
     uint32_t _session_id;

--- a/Frame.h
+++ b/Frame.h
@@ -159,7 +159,7 @@ private:
         const std::function<void(std::vector<float>, float)>& partial_results_callback);
     // get region stats data
     bool GetRegionSpectralData(int region_id, int profile_index, int profile_stokes,
-        const std::function<void(std::vector<std::vector<double>>, float)>& partial_results_callback);
+        const std::function<void(std::map<CARTA::StatsType, std::vector<double>>, float)>& partial_results_callback);
 
     // Functions used to set cursor and region states
     void SetConnectionFlag(bool connected);

--- a/Frame.h
+++ b/Frame.h
@@ -105,7 +105,7 @@ public:
     RegionState GetRegionState(int region_id);
 
     // Interrupt conditions
-    bool Interrupt(const CursorXy& cursor1, const CursorXy& cursor2); // cursor and point regions
+    bool Interrupt(int region_id, const CursorXy& cursor1, const CursorXy& cursor2); // cursor and point regions
     bool Interrupt(int region_id, const RegionState& region_state);
     bool Interrupt(int region_id, int num_profiles, int profile_index, int profile_stokes,
         const RegionState& region_state, const std::vector<int>& config_stats);
@@ -159,9 +159,11 @@ private:
     // Functions used to set cursor and region states
     void SetConnectionFlag(bool connected);
     void SetCursorXy(float x, float y);
+    void SetRegionId(int region_id);
 
     // Functions used to check cursor and region states
     bool IsConnected();
+    bool IsSameRegionId(int region_id);
     bool IsSameRegionState(int region_id, const RegionState& region_state);
     bool IsSameRegionSpectralConfig(int region_id, int num_profiles, int profile_index, int profile_stokes,
         const std::vector<int>& config_stats);
@@ -201,6 +203,8 @@ private:
     volatile bool _connected = true;
     // Current cursor's x-y coordinate
     CursorXy _cursor_xy;
+    // Current region id;
+    int _region_id;
 };
 
 #endif // CARTA_BACKEND__FRAME_H_

--- a/Frame.h
+++ b/Frame.h
@@ -105,7 +105,7 @@ public:
     RegionState GetRegionState(int region_id);
 
     // Interrupt conditions
-    bool Interrupt(const CursorXy& cursor1, const CursorXy& cursor2); // cursor and point regions
+    bool Interrupt(int region_id, const CursorXy& cursor1, const CursorXy& cursor2); // cursor and point regions
     bool Interrupt(int region_id, const RegionState& region_state);
     bool Interrupt(int region_id, const RegionState& region_state, const ZProfileWidget& config_stats);
 
@@ -158,9 +158,11 @@ private:
     // Functions used to set cursor and region states
     void SetConnectionFlag(bool connected);
     void SetCursorXy(float x, float y);
+    void SetRegionId(int region_id);
 
     // Functions used to check cursor and region states
     bool IsConnected();
+    bool IsSameRegionId(int region_id);
     bool IsSameRegionState(int region_id, const RegionState& region_state);
     bool IsSameRegionSpectralConfig(int region_id, const ZProfileWidget& config_stats);
 
@@ -199,6 +201,8 @@ private:
     volatile bool _connected = true;
     // Current cursor's x-y coordinate
     CursorXy _cursor_xy;
+    // Current region id;
+    int _region_id;
 };
 
 #endif // CARTA_BACKEND__FRAME_H_

--- a/ImageData/FileLoader.cc
+++ b/ImageData/FileLoader.cc
@@ -462,8 +462,9 @@ bool FileLoader::UseRegionSpectralData(const std::shared_ptr<casacore::ArrayLatt
     return false;
 }
 
-bool FileLoader::GetRegionSpectralData(int stokes, int region_id, const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask,
-    IPos origin, const std::function<void(std::map<CARTA::StatsType, std::vector<double>>*, float)>& partial_results_callback) {
+bool FileLoader::GetRegionSpectralData(int region_id, int profile_index, int stokes,
+    const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask, IPos origin,
+    const std::function<void(std::map<CARTA::StatsType, std::vector<double>>*, float)>& partial_results_callback) {
     // Must be implemented in subclasses
     return false;
 }

--- a/ImageData/FileLoader.h
+++ b/ImageData/FileLoader.h
@@ -151,8 +151,9 @@ public:
     virtual bool GetCursorSpectralData(std::vector<float>& data, int stokes, int cursor_x, int count_x, int cursor_y, int count_y);
     // check if one can apply swizzled data under such image format and region condition
     virtual bool UseRegionSpectralData(const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask);
-    virtual bool GetRegionSpectralData(int stokes, int region_id, const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask,
-        IPos origin, const std::function<void(std::map<CARTA::StatsType, std::vector<double>>*, float)>& partial_results_callback);
+    virtual bool GetRegionSpectralData(int region_id, int profile_index, int stokes,
+        const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask, IPos origin,
+        const std::function<void(std::map<CARTA::StatsType, std::vector<double>>*, float)>& partial_results_callback);
     virtual bool GetPixelMaskSlice(casacore::Array<bool>& mask, const casacore::Slicer& slicer) = 0;
     virtual void SetFramePtr(Frame* frame);
 

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -778,9 +778,16 @@ int Region::NumStatsToLoad(int profile_index) {
     return 0;
 }
 
-bool Region::GetSpectralConfigStats(int profile_index, std::vector<int>& stats) {
+bool Region::GetSpectralConfigStats(int profile_index, ZProfileWidget& stats) {
     if (_region_profiler) {
         return _region_profiler->GetSpectralConfigStats(profile_index, stats);
+    }
+    return false;
+}
+
+bool Region::IsValidSpectralConfigStats(const ZProfileWidget& stats) {
+    if (_region_profiler) {
+        return _region_profiler->IsValidSpectralConfigStats(stats);
     }
     return false;
 }

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -926,3 +926,17 @@ void Region::FillNaNSpectralProfileData(CARTA::SpectralProfileData& profile_data
         }
     }
 }
+
+bool Region::InitStatsData(int profile_index, size_t profile_size, std::vector<std::vector<double>>& stats_data) {
+    bool data_ok(false);
+    int stats_size = NumStatsToLoad(profile_index);
+    if (stats_size > 0) {
+        std::vector<std::vector<double>> results(stats_size);
+        for (int i = 0; i < stats_size; ++i) {
+            results[i].resize(profile_size, std::numeric_limits<double>::quiet_NaN());
+        }
+        stats_data = std::move(results);
+        data_ok = true;
+    }
+    return data_ok;
+}

--- a/Region/Region.h
+++ b/Region/Region.h
@@ -91,7 +91,8 @@ public:
     void SetSpectralProfileAllStatsSent(int profile_index, bool sent);
     void SetAllSpectralProfileStatsUnsent(); // enable sending new profiles
     int GetSpectralConfigStokes(int profile_index);
-    bool GetSpectralConfigStats(int profile_index, std::vector<int>& stats);
+    bool GetSpectralConfigStats(int profile_index, ZProfileWidget& stats);
+    bool IsValidSpectralConfigStats(const ZProfileWidget& stats);
     bool GetSpectralProfileData(std::vector<std::vector<double>>& stats_values, int profile_index, casacore::ImageInterface<float>& image);
     void FillPointSpectralProfileData(CARTA::SpectralProfileData& profile_data, int profile_index, std::vector<float>& spectral_data);
     void FillSpectralProfileData(

--- a/Region/Region.h
+++ b/Region/Region.h
@@ -96,12 +96,11 @@ public:
     int GetSpectralConfigStokes(int profile_index);
     bool GetSpectralConfigStats(int profile_index, ZProfileWidget& stats);
     bool IsValidSpectralConfigStats(const ZProfileWidget& stats);
-    bool GetSpectralProfileData(std::vector<std::vector<double>>& stats_values, int profile_index, casacore::ImageInterface<float>& image);
+    bool GetSpectralProfileData(
+        std::map<CARTA::StatsType, std::vector<double>>& stats_values, int profile_index, casacore::ImageInterface<float>& image);
     void FillPointSpectralProfileData(CARTA::SpectralProfileData& profile_data, int profile_index, std::vector<float>& spectral_data);
     void FillSpectralProfileData(
         CARTA::SpectralProfileData& profile_data, int profile_index, std::map<CARTA::StatsType, std::vector<double>>& stats_values);
-    void FillSpectralProfileData(
-        CARTA::SpectralProfileData& profile_data, int profile_index, const std::vector<std::vector<double>>& stats_values);
     void FillNaNSpectralProfileData(CARTA::SpectralProfileData& profile_data, int profile_index);
 
     // Stats: pass through to RegionStats
@@ -115,7 +114,7 @@ public:
     RegionState GetRegionState();
 
     // Initialize the stats data
-    bool InitStatsData(int profile_index, size_t profile_size, std::vector<std::vector<double>>& stats_data);
+    bool InitStatsData(int profile_index, size_t profile_size, std::map<CARTA::StatsType, std::vector<double>>& stats_data);
 
     // Communication
     bool IsConnected();

--- a/Region/Region.h
+++ b/Region/Region.h
@@ -107,7 +107,11 @@ public:
     void FillStatsData(CARTA::RegionStatsData& stats_data, std::map<CARTA::StatsType, double>& stats_values);
     void FillNaNStatsData(CARTA::RegionStatsData& stats_data);
 
+    // Get current region state
     RegionState GetRegionState();
+
+    // Initialize the stats data
+    bool InitStatsData(int profile_index, size_t profile_size, std::vector<std::vector<double>>& stats_data);
 
 private:
     // bounds checking for Region parameters

--- a/Region/RegionProfiler.cc
+++ b/Region/RegionProfiler.cc
@@ -212,11 +212,24 @@ std::string RegionProfiler::GetSpectralCoordinate(int profile_index) {
     }
 }
 
-bool RegionProfiler::GetSpectralConfigStats(int profile_index, std::vector<int>& stats) {
+bool RegionProfiler::GetSpectralConfigStats(int profile_index, ZProfileWidget& stats) {
     // return stats_types at given index; return false if index out of range
     if (profile_index < _spectral_profiles.size()) {
-        stats = _spectral_profiles[profile_index].stats_types;
+        stats = ZProfileWidget(_spectral_profiles[profile_index].stokes_index, _spectral_profiles[profile_index].stats_types);
         return true;
+    }
+    return false;
+}
+
+bool RegionProfiler::IsValidSpectralConfigStats(const ZProfileWidget& stats) {
+    if (_spectral_profiles.size() > 0) {
+        for (const auto& spectral_profile : _spectral_profiles) {
+            if (stats.stokes_index == spectral_profile.stokes_index) {
+                if (stats.stats_types == spectral_profile.stats_types) {
+                    return true;
+                }
+            }
+        }
     }
     return false;
 }

--- a/Region/RegionProfiler.cc
+++ b/Region/RegionProfiler.cc
@@ -153,7 +153,7 @@ bool RegionProfiler::SetSpectralRequirements(
     }
     bool valid(false);
     _spectral_profiles = new_profiles;
-    if (configs.size() == _spectral_profiles.size()) {
+    if (configs.size() == NumSpectralProfiles()) {
         // Determine diff for required data streams
         DiffSpectralRequirements(last_profiles);
         valid = true;
@@ -185,7 +185,7 @@ size_t RegionProfiler::NumSpectralProfiles() {
 
 int RegionProfiler::NumStatsToLoad(int profile_index) {
     int num_unsent(0);
-    if (profile_index < _spectral_profiles.size()) {
+    if (profile_index < NumSpectralProfiles()) {
         SpectralProfile profile = _spectral_profiles[profile_index];
         for (auto sent : profile.profiles_sent) {
             if (!sent) {
@@ -198,14 +198,14 @@ int RegionProfiler::NumStatsToLoad(int profile_index) {
 
 int RegionProfiler::GetSpectralConfigStokes(int profile_index) {
     // return Stokes int value at given index; return false if index out of range
-    if (profile_index < _spectral_profiles.size()) {
+    if (profile_index < NumSpectralProfiles()) {
         return _spectral_profiles[profile_index].stokes_index;
     }
     return CURRENT_STOKES - 1; // invalid
 }
 
 std::string RegionProfiler::GetSpectralCoordinate(int profile_index) {
-    if (profile_index < _spectral_profiles.size()) {
+    if (profile_index < NumSpectralProfiles()) {
         return _spectral_profiles[profile_index].coordinate;
     } else {
         return std::string();
@@ -214,7 +214,7 @@ std::string RegionProfiler::GetSpectralCoordinate(int profile_index) {
 
 bool RegionProfiler::GetSpectralConfigStats(int profile_index, ZProfileWidget& stats) {
     // return stats_types at given index; return false if index out of range
-    if (profile_index < _spectral_profiles.size()) {
+    if (profile_index < NumSpectralProfiles()) {
         stats = ZProfileWidget(_spectral_profiles[profile_index].stokes_index, _spectral_profiles[profile_index].stats_types);
         return true;
     }
@@ -222,7 +222,8 @@ bool RegionProfiler::GetSpectralConfigStats(int profile_index, ZProfileWidget& s
 }
 
 bool RegionProfiler::IsValidSpectralConfigStats(const ZProfileWidget& stats) {
-    if (_spectral_profiles.size() > 0) {
+    // (NumSpectralProfiles() == 0) means the region id is removed from the frontend zprofile widgets
+    if (NumSpectralProfiles() > 0) {
         for (const auto& spectral_profile : _spectral_profiles) {
             if (stats.stokes_index == spectral_profile.stokes_index) {
                 if (stats.stats_types == spectral_profile.stats_types) {
@@ -236,7 +237,7 @@ bool RegionProfiler::IsValidSpectralConfigStats(const ZProfileWidget& stats) {
 
 bool RegionProfiler::GetSpectralStatsToLoad(int profile_index, std::vector<int>& stats) {
     // Return vector of stats that were not sent
-    if (profile_index < _spectral_profiles.size()) {
+    if (profile_index < NumSpectralProfiles()) {
         stats.clear();
         for (size_t i = 0; i < _spectral_profiles[profile_index].profiles_sent.size(); ++i) {
             if (!_spectral_profiles[profile_index].profiles_sent[i]) {
@@ -250,7 +251,7 @@ bool RegionProfiler::GetSpectralStatsToLoad(int profile_index, std::vector<int>&
 
 bool RegionProfiler::GetSpectralProfileStatSent(int profile_index, int stats_type) {
     bool stat_sent(false);
-    if (profile_index < _spectral_profiles.size()) {
+    if (profile_index < NumSpectralProfiles()) {
         SpectralProfile profile = _spectral_profiles[profile_index];
         for (size_t i = 0; i < profile.stats_types.size(); ++i) {
             if (profile.stats_types[i] == stats_type) {
@@ -263,7 +264,7 @@ bool RegionProfiler::GetSpectralProfileStatSent(int profile_index, int stats_typ
 }
 
 void RegionProfiler::SetSpectralProfileStatSent(int profile_index, int stats_type, bool sent) {
-    if (profile_index < _spectral_profiles.size()) {
+    if (profile_index < NumSpectralProfiles()) {
         for (size_t i = 0; i < _spectral_profiles[profile_index].stats_types.size(); ++i) {
             if (_spectral_profiles[profile_index].stats_types[i] == stats_type) {
                 _spectral_profiles[profile_index].profiles_sent[i] = sent;
@@ -274,7 +275,7 @@ void RegionProfiler::SetSpectralProfileStatSent(int profile_index, int stats_typ
 }
 
 void RegionProfiler::SetSpectralProfileAllStatsSent(int profile_index, bool sent) {
-    if (profile_index < _spectral_profiles.size()) {
+    if (profile_index < NumSpectralProfiles()) {
         for (size_t i = 0; i < _spectral_profiles[profile_index].profiles_sent.size(); ++i) {
             _spectral_profiles[profile_index].profiles_sent[i] = sent;
         }
@@ -282,7 +283,7 @@ void RegionProfiler::SetSpectralProfileAllStatsSent(int profile_index, bool sent
 }
 
 void RegionProfiler::SetAllSpectralProfilesUnsent() {
-    for (size_t i = 0; i < _spectral_profiles.size(); ++i) {
+    for (size_t i = 0; i < NumSpectralProfiles(); ++i) {
         for (size_t j = 0; j < _spectral_profiles[i].profiles_sent.size(); ++j) {
             _spectral_profiles[i].profiles_sent[j] = false;
         }

--- a/Region/RegionProfiler.h
+++ b/Region/RegionProfiler.h
@@ -7,6 +7,8 @@
 #include <utility>
 #include <vector>
 
+#include "../Util.h"
+
 #include <carta-protobuf/region_requirements.pb.h>
 
 namespace carta {
@@ -41,7 +43,8 @@ public:
     int NumStatsToLoad(int profile_index);
     int GetSpectralConfigStokes(int profile_index);
     std::string GetSpectralCoordinate(int profile_index);
-    bool GetSpectralConfigStats(int profile_index, std::vector<int>& stats); // all requested
+    bool GetSpectralConfigStats(int profile_index, ZProfileWidget& stats); // all requested
+    bool IsValidSpectralConfigStats(const ZProfileWidget& stats);
     bool GetSpectralStatsToLoad(int profile_index, std::vector<int>& stats); // diff of requested and already sent
     bool GetSpectralProfileStatSent(int profile_index, int stats_type);
     void SetSpectralProfileStatSent(int profile_index, int stats_type, bool sent);

--- a/Region/RegionStats.h
+++ b/Region/RegionStats.h
@@ -39,7 +39,7 @@ public:
     size_t NumStats();
     void FillStatsData(CARTA::RegionStatsData& stats_data, const casacore::ImageInterface<float>& image, int channel, int stokes);
     void FillStatsData(CARTA::RegionStatsData& stats_data, std::map<CARTA::StatsType, double>& stats_values);
-    bool CalcStatsValues(std::vector<std::vector<double>>& stats_values, const std::vector<int>& requested_stats,
+    bool CalcStatsValues(std::map<CARTA::StatsType, std::vector<double>>& stats_values, const std::vector<int>& requested_stats,
         const casacore::ImageInterface<float>& image, bool per_channel = true);
 
     // invalidate stored calculations for previous region settings

--- a/Util.h
+++ b/Util.h
@@ -132,4 +132,15 @@ struct RegionState {
     }
 };
 
+struct ZProfileWidget {
+    int stokes_index;
+    std::vector<int> stats_types;
+
+    ZProfileWidget() {}
+    ZProfileWidget(int stokes_index_, std::vector<int> stats_types_) {
+        stokes_index = stokes_index_;
+        stats_types = stats_types_;
+    }
+};
+
 #endif // CARTA_BACKEND__UTIL_H_

--- a/Util.h
+++ b/Util.h
@@ -132,32 +132,4 @@ struct RegionState {
     }
 };
 
-struct RegionRequest {
-    std::vector<CARTA::SetSpectralRequirements_SpectralConfig> config;
-    RegionRequest() {}
-    RegionRequest(std::vector<CARTA::SetSpectralRequirements_SpectralConfig> config_) {
-        config = config_;
-    }
-    void UpdateRequest(std::vector<CARTA::SetSpectralRequirements_SpectralConfig> config_) {
-        config.clear();
-        config = config_;
-    }
-    bool IsAmong(int profile_index, std::vector<int> other_stats) {
-        if (config.size() > profile_index) {
-            std::vector<int> requested_stats(config[profile_index].stats_types().begin(), config[profile_index].stats_types().end());
-            if (requested_stats.size() != other_stats.size()) {
-                return false;
-            }
-            for (int i = 0; i < requested_stats.size(); ++i) {
-                if (requested_stats[i] != other_stats[i]) {
-                    return false;
-                }
-            }
-        } else {
-            return false;
-        }
-        return true;
-    }
-};
-
 #endif // CARTA_BACKEND__UTIL_H_


### PR DESCRIPTION
Bellow in the order of commitments, I did:

1. Remove `_region_states` and `region_requests` from the `Frame`. Use the region states and region configs which are already stored in the `Region`.
2. Add `_region_id` in the `Frame` which represents the current region id for cursor or region spectral profile. And use it as an additional condition for interruption checks.