### PR TITLE
Delete a Region after its spectral profile is finished

### DIFF
--- a/Frame.cc
+++ b/Frame.cc
@@ -961,11 +961,12 @@ bool Frame::FillSpectralProfileData(
                         region->FillPointSpectralProfileData(profile_data, i, spectral_data);
                         // send result to Session
                         cb(profile_data);
+                        profile_ok = true;
                     } else {
                         casacore::SubImage<float> sub_image;
                         std::unique_lock<std::mutex> guard(_image_mutex);
                         GetRegionSubImage(region_id, sub_image, profile_stokes, ChannelRange());
-                        GetPointSpectralData(
+                        profile_ok = GetPointSpectralData(
                             spectral_data, region_id, sub_image, [&](std::vector<float> tmp_spectral_data, float progress) {
                                 CARTA::SpectralProfileData profile_data;
                                 profile_data.set_stokes(curr_stokes);
@@ -994,7 +995,7 @@ bool Frame::FillSpectralProfileData(
 
                     if (use_swizzled_data) {
                         std::unique_lock<std::mutex> guard(_image_mutex);
-                        _loader->GetRegionSpectralData(profile_stokes, region_id, mask, region->XyOrigin(),
+                        profile_ok = _loader->GetRegionSpectralData(profile_stokes, region_id, mask, region->XyOrigin(),
                             [&](std::map<CARTA::StatsType, std::vector<double>>* stats_values, float progress) {
                                 CARTA::SpectralProfileData profile_data;
                                 profile_data.set_stokes(curr_stokes);
@@ -1007,7 +1008,7 @@ bool Frame::FillSpectralProfileData(
                     } else {
                         std::vector<std::vector<double>> stats_values;
                         std::unique_lock<std::mutex> guard(_image_mutex);
-                        GetRegionSpectralData(
+                        profile_ok = GetRegionSpectralData(
                             stats_values, region_id, i, profile_stokes, [&](std::vector<std::vector<double>> results, float progress) {
                                 CARTA::SpectralProfileData profile_data;
                                 profile_data.set_stokes(curr_stokes);
@@ -1024,8 +1025,6 @@ bool Frame::FillSpectralProfileData(
 
         // Decrease the spectral profile count
         region->DecreaseZProfileCount();
-
-        profile_ok = true;
     }
     return profile_ok;
 }

--- a/Frame.cc
+++ b/Frame.cc
@@ -890,10 +890,6 @@ bool Frame::FillSpectralProfileData(
         if (!region->IsValid()) {
             return false;
         }
-
-        // Increase the spectral profile count
-        region->IncreaseZProfileCount();
-
         size_t num_profiles(region->NumSpectralProfiles());
         if (num_profiles == 0) {
             return false; // not requested
@@ -1022,9 +1018,6 @@ bool Frame::FillSpectralProfileData(
                 }
             }
         }
-
-        // Decrease the spectral profile count
-        region->DecreaseZProfileCount();
     }
     return profile_ok;
 }

--- a/Frame.h
+++ b/Frame.h
@@ -94,10 +94,16 @@ public:
     // set the flag connected = false, in order to stop the jobs and wait for jobs finished
     void DisconnectCalled();
 
-    void IncreaseZProfileCount() {
+    void IncreaseZProfileCount(int region_id) {
+        if (_regions.count(region_id)) {
+            _regions[region_id]->IncreaseZProfileCount();
+        }
         ++_z_profile_count;
     }
-    void DecreaseZProfileCount() {
+    void DecreaseZProfileCount(int region_id) {
+        if (_regions.count(region_id)) {
+            _regions[region_id]->DecreaseZProfileCount();
+        }
         --_z_profile_count;
     }
 

--- a/Frame.h
+++ b/Frame.h
@@ -105,7 +105,7 @@ public:
     RegionState GetRegionState(int region_id);
 
     // Interrupt conditions
-    bool Interrupt(const CursorXy& cursor1, const CursorXy& cursor2); // cursor and point regions
+    bool Interrupt(int region_id, const CursorXy& cursor1, const CursorXy& cursor2); // cursor and point regions
     bool Interrupt(int region_id, const RegionState& region_state);
     bool Interrupt(int region_id, int profile_index, const RegionState& region_state, const std::vector<int>& requested_stats);
 
@@ -162,7 +162,7 @@ private:
     void SetRegionSpectralRequests(int region_id, const std::vector<CARTA::SetSpectralRequirements_SpectralConfig>& profiles);
 
     // Functions used to check cursor and region states
-    bool IsConnected();
+    bool IsConnected(int region_id);
     bool IsSameRegionState(int region_id, const RegionState& region_state);
     bool AreSameRegionSpectralRequests(int region_id, int profile_index, const std::vector<int>& requested_stats);
 

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -928,3 +928,18 @@ void Region::FillNaNSpectralProfileData(CARTA::SpectralProfileData& profile_data
         }
     }
 }
+
+void Region::SetConnectionFlag(bool connected) {
+    _connected = connected;
+}
+
+bool Region::IsConnected() {
+    return _connected;
+}
+
+void Region::DisconnectCalled() {
+    SetConnectionFlag(false); // set a false flag to interrupt the running jobs in the Region
+    while (_z_profile_count) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    } // wait for the jobs finished
+}

--- a/Region/Region.h
+++ b/Region/Region.h
@@ -10,6 +10,9 @@
 
 #include <carta-protobuf/spectral_profile.pb.h>
 
+#include <tbb/atomic.h>
+#include <thread>
+
 #include "../InterfaceConstants.h"
 #include "../Util.h"
 #include "RegionProfiler.h"
@@ -109,6 +112,17 @@ public:
 
     RegionState GetRegionState();
 
+    // Communication
+    bool IsConnected();
+    void DisconnectCalled();
+
+    void IncreaseZProfileCount() {
+        ++_z_profile_count;
+    }
+    void DecreaseZProfileCount() {
+        --_z_profile_count;
+    }
+
 private:
     // bounds checking for Region parameters
     bool SetPoints(const std::vector<CARTA::Point>& points);
@@ -134,6 +148,8 @@ private:
     std::string GetSpectralCoordinate(int profile_index);
     bool GetSpectralStatsToLoad(int profile_index, std::vector<int>& stats);
     bool GetSpectralProfileStatSent(int profile_index, int stats_type);
+
+    void SetConnectionFlag(bool connected);
 
     // region definition (ICD SET_REGION parameters)
     std::string _name;
@@ -161,6 +177,12 @@ private:
     // classes for requirements, calculations
     std::unique_ptr<carta::RegionStats> _region_stats;
     std::unique_ptr<carta::RegionProfiler> _region_profiler;
+
+    // Communication
+    volatile bool _connected = true;
+
+    // Spectral profile counter, which is used to determine whether the Region object can be destroyed (_z_profile_count == 0 ?).
+    tbb::atomic<int> _z_profile_count;
 };
 
 } // namespace carta

--- a/Session.cc
+++ b/Session.cc
@@ -447,12 +447,12 @@ void Session::OnSetRegion(const CARTA::SetRegion& message, uint32_t request_id) 
     SendEvent(CARTA::EventType::SET_REGION_ACK, request_id, ack);
     // update data streams if requirements set
     if (success && _frames.at(file_id)->RegionChanged(region_id)) {
-        _frames.at(file_id)->IncreaseZProfileCount();
+        _frames.at(file_id)->IncreaseZProfileCount(region_id);
         SendRegionStatsData(file_id, region_id);
         SendSpatialProfileData(file_id, region_id);
         SendRegionHistogramData(file_id, region_id);
         SendSpectralProfileData(file_id, region_id);
-        _frames.at(file_id)->DecreaseZProfileCount();
+        _frames.at(file_id)->DecreaseZProfileCount(region_id);
     }
 }
 
@@ -824,7 +824,7 @@ bool Session::SendSpectralProfileData(int file_id, int region_id, bool channel_c
             if (region_id == CURSOR_REGION_ID && !_frames.at(file_id)->IsCursorSet()) {
                 return data_sent; // do not send profile unless frontend set cursor
             }
-            _frames.at(file_id)->IncreaseZProfileCount();
+            _frames.at(file_id)->IncreaseZProfileCount(region_id);
             bool profile_ok = _frames.at(file_id)->FillSpectralProfileData(
                 [&](CARTA::SpectralProfileData profile_data) {
                     if (profile_data.profiles_size() > 0) { // update needed (not for new channel)
@@ -835,7 +835,7 @@ bool Session::SendSpectralProfileData(int file_id, int region_id, bool channel_c
                     }
                 },
                 region_id, channel_changed, stokes_changed);
-            _frames.at(file_id)->DecreaseZProfileCount();
+            _frames.at(file_id)->DecreaseZProfileCount(region_id);
             if (profile_ok) {
                 data_sent = true;
             }
@@ -889,7 +889,7 @@ void Session::UpdateRegionData(int file_id, bool send_image_histogram, bool chan
         std::vector<int> regions(_frames.at(file_id)->GetRegionIds());
         for (auto region_id : regions) {
             // CHECK FOR CANCEL HERE ??
-            _frames.at(file_id)->IncreaseZProfileCount();
+            _frames.at(file_id)->IncreaseZProfileCount(region_id);
             SendRegionStatsData(file_id, region_id);
             SendSpatialProfileData(file_id, region_id, stokes_changed);
             if ((region_id == IMAGE_REGION_ID) && send_image_histogram) {
@@ -898,7 +898,7 @@ void Session::UpdateRegionData(int file_id, bool send_image_histogram, bool chan
                 SendRegionHistogramData(file_id, region_id, channel_changed);
             }
             SendSpectralProfileData(file_id, region_id, channel_changed, stokes_changed);
-            _frames.at(file_id)->DecreaseZProfileCount();
+            _frames.at(file_id)->DecreaseZProfileCount(region_id);
         }
     }
 }


### PR DESCRIPTION
This is for issue #299.

While deleting the Region:
1. Set the connection flag is false to interrupt the running job.
2. Wait for the job finished before deleting the Region.