### PR TITLE
Rwjs/mongodb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ INCLUDE_DIRECTORIES(/usr/include/casacore)
 INCLUDE_DIRECTORIES(/usr/local/include/casacode)
 
 if (AuthServer)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_AUTH_SERVER_")
+    add_compile_definitions(_AUTH_SERVER_)
     INCLUDE_DIRECTORIES(/usr/include/libbson-1.0/)
     INCLUDE_DIRECTORIES(/usr/include/libmongoc-1.0/)
     set(LINK_LIBS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 #set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=native")
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
 
-# use -DAuthServer=ON to link mongodb and jsonccpp
+# use -DAuthServer:BOOL=ON to link mongodb and jsonccpp
 option(AuthServer "AuthServer" OFF)
 
 # Needed by clang-tidy and other clang tools
@@ -28,6 +28,7 @@ INCLUDE_DIRECTORIES(/usr/include/casacore)
 INCLUDE_DIRECTORIES(/usr/local/include/casacode)
 
 if(AuthServer)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_AUTH_SERVER_")
 INCLUDE_DIRECTORIES(/usr/include/libbson-1.0/)
 INCLUDE_DIRECTORIES(/usr/include/libmongoc-1.0/)
 set(LINK_LIBS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,8 @@ INCLUDE_DIRECTORIES(${HDF5_INCLUDE_DIR})
 ADD_SUBDIRECTORY(carta-protobuf)
 INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
 INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR}/ImageData)
-INCLUDE_DIRECTORIES(/usr/local/include/libbson-1.0/)
-INCLUDE_DIRECTORIES(/usr/local/include/libmongoc-1.0/)
+INCLUDE_DIRECTORIES(/usr/include/libbson-1.0/)
+INCLUDE_DIRECTORIES(/usr/include/libmongoc-1.0/)
 set(LINK_LIBS
         ${LINK_LIBS}
         carta-protobuf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ INCLUDE_DIRECTORIES(${HDF5_INCLUDE_DIR})
 ADD_SUBDIRECTORY(carta-protobuf)
 INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
 INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR}/ImageData)
+INCLUDE_DIRECTORIES(/usr/local/include/libbson-1.0/)
+INCLUDE_DIRECTORIES(/usr/local/include/libmongoc-1.0/)
 set(LINK_LIBS
         ${LINK_LIBS}
         carta-protobuf
@@ -42,6 +44,8 @@ set(LINK_LIBS
         casa_mirlib
         casa_scimath
         jsoncpp
+	mongoc-1.0
+	bson-1.0
         ${HDF5_LIBRARIES}
         ${CMAKE_THREAD_LIBS_INIT})
 
@@ -62,7 +66,8 @@ set(SOURCE_FILES
         FileSettings.cc
         Util.cc
         FileListHandler.cc
-        Tile.cc)
+        Tile.cc
+	DBConnect.cc)
 add_definitions(-DHAVE_HDF5)
 add_executable(carta_backend ${SOURCE_FILES})
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ INCLUDE_DIRECTORIES(${HDF5_INCLUDE_DIR})
 ADD_SUBDIRECTORY(carta-protobuf)
 INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
 INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR}/ImageData)
+INCLUDE_DIRECTORIES(/usr/include/casacore)
+INCLUDE_DIRECTORIES(/usr/local/include/casacode)
 
 if(AuthServer)
 INCLUDE_DIRECTORIES(/usr/include/libbson-1.0/)
@@ -58,7 +60,6 @@ set(LINK_LIBS
         casa_mirlib
         casa_scimath
 	imageanalysis
-        jsoncpp
         ${HDF5_LIBRARIES}
         ${CMAKE_THREAD_LIBS_INIT})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,17 +27,17 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR}/ImageData)
 INCLUDE_DIRECTORIES(/usr/include/casacore)
 INCLUDE_DIRECTORIES(/usr/local/include/casacode)
 
-if(AuthServer)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_AUTH_SERVER_")
-INCLUDE_DIRECTORIES(/usr/include/libbson-1.0/)
-INCLUDE_DIRECTORIES(/usr/include/libmongoc-1.0/)
-set(LINK_LIBS
-        jsoncpp
-	mongoc-1.0
-	bson-1.0)
-set(SOURCE_FILES
-	DBConnect.cc)
-endif(AuthServer)
+if (AuthServer)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_AUTH_SERVER_")
+    INCLUDE_DIRECTORIES(/usr/include/libbson-1.0/)
+    INCLUDE_DIRECTORIES(/usr/include/libmongoc-1.0/)
+    set(LINK_LIBS
+            jsoncpp
+            mongoc-1.0
+            bson-1.0)
+    set(SOURCE_FILES
+            DBConnect.cc)
+endif (AuthServer)
 
 
 set(LINK_LIBS
@@ -60,12 +60,12 @@ set(LINK_LIBS
         casa_measures
         casa_mirlib
         casa_scimath
-	imageanalysis
+        imageanalysis
         ${HDF5_LIBRARIES}
         ${CMAKE_THREAD_LIBS_INIT})
 
- set(SOURCE_FILES
-	${SOURCE_FILES}
+set(SOURCE_FILES
+        ${SOURCE_FILES}
         Main.cc
         Session.cc
         Frame.cc
@@ -95,16 +95,16 @@ endif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
 # Tests
 option(test "Build all tests." OFF)
-if(test)
-  enable_testing()
-  find_package(GTest)
-  include_directories(${GTEST_INCLUDE_DIRS} ${CMAKE_SOURCE_DIR})
+if (test)
+    enable_testing()
+    find_package(GTest)
+    include_directories(${GTEST_INCLUDE_DIRS} ${CMAKE_SOURCE_DIR})
 
-  add_executable(testTileEncoding test/TestTileEncoding.cc)
-  target_link_libraries(testTileEncoding gtest gtest_main Threads::Threads fmt)
+    add_executable(testTileEncoding test/TestTileEncoding.cc)
+    target_link_libraries(testTileEncoding gtest gtest_main Threads::Threads fmt)
 
-  add_test(NAME TestTileEncoding COMMAND testTileEncoding)
-endif(test)
+    add_test(NAME TestTileEncoding COMMAND testTileEncoding)
+endif (test)
 
 # Install executable
 install(TARGETS carta_backend DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 #set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=native")
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
 
+# use -DAuthServer=ON to link mongodb and jsonccpp
+option(AuthServer "AuthServer" OFF)
+
 # Needed by clang-tidy and other clang tools
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
@@ -21,8 +24,19 @@ INCLUDE_DIRECTORIES(${HDF5_INCLUDE_DIR})
 ADD_SUBDIRECTORY(carta-protobuf)
 INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
 INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR}/ImageData)
+
+if(AuthServer)
 INCLUDE_DIRECTORIES(/usr/include/libbson-1.0/)
 INCLUDE_DIRECTORIES(/usr/include/libmongoc-1.0/)
+set(LINK_LIBS
+        jsoncpp
+	mongoc-1.0
+	bson-1.0)
+set(SOURCE_FILES
+	DBConnect.cc)
+endif(AuthServer)
+
+
 set(LINK_LIBS
         ${LINK_LIBS}
         carta-protobuf
@@ -43,13 +57,11 @@ set(LINK_LIBS
         casa_measures
         casa_mirlib
         casa_scimath
-        jsoncpp
-	mongoc-1.0
-	bson-1.0
         ${HDF5_LIBRARIES}
         ${CMAKE_THREAD_LIBS_INIT})
 
-set(SOURCE_FILES
+ set(SOURCE_FILES
+	${SOURCE_FILES}
         Main.cc
         Session.cc
         Frame.cc
@@ -66,8 +78,8 @@ set(SOURCE_FILES
         FileSettings.cc
         Util.cc
         FileListHandler.cc
-        Tile.cc
-	DBConnect.cc)
+        Tile.cc)
+
 add_definitions(-DHAVE_HDF5)
 add_executable(carta_backend ${SOURCE_FILES})
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/Carta.h
+++ b/Carta.h
@@ -2,11 +2,11 @@
 #define __CARTA_H__
 
 namespace CARTA {
-  extern int global_thread_count;
-  extern std::string token;
-  extern std::string mongo_db_contact_string;
-  
-  const int MAX_TILING_TASKS = 8;
+extern int global_thread_count;
+extern std::string token;
+extern std::string mongo_db_contact_string;
+
+const int MAX_TILING_TASKS = 8;
 } // namespace CARTA
 
 #endif // __CARTA_H__

--- a/Carta.h
+++ b/Carta.h
@@ -2,9 +2,11 @@
 #define __CARTA_H__
 
 namespace CARTA {
-extern int global_thread_count;
-
-const int MAX_TILING_TASKS = 8;
+  extern int global_thread_count;
+  extern std::string token;
+  extern std::string mongo_db_contact_string;
+  
+  const int MAX_TILING_TASKS = 8;
 } // namespace CARTA
 
 #endif // __CARTA_H__

--- a/DBConnect.cc
+++ b/DBConnect.cc
@@ -4,8 +4,8 @@
 #include <iostream>
 #include <sstream>
 
-#include <bson/bson.h>
-#include <mongoc/mongoc.h>
+#include <bson.h>
+#include <mongoc.h>
 #include <stdio.h>
 
 #include "Carta.h"
@@ -44,7 +44,7 @@ void ConnectToMongoDB(void) {
   }
 
   bson_destroy (query);
-  Mongoc_cursor_destroy (cursor);
+  mongoc_cursor_destroy (cursor);
   mongoc_collection_destroy (collection);
   mongoc_client_destroy (client);
   mongoc_cleanup ();

--- a/DBConnect.cc
+++ b/DBConnect.cc
@@ -14,7 +14,7 @@
 
 #include "Carta.h"
 
-void ConnectToMongoDB(void) {
+void ConnectToMongoDB() {
     mongoc_client_t* client;
     mongoc_collection_t* collection;
     mongoc_cursor_t* cursor;
@@ -38,7 +38,7 @@ void ConnectToMongoDB(void) {
 
     query = bson_new();
     BSON_APPEND_UTF8(query, "username", user);
-    cursor = mongoc_collection_find_with_opts(collection, query, NULL, NULL);
+    cursor = mongoc_collection_find_with_opts(collection, query, nullptr, nullptr);
 
     while (mongoc_cursor_next(cursor, &doc)) {
         reader.parse(str, json_config);

--- a/DBConnect.cc
+++ b/DBConnect.cc
@@ -14,44 +14,43 @@
 
 #include "Carta.h"
 
-
 void ConnectToMongoDB(void) {
-  mongoc_client_t *client;
-  mongoc_collection_t *collection;
-  mongoc_cursor_t *cursor;
-  const bson_t *doc;
-  bson_t *query;
-  char *str;
-  char user[50];
-  std::string start_string;
-  Json::Value json_config;
-  Json::Reader reader;
-  std::ostringstream stringStream;
+    mongoc_client_t* client;
+    mongoc_collection_t* collection;
+    mongoc_cursor_t* cursor;
+    const bson_t* doc;
+    bson_t* query;
+    char* str;
+    char user[50];
+    std::string start_string;
+    Json::Value json_config;
+    Json::Reader reader;
+    std::ostringstream stringStream;
 
-  mongoc_init();
+    mongoc_init();
 
-  cuserid(user);
+    cuserid(user);
 
-  stringStream << CARTA::mongo_db_contact_string << "?appname=carta_backend-" << user;
-  start_string  = stringStream.str();
-  client = mongoc_client_new (start_string.c_str());
-  collection = mongoc_client_get_collection (client, "CARTA", "userconf");
+    stringStream << CARTA::mongo_db_contact_string << "?appname=carta_backend-" << user;
+    start_string = stringStream.str();
+    client = mongoc_client_new(start_string.c_str());
+    collection = mongoc_client_get_collection(client, "CARTA", "userconf");
 
-  query = bson_new ();
-  BSON_APPEND_UTF8 (query, "username", user);
-  cursor = mongoc_collection_find_with_opts (collection, query, NULL, NULL);
-  
-  while (mongoc_cursor_next (cursor, &doc)) {
-    reader.parse(str, json_config);
-    CARTA::token = json_config["token"].asString();
-    bson_free (str);       
-  }
+    query = bson_new();
+    BSON_APPEND_UTF8(query, "username", user);
+    cursor = mongoc_collection_find_with_opts(collection, query, NULL, NULL);
 
-  bson_destroy (query);
-  mongoc_cursor_destroy (cursor);
-  mongoc_collection_destroy (collection);
-  mongoc_client_destroy (client);
-  mongoc_cleanup ();
+    while (mongoc_cursor_next(cursor, &doc)) {
+        reader.parse(str, json_config);
+        CARTA::token = json_config["token"].asString();
+        bson_free(str);
+    }
+
+    bson_destroy(query);
+    mongoc_cursor_destroy(cursor);
+    mongoc_collection_destroy(collection);
+    mongoc_client_destroy(client);
+    mongoc_cleanup();
 }
 
 #endif // AuthServer

--- a/DBConnect.cc
+++ b/DBConnect.cc
@@ -1,6 +1,6 @@
 
 
-#if AuthServer // defined in cmake files
+#if _AUTH_SERVER_ // defined in cmake files
 
 #include <jsoncpp/json/json.h>
 #include <jsoncpp/json/value.h>
@@ -53,4 +53,4 @@ void ConnectToMongoDB(void) {
     mongoc_cleanup();
 }
 
-#endif // AuthServer
+#endif // _AUTH_SERVER_

--- a/DBConnect.cc
+++ b/DBConnect.cc
@@ -1,3 +1,7 @@
+
+
+#if AuthServer // defined in cmake files
+
 #include <jsoncpp/json/json.h>
 #include <jsoncpp/json/value.h>
 #include <fstream>
@@ -49,3 +53,5 @@ void ConnectToMongoDB(void) {
   mongoc_client_destroy (client);
   mongoc_cleanup ();
 }
+
+#endif // AuthServer

--- a/DBConnect.cc
+++ b/DBConnect.cc
@@ -1,0 +1,51 @@
+#include <jsoncpp/json/json.h>
+#include <jsoncpp/json/value.h>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+#include <bson/bson.h>
+#include <mongoc/mongoc.h>
+#include <stdio.h>
+
+#include "Carta.h"
+
+
+void ConnectToMongoDB(void) {
+  mongoc_client_t *client;
+  mongoc_collection_t *collection;
+  mongoc_cursor_t *cursor;
+  const bson_t *doc;
+  bson_t *query;
+  char *str;
+  char user[50];
+  std::string start_string;
+  Json::Value json_config;
+  Json::Reader reader;
+  std::ostringstream stringStream;
+
+  mongoc_init();
+
+  cuserid(user);
+
+  stringStream << CARTA::mongo_db_contact_string << "?appname=carta_backend-" << user;
+  start_string  = stringStream.str();
+  client = mongoc_client_new (start_string.c_str());
+  collection = mongoc_client_get_collection (client, "CARTA", "userconf");
+
+  query = bson_new ();
+  BSON_APPEND_UTF8 (query, "username", user);
+  cursor = mongoc_collection_find_with_opts (collection, query, NULL, NULL);
+  
+  while (mongoc_cursor_next (cursor, &doc)) {
+    reader.parse(str, json_config);
+    CARTA::token = json_config["token"].asString();
+    bson_free (str);       
+  }
+
+  bson_destroy (query);
+  Mongoc_cursor_destroy (cursor);
+  mongoc_collection_destroy (collection);
+  mongoc_client_destroy (client);
+  mongoc_cleanup ();
+}

--- a/DBConnect.h
+++ b/DBConnect.h
@@ -1,6 +1,6 @@
 #ifndef __DB_CONNECT__
 #define __DB_CONNECT__
 
-extern void ConnectToMongoDB(void);
+extern void ConnectToMongoDB();
 
 #endif // __DB_CONNECT__

--- a/DBConnect.h
+++ b/DBConnect.h
@@ -1,0 +1,6 @@
+#ifndef __DB_CONNECT__
+#define __DB_CONNECT__
+
+extern void ConnectToMongoDB(void);
+
+#endif // __DB_CONNECT__

--- a/Main.cc
+++ b/Main.cc
@@ -31,7 +31,6 @@
 #include "Session.h"
 #include "Util.h"
 
-
 using namespace std;
 
 namespace CARTA {
@@ -50,15 +49,15 @@ static uWS::Hub websocket_hub;
 static string root_folder("/"), base_folder("."), version_id("1.1");
 static bool verbose, use_permissions, use_mongodb;
 namespace CARTA {
-  string token;
-  string mongo_db_contact_string;
-}
+string token;
+string mongo_db_contact_string;
+} // namespace CARTA
 
 // Called on connection. Creates session objects and assigns UUID and API keys to it
 void OnConnect(uWS::WebSocket<uWS::SERVER>* ws, uWS::HttpRequest http_request) {
     // Check for authorization token
-  if (!CARTA::token.empty()) {
-    string expected_auth_header = fmt::format("CARTA-Authorization={}", CARTA::token);
+    if (!CARTA::token.empty()) {
+        string expected_auth_header = fmt::format("CARTA-Authorization={}", CARTA::token);
         auto cookie_header = http_request.getHeader("cookie");
         string auth_header_string(cookie_header.value, cookie_header.valueLength);
         if (auth_header_string.find(expected_auth_header) == string::npos) {
@@ -321,7 +320,7 @@ void ExitBackend(int s) {
 
 void ReadJSONfile(string fname) {
 #if AuthServer
-  std::ifstream config_file(fname);
+    std::ifstream config_file(fname);
     if (!config_file.is_open()) {
         std::cerr << "Failed to open config file " << fname << std::endl;
         exit(1);
@@ -366,26 +365,26 @@ int main(int argc, const char* argv[]) {
             inp.create("exit_after", "", "number of seconds to stay alive after last sessions exists", "Int");
             inp.create("init_exit_after", "", "number of seconds to stay alive at start if no clents connect", "Int");
             inp.create("read_json_file", json_fname, "read in json file with secure token", "String");
-	    inp.create("use_mongodb", "False", "use mongo db", "Bool");
+            inp.create("use_mongodb", "False", "use mongo db", "Bool");
             inp.readArguments(argc, argv);
 
             verbose = inp.getBool("verbose");
-	    use_mongodb = inp.getBool("use_mongodb");
+            use_mongodb = inp.getBool("use_mongodb");
             use_permissions = inp.getBool("permissions");
             port = inp.getInt("port");
             thread_count = inp.getInt("threads");
             base_folder = inp.getString("base");
             root_folder = inp.getString("root");
-	    CARTA::token = inp.getString("token");
-	    CARTA::mongo_db_contact_string = "mongodb://localhost:27017/";
-	    if (use_mongodb) {
+            CARTA::token = inp.getString("token");
+            CARTA::mongo_db_contact_string = "mongodb://localhost:27017/";
+            if (use_mongodb) {
 #if AuthServer
-	      ConnectToMongoDB();
+                ConnectToMongoDB();
 #else
-	      std::cerr << "Not configured to use MongoDB" << std::endl;
-	      exit(1);
+                std::cerr << "Not configured to use MongoDB" << std::endl;
+                exit(1);
 #endif
-	    }
+            }
             bool has_exit_after_arg = inp.getString("exit_after").size();
             if (has_exit_after_arg) {
                 int wait_time = inp.getInt("exit_after");

--- a/Main.cc
+++ b/Main.cc
@@ -1,5 +1,11 @@
+
+
+#if AuthServer
 #include <jsoncpp/json/json.h>
 #include <jsoncpp/json/value.h>
+#include "DBConnect.h"
+#endif
+
 #include <fstream>
 #include <iostream>
 #include <mutex>
@@ -24,7 +30,7 @@
 #include "OnMessageTask.h"
 #include "Session.h"
 #include "Util.h"
-#include "DBConnect.h"
+
 
 using namespace std;
 
@@ -278,7 +284,8 @@ void ExitBackend(int s) {
 }
 
 void ReadJSONfile(string fname) {
-    std::ifstream config_file(fname);
+#if AuthServer
+  std::ifstream config_file(fname);
     if (!config_file.is_open()) {
         std::cerr << "Failed to open config file " << fname << std::endl;
         exit(1);
@@ -291,6 +298,9 @@ void ReadJSONfile(string fname) {
         std::cerr << "Bad config file.\n";
         exit(1);
     }
+#else
+    std::cerr << "Not configured to use JSON." << std::endl;
+#endif
 }
 
 // Entry point. Parses command line arguments and starts server listening
@@ -332,7 +342,12 @@ int main(int argc, const char* argv[]) {
 	    CARTA::token = inp.getString("token");
 	    CARTA::mongo_db_contact_string = "mongodb://localhost:27017/";
 	    if (use_mongodb) {
+#if AuthServer
 	      ConnectToMongoDB();
+#else
+	      std::cerr << "Not configured to use MongoDB" << std::endl;
+	      exit(1);
+#endif
 	    }
 	    
             bool has_exit_after_arg = inp.getString("exit_after").size();

--- a/Main.cc
+++ b/Main.cc
@@ -318,8 +318,8 @@ void ExitBackend(int s) {
     exit(0);
 }
 
-void ReadJSONfile(string fname) {
-#if _AUTH_SERVER
+void ReadJsonFile(const string& fname) {
+#if _AUTH_SERVER_
     std::ifstream config_file(fname);
     if (!config_file.is_open()) {
         std::cerr << "Failed to open config file " << fname << std::endl;
@@ -398,7 +398,7 @@ int main(int argc, const char* argv[]) {
             bool should_read_json_file = inp.getString("read_json_file").size();
             if (should_read_json_file) {
                 json_fname = inp.getString("read_json_file");
-                ReadJSONfile(json_fname);
+                ReadJsonFile(json_fname);
             }
         }
 

--- a/Main.cc
+++ b/Main.cc
@@ -1,6 +1,6 @@
 
 
-#if AuthServer
+#if _AUTH_SERVER_
 #include <jsoncpp/json/json.h>
 #include <jsoncpp/json/value.h>
 #include "DBConnect.h"
@@ -378,7 +378,7 @@ int main(int argc, const char* argv[]) {
             CARTA::token = inp.getString("token");
             CARTA::mongo_db_contact_string = "mongodb://localhost:27017/";
             if (use_mongodb) {
-#if AuthServer
+#if _AUTH_SERVER_
                 ConnectToMongoDB();
 #else
                 std::cerr << "Not configured to use MongoDB" << std::endl;

--- a/Main.cc
+++ b/Main.cc
@@ -334,6 +334,7 @@ int main(int argc, const char* argv[]) {
             inp.readArguments(argc, argv);
 
             verbose = inp.getBool("verbose");
+	    use_mongodb = inp.getBool("use_mongodb");
             use_permissions = inp.getBool("permissions");
             port = inp.getInt("port");
             thread_count = inp.getInt("threads");
@@ -349,7 +350,6 @@ int main(int argc, const char* argv[]) {
 	      exit(1);
 #endif
 	    }
-	    
             bool has_exit_after_arg = inp.getString("exit_after").size();
             if (has_exit_after_arg) {
                 int wait_time = inp.getInt("exit_after");

--- a/Main.cc
+++ b/Main.cc
@@ -319,7 +319,7 @@ void ExitBackend(int s) {
 }
 
 void ReadJSONfile(string fname) {
-#if AuthServer
+#if _AUTH_SERVER
     std::ifstream config_file(fname);
     if (!config_file.is_open()) {
         std::cerr << "Failed to open config file " << fname << std::endl;


### PR DESCRIPTION
This adds the use of mongodb for the authenticating server deployment of the backend. Note that by default cmake will create a non-authenticating version for desktop deployments and will not link mongoc, bson or jsoncpp. To build the authenticating version you need to run:

        cmake -DAuthServer:BOOL=ON ..

