### PR TITLE
Extend code for using mask creation to check if the region is out of bounds to point regions.

### DIFF
--- a/Frame.cc
+++ b/Frame.cc
@@ -889,12 +889,34 @@ bool Frame::FillSpectralProfileData(
         if (!region->IsValid()) {
             return false;
         }
+
+        int curr_stokes(CurrentStokes());
+
+        const casacore::ArrayLattice<casacore::Bool>* mask = nullptr;
+        std::unique_lock<std::mutex> guard(_image_mutex);
+        try {
+            // check is the region mask valid (outside the lattice or not)
+            mask = region->XyMask();
+        } catch (casacore::AipsError& err) {
+        }
+        guard.unlock();
+        if (!mask) {
+            // if region mask not valid, send a NaN to the frontend
+            CARTA::SpectralProfileData profile_data;
+            profile_data.set_stokes(curr_stokes);
+            profile_data.set_progress(1.0);
+            region->FillNaNSpectralProfileData(profile_data, 0);
+            // send empty (NaN) result to Session
+            cb(profile_data);
+            profile_ok = true;
+            return profile_ok;
+        }
+
         size_t num_profiles(region->NumSpectralProfiles());
         if (num_profiles == 0) {
             return false; // not requested
         }
         // set profile parameters
-        int curr_stokes(CurrentStokes());
         // send profile and stats together
         // set stats profiles
         for (size_t i = 0; i < num_profiles; ++i) {
@@ -962,29 +984,10 @@ bool Frame::FillSpectralProfileData(
                         profile_ok = true;
                         return profile_ok;
                     }
-                    bool use_swizzled_data(false);
-                    const casacore::ArrayLattice<casacore::Bool>* mask = nullptr;
-                    std::unique_lock<std::mutex> guard(_image_mutex);
-                    try {
-                        // check is the region mask valid (outside the lattice or not)
-                        mask = region->XyMask();
-                    } catch (...) {
-                    }
-                    guard.unlock();
-                    if (mask) {
-                        // if region mask is valid, then check is swizzled data available
-                        use_swizzled_data = _loader->UseRegionSpectralData(mask);
-                    } else {
-                        // if region mask not valid, send a NaN to the frontend
-                        CARTA::SpectralProfileData profile_data;
-                        profile_data.set_stokes(curr_stokes);
-                        profile_data.set_progress(1.0);
-                        region->FillNaNSpectralProfileData(profile_data, i);
-                        // send empty (NaN) result to Session
-                        cb(profile_data);
-                        profile_ok = true;
-                        return profile_ok;
-                    }
+
+                    // if region mask is valid, then check is swizzled data available
+                    bool use_swizzled_data(_loader->UseRegionSpectralData(mask));
+
                     if (use_swizzled_data) {
                         std::unique_lock<std::mutex> guard(_image_mutex);
                         _loader->GetRegionSpectralData(profile_stokes, region_id, mask, region->XyOrigin(),

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -537,23 +537,25 @@ const casacore::ArrayLattice<casacore::Bool>* Region::XyMask() {
     casacore::ArrayLattice<casacore::Bool>* mask;
 
     if (_xy_region != nullptr) {
-        // get extended region
-        auto extended_region = static_cast<casacore::LCExtension*>(_xy_region->toLCRegion(_coord_sys, _image_shape));
+        // get extended region (or original region for points)
+        auto lc_region = _xy_region->toLCRegion(_coord_sys, _image_shape);
 
         // get original region
         switch (_type) {
             case CARTA::POINT: {
-                auto region = static_cast<const casacore::LCBox&>(extended_region->region());
-                mask = new casacore::ArrayLattice<casacore::Bool>(region.getMask());
+                auto region = static_cast<const casacore::LCBox*>(lc_region);
+                mask = new casacore::ArrayLattice<casacore::Bool>(region->getMask());
                 break;
             }
             case CARTA::RECTANGLE:
             case CARTA::POLYGON: {
+                auto extended_region = static_cast<casacore::LCExtension*>(lc_region);
                 auto region = static_cast<const casacore::LCPolygon&>(extended_region->region());
                 mask = new casacore::ArrayLattice<casacore::Bool>(region.getMask());
                 break;
             }
             case CARTA::ELLIPSE: {
+                auto extended_region = static_cast<casacore::LCExtension*>(lc_region);
                 auto region = static_cast<const casacore::LCEllipsoid&>(extended_region->region());
                 mask = new casacore::ArrayLattice<casacore::Bool>(region.getMask());
                 break;


### PR DESCRIPTION
Should fix #292.

* The code in `Frame::FillSpectralProfileData` which attempts to create a mask (which will fail if the region is entirely outside the image) is now applied to all regions.
* `Region::XyMask` now handles point regions correctly and no longer segfaults. It produces empty masks for point regions, which is not terribly useful, but it fails in a consistent way if the point region is outside the image (which allows us to check all regions in the same way).