### PR TITLE
Always open HDF5 file as read-only

### DIFF
--- a/FileInfoLoader.cc
+++ b/FileInfoLoader.cc
@@ -238,7 +238,7 @@ bool FileInfoLoader::FillFileExtInfo(CARTA::FileInfoExtended* ext_info, std::str
 bool FileInfoLoader::FillHdf5ExtFileInfo(CARTA::FileInfoExtended* ext_info, std::string& hdu, std::string& message) {
     // Add extended info for HDF5 file
     try {
-        auto hdf_file_ptr = new casacore::HDF5File(_filename);
+        auto hdf_file_ptr = casacore::CountedPtr<casacore::HDF5File>(new casacore::HDF5File(_filename));
 
         if (hdu.empty()) { // use first
             hdu = casacore::HDF5Group::linkNames(*hdf_file_ptr)[0];
@@ -262,10 +262,8 @@ bool FileInfoLoader::FillHdf5ExtFileInfo(CARTA::FileInfoExtended* ext_info, std:
         casacore::uInt num_dims;
         casacore::IPosition data_shape;
 
-        auto counted_ptr = casacore::CountedPtr<casacore::HDF5File>(hdf_file_ptr);
-
         try {
-            casacore::HDF5Lattice<float> hdf5_lattice = casacore::HDF5Lattice<float>(counted_ptr, "DATA", hdu);
+            casacore::HDF5Lattice<float> hdf5_lattice = casacore::HDF5Lattice<float>(hdf_file_ptr, "DATA", hdu);
             data_shape = hdf5_lattice.shape();
             num_dims = data_shape.size();
         } catch (casacore::AipsError& err) {

--- a/Frame.cc
+++ b/Frame.cc
@@ -941,13 +941,13 @@ bool Frame::FillSpectralProfileData(
                         GetRegionSubImage(region_id, sub_image, profile_stokes, ChannelRange());
                         GetPointSpectralData(
                             spectral_data, region_id, sub_image, [&](std::vector<float> tmp_spectral_data, float progress) {
-                            CARTA::SpectralProfileData profile_data;
-                            profile_data.set_stokes(curr_stokes);
-                            profile_data.set_progress(progress);
-                            region->FillPointSpectralProfileData(profile_data, i, tmp_spectral_data);
-                            // send (partial) result to Session
-                            cb(profile_data);
-                        });
+                                CARTA::SpectralProfileData profile_data;
+                                profile_data.set_stokes(curr_stokes);
+                                profile_data.set_progress(progress);
+                                region->FillPointSpectralProfileData(profile_data, i, tmp_spectral_data);
+                                // send (partial) result to Session
+                                cb(profile_data);
+                            });
                         guard.unlock();
                     }
                 } else { // statistics
@@ -968,7 +968,8 @@ bool Frame::FillSpectralProfileData(
                     try {
                         // check is the region mask valid (outside the lattice or not)
                         mask = region->XyMask();
-                    } catch (...) { }
+                    } catch (...) {
+                    }
                     guard.unlock();
                     if (mask) {
                         // if region mask is valid, then check is swizzled data available
@@ -1226,8 +1227,7 @@ bool Frame::GetSubImageXy(casacore::SubImage<float>& sub_image, CursorXy& cursor
     return result;
 }
 
-bool Frame::GetPointSpectralData(
-    std::vector<float>& data, int region_id, casacore::SubImage<float>& sub_image,
+bool Frame::GetPointSpectralData(std::vector<float>& data, int region_id, casacore::SubImage<float>& sub_image,
     const std::function<void(std::vector<float>, float)>& partial_results_callback) {
     // slice image data for point region (including cursor)
     bool data_ok(false);
@@ -1257,7 +1257,7 @@ bool Frame::GetPointSpectralData(
                     if (_regions.count(region_id)) {
                         std::vector<CARTA::Point> region_points = _regions[region_id]->GetControlPoints();
                         // round the region cursor float values since subimage cursor comes from IPosition
-                        CursorXy region_cursor(round(region_points[0].x()), round(region_points[0].y())); 
+                        CursorXy region_cursor(round(region_points[0].x()), round(region_points[0].y()));
                         if (Interrupt(region_cursor, subimage_cursor)) { // point region moved
                             return false;
                         }

--- a/ImageData/CartaHdf5Image.cc
+++ b/ImageData/CartaHdf5Image.cc
@@ -21,7 +21,9 @@ CartaHdf5Image::CartaHdf5Image(const std::string& filename, const std::string& a
       _valid(false),
       _pixel_mask(nullptr),
       _mask_spec(mask_spec) {
-    _lattice = casacore::HDF5Lattice<float>(filename, array_name, hdu);
+    auto hdf_file_ptr = new casacore::HDF5File(filename);
+    auto counted_ptr = casacore::CountedPtr<casacore::HDF5File>(hdf_file_ptr);
+    _lattice = casacore::HDF5Lattice<float>(counted_ptr, array_name, hdu);
     _shape = _lattice.shape();
     _pixel_mask = new casacore::ArrayLattice<bool>();
     _valid = Setup(filename, hdu, info);

--- a/ImageData/CartaHdf5Image.cc
+++ b/ImageData/CartaHdf5Image.cc
@@ -21,9 +21,7 @@ CartaHdf5Image::CartaHdf5Image(const std::string& filename, const std::string& a
       _valid(false),
       _pixel_mask(nullptr),
       _mask_spec(mask_spec) {
-    auto hdf_file_ptr = new casacore::HDF5File(filename);
-    auto counted_ptr = casacore::CountedPtr<casacore::HDF5File>(hdf_file_ptr);
-    _lattice = casacore::HDF5Lattice<float>(counted_ptr, array_name, hdu);
+    _lattice = casacore::HDF5Lattice<float>(casacore::CountedPtr<casacore::HDF5File>(new casacore::HDF5File(filename)), array_name, hdu);
     _shape = _lattice.shape();
     _pixel_mask = new casacore::ArrayLattice<bool>();
     _valid = Setup(filename, hdu, info);

--- a/ImageData/Hdf5Loader.h
+++ b/ImageData/Hdf5Loader.h
@@ -62,8 +62,10 @@ void Hdf5Loader::OpenFile(const std::string& hdu, const CARTA::FileInfoExtended*
 
     // Load swizzled image lattice
     if (HasData(FileInfo::Data::SWIZZLED)) {
+        auto hdf_file_ptr = new casacore::HDF5File(_filename);
+        auto counted_ptr = casacore::CountedPtr<casacore::HDF5File>(hdf_file_ptr);
         _swizzled_image = std::unique_ptr<casacore::HDF5Lattice<float>>(
-            new casacore::HDF5Lattice<float>(_filename, DataSetToString(FileInfo::Data::SWIZZLED), hdu));
+            new casacore::HDF5Lattice<float>(counted_ptr, DataSetToString(FileInfo::Data::SWIZZLED), hdu));
     }
 }
 

--- a/ImageData/Hdf5Loader.h
+++ b/ImageData/Hdf5Loader.h
@@ -62,10 +62,8 @@ void Hdf5Loader::OpenFile(const std::string& hdu, const CARTA::FileInfoExtended*
 
     // Load swizzled image lattice
     if (HasData(FileInfo::Data::SWIZZLED)) {
-        auto hdf_file_ptr = new casacore::HDF5File(_filename);
-        auto counted_ptr = casacore::CountedPtr<casacore::HDF5File>(hdf_file_ptr);
-        _swizzled_image = std::unique_ptr<casacore::HDF5Lattice<float>>(
-            new casacore::HDF5Lattice<float>(counted_ptr, DataSetToString(FileInfo::Data::SWIZZLED), hdu));
+        _swizzled_image = std::unique_ptr<casacore::HDF5Lattice<float>>(new casacore::HDF5Lattice<float>(
+            casacore::CountedPtr<casacore::HDF5File>(new casacore::HDF5File(_filename)), DataSetToString(FileInfo::Data::SWIZZLED), hdu));
     }
 }
 

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -690,18 +690,17 @@ void Region::FillNaNStatsData(CARTA::RegionStatsData& stats_data) {
     for (int i = CARTA::StatsType::NumPixels; i < CARTA::StatsType::Blc; ++i) {
         auto carta_stats_type = static_cast<CARTA::StatsType>(i);
         double nan_value = std::numeric_limits<double>::quiet_NaN();
-	if (carta_stats_type == CARTA::StatsType::NanCount) { // not implemented
+        if (carta_stats_type == CARTA::StatsType::NanCount) { // not implemented
             continue;
         }
-	if (carta_stats_type == CARTA::StatsType::NumPixels) {
+        if (carta_stats_type == CARTA::StatsType::NumPixels) {
             nan_value = 0.0;
         }
-	auto stats_value = stats_data.add_statistics();
+        auto stats_value = stats_data.add_statistics();
         stats_value->set_stats_type(carta_stats_type);
         stats_value->set_value(nan_value);
     }
 }
-
 
 // ***********************************
 // RegionProfiler


### PR DESCRIPTION
I believe that this causes the HDF5 file to be opened as read-only in all three places where we do this, which fixes #87 (files open in CARTA are blocked from being opened by other processes) and #76 (if the info loader fails to open a file, it stays blocked until CARTA is shut down).

But this seems suspiciously easy, so I'd appreciate a review. Is this correct use of `CountedPtr`, and is it OK to remove the explicit closing of the HDF5 group and file in the info loader (as far as I can see, the destructors of the casacore classes clean them up automatically)?