### PR TITLE
Use shared pointers for some attributes to avoid causing crashes through premature deletion

### DIFF
--- a/Frame.cc
+++ b/Frame.cc
@@ -920,14 +920,12 @@ bool Frame::FillSpectralProfileData(
                 }
 
                 // Return NaNs if the region is entirely outside the image
-                const casacore::ArrayLattice<casacore::Bool>* mask = nullptr;
-                std::unique_lock<std::mutex> guard(_image_mutex);
+                std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask;
                 try {
                     // check is the region mask valid (outside the lattice or not)
                     mask = region->XyMask();
                 } catch (casacore::AipsError& err) {
                 }
-                guard.unlock();
                 if (!mask) {
                     // if region mask not valid, send a NaN to the frontend
                     CARTA::SpectralProfileData profile_data;

--- a/ImageData/FileLoader.cc
+++ b/ImageData/FileLoader.cc
@@ -457,13 +457,13 @@ bool FileLoader::GetCursorSpectralData(std::vector<float>& data, int stokes, int
     return false;
 }
 
-bool FileLoader::UseRegionSpectralData(const casacore::ArrayLattice<casacore::Bool>* mask) {
+bool FileLoader::UseRegionSpectralData(const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask) {
     // Must be implemented in subclasses
     return false;
 }
 
-bool FileLoader::GetRegionSpectralData(int stokes, int region_id, const casacore::ArrayLattice<casacore::Bool>* mask, IPos origin,
-    const std::function<void(std::map<CARTA::StatsType, std::vector<double>>*, float)>& partial_results_callback) {
+bool FileLoader::GetRegionSpectralData(int stokes, int region_id, const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask,
+    IPos origin, const std::function<void(std::map<CARTA::StatsType, std::vector<double>>*, float)>& partial_results_callback) {
     // Must be implemented in subclasses
     return false;
 }

--- a/ImageData/FileLoader.h
+++ b/ImageData/FileLoader.h
@@ -150,9 +150,9 @@ public:
     virtual ImageRef LoadData(FileInfo::Data ds) = 0;
     virtual bool GetCursorSpectralData(std::vector<float>& data, int stokes, int cursor_x, int count_x, int cursor_y, int count_y);
     // check if one can apply swizzled data under such image format and region condition
-    virtual bool UseRegionSpectralData(const casacore::ArrayLattice<casacore::Bool>* mask);
-    virtual bool GetRegionSpectralData(int stokes, int region_id, const casacore::ArrayLattice<casacore::Bool>* mask, IPos origin,
-        const std::function<void(std::map<CARTA::StatsType, std::vector<double>>*, float)>& partial_results_callback);
+    virtual bool UseRegionSpectralData(const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask);
+    virtual bool GetRegionSpectralData(int stokes, int region_id, const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask,
+        IPos origin, const std::function<void(std::map<CARTA::StatsType, std::vector<double>>*, float)>& partial_results_callback);
     virtual bool GetPixelMaskSlice(casacore::Array<bool>& mask, const casacore::Slicer& slicer) = 0;
     virtual void SetFramePtr(Frame* frame);
 

--- a/ImageData/Hdf5Loader.h
+++ b/ImageData/Hdf5Loader.h
@@ -21,8 +21,8 @@ public:
     ImageRef LoadData(FileInfo::Data ds) override;
     bool GetPixelMaskSlice(casacore::Array<bool>& mask, const casacore::Slicer& slicer) override;
     bool GetCursorSpectralData(std::vector<float>& data, int stokes, int cursor_x, int count_x, int cursor_y, int count_y) override;
-    bool UseRegionSpectralData(const casacore::ArrayLattice<casacore::Bool>* mask) override;
-    bool GetRegionSpectralData(int stokes, int region_id, const casacore::ArrayLattice<casacore::Bool>* mask, IPos origin,
+    bool UseRegionSpectralData(const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask) override;
+    bool GetRegionSpectralData(int stokes, int region_id, const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask, IPos origin,
         const std::function<void(std::map<CARTA::StatsType, std::vector<double>>*, float)>& partial_results_callback) override;
     void SetFramePtr(Frame* frame) override;
 
@@ -310,7 +310,7 @@ bool Hdf5Loader::GetCursorSpectralData(std::vector<float>& data, int stokes, int
     return data_ok;
 }
 
-bool Hdf5Loader::UseRegionSpectralData(const casacore::ArrayLattice<casacore::Bool>* mask) {
+bool Hdf5Loader::UseRegionSpectralData(const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask) {
     if (!HasData(FileInfo::Data::SWIZZLED)) {
         return false;
     }
@@ -328,8 +328,8 @@ bool Hdf5Loader::UseRegionSpectralData(const casacore::ArrayLattice<casacore::Bo
     return true;
 }
 
-bool Hdf5Loader::GetRegionSpectralData(int stokes, int region_id, const casacore::ArrayLattice<casacore::Bool>* mask, IPos origin,
-    const std::function<void(std::map<CARTA::StatsType, std::vector<double>>*, float)>& partial_results_callback) {
+bool Hdf5Loader::GetRegionSpectralData(int stokes, int region_id, const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask,
+    IPos origin, const std::function<void(std::map<CARTA::StatsType, std::vector<double>>*, float)>& partial_results_callback) {
     if (!HasData(FileInfo::Data::SWIZZLED)) {
         return false;
     }

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -480,9 +480,11 @@ bool Region::MakeExtensionBox(casacore::WCBox& extend_box, int stokes, ChannelRa
 }
 
 casacore::WCRegion* Region::MakeExtendedRegion(int stokes, ChannelRange channel_range) {
+    std::shared_ptr<casacore::WCRegion> current_xy_region = _xy_region;
+
     // Return 2D wcregion extended by chan, stokes; xyregion if 2D
     if (_num_dims == 2) {
-        return _xy_region->cloneRegion(); // copy: this ptr owned by ImageRegion
+        return current_xy_region->cloneRegion(); // copy: this ptr owned by ImageRegion
     }
 
     casacore::WCExtension* region(nullptr);
@@ -493,7 +495,7 @@ casacore::WCRegion* Region::MakeExtendedRegion(int stokes, ChannelRange channel_
             return region; // nullptr, extension box failed
 
         // apply extension box with extension axes to xy region
-        region = new casacore::WCExtension(*_xy_region, ext_box);
+        region = new casacore::WCExtension(*current_xy_region, ext_box);
     } catch (casacore::AipsError& err) {
         std::cerr << "ERROR: Region extension failed: " << err.getMesg() << std::endl;
     }
@@ -502,9 +504,10 @@ casacore::WCRegion* Region::MakeExtendedRegion(int stokes, ChannelRange channel_
 
 casacore::IPosition Region::XyShape() {
     // returns bounding box shape of xy region
+    std::shared_ptr<casacore::WCRegion> current_xy_region = _xy_region;
     casacore::IPosition xy_shape;
-    if (_xy_region) {
-        casacore::LCRegion* region = _xy_region->toLCRegion(_coord_sys, _image_shape);
+    if (current_xy_region) {
+        casacore::LCRegion* region = current_xy_region->toLCRegion(_coord_sys, _image_shape);
         if (region != nullptr)
             xy_shape = region->shape().keepAxes(_xy_axes);
     }
@@ -513,9 +516,10 @@ casacore::IPosition Region::XyShape() {
 
 casacore::IPosition Region::XyOrigin() {
     // returns bottom-left position of bounding box of xy region
+    std::shared_ptr<casacore::WCRegion> current_xy_region = _xy_region;
     casacore::IPosition xy_origin;
-    if (_xy_region) {
-        auto extended_region = static_cast<casacore::LCExtension*>(_xy_region->toLCRegion(_coord_sys, _image_shape));
+    if (current_xy_region) {
+        auto extended_region = static_cast<casacore::LCExtension*>(current_xy_region->toLCRegion(_coord_sys, _image_shape));
         if (extended_region != nullptr)
             xy_origin = extended_region->region().expand(casacore::IPosition(2, 0, 0));
     }
@@ -524,11 +528,12 @@ casacore::IPosition Region::XyOrigin() {
 
 std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> Region::XyMask() {
     // returns boolean mask of xy region
+    std::shared_ptr<casacore::WCRegion> current_xy_region = _xy_region;
     std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask;
 
-    if (_xy_region) {
+    if (current_xy_region) {
         // get extended region (or original region for points)
-        auto lc_region = _xy_region->toLCRegion(_coord_sys, _image_shape);
+        auto lc_region = current_xy_region->toLCRegion(_coord_sys, _image_shape);
 
         // get original region
         switch (_type) {

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -44,11 +44,7 @@ RegionState Region::GetRegionState() {
     return region_state;
 }
 
-Region::~Region() {
-    // TODO: is it really necessary to do this explicitly?
-    _region_stats.reset();
-    _region_profiler.reset();
-}
+Region::~Region() {}
 
 // *************************************************************************
 // Region settings

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -217,7 +217,7 @@ bool Region::SetXyRegion(const std::vector<CARTA::Point>& points, float rotation
         std::cerr << "ERROR: xy region type " << region_type << " failed: " << err.getMesg() << std::endl;
     }
 
-    _xy_region = region;
+    std::atomic_store(&_xy_region, region);
     return bool(_xy_region);
 }
 
@@ -480,7 +480,7 @@ bool Region::MakeExtensionBox(casacore::WCBox& extend_box, int stokes, ChannelRa
 }
 
 casacore::WCRegion* Region::MakeExtendedRegion(int stokes, ChannelRange channel_range) {
-    std::shared_ptr<casacore::WCRegion> current_xy_region = _xy_region;
+    std::shared_ptr<casacore::WCRegion> current_xy_region = std::atomic_load(&_xy_region);
 
     // Return 2D wcregion extended by chan, stokes; xyregion if 2D
     if (_num_dims == 2) {
@@ -504,7 +504,7 @@ casacore::WCRegion* Region::MakeExtendedRegion(int stokes, ChannelRange channel_
 
 casacore::IPosition Region::XyShape() {
     // returns bounding box shape of xy region
-    std::shared_ptr<casacore::WCRegion> current_xy_region = _xy_region;
+    std::shared_ptr<casacore::WCRegion> current_xy_region = std::atomic_load(&_xy_region);
     casacore::IPosition xy_shape;
     if (current_xy_region) {
         casacore::LCRegion* region = current_xy_region->toLCRegion(_coord_sys, _image_shape);
@@ -516,7 +516,7 @@ casacore::IPosition Region::XyShape() {
 
 casacore::IPosition Region::XyOrigin() {
     // returns bottom-left position of bounding box of xy region
-    std::shared_ptr<casacore::WCRegion> current_xy_region = _xy_region;
+    std::shared_ptr<casacore::WCRegion> current_xy_region = std::atomic_load(&_xy_region);
     casacore::IPosition xy_origin;
     if (current_xy_region) {
         auto extended_region = static_cast<casacore::LCExtension*>(current_xy_region->toLCRegion(_coord_sys, _image_shape));
@@ -528,7 +528,7 @@ casacore::IPosition Region::XyOrigin() {
 
 std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> Region::XyMask() {
     // returns boolean mask of xy region
-    std::shared_ptr<casacore::WCRegion> current_xy_region = _xy_region;
+    std::shared_ptr<casacore::WCRegion> current_xy_region = std::atomic_load(&_xy_region);
     std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask;
 
     if (current_xy_region) {
@@ -560,8 +560,8 @@ std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> Region::XyMask() {
         }
     }
 
-    _xy_mask = mask;
-    return _xy_mask;
+    std::atomic_store(&_xy_mask, mask);
+    return std::atomic_load(&_xy_mask);
 }
 
 // ***********************************

--- a/Region/Region.h
+++ b/Region/Region.h
@@ -51,9 +51,9 @@ public:
     };
     casacore::IPosition XyShape();
     casacore::IPosition XyOrigin();
-    const casacore::ArrayLattice<casacore::Bool>* XyMask();
+    std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> XyMask();
     inline bool XyRegionValid() {
-        return (_xy_region != nullptr);
+        return bool(_xy_region);
     };
 
     // get image region for requested stokes and (optionally) single channel
@@ -150,10 +150,10 @@ private:
     int _num_dims, _spectral_axis, _stokes_axis;
 
     // stored 2D region
-    casacore::WCRegion* _xy_region;
+    std::shared_ptr<casacore::WCRegion> _xy_region;
 
     // stored 2D mask
-    casacore::ArrayLattice<casacore::Bool>* _xy_mask;
+    std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> _xy_mask;
 
     // coordinate system
     casacore::CoordinateSystem _coord_sys;

--- a/Region/Region.h
+++ b/Region/Region.h
@@ -125,6 +125,8 @@ private:
     casacore::WCRegion* MakeRectangleRegion(const std::vector<CARTA::Point>& points, float rotation);
     casacore::WCRegion* MakeEllipseRegion(const std::vector<CARTA::Point>& points, float rotation);
     casacore::WCRegion* MakePolygonRegion(const std::vector<CARTA::Point>& points);
+    // Creation of casacore regions is not threadsafe
+    std::mutex _casacore_region_mutex;
 
     // Extend xy region to make LCRegion
     bool MakeExtensionBox(casacore::WCBox& extend_box, int stokes, ChannelRange channel_range); // for extended region


### PR DESCRIPTION
This is an attempt to fix #301 and possibly some related issues. I am using shared pointers for the `_xy_region` and `_xy_mask` attributes, and using local shared pointers to the `_xy_region` object in functions which use it for calculations, so that they don't crash if the region changes and the old object is deleted.

I haven't modified any of the functions which create the region objects -- they all still return raw pointers.

Does this make sense, and does it fix the bug(s)? I have an SSD, so I haven't been able to reproduce the Z-profile crashes locally.