### PR TITLE
Remove profile index access for spectral profiles

### DIFF
--- a/Frame.cc
+++ b/Frame.cc
@@ -1317,10 +1317,6 @@ bool Frame::GetRegionSpectralData(int region_id, int profile_index, int profile_
         return data_ok;
     }
 
-    if (!region->GetSpectralConfigStats(profile_index, config_stats)) { // stats in config, to see if req changed
-        return data_ok;
-    }
-
     // initialize the stats data
     std::map<CARTA::StatsType, std::vector<double>> results;
     size_t profile_size = NumChannels(); // total number of channels

--- a/Frame.cc
+++ b/Frame.cc
@@ -1193,7 +1193,7 @@ bool Frame::FillSpectralProfileData(
                     auto cursor_point = region->GetControlPoints()[0];
                     // try use the loader's optimized cursor profile reader first
                     bool have_spectral_data = _loader->GetCursorSpectralData(
-                            spectral_data, profile_stokes, cursor_point.x() + 0.5, 1, cursor_point.y() + 0.5, 1, _image_mutex);
+                        spectral_data, profile_stokes, cursor_point.x() + 0.5, 1, cursor_point.y() + 0.5, 1, _image_mutex);
                     if (have_spectral_data) {
                         CARTA::SpectralProfileData profile_message;
                         profile_message.set_stokes(curr_stokes);
@@ -1208,15 +1208,15 @@ bool Frame::FillSpectralProfileData(
                         bool has_subimage = GetRegionSubImage(region_id, sub_image, profile_stokes, ChannelRange());
                         guard.unlock();
                         if (has_subimage) {
-                            profile_ok = GetPointSpectralData(
-                                region_id, sub_image, [&](std::vector<float> tmp_spectral_data, float progress) {
-                                CARTA::SpectralProfileData profile_message;
-                                profile_message.set_stokes(curr_stokes);
-                                profile_message.set_progress(progress);
-                                region->FillPointSpectralProfileDataMessage(profile_message, config_stokes, tmp_spectral_data);
-                                // send (partial) result to Session
-                                cb(profile_message);
-                            });
+                            profile_ok =
+                                GetPointSpectralData(region_id, sub_image, [&](std::vector<float> tmp_spectral_data, float progress) {
+                                    CARTA::SpectralProfileData profile_message;
+                                    profile_message.set_stokes(curr_stokes);
+                                    profile_message.set_progress(progress);
+                                    region->FillPointSpectralProfileDataMessage(profile_message, config_stokes, tmp_spectral_data);
+                                    // send (partial) result to Session
+                                    cb(profile_message);
+                                });
                         }
                     }
                 } else {

--- a/Frame.cc
+++ b/Frame.cc
@@ -156,8 +156,6 @@ bool Frame::SetRegion(int region_id, const std::string& name, CARTA::RegionType 
     if (region_set) {
         if (name == "cursor" && type == CARTA::RegionType::POINT) { // update current cursor's x-y coordinate
             SetCursorXy(points[0].x(), points[0].y());
-        } else { // update current region's states
-            SetRegionState(region_id, name, type, points, rotation);
         }
     } else {
         message = fmt::format("Region parameters failed to validate for region id {}", region_id);
@@ -1422,7 +1420,10 @@ bool Frame::IsConnected() {
 }
 
 bool Frame::IsSameRegionState(int region_id, const RegionState& region_state) {
-    return (_region_states.count(region_id) && _region_states[region_id] == region_state);
+    if (_regions.count(region_id)) {
+        return (_regions[region_id]->GetRegionState() == region_state);
+    }
+    return false;
 }
 
 bool Frame::AreSameRegionSpectralRequests(int region_id, int profile_index, const std::vector<int>& requested_stats) {
@@ -1437,14 +1438,15 @@ void Frame::SetCursorXy(float x, float y) {
     _cursor_xy = CursorXy(x, y);
 }
 
-void Frame::SetRegionState(int region_id, std::string name, CARTA::RegionType type, std::vector<CARTA::Point> points, float rotation) {
-    _region_states[region_id].UpdateState(name, type, points, rotation);
-}
-
 void Frame::SetRegionSpectralRequests(int region_id, const std::vector<CARTA::SetSpectralRequirements_SpectralConfig>& profiles) {
     _region_requests[region_id].UpdateRequest(profiles);
 }
 
 RegionState Frame::GetRegionState(int region_id) {
-    return _region_states[region_id];
+    if (_regions.count(region_id)) {
+        return _regions[region_id]->GetRegionState();
+    } else {
+        std::cerr << "ERROR: region id " << region_id << " does not exist!" << std::endl;
+    }
+    return RegionState();
 }

--- a/Frame.cc
+++ b/Frame.cc
@@ -1181,7 +1181,8 @@ bool Frame::FillSpectralProfileData(
                 int profile_stokes = (config_stokes == CURRENT_STOKES ? curr_stokes : config_stokes);
 
                 // fill SpectralProfiles for this config
-                if (region->IsPoint()) { // values in image slice
+                if (region->IsPoint()) {
+                    // profile is values in image slice
                     std::vector<float> spectral_data;
                     auto cursor_point = region->GetControlPoints()[0];
                     // try use the loader's optimized cursor profile reader first
@@ -1211,7 +1212,8 @@ bool Frame::FillSpectralProfileData(
                         });
                         guard.unlock();
                     }
-                } else { // statistics for image region (SubImage)
+                } else {
+                    // profile is statistics for image region (SubImage)
                     if (_image_shape.size() < 3) { // no spectral axis
                         // send empty (NaN) result
                         CARTA::SpectralProfileData profile_message;
@@ -1473,7 +1475,8 @@ bool Frame::GetPointSpectralData(
     data.resize(sub_image_shape.product(), std::numeric_limits<double>::quiet_NaN());
 
     try {
-        if ((sub_image_shape.size() > 2) && (_spectral_axis >= 0)) { // stoppable spectral profile process
+        if ((sub_image_shape.size() > 2) && (_spectral_axis >= 0)) {
+            // stoppable spectral profile process
             size_t delta_channels = INIT_DELTA_CHANNEL; // the increment of channels for each step
             size_t dt_target = TARGET_DELTA_TIME;       // the target time elapse for each step, in the unit of milliseconds
             size_t profile_size = NumChannels();        // profile vector size
@@ -1538,7 +1541,8 @@ bool Frame::GetPointSpectralData(
                 }
                 data_ok = true;
             }
-        } else { // non-stoppable spectral profile process
+        } else {
+            // non-stoppable spectral profile process
             casacore::Array<float> tmp(sub_image_shape, data.data(), casacore::StorageInitPolicy::SHARE);
             sub_image.doGetSlice(tmp, casacore::Slicer(casacore::IPosition(sub_image_shape.size(), 0), sub_image_shape));
             data_ok = true;
@@ -1569,7 +1573,8 @@ bool Frame::GetRegionSpectralData(int region_id, int config_stokes, int profile_
         // initialize the spectral data
         std::map<CARTA::StatsType, std::vector<double>> results;
         size_t profile_size = NumChannels(); // total number of channels
-        if (!region->InitSpectralData(config_stokes, profile_size, results)) { // config removed or no unsent stats
+        if (!region->InitSpectralData(config_stokes, profile_size, results)) {
+            // config removed or no unsent stats
             return false;
         }
 
@@ -1608,8 +1613,8 @@ bool Frame::GetRegionSpectralData(int region_id, int config_stokes, int profile_
                     }
                 } else {
                     if (_verbose) {
-                        std::cerr << "Can not get zprofile, region id: " << region_id << ", channel range: [" << start << "," << end
-                                  << "]" << std::endl;
+                        std::cerr << "Can not get zprofile, region id: " << region_id << ", channel range: [" << start << "," << end << "]"
+                                  << std::endl;
                     }
                     return data_ok;
                 }
@@ -1667,8 +1672,8 @@ bool Frame::Interrupt(int region_id, const CursorXy& cursor1, const CursorXy& cu
     return false;
 }
 
-bool Frame::Interrupt(int region_id, int profile_stokes, const RegionState& start_region_state,
-    const SpectralConfig& start_config_stats, bool is_HDF5) {
+bool Frame::Interrupt(
+    int region_id, int profile_stokes, const RegionState& start_region_state, const SpectralConfig& start_config_stats, bool is_HDF5) {
     // check if region, current stokes, spectral requirements changed
     bool interrupt(true);
     if (!IsConnected(region_id)) {
@@ -1707,8 +1712,7 @@ bool Frame::IsSameRegionState(int region_id, const RegionState& region_state) {
     return false;
 }
 
-bool Frame::IsSameRegionSpectralConfig(
-    int region_id, int profile_stokes, const SpectralConfig& start_config_stats, bool is_HDF5) {
+bool Frame::IsSameRegionSpectralConfig(int region_id, int profile_stokes, const SpectralConfig& start_config_stats, bool is_HDF5) {
     // compare stokes, spectral requirements
     if (!_regions.count(region_id)) { // region closed
         return false;

--- a/Frame.cc
+++ b/Frame.cc
@@ -1257,7 +1257,7 @@ bool Frame::GetPointSpectralData(std::vector<float>& data, int region_id, casaco
                     if (_regions.count(region_id)) {
                         std::vector<CARTA::Point> region_points = _regions[region_id]->GetControlPoints();
                         // round the region cursor float values since subimage cursor comes from IPosition
-                        CursorXy region_cursor(round(region_points[0].x()), round(region_points[0].y())); 
+                        CursorXy region_cursor(round(region_points[0].x()), round(region_points[0].y()));
                         if (Interrupt(region_id, region_cursor, subimage_cursor)) { // point region moved
                             return false;
                         }
@@ -1416,8 +1416,8 @@ bool Frame::Interrupt(int region_id, const RegionState& region_state) {
     return interrupt;
 }
 
-bool Frame::Interrupt(int region_id, int num_profiles, int profile_index, int profile_stokes,
-    const RegionState& region_state, const std::vector<int>& config_stats) {
+bool Frame::Interrupt(int region_id, int num_profiles, int profile_index, int profile_stokes, const RegionState& region_state,
+    const std::vector<int>& config_stats) {
     bool interrupt(true);
     if (!IsConnected()) {
         std::cerr << "[Region " << region_id << "] closing image, exit zprofile (statistics) before complete" << std::endl;
@@ -1454,8 +1454,8 @@ bool Frame::IsSameRegionState(int region_id, const RegionState& region_state) {
     return false;
 }
 
-bool Frame::IsSameRegionSpectralConfig(int region_id, int num_profiles, int profile_index, int profile_stokes,
-    const std::vector<int>& config_stats) {
+bool Frame::IsSameRegionSpectralConfig(
+    int region_id, int num_profiles, int profile_index, int profile_stokes, const std::vector<int>& config_stats) {
     bool is_same(false);
     if (_regions.count(region_id)) {
         auto& region = _regions[region_id];

--- a/Frame.cc
+++ b/Frame.cc
@@ -435,6 +435,9 @@ bool Frame::SetRegionSpectralRequirements(int region_id, const std::vector<CARTA
     if (_regions.count(region_id)) {
         auto& region = _regions[region_id];
         region_ok = region->SetSpectralRequirements(profiles, NumStokes());
+        if (profiles.size() > 0) {
+            SetRegionId(region_id);
+        }
     }
     return region_ok;
 }
@@ -1244,7 +1247,7 @@ bool Frame::GetPointSpectralData(
                 // start the timer
                 auto t_start = std::chrono::high_resolution_clock::now();
                 // check if region point changed from subimage point
-                if ((region_id == CURSOR_REGION_ID) && (Interrupt(_cursor_xy, subimage_cursor))) {
+                if ((region_id == CURSOR_REGION_ID) && (Interrupt(region_id, _cursor_xy, subimage_cursor))) {
                     return false; // cursor moved
                 }
                 if (region_id > CURSOR_REGION_ID) {
@@ -1252,7 +1255,7 @@ bool Frame::GetPointSpectralData(
                         std::vector<CARTA::Point> region_points = _regions[region_id]->GetControlPoints();
                         // round the region cursor float values since subimage cursor comes from IPosition
                         CursorXy region_cursor(round(region_points[0].x()), round(region_points[0].y())); 
-                        if (Interrupt(region_cursor, subimage_cursor)) { // point region moved
+                        if (Interrupt(region_id, region_cursor, subimage_cursor)) { // point region moved
                             return false;
                         }
                     } else { // region closed
@@ -1374,49 +1377,71 @@ bool Frame::GetRegionSpectralData(std::vector<std::vector<double>>& stats_values
     return true;
 }
 
-bool Frame::Interrupt(const CursorXy& cursor1, const CursorXy& cursor2) {
+bool Frame::Interrupt(int region_id, const CursorXy& cursor1, const CursorXy& cursor2) {
+    bool interrupt(true);
     if (!IsConnected()) {
         std::cerr << "Closing image, exit zprofile before complete" << std::endl;
-        return true;
+        return interrupt;
+    }
+    if (!IsSameRegionId(region_id)) {
+        std::cerr << "[Region " << region_id << "] region changed, exit zprofile (statistics) before complete" << std::endl;
+        return interrupt;
     }
     if (!(cursor1 == cursor2)) {
         std::cerr << "Cursor/Point changed, exit zprofile before complete" << std::endl;
-        return true;
+        return interrupt;
     }
-    return false;
+    interrupt = false;
+    return interrupt;
 }
 
 bool Frame::Interrupt(int region_id, const RegionState& region_state) {
+    bool interrupt(true);
     if (!IsConnected()) {
         std::cerr << "[Region " << region_id << "] closing image, exit zprofile (statistics) before complete" << std::endl;
-        return true;
+        return interrupt;
+    }
+    if (!IsSameRegionId(region_id)) {
+        std::cerr << "[Region " << region_id << "] region changed, exit zprofile (statistics) before complete" << std::endl;
+        return interrupt;
     }
     if (!IsSameRegionState(region_id, region_state)) {
         std::cerr << "[Region " << region_id << "] region state changed, exit zprofile (statistics) before complete" << std::endl;
-        return true;
+        return interrupt;
     }
-    return false;
+    interrupt = false;
+    return interrupt;
 }
 
 bool Frame::Interrupt(int region_id, int num_profiles, int profile_index, int profile_stokes,
     const RegionState& region_state, const std::vector<int>& config_stats) {
+    bool interrupt(true);
     if (!IsConnected()) {
         std::cerr << "[Region " << region_id << "] closing image, exit zprofile (statistics) before complete" << std::endl;
-        return true;
+        return interrupt;
+    }
+    if (!IsSameRegionId(region_id)) {
+        std::cerr << "[Region " << region_id << "] region changed, exit zprofile (statistics) before complete" << std::endl;
+        return interrupt;
     }
     if (!IsSameRegionState(region_id, region_state)) {
         std::cerr << "[Region " << region_id << "] region state changed, exit zprofile (statistics) before complete" << std::endl;
-        return true;
+        return interrupt;
     }
     if (!IsSameRegionSpectralConfig(region_id, num_profiles, profile_index, profile_stokes, config_stats)) {
         std::cerr << "[Region " << region_id << "] region requirement changed, exit zprofile (statistics) before complete" << std::endl;
-        return true;
+        return interrupt;
     }
-    return false;
+    interrupt = false;
+    return interrupt;
 }
 
 bool Frame::IsConnected() {
     return _connected;
+}
+
+bool Frame::IsSameRegionId(int region_id) {
+    return (_region_id == region_id);
 }
 
 bool Frame::IsSameRegionState(int region_id, const RegionState& region_state) {
@@ -1460,6 +1485,10 @@ void Frame::SetConnectionFlag(bool connected) {
 
 void Frame::SetCursorXy(float x, float y) {
     _cursor_xy = CursorXy(x, y);
+}
+
+void Frame::SetRegionId(int region_id) {
+    _region_id = region_id;
 }
 
 RegionState Frame::GetRegionState(int region_id) {

--- a/Frame.cc
+++ b/Frame.cc
@@ -1453,22 +1453,25 @@ bool Frame::IsSameRegionState(int region_id, const RegionState& region_state) {
 
 bool Frame::IsSameRegionSpectralConfig(int region_id, int num_profiles, int profile_index, int profile_stokes,
     const std::vector<int>& config_stats) {
+    bool is_same(false);
     if (_regions.count(region_id)) {
         auto& region = _regions[region_id];
         // check is number of profiles changed
         size_t new_num_profiles(region->NumSpectralProfiles());
         if ((new_num_profiles == 0) || (new_num_profiles != num_profiles)) {
-            return false;
+            return is_same;
         }
         // check is profile stoke changed
         int new_profile_stokes = region->GetSpectralConfigStokes(profile_index);
-        if (new_profile_stokes == CURRENT_STOKES) {
-            new_profile_stokes = CurrentStokes();
+        if (new_profile_stokes >= CURRENT_STOKES) {
+            if (new_profile_stokes == CURRENT_STOKES) {
+                new_profile_stokes = CurrentStokes();
+            }
             if (new_profile_stokes != profile_stokes) {
-                return false;
+                return is_same;
             }
         } else {
-            return false;
+            return is_same;
         }
         // check are stats requirements changed
         std::vector<int> new_config_stats;
@@ -1476,7 +1479,7 @@ bool Frame::IsSameRegionSpectralConfig(int region_id, int num_profiles, int prof
             return (new_config_stats == config_stats);
         }
     }
-    return false;
+    return is_same;
 }
 
 void Frame::SetConnectionFlag(bool connected) {

--- a/Frame.cc
+++ b/Frame.cc
@@ -435,6 +435,10 @@ bool Frame::SetRegionSpectralRequirements(int region_id, const std::vector<CARTA
     if (_regions.count(region_id)) {
         auto& region = _regions[region_id];
         region_ok = region->SetSpectralRequirements(profiles, NumStokes());
+        // set the current requested region id
+        if (profiles.size() > 0) {
+            SetRegionId(region_id);
+        }
     }
     return region_ok;
 }
@@ -1245,7 +1249,7 @@ bool Frame::GetPointSpectralData(std::vector<float>& data, int region_id, casaco
                 // start the timer
                 auto t_start = std::chrono::high_resolution_clock::now();
                 // check if region point changed from subimage point
-                if ((region_id == CURSOR_REGION_ID) && (Interrupt(_cursor_xy, subimage_cursor))) {
+                if ((region_id == CURSOR_REGION_ID) && (Interrupt(region_id, _cursor_xy, subimage_cursor))) {
                     return false; // cursor moved
                 }
                 if (region_id > CURSOR_REGION_ID) {
@@ -1253,7 +1257,7 @@ bool Frame::GetPointSpectralData(std::vector<float>& data, int region_id, casaco
                         std::vector<CARTA::Point> region_points = _regions[region_id]->GetControlPoints();
                         // round the region cursor float values since subimage cursor comes from IPosition
                         CursorXy region_cursor(round(region_points[0].x()), round(region_points[0].y()));
-                        if (Interrupt(region_cursor, subimage_cursor)) { // point region moved
+                        if (Interrupt(region_id, region_cursor, subimage_cursor)) { // point region moved
                             return false;
                         }
                     } else { // region closed
@@ -1390,10 +1394,14 @@ bool Frame::GetRegionSpectralData(int region_id, int profile_index, int profile_
     return data_ok;
 }
 
-bool Frame::Interrupt(const CursorXy& cursor1, const CursorXy& cursor2) {
+bool Frame::Interrupt(int region_id, const CursorXy& cursor1, const CursorXy& cursor2) {
     bool interrupt(true);
     if (!IsConnected()) {
         std::cerr << "Closing image, exit zprofile before complete" << std::endl;
+        return interrupt;
+    }
+    if (!IsSameRegionId(region_id)) {
+        std::cerr << "[Region " << region_id << "] region changed, exit zprofile (statistics) before complete" << std::endl;
         return interrupt;
     }
     if (!(cursor1 == cursor2)) {
@@ -1410,6 +1418,10 @@ bool Frame::Interrupt(int region_id, const RegionState& region_state) {
         std::cerr << "[Region " << region_id << "] closing image, exit zprofile (statistics) before complete" << std::endl;
         return interrupt;
     }
+    if (!IsSameRegionId(region_id)) {
+        std::cerr << "[Region " << region_id << "] region changed, exit zprofile (statistics) before complete" << std::endl;
+        return interrupt;
+    }
     if (!IsSameRegionState(region_id, region_state)) {
         std::cerr << "[Region " << region_id << "] region state changed, exit zprofile (statistics) before complete" << std::endl;
         return interrupt;
@@ -1422,6 +1434,10 @@ bool Frame::Interrupt(int region_id, const RegionState& region_state, const ZPro
     bool interrupt(true);
     if (!IsConnected()) {
         std::cerr << "[Region " << region_id << "] closing image, exit zprofile (statistics) before complete" << std::endl;
+        return interrupt;
+    }
+    if (!IsSameRegionId(region_id)) {
+        std::cerr << "[Region " << region_id << "] region changed, exit zprofile (statistics) before complete" << std::endl;
         return interrupt;
     }
     if (!IsSameRegionState(region_id, region_state)) {
@@ -1438,6 +1454,10 @@ bool Frame::Interrupt(int region_id, const RegionState& region_state, const ZPro
 
 bool Frame::IsConnected() {
     return _connected;
+}
+
+bool Frame::IsSameRegionId(int region_id) {
+    return (_region_id == region_id);
 }
 
 bool Frame::IsSameRegionState(int region_id, const RegionState& region_state) {
@@ -1463,6 +1483,10 @@ void Frame::SetConnectionFlag(bool connected) {
 
 void Frame::SetCursorXy(float x, float y) {
     _cursor_xy = CursorXy(x, y);
+}
+
+void Frame::SetRegionId(int region_id) {
+    _region_id = region_id;
 }
 
 RegionState Frame::GetRegionState(int region_id) {

--- a/Frame.cc
+++ b/Frame.cc
@@ -436,10 +436,6 @@ bool Frame::SetRegionSpectralRequirements(int region_id, const std::vector<CARTA
     if (_regions.count(region_id)) {
         auto& region = _regions[region_id];
         region_ok = region->SetSpectralRequirements(profiles, NumStokes());
-        // set the current requested region id
-        if (profiles.size() > 0) {
-            SetRegionId(region_id);
-        }
     }
     return region_ok;
 }
@@ -1402,10 +1398,6 @@ bool Frame::Interrupt(int region_id, const CursorXy& cursor1, const CursorXy& cu
         std::cerr << "Closing image/region, exit zprofile before complete" << std::endl;
         return interrupt;
     }
-    if (!IsSameRegionId(region_id)) {
-        std::cerr << "[Region " << region_id << "] region changed, exit zprofile (statistics) before complete" << std::endl;
-        return interrupt;
-    }
     if (!(cursor1 == cursor2)) {
         std::cerr << "Cursor/Point changed, exit zprofile before complete" << std::endl;
         return interrupt;
@@ -1420,10 +1412,6 @@ bool Frame::Interrupt(int region_id, const RegionState& region_state) {
         std::cerr << "[Region " << region_id << "] closing image/region, exit zprofile (statistics) before complete" << std::endl;
         return interrupt;
     }
-    if (!IsSameRegionId(region_id)) {
-        std::cerr << "[Region " << region_id << "] region changed, exit zprofile (statistics) before complete" << std::endl;
-        return interrupt;
-    }
     if (!IsSameRegionState(region_id, region_state)) {
         std::cerr << "[Region " << region_id << "] region state changed, exit zprofile (statistics) before complete" << std::endl;
         return interrupt;
@@ -1436,10 +1424,6 @@ bool Frame::Interrupt(int region_id, const RegionState& region_state, const ZPro
     bool interrupt(true);
     if (!IsConnected(region_id)) {
         std::cerr << "[Region " << region_id << "] closing image/region, exit zprofile (statistics) before complete" << std::endl;
-        return interrupt;
-    }
-    if (!IsSameRegionId(region_id)) {
-        std::cerr << "[Region " << region_id << "] region changed, exit zprofile (statistics) before complete" << std::endl;
         return interrupt;
     }
     if (!IsSameRegionState(region_id, region_state)) {
@@ -1459,10 +1443,6 @@ bool Frame::IsConnected(int region_id) {
         return (_connected && _regions[region_id]->IsConnected());
     }
     return _connected;
-}
-
-bool Frame::IsSameRegionId(int region_id) {
-    return (_region_id == region_id);
 }
 
 bool Frame::IsSameRegionState(int region_id, const RegionState& region_state) {
@@ -1488,10 +1468,6 @@ void Frame::SetConnectionFlag(bool connected) {
 
 void Frame::SetCursorXy(float x, float y) {
     _cursor_xy = CursorXy(x, y);
-}
-
-void Frame::SetRegionId(int region_id) {
-    _region_id = region_id;
 }
 
 RegionState Frame::GetRegionState(int region_id) {

--- a/Frame.h
+++ b/Frame.h
@@ -40,7 +40,7 @@ struct ViewSettings {
 class Frame {
 public:
     Frame(uint32_t session_id, const std::string& filename, const std::string& hdu, const CARTA::FileInfoExtended* info,
-        int default_channel = DEFAULT_CHANNEL);
+        bool verbose, int default_channel = DEFAULT_CHANNEL);
     ~Frame();
 
     // frame info
@@ -116,13 +116,13 @@ public:
 
     // Get current region states
     bool GetRegionState(int region_id, RegionState& region_state);
-    // Get current region configs
-    bool GetRegionConfigs(int region_id, int profile_index, ZProfileWidget& config_stats);
+    // Get current region spectral config
+    bool GetRegionSpectralConfig(int region_id, int config_stokes, SpectralConfig& config_stats);
 
     // Interrupt conditions
     bool Interrupt(int region_id, const CursorXy& cursor1, const CursorXy& cursor2); // cursor and point regions
-    bool Interrupt(
-        int region_id, int profile_stokes, const RegionState& region_state, const ZProfileWidget& config_stats, bool is_HDF5 = false);
+    bool Interrupt(int region_id, int profile_stokes, const RegionState& start_region_state, const SpectralConfig& start_config_stats,
+        bool is_HDF5 = false);
 
 private:
     // Internal regions: image, cursor
@@ -173,7 +173,7 @@ private:
     bool GetPointSpectralData(int region_id, casacore::SubImage<float>& sub_image,
         const std::function<void(std::vector<float>, float)>& partial_results_callback);
     // get region stats data
-    bool GetRegionSpectralData(int region_id, int profile_index, int profile_stokes,
+    bool GetRegionSpectralData(int region_id, int config_stokes, int profile_stokes,
         const std::function<void(std::map<CARTA::StatsType, std::vector<double>>, float)>& partial_results_callback);
 
     // Functions used to set cursor and region states
@@ -183,7 +183,7 @@ private:
     // Functions used to check cursor and region states
     bool IsConnected(int region_id);
     bool IsSameRegionState(int region_id, const RegionState& region_state);
-    bool IsSameRegionSpectralConfig(int region_id, int profile_stokes, const ZProfileWidget& config_stats, bool is_HDF5 = false);
+    bool IsSameRegionSpectralConfig(int region_id, int profile_stokes, const SpectralConfig& start_config_stats, bool is_HDF5 = false);
 
     // setup
     uint32_t _session_id;
@@ -215,11 +215,13 @@ private:
     // Region
     std::unordered_map<int, std::unique_ptr<carta::Region>> _regions; // key is region ID
     bool _cursor_set;                                                 // cursor region set by frontend, not internally
+    // Current cursor's x-y coordinate
+    CursorXy _cursor_xy;
 
     // Communication
     volatile bool _connected = true;
-    // Current cursor's x-y coordinate
-    CursorXy _cursor_xy;
+    bool _verbose;
+
 };
 
 #endif // CARTA_BACKEND__FRAME_H_

--- a/Frame.h
+++ b/Frame.h
@@ -39,8 +39,8 @@ struct ViewSettings {
 
 class Frame {
 public:
-    Frame(uint32_t session_id, const std::string& filename, const std::string& hdu, const CARTA::FileInfoExtended* info,
-        bool verbose, int default_channel = DEFAULT_CHANNEL);
+    Frame(uint32_t session_id, const std::string& filename, const std::string& hdu, const CARTA::FileInfoExtended* info, bool verbose,
+        int default_channel = DEFAULT_CHANNEL);
     ~Frame();
 
     // frame info
@@ -221,7 +221,6 @@ private:
     // Communication
     volatile bool _connected = true;
     bool _verbose;
-
 };
 
 #endif // CARTA_BACKEND__FRAME_H_

--- a/Frame.h
+++ b/Frame.h
@@ -105,7 +105,7 @@ public:
     RegionState GetRegionState(int region_id);
 
     // Interrupt conditions
-    bool Interrupt(int region_id, const CursorXy& cursor1, const CursorXy& cursor2); // cursor and point regions
+    bool Interrupt(const CursorXy& cursor1, const CursorXy& cursor2); // cursor and point regions
     bool Interrupt(int region_id, const RegionState& region_state);
     bool Interrupt(int region_id, int num_profiles, int profile_index, int profile_stokes, const RegionState& region_state,
         const std::vector<int>& config_stats);
@@ -159,11 +159,9 @@ private:
     // Functions used to set cursor and region states
     void SetConnectionFlag(bool connected);
     void SetCursorXy(float x, float y);
-    void SetRegionId(int region_id);
 
     // Functions used to check cursor and region states
     bool IsConnected();
-    bool IsSameRegionId(int region_id);
     bool IsSameRegionState(int region_id, const RegionState& region_state);
     bool IsSameRegionSpectralConfig(
         int region_id, int num_profiles, int profile_index, int profile_stokes, const std::vector<int>& config_stats);
@@ -203,8 +201,6 @@ private:
     volatile bool _connected = true;
     // Current cursor's x-y coordinate
     CursorXy _cursor_xy;
-    // Current region id;
-    int _region_id;
 };
 
 #endif // CARTA_BACKEND__FRAME_H_

--- a/Frame.h
+++ b/Frame.h
@@ -107,7 +107,8 @@ public:
     // Interrupt conditions
     bool Interrupt(const CursorXy& cursor1, const CursorXy& cursor2); // cursor and point regions
     bool Interrupt(int region_id, const RegionState& region_state);
-    bool Interrupt(int region_id, int profile_index, const RegionState& region_state, const std::vector<int>& requested_stats);
+    bool Interrupt(int region_id, int num_profiles, int profile_index, int profile_stokes,
+        const RegionState& region_state, const std::vector<int>& config_stats);
 
 private:
     // Internal regions: image, cursor
@@ -152,18 +153,18 @@ private:
     bool GetPointSpectralData(std::vector<float>& data, int region_id, casacore::SubImage<float>& sub_image,
         const std::function<void(std::vector<float>, float)>& partial_results_callback);
     // get regional spectral profile (statistics) data
-    bool GetRegionSpectralData(std::vector<std::vector<double>>& stats_values, int region_id, int profile_index, int profile_stokes,
-        const std::function<void(std::vector<std::vector<double>>, float)>& partial_results_callback);
+    bool GetRegionSpectralData(std::vector<std::vector<double>>& stats_values, int region_id, int num_profiles, int profile_index,
+        int profile_stokes, const std::function<void(std::vector<std::vector<double>>, float)>& partial_results_callback);
 
     // Functions used to set cursor and region states
     void SetConnectionFlag(bool connected);
     void SetCursorXy(float x, float y);
-    void SetRegionSpectralRequests(int region_id, const std::vector<CARTA::SetSpectralRequirements_SpectralConfig>& profiles);
 
     // Functions used to check cursor and region states
     bool IsConnected();
     bool IsSameRegionState(int region_id, const RegionState& region_state);
-    bool AreSameRegionSpectralRequests(int region_id, int profile_index, const std::vector<int>& requested_stats);
+    bool IsSameRegionSpectralConfig(int region_id, int num_profiles, int profile_index, int profile_stokes,
+        const std::vector<int>& config_stats);
 
     // setup
     uint32_t _session_id;
@@ -200,8 +201,6 @@ private:
     volatile bool _connected = true;
     // Current cursor's x-y coordinate
     CursorXy _cursor_xy;
-    // Current region configs
-    std::unordered_map<int, RegionRequest> _region_requests;
 };
 
 #endif // CARTA_BACKEND__FRAME_H_

--- a/Frame.h
+++ b/Frame.h
@@ -152,9 +152,9 @@ private:
     // get point spectral profile data from subimage
     bool GetPointSpectralData(std::vector<float>& data, int region_id, casacore::SubImage<float>& sub_image,
         const std::function<void(std::vector<float>, float)>& partial_results_callback);
-    // get regional spectral profile (statistics) data
-    bool GetRegionSpectralData(std::vector<std::vector<double>>& stats_values, int region_id, int num_profiles, int profile_index,
-        int profile_stokes, const std::function<void(std::vector<std::vector<double>>, float)>& partial_results_callback);
+    // get region stats data
+    bool GetRegionSpectralData(int region_id, int num_profiles, int profile_index, int profile_stokes,
+        const std::function<void(std::vector<std::vector<double>>, float)>& partial_results_callback);
 
     // Functions used to set cursor and region states
     void SetConnectionFlag(bool connected);

--- a/Frame.h
+++ b/Frame.h
@@ -164,11 +164,9 @@ private:
     // Functions used to set cursor and region states
     void SetConnectionFlag(bool connected);
     void SetCursorXy(float x, float y);
-    void SetRegionId(int region_id);
 
     // Functions used to check cursor and region states
     bool IsConnected(int region_id);
-    bool IsSameRegionId(int region_id);
     bool IsSameRegionState(int region_id, const RegionState& region_state);
     bool IsSameRegionSpectralConfig(int region_id, const ZProfileWidget& config_stats);
 
@@ -207,8 +205,6 @@ private:
     volatile bool _connected = true;
     // Current cursor's x-y coordinate
     CursorXy _cursor_xy;
-    // Current region id;
-    int _region_id;
 };
 
 #endif // CARTA_BACKEND__FRAME_H_

--- a/Frame.h
+++ b/Frame.h
@@ -107,8 +107,8 @@ public:
     // Interrupt conditions
     bool Interrupt(int region_id, const CursorXy& cursor1, const CursorXy& cursor2); // cursor and point regions
     bool Interrupt(int region_id, const RegionState& region_state);
-    bool Interrupt(int region_id, int num_profiles, int profile_index, int profile_stokes,
-        const RegionState& region_state, const std::vector<int>& config_stats);
+    bool Interrupt(int region_id, int num_profiles, int profile_index, int profile_stokes, const RegionState& region_state,
+        const std::vector<int>& config_stats);
 
 private:
     // Internal regions: image, cursor
@@ -165,8 +165,8 @@ private:
     bool IsConnected();
     bool IsSameRegionId(int region_id);
     bool IsSameRegionState(int region_id, const RegionState& region_state);
-    bool IsSameRegionSpectralConfig(int region_id, int num_profiles, int profile_index, int profile_stokes,
-        const std::vector<int>& config_stats);
+    bool IsSameRegionSpectralConfig(
+        int region_id, int num_profiles, int profile_index, int profile_stokes, const std::vector<int>& config_stats);
 
     // setup
     uint32_t _session_id;

--- a/Frame.h
+++ b/Frame.h
@@ -158,7 +158,6 @@ private:
     // Functions used to set cursor and region states
     void SetConnectionFlag(bool connected);
     void SetCursorXy(float x, float y);
-    void SetRegionState(int region_id, std::string name, CARTA::RegionType type, std::vector<CARTA::Point> points, float rotation);
     void SetRegionSpectralRequests(int region_id, const std::vector<CARTA::SetSpectralRequirements_SpectralConfig>& profiles);
 
     // Functions used to check cursor and region states
@@ -201,8 +200,6 @@ private:
     volatile bool _connected = true;
     // Current cursor's x-y coordinate
     CursorXy _cursor_xy;
-    // Current region states
-    std::unordered_map<int, RegionState> _region_states;
     // Current region configs
     std::unordered_map<int, RegionRequest> _region_requests;
 };

--- a/Frame.h
+++ b/Frame.h
@@ -107,8 +107,7 @@ public:
     // Interrupt conditions
     bool Interrupt(const CursorXy& cursor1, const CursorXy& cursor2); // cursor and point regions
     bool Interrupt(int region_id, const RegionState& region_state);
-    bool Interrupt(int region_id, int num_profiles, int profile_index, int profile_stokes, const RegionState& region_state,
-        const std::vector<int>& config_stats);
+    bool Interrupt(int region_id, const RegionState& region_state, const ZProfileWidget& config_stats);
 
 private:
     // Internal regions: image, cursor
@@ -153,7 +152,7 @@ private:
     bool GetPointSpectralData(std::vector<float>& data, int region_id, casacore::SubImage<float>& sub_image,
         const std::function<void(std::vector<float>, float)>& partial_results_callback);
     // get region stats data
-    bool GetRegionSpectralData(int region_id, int num_profiles, int profile_index, int profile_stokes,
+    bool GetRegionSpectralData(int region_id, int profile_index, int profile_stokes,
         const std::function<void(std::vector<std::vector<double>>, float)>& partial_results_callback);
 
     // Functions used to set cursor and region states
@@ -163,8 +162,7 @@ private:
     // Functions used to check cursor and region states
     bool IsConnected();
     bool IsSameRegionState(int region_id, const RegionState& region_state);
-    bool IsSameRegionSpectralConfig(
-        int region_id, int num_profiles, int profile_index, int profile_stokes, const std::vector<int>& config_stats);
+    bool IsSameRegionSpectralConfig(int region_id, const ZProfileWidget& config_stats);
 
     // setup
     uint32_t _session_id;

--- a/Frame.h
+++ b/Frame.h
@@ -108,12 +108,14 @@ public:
     }
 
     // Get current region states
-    RegionState GetRegionState(int region_id);
+    bool GetRegionState(int region_id, RegionState& region_state);
+    // Get current region configs
+    bool GetRegionConfigs(int region_id, int profile_index, ZProfileWidget& config_stats);
 
     // Interrupt conditions
     bool Interrupt(int region_id, const CursorXy& cursor1, const CursorXy& cursor2); // cursor and point regions
-    bool Interrupt(int region_id, const RegionState& region_state);
-    bool Interrupt(int region_id, int profile_stokes, const RegionState& region_state, const ZProfileWidget& config_stats);
+    bool Interrupt(
+        int region_id, int profile_stokes, const RegionState& region_state, const ZProfileWidget& config_stats, bool is_HDF5 = false);
 
 private:
     // Internal regions: image, cursor
@@ -168,7 +170,7 @@ private:
     // Functions used to check cursor and region states
     bool IsConnected(int region_id);
     bool IsSameRegionState(int region_id, const RegionState& region_state);
-    bool IsSameRegionSpectralConfig(int region_id, int profile_stokes, const ZProfileWidget& config_stats);
+    bool IsSameRegionSpectralConfig(int region_id, int profile_stokes, const ZProfileWidget& config_stats, bool is_HDF5 = false);
 
     // setup
     uint32_t _session_id;

--- a/Frame.h
+++ b/Frame.h
@@ -157,7 +157,7 @@ private:
     // get cursor's x-y coordinate from subimage
     bool GetSubImageXy(casacore::SubImage<float>& sub_image, CursorXy& cursor_xy);
     // get point spectral profile data from subimage
-    bool GetPointSpectralData(std::vector<float>& data, int region_id, casacore::SubImage<float>& sub_image,
+    bool GetPointSpectralData(int region_id, casacore::SubImage<float>& sub_image,
         const std::function<void(std::vector<float>, float)>& partial_results_callback);
     // get region stats data
     bool GetRegionSpectralData(int region_id, int profile_index, int profile_stokes,

--- a/Frame.h
+++ b/Frame.h
@@ -113,7 +113,7 @@ public:
     // Interrupt conditions
     bool Interrupt(int region_id, const CursorXy& cursor1, const CursorXy& cursor2); // cursor and point regions
     bool Interrupt(int region_id, const RegionState& region_state);
-    bool Interrupt(int region_id, const RegionState& region_state, const ZProfileWidget& config_stats);
+    bool Interrupt(int region_id, int profile_stokes, const RegionState& region_state, const ZProfileWidget& config_stats);
 
 private:
     // Internal regions: image, cursor
@@ -168,7 +168,7 @@ private:
     // Functions used to check cursor and region states
     bool IsConnected(int region_id);
     bool IsSameRegionState(int region_id, const RegionState& region_state);
-    bool IsSameRegionSpectralConfig(int region_id, const ZProfileWidget& config_stats);
+    bool IsSameRegionSpectralConfig(int region_id, int profile_stokes, const ZProfileWidget& config_stats);
 
     // setup
     uint32_t _session_id;

--- a/Frame.h
+++ b/Frame.h
@@ -159,7 +159,7 @@ private:
         const std::function<void(std::vector<float>, float)>& partial_results_callback);
     // get region stats data
     bool GetRegionSpectralData(int region_id, int profile_index, int profile_stokes,
-        const std::function<void(std::vector<std::vector<double>>, float)>& partial_results_callback);
+        const std::function<void(std::map<CARTA::StatsType, std::vector<double>>, float)>& partial_results_callback);
 
     // Functions used to set cursor and region states
     void SetConnectionFlag(bool connected);

--- a/Frame.h
+++ b/Frame.h
@@ -105,7 +105,7 @@ public:
     RegionState GetRegionState(int region_id);
 
     // Interrupt conditions
-    bool Interrupt(const CursorXy& cursor1, const CursorXy& cursor2); // cursor and point regions
+    bool Interrupt(int region_id, const CursorXy& cursor1, const CursorXy& cursor2); // cursor and point regions
     bool Interrupt(int region_id, const RegionState& region_state);
     bool Interrupt(int region_id, int num_profiles, int profile_index, int profile_stokes,
         const RegionState& region_state, const std::vector<int>& config_stats);
@@ -159,9 +159,11 @@ private:
     // Functions used to set cursor and region states
     void SetConnectionFlag(bool connected);
     void SetCursorXy(float x, float y);
+    void SetRegionId(int region_id);
 
     // Functions used to check cursor and region states
     bool IsConnected();
+    bool IsSameRegionId(int region_id);
     bool IsSameRegionState(int region_id, const RegionState& region_state);
     bool IsSameRegionSpectralConfig(int region_id, int num_profiles, int profile_index, int profile_stokes,
         const std::vector<int>& config_stats);
@@ -201,6 +203,8 @@ private:
     volatile bool _connected = true;
     // Current cursor's x-y coordinate
     CursorXy _cursor_xy;
+    // Current region id;
+    int _region_id;
 };
 
 #endif // CARTA_BACKEND__FRAME_H_

--- a/Frame.h
+++ b/Frame.h
@@ -105,7 +105,7 @@ public:
     RegionState GetRegionState(int region_id);
 
     // Interrupt conditions
-    bool Interrupt(const CursorXy& cursor1, const CursorXy& cursor2); // cursor and point regions
+    bool Interrupt(int region_id, const CursorXy& cursor1, const CursorXy& cursor2); // cursor and point regions
     bool Interrupt(int region_id, const RegionState& region_state);
     bool Interrupt(int region_id, const RegionState& region_state, const ZProfileWidget& config_stats);
 
@@ -158,9 +158,11 @@ private:
     // Functions used to set cursor and region states
     void SetConnectionFlag(bool connected);
     void SetCursorXy(float x, float y);
+    void SetRegionId(int region_id);
 
     // Functions used to check cursor and region states
     bool IsConnected();
+    bool IsSameRegionId(int region_id);
     bool IsSameRegionState(int region_id, const RegionState& region_state);
     bool IsSameRegionSpectralConfig(int region_id, const ZProfileWidget& config_stats);
 
@@ -199,6 +201,8 @@ private:
     volatile bool _connected = true;
     // Current cursor's x-y coordinate
     CursorXy _cursor_xy;
+    // Current region id;
+    int _region_id;
 };
 
 #endif // CARTA_BACKEND__FRAME_H_

--- a/ImageData/FileLoader.cc
+++ b/ImageData/FileLoader.cc
@@ -462,8 +462,9 @@ bool FileLoader::UseRegionSpectralData(const std::shared_ptr<casacore::ArrayLatt
     return false;
 }
 
-bool FileLoader::GetRegionSpectralData(int stokes, int region_id, const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask,
-    IPos origin, const std::function<void(std::map<CARTA::StatsType, std::vector<double>>*, float)>& partial_results_callback) {
+bool FileLoader::GetRegionSpectralData(int region_id, int profile_index, int stokes,
+    const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask, IPos origin,
+    const std::function<void(std::map<CARTA::StatsType, std::vector<double>>*, float)>& partial_results_callback) {
     // Must be implemented in subclasses
     return false;
 }

--- a/ImageData/FileLoader.cc
+++ b/ImageData/FileLoader.cc
@@ -462,7 +462,7 @@ bool FileLoader::UseRegionSpectralData(const std::shared_ptr<casacore::ArrayLatt
     return false;
 }
 
-bool FileLoader::GetRegionSpectralData(int region_id, int profile_index, int stokes,
+bool FileLoader::GetRegionSpectralData(int region_id, int config_stokes, int profile_stokes,
     const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask, IPos origin,
     const std::function<void(std::map<CARTA::StatsType, std::vector<double>>*, float)>& partial_results_callback) {
     // Must be implemented in subclasses

--- a/ImageData/FileLoader.cc
+++ b/ImageData/FileLoader.cc
@@ -452,18 +452,19 @@ FileInfo::ImageStats& FileLoader::GetImageStats(int current_stokes, int channel)
     return (channel >= 0 ? _channel_stats[current_stokes][channel] : _cube_stats[current_stokes]);
 }
 
-bool FileLoader::GetCursorSpectralData(std::vector<float>& data, int stokes, int cursor_x, int count_x, int cursor_y, int count_y) {
+bool FileLoader::GetCursorSpectralData(
+    std::vector<float>& data, int stokes, int cursor_x, int count_x, int cursor_y, int count_y, std::mutex& image_mutex) {
     // Must be implemented in subclasses
     return false;
 }
 
-bool FileLoader::UseRegionSpectralData(const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask) {
+bool FileLoader::UseRegionSpectralData(const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask, std::mutex& image_mutex) {
     // Must be implemented in subclasses
     return false;
 }
 
 bool FileLoader::GetRegionSpectralData(int region_id, int config_stokes, int profile_stokes,
-    const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask, IPos origin,
+    const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask, IPos origin, std::mutex& image_mutex,
     const std::function<void(std::map<CARTA::StatsType, std::vector<double>>*, float)>& partial_results_callback) {
     // Must be implemented in subclasses
     return false;

--- a/ImageData/FileLoader.h
+++ b/ImageData/FileLoader.h
@@ -151,8 +151,9 @@ public:
     virtual bool GetCursorSpectralData(std::vector<float>& data, int stokes, int cursor_x, int count_x, int cursor_y, int count_y);
     // check if one can apply swizzled data under such image format and region condition
     virtual bool UseRegionSpectralData(const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask);
-    virtual bool GetRegionSpectralData(int stokes, int region_id, const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask,
-        IPos origin, const std::function<void(std::map<CARTA::StatsType, std::vector<double>>*, float)>& partial_results_callback);
+    virtual bool GetRegionSpectralData(int region_id, int profile_index, int stokes,
+        const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask, IPos origin,
+        const std::function<void(std::map<CARTA::StatsType, std::vector<double>>*, float)>& partial_results_callback);
     virtual bool GetPixelMaskSlice(casacore::Array<bool>& mask, const casacore::Slicer& slicer) = 0;
     virtual void SetFramePtr(Frame* frame);
 

--- a/ImageData/FileLoader.h
+++ b/ImageData/FileLoader.h
@@ -148,12 +148,15 @@ public:
     // Return a casacore image type representing the data stored in the
     // specified HDU/group/table/etc.
     virtual ImageRef LoadData(FileInfo::Data ds) = 0;
-    virtual bool GetCursorSpectralData(std::vector<float>& data, int stokes, int cursor_x, int count_x, int cursor_y, int count_y);
+
+    virtual bool GetCursorSpectralData(
+        std::vector<float>& data, int stokes, int cursor_x, int count_x, int cursor_y, int count_y, std::mutex& image_mutex);
     // check if one can apply swizzled data under such image format and region condition
-    virtual bool UseRegionSpectralData(const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask);
+    virtual bool UseRegionSpectralData(const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask, std::mutex& image_mutex);
     virtual bool GetRegionSpectralData(int region_id, int config_stokes, int profile_stokes,
-        const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask, IPos origin,
+        const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask, IPos origin, std::mutex& image_mutex,
         const std::function<void(std::map<CARTA::StatsType, std::vector<double>>*, float)>& partial_results_callback);
+
     virtual bool GetPixelMaskSlice(casacore::Array<bool>& mask, const casacore::Slicer& slicer) = 0;
     virtual void SetFramePtr(Frame* frame);
 

--- a/ImageData/FileLoader.h
+++ b/ImageData/FileLoader.h
@@ -151,7 +151,7 @@ public:
     virtual bool GetCursorSpectralData(std::vector<float>& data, int stokes, int cursor_x, int count_x, int cursor_y, int count_y);
     // check if one can apply swizzled data under such image format and region condition
     virtual bool UseRegionSpectralData(const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask);
-    virtual bool GetRegionSpectralData(int region_id, int profile_index, int stokes,
+    virtual bool GetRegionSpectralData(int region_id, int config_stokes, int profile_stokes,
         const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask, IPos origin,
         const std::function<void(std::map<CARTA::StatsType, std::vector<double>>*, float)>& partial_results_callback);
     virtual bool GetPixelMaskSlice(casacore::Array<bool>& mask, const casacore::Slicer& slicer) = 0;

--- a/ImageData/Hdf5Loader.h
+++ b/ImageData/Hdf5Loader.h
@@ -346,8 +346,8 @@ bool Hdf5Loader::GetRegionSpectralData(int region_id, int config_stokes, int pro
     auto region_stats_id = FileInfo::RegionStatsId(region_id, profile_stokes);
 
     if (_region_stats.find(region_stats_id) == _region_stats.end()) { // region stats never calculated
-        _region_stats.emplace(
-            std::piecewise_construct, std::forward_as_tuple(region_id, profile_stokes), std::forward_as_tuple(origin, mask->shape(), num_z));
+        _region_stats.emplace(std::piecewise_construct, std::forward_as_tuple(region_id, profile_stokes),
+            std::forward_as_tuple(origin, mask->shape(), num_z));
         recalculate = true;
     } else if (!_region_stats[region_stats_id].IsValid(origin, mask->shape())) { // region stats expired
         _region_stats[region_stats_id].origin = origin;

--- a/ImageData/Hdf5Loader.h
+++ b/ImageData/Hdf5Loader.h
@@ -20,10 +20,11 @@ public:
     bool HasData(FileInfo::Data ds) const override;
     ImageRef LoadData(FileInfo::Data ds) override;
     bool GetPixelMaskSlice(casacore::Array<bool>& mask, const casacore::Slicer& slicer) override;
-    bool GetCursorSpectralData(std::vector<float>& data, int stokes, int cursor_x, int count_x, int cursor_y, int count_y) override;
-    bool UseRegionSpectralData(const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask) override;
+    bool GetCursorSpectralData(
+        std::vector<float>& data, int stokes, int cursor_x, int count_x, int cursor_y, int count_y, std::mutex& image_mutex) override;
+    bool UseRegionSpectralData(const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask, std::mutex& image_mutex) override;
     bool GetRegionSpectralData(int region_id, int profile_index, int stokes,
-        const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask, IPos origin,
+        const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask, IPos origin, std::mutex& image_mutex,
         const std::function<void(std::map<CARTA::StatsType, std::vector<double>>*, float)>& partial_results_callback) override;
     void SetFramePtr(Frame* frame) override;
 
@@ -288,9 +289,13 @@ casacore::ArrayBase* Hdf5Loader::GetStatsDataTyped(FileInfo::Data ds) {
     return data;
 }
 
-bool Hdf5Loader::GetCursorSpectralData(std::vector<float>& data, int stokes, int cursor_x, int count_x, int cursor_y, int count_y) {
+bool Hdf5Loader::GetCursorSpectralData(
+    std::vector<float>& data, int stokes, int cursor_x, int count_x, int cursor_y, int count_y, std::mutex& image_mutex) {
     bool data_ok(false);
-    if (HasData(FileInfo::Data::SWIZZLED)) {
+    std::unique_lock<std::mutex> ulock(image_mutex);
+    bool has_swizzled = HasData(FileInfo::Data::SWIZZLED);
+    ulock.unlock();
+    if (has_swizzled) {
         casacore::Slicer slicer;
         if (_num_dims == 4) {
             slicer = casacore::Slicer(IPos(4, 0, cursor_y, cursor_x, stokes), IPos(4, _num_channels, count_y, count_x, 1));
@@ -300,6 +305,7 @@ bool Hdf5Loader::GetCursorSpectralData(std::vector<float>& data, int stokes, int
 
         data.resize(_num_channels * count_y * count_x);
         casacore::Array<float> tmp(slicer.length(), data.data(), casacore::StorageInitPolicy::SHARE);
+        std::lock_guard<std::mutex> lguard(image_mutex);
         try {
             LoadSwizzledData(FileInfo::Data::SWIZZLED)->doGetSlice(tmp, slicer);
             data_ok = true;
@@ -307,12 +313,14 @@ bool Hdf5Loader::GetCursorSpectralData(std::vector<float>& data, int stokes, int
             std::cerr << "Could not load cursor spectral data from swizzled HDF5 dataset. AIPS ERROR: " << err.getMesg() << std::endl;
         }
     }
-
     return data_ok;
 }
 
-bool Hdf5Loader::UseRegionSpectralData(const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask) {
-    if (!HasData(FileInfo::Data::SWIZZLED)) {
+bool Hdf5Loader::UseRegionSpectralData(const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask, std::mutex& image_mutex) {
+    std::unique_lock<std::mutex> ulock(image_mutex);
+    bool has_swizzled = HasData(FileInfo::Data::SWIZZLED);
+    ulock.unlock();
+    if (!has_swizzled) {
         return false;
     }
 
@@ -330,11 +338,14 @@ bool Hdf5Loader::UseRegionSpectralData(const std::shared_ptr<casacore::ArrayLatt
 }
 
 bool Hdf5Loader::GetRegionSpectralData(int region_id, int config_stokes, int profile_stokes,
-    const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask, IPos origin,
+    const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask, IPos origin, std::mutex& image_mutex,
     const std::function<void(std::map<CARTA::StatsType, std::vector<double>>*, float)>& partial_results_callback) {
     // config_stokes is the stokes value in the spectral config, could be -1 for CURRENT_STOKES; used to retrieve config from region
     // profile_stokes is the stokes index to use for slicing image data
-    if (!HasData(FileInfo::Data::SWIZZLED)) {
+    std::unique_lock<std::mutex> ulock(image_mutex);
+    bool has_swizzled = HasData(FileInfo::Data::SWIZZLED);
+    ulock.unlock();
+    if (!has_swizzled) {
         return false;
     }
 
@@ -452,7 +463,7 @@ bool Hdf5Loader::GetRegionSpectralData(int region_id, int config_stokes, int pro
                 return false;
             }
 
-            bool have_spectral_data = GetCursorSpectralData(slice_data, profile_stokes, x + x_min, 1, y_min, num_y);
+            bool have_spectral_data = GetCursorSpectralData(slice_data, profile_stokes, x + x_min, 1, y_min, num_y, image_mutex);
             if (!have_spectral_data) {
                 return false;
             }

--- a/ImageData/Hdf5Loader.h
+++ b/ImageData/Hdf5Loader.h
@@ -329,9 +329,11 @@ bool Hdf5Loader::UseRegionSpectralData(const std::shared_ptr<casacore::ArrayLatt
     return true;
 }
 
-bool Hdf5Loader::GetRegionSpectralData(int region_id, int profile_index, int stokes,
+bool Hdf5Loader::GetRegionSpectralData(int region_id, int config_stokes, int profile_stokes,
     const std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> mask, IPos origin,
     const std::function<void(std::map<CARTA::StatsType, std::vector<double>>*, float)>& partial_results_callback) {
+    // config_stokes is the stokes value in the spectral config, could be -1 for CURRENT_STOKES; used to retrieve config from region
+    // profile_stokes is the stokes index to use for slicing image data
     if (!HasData(FileInfo::Data::SWIZZLED)) {
         return false;
     }
@@ -341,11 +343,11 @@ bool Hdf5Loader::GetRegionSpectralData(int region_id, int profile_index, int sto
     int num_z = _num_channels;
 
     bool recalculate(false);
-    auto region_stats_id = FileInfo::RegionStatsId(region_id, stokes);
+    auto region_stats_id = FileInfo::RegionStatsId(region_id, profile_stokes);
 
     if (_region_stats.find(region_stats_id) == _region_stats.end()) { // region stats never calculated
         _region_stats.emplace(
-            std::piecewise_construct, std::forward_as_tuple(region_id, stokes), std::forward_as_tuple(origin, mask->shape(), num_z));
+            std::piecewise_construct, std::forward_as_tuple(region_id, profile_stokes), std::forward_as_tuple(origin, mask->shape(), num_z));
         recalculate = true;
     } else if (!_region_stats[region_stats_id].IsValid(origin, mask->shape())) { // region stats expired
         _region_stats[region_stats_id].origin = origin;
@@ -399,8 +401,8 @@ bool Hdf5Loader::GetRegionSpectralData(int region_id, int profile_index, int sto
         }
 
         // get a copy of current region configs
-        ZProfileWidget config_stats;
-        if (!_frame->GetRegionConfigs(region_id, profile_index, config_stats)) {
+        SpectralConfig config_stats;
+        if (!_frame->GetRegionSpectralConfig(region_id, config_stokes, config_stats)) {
             return false;
         }
 
@@ -444,13 +446,13 @@ bool Hdf5Loader::GetRegionSpectralData(int region_id, int profile_index, int sto
         // Load each X slice of the swizzled region bounding box and update Z stats incrementally
         for (size_t x = x_start; x < num_x; x++) {
             // check if frontend's requirements changed
-            if (_frame != nullptr && _frame->Interrupt(region_id, stokes, region_state, config_stats, true)) {
+            if (_frame != nullptr && _frame->Interrupt(region_id, profile_stokes, region_state, config_stats, true)) {
                 // remember the latest x step
                 _region_stats[region_stats_id].latest_x = x;
                 return false;
             }
 
-            bool have_spectral_data = GetCursorSpectralData(slice_data, stokes, x + x_min, 1, y_min, num_y);
+            bool have_spectral_data = GetCursorSpectralData(slice_data, profile_stokes, x + x_min, 1, y_min, num_y);
             if (!have_spectral_data) {
                 return false;
             }

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -778,9 +778,16 @@ int Region::NumStatsToLoad(int profile_index) {
     return 0;
 }
 
-bool Region::GetSpectralConfigStats(int profile_index, std::vector<int>& stats) {
+bool Region::GetSpectralConfigStats(int profile_index, ZProfileWidget& stats) {
     if (_region_profiler) {
         return _region_profiler->GetSpectralConfigStats(profile_index, stats);
+    }
+    return false;
+}
+
+bool Region::IsValidSpectralConfigStats(const ZProfileWidget& stats) {
+    if (_region_profiler) {
+        return _region_profiler->IsValidSpectralConfigStats(stats);
     }
     return false;
 }

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -1147,7 +1147,7 @@ void Region::SetSpatialProfileSent(int profile_index, bool sent) {
     }
 }
 
-// spectral
+// spectral requirements
 
 bool Region::SetSpectralRequirements(const std::vector<CARTA::SetSpectralRequirements_SpectralConfig>& configs, const int num_stokes) {
     if (_region_profiler) {
@@ -1163,156 +1163,162 @@ size_t Region::NumSpectralProfiles() {
     return 0;
 }
 
-int Region::NumStatsToLoad(int profile_index) {
+bool Region::IsValidSpectralConfig(const SpectralConfig& config) {
     if (_region_profiler) {
-        return _region_profiler->NumStatsToLoad(profile_index);
-    }
-    return 0;
-}
-
-bool Region::GetSpectralConfigStats(int profile_index, ZProfileWidget& stats) {
-    if (_region_profiler) {
-        return _region_profiler->GetSpectralConfigStats(profile_index, stats);
+        return _region_profiler->IsValidSpectralConfig(config);
     }
     return false;
 }
 
-bool Region::IsValidSpectralConfigStats(const ZProfileWidget& stats) {
+std::vector<SpectralProfile> Region::GetSpectralProfiles() {
     if (_region_profiler) {
-        return _region_profiler->IsValidSpectralConfigStats(stats);
+        return _region_profiler->GetSpectralProfiles();
+    }
+    return std::vector<SpectralProfile>();
+}
+
+bool Region::GetSpectralConfig(int config_stokes, SpectralConfig& config) {
+    if (_region_profiler) {
+        return _region_profiler->GetSpectralConfig(config_stokes, config);
     }
     return false;
 }
 
-bool Region::GetSpectralStatsToLoad(int profile_index, std::vector<int>& stats) {
+bool Region::GetSpectralProfileAllStatsSent(int config_stokes) {
     if (_region_profiler) {
-        return _region_profiler->GetSpectralStatsToLoad(profile_index, stats);
+        return _region_profiler->GetSpectralProfileAllStatsSent(config_stokes);
     }
-    return false;
+    return true;
 }
 
-bool Region::GetSpectralProfileStatSent(int profile_index, int stats_type) {
+void Region::SetSpectralProfileAllStatsSent(int config_stokes, bool sent) {
     if (_region_profiler) {
-        return _region_profiler->GetSpectralProfileStatSent(profile_index, stats_type);
-    }
-    return false;
-}
-
-void Region::SetSpectralProfileStatSent(int profile_index, int stats_type, bool sent) {
-    if (_region_profiler) {
-        _region_profiler->SetSpectralProfileStatSent(profile_index, stats_type, sent);
+        _region_profiler->SetSpectralProfileAllStatsSent(config_stokes, sent);
     }
 }
 
-void Region::SetSpectralProfileAllStatsSent(int profile_index, bool sent) {
-    // for fixed stokes profiles when stokes changed, do not resend
+void Region::SetAllSpectralProfilesUnsent() {
     if (_region_profiler) {
-        _region_profiler->SetSpectralProfileAllStatsSent(profile_index, sent);
+        _region_profiler->SetAllSpectralProfilesUnsent();
     }
 }
 
-int Region::GetSpectralConfigStokes(int profile_index) {
-    if (_region_profiler) {
-        return _region_profiler->GetSpectralConfigStokes(profile_index);
-    }
-    return CURRENT_STOKES - 1; // invalid
-}
-
-std::string Region::GetSpectralCoordinate(int profile_index) {
-    if (_region_profiler) {
-        return _region_profiler->GetSpectralCoordinate(profile_index);
-    }
-    return std::string();
-}
+// spectral data
 
 bool Region::GetSpectralProfileData(
-    std::map<CARTA::StatsType, std::vector<double>>& stats_values, int profile_index, casacore::ImageInterface<float>& image) {
-    // Get SpectralProfile with statistics values to load according to config stored in RegionProfiler
+    std::map<CARTA::StatsType, std::vector<double>>& spectral_data, int config_stokes, casacore::ImageInterface<float>& image) {
+    // Return spectral data for unsent stats in spectral config
     bool have_stats(false);
-    std::vector<int> required_stats;
-    if (GetSpectralStatsToLoad(profile_index, required_stats)) {
-        if ((required_stats.size() > 0) && _region_stats) { // get required stats values
-            have_stats = _region_stats->CalcStatsValues(stats_values, required_stats, image);
+    if (_region_profiler) {
+        std::vector<int> unsent_stats;
+        if (_region_profiler->GetUnsentStatsForProfile(config_stokes, unsent_stats)) {
+            if (!unsent_stats.empty() && _region_stats) {
+                have_stats = _region_stats->CalcStatsValues(spectral_data, unsent_stats, image);
+            }
         }
     }
     return have_stats;
 }
 
-void Region::FillPointSpectralProfileData(CARTA::SpectralProfileData& profile_data, int profile_index, std::vector<float>& spectral_data) {
-    // Fill SpectralProfile with values for point region; assumes one spectral config with StatsType::Sum
-    if (IsPoint()) {
-        CARTA::StatsType type = CARTA::StatsType::Sum;
-        if (!GetSpectralProfileStatSent(profile_index, type)) {
-            std::string profile_coord(GetSpectralCoordinate(profile_index));
-            auto new_profile = profile_data.add_profiles();
-            new_profile->set_coordinate(profile_coord);
-            new_profile->set_stats_type(type);
-            new_profile->set_raw_values_fp32(spectral_data.data(), spectral_data.size() * sizeof(float));
-            if (profile_data.progress() == PROFILE_COMPLETE) {
-                SetSpectralProfileStatSent(profile_index, type, true);
+void Region::FillPointSpectralProfileDataMessage(
+    CARTA::SpectralProfileData& profile_message, int config_stokes, std::vector<float>& spectral_data) {
+    // Fill SpectralProfileData with unsent spectral_data for point region; assumes one spectral config stats type
+    if (IsPoint() && _region_profiler) {
+        std::vector<int> unsent_stats;
+        if (_region_profiler->GetUnsentStatsForProfile(config_stokes, unsent_stats)) { // true if profile still exists
+            if (!unsent_stats.empty()) {
+                std::string config_coord(_region_profiler->GetSpectralCoordinate(config_stokes));
+                if (!config_coord.empty()) { // not empty if profile still exists
+                    auto new_profile = profile_message.add_profiles();
+                    new_profile->set_coordinate(config_coord);
+                    auto stats_type = static_cast<CARTA::StatsType>(unsent_stats[0]);
+                    new_profile->set_stats_type(stats_type);
+                    new_profile->set_raw_values_fp32(spectral_data.data(), spectral_data.size() * sizeof(float));
+                    if (profile_message.progress() == PROFILE_COMPLETE) {
+                        _region_profiler->SetSpectralProfileStatSent(config_stokes, stats_type, true);
+                    }
+                }
             }
         }
     }
 }
 
-void Region::FillSpectralProfileData(
-    CARTA::SpectralProfileData& profile_data, int profile_index, std::map<CARTA::StatsType, std::vector<double>>& stats_values) {
-    // Fill SpectralProfile with statistics values according to config stored in RegionProfiler
-    // using values calculated externally and passed in as a parameter
-    std::vector<int> required_stats;
-    if (GetSpectralStatsToLoad(profile_index, required_stats)) {
-        std::string profile_coord(GetSpectralCoordinate(profile_index));
-        for (size_t i = 0; i < required_stats.size(); ++i) {
-            // one SpectralProfile per stats type
-            auto new_profile = profile_data.add_profiles();
-            new_profile->set_coordinate(profile_coord);
-            auto stat_type = static_cast<CARTA::StatsType>(required_stats[i]);
-            new_profile->set_stats_type(stat_type);
-            if (stats_values.find(stat_type) == stats_values.end()) { // stat not provided
-                double nan_value = std::numeric_limits<double>::quiet_NaN();
-                new_profile->set_raw_values_fp64(&nan_value, sizeof(double));
-            } else {
-                new_profile->set_raw_values_fp64(stats_values[stat_type].data(), stats_values[stat_type].size() * sizeof(double));
-            }
-            if (profile_data.progress() == PROFILE_COMPLETE) {
-                SetSpectralProfileStatSent(profile_index, stat_type, true);
+void Region::FillSpectralProfileDataMessage(
+    CARTA::SpectralProfileData& profile_message, int config_stokes, std::map<CARTA::StatsType, std::vector<double>>& spectral_data) {
+    // Fill SpectralProfileData with unsent statistics values (results) for stats in spectral config, using supplied results
+    if (_region_profiler) {
+        std::vector<int> unsent_stats;
+        if (_region_profiler->GetUnsentStatsForProfile(config_stokes, unsent_stats)) { // true if profile still exists
+            if (!unsent_stats.empty()) {
+                std::string config_coord(_region_profiler->GetSpectralCoordinate(config_stokes));
+                if (!config_coord.empty()) { // not empty if profile still exists
+                    for (size_t i = 0; i < unsent_stats.size(); ++i) {
+                        // one SpectralProfile per stats type
+                        auto new_profile = profile_message.add_profiles();
+                        new_profile->set_coordinate(config_coord);
+                        auto stats_type = static_cast<CARTA::StatsType>(unsent_stats[i]);
+                        new_profile->set_stats_type(stats_type);
+                        if (spectral_data.find(stats_type) == spectral_data.end()) { // stat not provided
+                            double nan_value = std::numeric_limits<double>::quiet_NaN();
+                            new_profile->set_raw_values_fp64(&nan_value, sizeof(double));
+                        } else {
+                            new_profile->set_raw_values_fp64(
+                                spectral_data[stats_type].data(), spectral_data[stats_type].size() * sizeof(double));
+                        }
+                        if (profile_message.progress() == PROFILE_COMPLETE) {
+                            _region_profiler->SetSpectralProfileStatSent(config_stokes, stats_type, true);
+                        }
+                    }
+                }
             }
         }
     }
 }
 
-void Region::FillNaNSpectralProfileData(CARTA::SpectralProfileData& profile_data, int profile_index) {
-    // Fill spectral profile with NaN statistics values according to config stored in RegionProfiler
-    std::vector<int> required_stats;
-    if (GetSpectralStatsToLoad(profile_index, required_stats)) {
-        std::string profile_coord(GetSpectralCoordinate(profile_index));
-        for (size_t i = 0; i < required_stats.size(); ++i) {
-            // one SpectralProfile per stats type
-            auto new_profile = profile_data.add_profiles();
-            new_profile->set_coordinate(profile_coord);
-            auto stat_type = static_cast<CARTA::StatsType>(required_stats[i]);
-            new_profile->set_stats_type(stat_type);
-            // region outside image or NaNs
-            double nan_value = std::numeric_limits<double>::quiet_NaN();
-            new_profile->set_raw_values_fp64(&nan_value, sizeof(double));
-            SetSpectralProfileStatSent(profile_index, stat_type, true);
+void Region::FillNaNSpectralProfileDataMessage(CARTA::SpectralProfileData& profile_message, int config_stokes) {
+    // Fill SpectralProfileData with a single NaN value for stats in spectral config; region is fully masked (outside image or NaNs)
+    if (_region_profiler) {
+        std::vector<int> unsent_stats;
+        if (_region_profiler->GetUnsentStatsForProfile(config_stokes, unsent_stats)) { // true if profile still exists
+            if (!unsent_stats.empty()) {
+                std::string config_coord(_region_profiler->GetSpectralCoordinate(config_stokes));
+                if (!config_coord.empty()) { // not empty if profile still exists
+                    for (size_t i = 0; i < unsent_stats.size(); ++i) {
+                        // one SpectralProfile per stats type
+                        auto new_profile = profile_message.add_profiles();
+                        new_profile->set_coordinate(config_coord);
+                        auto stat_type = static_cast<CARTA::StatsType>(unsent_stats[i]);
+                        new_profile->set_stats_type(stat_type);
+                        double nan_value = std::numeric_limits<double>::quiet_NaN();
+                        new_profile->set_raw_values_fp64(&nan_value, sizeof(double));
+                        _region_profiler->SetSpectralProfileStatSent(config_stokes, stat_type, true);
+                    }
+                }
+            }
         }
     }
 }
 
-bool Region::InitStatsData(int profile_index, size_t profile_size, std::map<CARTA::StatsType, std::vector<double>>& stats_data) {
-    bool data_ok(false);
-    std::vector<int> required_stats;
-    if (GetSpectralStatsToLoad(profile_index, required_stats)) {
-        for (size_t i = 0; i < required_stats.size(); ++i) {
-            auto stats_type = static_cast<CARTA::StatsType>(required_stats[i]);
-            std::vector<double> init_stats_data(profile_size, std::numeric_limits<double>::quiet_NaN());
-            stats_data.emplace(stats_type, init_stats_data);
+bool Region::InitSpectralData(int config_stokes, size_t profile_size, std::map<CARTA::StatsType, std::vector<double>>& spectral_data) {
+    // Initialize spectral data map for unsent stats to NaN
+    bool data_init(false);
+    if (_region_profiler) {
+        std::vector<int> unsent_stats;
+        if (_region_profiler->GetUnsentStatsForProfile(config_stokes, unsent_stats)) { // true if profile still exists
+            if (!unsent_stats.empty()) {
+                for (size_t i = 0; i < unsent_stats.size(); ++i) {
+                    auto stats_type = static_cast<CARTA::StatsType>(unsent_stats[i]);
+                    std::vector<double> init_spectral_data(profile_size, std::numeric_limits<double>::quiet_NaN());
+                    spectral_data.emplace(stats_type, init_spectral_data);
+                }
+                data_init = true;
+            }
         }
-        data_ok = true;
     }
-    return data_ok;
+    return data_init;
 }
+
+// Region connection state
 
 void Region::SetConnectionFlag(bool connected) {
     _connected = connected;

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -926,3 +926,17 @@ void Region::FillNaNSpectralProfileData(CARTA::SpectralProfileData& profile_data
         }
     }
 }
+
+bool Region::InitStatsData(int profile_index, size_t profile_size, std::vector<std::vector<double>>& stats_data) {
+    bool data_ok(false);
+    int stats_size = NumStatsToLoad(profile_index);
+    if (stats_size > 0) {
+        std::vector<std::vector<double>> results(stats_size);
+        for (int i = 0; i < stats_size; ++i) {
+            results[i].resize(profile_size, std::numeric_limits<double>::quiet_NaN());
+        }
+        stats_data = std::move(results);
+        data_ok = true;
+    }
+    return data_ok;
+}

--- a/Region/Region.h
+++ b/Region/Region.h
@@ -111,7 +111,8 @@ public:
     // Spectral data
     bool GetSpectralProfileData(
         std::map<CARTA::StatsType, std::vector<double>>& spectral_data, int config_stokes, casacore::ImageInterface<float>& image);
-    void FillPointSpectralProfileDataMessage(CARTA::SpectralProfileData& profile_message, int config_stokes, std::vector<float>& spectral_data);
+    void FillPointSpectralProfileDataMessage(
+        CARTA::SpectralProfileData& profile_message, int config_stokes, std::vector<float>& spectral_data);
     void FillSpectralProfileDataMessage(
         CARTA::SpectralProfileData& profile_message, int config_stokes, std::map<CARTA::StatsType, std::vector<double>>& spectral_data);
     void FillNaNSpectralProfileDataMessage(CARTA::SpectralProfileData& profile_message, int config_stokes);

--- a/Region/Region.h
+++ b/Region/Region.h
@@ -91,7 +91,8 @@ public:
     void SetSpectralProfileAllStatsSent(int profile_index, bool sent);
     void SetAllSpectralProfileStatsUnsent(); // enable sending new profiles
     int GetSpectralConfigStokes(int profile_index);
-    bool GetSpectralConfigStats(int profile_index, std::vector<int>& stats);
+    bool GetSpectralConfigStats(int profile_index, ZProfileWidget& stats);
+    bool IsValidSpectralConfigStats(const ZProfileWidget& stats);
     bool GetSpectralProfileData(std::vector<std::vector<double>>& stats_values, int profile_index, casacore::ImageInterface<float>& image);
     void FillPointSpectralProfileData(CARTA::SpectralProfileData& profile_data, int profile_index, std::vector<float>& spectral_data);
     void FillSpectralProfileData(

--- a/Region/Region.h
+++ b/Region/Region.h
@@ -96,12 +96,11 @@ public:
     int GetSpectralConfigStokes(int profile_index);
     bool GetSpectralConfigStats(int profile_index, ZProfileWidget& stats);
     bool IsValidSpectralConfigStats(const ZProfileWidget& stats);
-    bool GetSpectralProfileData(std::vector<std::vector<double>>& stats_values, int profile_index, casacore::ImageInterface<float>& image);
+    bool GetSpectralProfileData(
+        std::map<CARTA::StatsType, std::vector<double>>& stats_values, int profile_index, casacore::ImageInterface<float>& image);
     void FillPointSpectralProfileData(CARTA::SpectralProfileData& profile_data, int profile_index, std::vector<float>& spectral_data);
     void FillSpectralProfileData(
         CARTA::SpectralProfileData& profile_data, int profile_index, std::map<CARTA::StatsType, std::vector<double>>& stats_values);
-    void FillSpectralProfileData(
-        CARTA::SpectralProfileData& profile_data, int profile_index, const std::vector<std::vector<double>>& stats_values);
     void FillNaNSpectralProfileData(CARTA::SpectralProfileData& profile_data, int profile_index);
 
     // Stats: pass through to RegionStats
@@ -115,7 +114,7 @@ public:
     RegionState GetRegionState();
 
     // Initialize the stats data
-    bool InitStatsData(int profile_index, size_t profile_size, std::vector<std::vector<double>>& stats_data);
+    bool InitStatsData(int profile_index, size_t profile_size, std::map<CARTA::StatsType, std::vector<double>>& stats_data);
 
     // Communication
     bool IsConnected();

--- a/Region/Region.h
+++ b/Region/Region.h
@@ -107,7 +107,11 @@ public:
     void FillStatsData(CARTA::RegionStatsData& stats_data, std::map<CARTA::StatsType, double>& stats_values);
     void FillNaNStatsData(CARTA::RegionStatsData& stats_data);
 
+    // Get current region state
     RegionState GetRegionState();
+
+    // Initialize the stats data
+    bool InitStatsData(int profile_index, size_t profile_size, std::vector<std::vector<double>>& stats_data);
 
 private:
     // bounds checking for Region parameters

--- a/Region/Region.h
+++ b/Region/Region.h
@@ -90,7 +90,7 @@ public:
 
     void SetAllProfilesUnsent(); // enable sending new spatial and spectral profiles
 
-    // Spatial: pass through to RegionProfiler
+    // Spatial requirements: pass through to RegionProfiler
     bool SetSpatialRequirements(const std::vector<std::string>& profiles, const int num_stokes);
     size_t NumSpatialProfiles();
     std::string GetSpatialCoordinate(int profile_index);
@@ -98,22 +98,24 @@ public:
     bool GetSpatialProfileSent(int profile_index);
     void SetSpatialProfileSent(int profile_index, bool sent);
 
-    // Spectral: pass through to RegionProfiler
+    // Spectral requirements: pass through to RegionProfiler
     bool SetSpectralRequirements(const std::vector<CARTA::SetSpectralRequirements_SpectralConfig>& profiles, const int num_stokes);
     size_t NumSpectralProfiles();
-    int NumStatsToLoad(int profile_index);
-    void SetSpectralProfileStatSent(int profile_index, int stats_type, bool sent);
-    void SetSpectralProfileAllStatsSent(int profile_index, bool sent);
-    void SetAllSpectralProfileStatsUnsent(); // enable sending new profiles
-    int GetSpectralConfigStokes(int profile_index);
-    bool GetSpectralConfigStats(int profile_index, ZProfileWidget& stats);
-    bool IsValidSpectralConfigStats(const ZProfileWidget& stats);
+    bool IsValidSpectralConfig(const SpectralConfig& stats);
+    std::vector<SpectralProfile> GetSpectralProfiles();
+    bool GetSpectralConfig(int config_stokes, SpectralConfig& config);
+    bool GetSpectralProfileAllStatsSent(int config_stokes);
+    void SetSpectralProfileAllStatsSent(int config_stokes, bool sent);
+    void SetAllSpectralProfilesUnsent();
+
+    // Spectral data
     bool GetSpectralProfileData(
-        std::map<CARTA::StatsType, std::vector<double>>& stats_values, int profile_index, casacore::ImageInterface<float>& image);
-    void FillPointSpectralProfileData(CARTA::SpectralProfileData& profile_data, int profile_index, std::vector<float>& spectral_data);
-    void FillSpectralProfileData(
-        CARTA::SpectralProfileData& profile_data, int profile_index, std::map<CARTA::StatsType, std::vector<double>>& stats_values);
-    void FillNaNSpectralProfileData(CARTA::SpectralProfileData& profile_data, int profile_index);
+        std::map<CARTA::StatsType, std::vector<double>>& spectral_data, int config_stokes, casacore::ImageInterface<float>& image);
+    void FillPointSpectralProfileDataMessage(CARTA::SpectralProfileData& profile_message, int config_stokes, std::vector<float>& spectral_data);
+    void FillSpectralProfileDataMessage(
+        CARTA::SpectralProfileData& profile_message, int config_stokes, std::map<CARTA::StatsType, std::vector<double>>& spectral_data);
+    void FillNaNSpectralProfileDataMessage(CARTA::SpectralProfileData& profile_message, int config_stokes);
+    bool InitSpectralData(int profile_index, size_t profile_size, std::map<CARTA::StatsType, std::vector<double>>& stats_data);
 
     // Stats: pass through to RegionStats
     void SetStatsRequirements(const std::vector<int>& stats_types);
@@ -124,9 +126,6 @@ public:
 
     // Get current region state
     RegionState GetRegionState();
-
-    // Initialize the stats data
-    bool InitStatsData(int profile_index, size_t profile_size, std::map<CARTA::StatsType, std::vector<double>>& stats_data);
 
     // Communication
     bool IsConnected();

--- a/Region/RegionProfiler.cc
+++ b/Region/RegionProfiler.cc
@@ -255,7 +255,7 @@ bool RegionProfiler::GetSpectralProfileAllStatsSent(int config_stokes) {
         if (profile.config.stokes_index == config_stokes) { // found config_stokes
             found_profile = true;
             for (size_t j = 0; j < profile.config.stats_types.size(); ++j) {
-                all_sent &= profile.profiles_sent[j];  // false if any false
+                all_sent &= profile.profiles_sent[j]; // false if any false
             }
         }
     }

--- a/Region/RegionProfiler.cc
+++ b/Region/RegionProfiler.cc
@@ -212,11 +212,24 @@ std::string RegionProfiler::GetSpectralCoordinate(int profile_index) {
     }
 }
 
-bool RegionProfiler::GetSpectralConfigStats(int profile_index, std::vector<int>& stats) {
+bool RegionProfiler::GetSpectralConfigStats(int profile_index, ZProfileWidget& stats) {
     // return stats_types at given index; return false if index out of range
     if (profile_index < _spectral_profiles.size()) {
-        stats = _spectral_profiles[profile_index].stats_types;
+        stats = ZProfileWidget(_spectral_profiles[profile_index].stokes_index, _spectral_profiles[profile_index].stats_types);
         return true;
+    }
+    return false;
+}
+
+bool RegionProfiler::IsValidSpectralConfigStats(const ZProfileWidget& stats) {
+    if (_spectral_profiles.size() > 0) {
+        for (const auto& spectral_profile : _spectral_profiles) {
+            if (stats.stokes_index == spectral_profile.stokes_index) {
+                if (stats.stats_types == spectral_profile.stats_types) {
+                    return true;
+                }
+            }
+        }
     }
     return false;
 }

--- a/Region/RegionProfiler.cc
+++ b/Region/RegionProfiler.cc
@@ -153,7 +153,7 @@ bool RegionProfiler::SetSpectralRequirements(
     }
     bool valid(false);
     _spectral_profiles = new_profiles;
-    if (configs.size() == _spectral_profiles.size()) {
+    if (configs.size() == NumSpectralProfiles()) {
         // Determine diff for required data streams
         DiffSpectralRequirements(last_profiles);
         valid = true;
@@ -185,7 +185,7 @@ size_t RegionProfiler::NumSpectralProfiles() {
 
 int RegionProfiler::NumStatsToLoad(int profile_index) {
     int num_unsent(0);
-    if (profile_index < _spectral_profiles.size()) {
+    if (profile_index < NumSpectralProfiles()) {
         SpectralProfile profile = _spectral_profiles[profile_index];
         for (auto sent : profile.profiles_sent) {
             if (!sent) {
@@ -198,14 +198,14 @@ int RegionProfiler::NumStatsToLoad(int profile_index) {
 
 int RegionProfiler::GetSpectralConfigStokes(int profile_index) {
     // return Stokes int value at given index; return false if index out of range
-    if (profile_index < _spectral_profiles.size()) {
+    if (profile_index < NumSpectralProfiles()) {
         return _spectral_profiles[profile_index].stokes_index;
     }
     return CURRENT_STOKES - 1; // invalid
 }
 
 std::string RegionProfiler::GetSpectralCoordinate(int profile_index) {
-    if (profile_index < _spectral_profiles.size()) {
+    if (profile_index < NumSpectralProfiles()) {
         return _spectral_profiles[profile_index].coordinate;
     } else {
         return std::string();
@@ -214,7 +214,7 @@ std::string RegionProfiler::GetSpectralCoordinate(int profile_index) {
 
 bool RegionProfiler::GetSpectralConfigStats(int profile_index, ZProfileWidget& stats) {
     // return stats_types at given index; return false if index out of range
-    if (profile_index < _spectral_profiles.size()) {
+    if (profile_index < NumSpectralProfiles()) {
         stats = ZProfileWidget(_spectral_profiles[profile_index].stokes_index, _spectral_profiles[profile_index].stats_types);
         return true;
     }
@@ -222,7 +222,8 @@ bool RegionProfiler::GetSpectralConfigStats(int profile_index, ZProfileWidget& s
 }
 
 bool RegionProfiler::IsValidSpectralConfigStats(const ZProfileWidget& stats) {
-    if (_spectral_profiles.size() > 0) {
+    // (NumSpectralProfiles() == 0) means the region id is removed from the frontend zprofile widgets
+    if (NumSpectralProfiles() > 0) {
         for (const auto& spectral_profile : _spectral_profiles) {
             if (stats.stokes_index == spectral_profile.stokes_index) {
                 if (stats.stats_types == spectral_profile.stats_types) {
@@ -236,7 +237,7 @@ bool RegionProfiler::IsValidSpectralConfigStats(const ZProfileWidget& stats) {
 
 bool RegionProfiler::GetSpectralStatsToLoad(int profile_index, std::vector<int>& stats) {
     // Return vector of stats that were not sent
-    if (profile_index < _spectral_profiles.size()) {
+    if (profile_index < NumSpectralProfiles()) {
         stats.clear();
         for (size_t i = 0; i < _spectral_profiles[profile_index].profiles_sent.size(); ++i) {
             if (!_spectral_profiles[profile_index].profiles_sent[i]) {
@@ -250,7 +251,7 @@ bool RegionProfiler::GetSpectralStatsToLoad(int profile_index, std::vector<int>&
 
 bool RegionProfiler::GetSpectralProfileStatSent(int profile_index, int stats_type) {
     bool stat_sent(false);
-    if (profile_index < _spectral_profiles.size()) {
+    if (profile_index < NumSpectralProfiles()) {
         SpectralProfile profile = _spectral_profiles[profile_index];
         for (size_t i = 0; i < profile.stats_types.size(); ++i) {
             if (profile.stats_types[i] == stats_type) {
@@ -263,7 +264,7 @@ bool RegionProfiler::GetSpectralProfileStatSent(int profile_index, int stats_typ
 }
 
 void RegionProfiler::SetSpectralProfileStatSent(int profile_index, int stats_type, bool sent) {
-    if (profile_index < _spectral_profiles.size()) {
+    if (profile_index < NumSpectralProfiles()) {
         for (size_t i = 0; i < _spectral_profiles[profile_index].stats_types.size(); ++i) {
             if (_spectral_profiles[profile_index].stats_types[i] == stats_type) {
                 _spectral_profiles[profile_index].profiles_sent[i] = sent;
@@ -274,7 +275,7 @@ void RegionProfiler::SetSpectralProfileStatSent(int profile_index, int stats_typ
 }
 
 void RegionProfiler::SetSpectralProfileAllStatsSent(int profile_index, bool sent) {
-    if (profile_index < _spectral_profiles.size()) {
+    if (profile_index < NumSpectralProfiles()) {
         for (size_t i = 0; i < _spectral_profiles[profile_index].profiles_sent.size(); ++i) {
             _spectral_profiles[profile_index].profiles_sent[i] = sent;
         }
@@ -282,7 +283,7 @@ void RegionProfiler::SetSpectralProfileAllStatsSent(int profile_index, bool sent
 }
 
 void RegionProfiler::SetAllSpectralProfilesUnsent() {
-    for (size_t i = 0; i < _spectral_profiles.size(); ++i) {
+    for (size_t i = 0; i < NumSpectralProfiles(); ++i) {
         for (size_t j = 0; j < _spectral_profiles[i].profiles_sent.size(); ++j) {
             _spectral_profiles[i].profiles_sent[j] = false;
         }

--- a/Region/RegionProfiler.h
+++ b/Region/RegionProfiler.h
@@ -21,8 +21,7 @@ struct SpatialProfile {
 
 struct SpectralProfile {
     std::string coordinate;
-    int stokes_index;
-    std::vector<int> stats_types;
+    SpectralConfig config;
     std::vector<bool> profiles_sent;
 };
 
@@ -40,16 +39,15 @@ public:
     // spectral
     bool SetSpectralRequirements(const std::vector<CARTA::SetSpectralRequirements_SpectralConfig>& profiles, const int num_stokes);
     size_t NumSpectralProfiles();
-    int NumStatsToLoad(int profile_index);
-    int GetSpectralConfigStokes(int profile_index);
-    std::string GetSpectralCoordinate(int profile_index);
-    bool GetSpectralConfigStats(int profile_index, ZProfileWidget& stats); // all requested
-    bool IsValidSpectralConfigStats(const ZProfileWidget& stats);
-    bool GetSpectralStatsToLoad(int profile_index, std::vector<int>& stats); // diff of requested and already sent
-    bool GetSpectralProfileStatSent(int profile_index, int stats_type);
-    void SetSpectralProfileStatSent(int profile_index, int stats_type, bool sent);
-    void SetSpectralProfileAllStatsSent(int profile_index, bool sent);
-    void SetAllSpectralProfilesUnsent(); // enable sending new profiles
+    bool IsValidSpectralConfig(const SpectralConfig& config);
+    std::vector<SpectralProfile> GetSpectralProfiles();
+    std::string GetSpectralCoordinate(int config_stokes);
+    bool GetSpectralConfig(int config_stokes, SpectralConfig& config);
+    bool GetUnsentStatsForProfile(int config_stokes, std::vector<int>& stats);
+    bool GetSpectralProfileAllStatsSent(int config_stokes);
+    void SetSpectralProfileStatSent(int config_stokes, int stats_type, bool sent);
+    void SetSpectralProfileAllStatsSent(int config_stokes, bool sent);
+    void SetAllSpectralProfilesUnsent(); // enable sending new profile data, e.g. when region changes
 
 private:
     // parse coordinate strings into <axisIndex, stokesIndex> pairs

--- a/Region/RegionProfiler.h
+++ b/Region/RegionProfiler.h
@@ -7,6 +7,8 @@
 #include <utility>
 #include <vector>
 
+#include "../Util.h"
+
 #include <carta-protobuf/region_requirements.pb.h>
 
 namespace carta {
@@ -41,7 +43,8 @@ public:
     int NumStatsToLoad(int profile_index);
     int GetSpectralConfigStokes(int profile_index);
     std::string GetSpectralCoordinate(int profile_index);
-    bool GetSpectralConfigStats(int profile_index, std::vector<int>& stats); // all requested
+    bool GetSpectralConfigStats(int profile_index, ZProfileWidget& stats); // all requested
+    bool IsValidSpectralConfigStats(const ZProfileWidget& stats);
     bool GetSpectralStatsToLoad(int profile_index, std::vector<int>& stats); // diff of requested and already sent
     bool GetSpectralProfileStatSent(int profile_index, int stats_type);
     void SetSpectralProfileStatSent(int profile_index, int stats_type, bool sent);

--- a/Region/RegionStats.h
+++ b/Region/RegionStats.h
@@ -39,7 +39,7 @@ public:
     size_t NumStats();
     void FillStatsData(CARTA::RegionStatsData& stats_data, const casacore::ImageInterface<float>& image, int channel, int stokes);
     void FillStatsData(CARTA::RegionStatsData& stats_data, std::map<CARTA::StatsType, double>& stats_values);
-    bool CalcStatsValues(std::vector<std::vector<double>>& stats_values, const std::vector<int>& requested_stats,
+    bool CalcStatsValues(std::map<CARTA::StatsType, std::vector<double>>& stats_values, const std::vector<int>& requested_stats,
         const casacore::ImageInterface<float>& image, bool per_channel = true);
 
     // invalidate stored calculations for previous region settings

--- a/Session.cc
+++ b/Session.cc
@@ -292,7 +292,7 @@ void Session::OnOpenFile(const CARTA::OpenFile& message, uint32_t request_id) {
         string abs_filename(root_path.resolvedName());
 
         // create Frame for open file
-        auto frame = std::unique_ptr<Frame>(new Frame(_id, abs_filename, hdu, _selected_file_info_extended));
+        auto frame = std::unique_ptr<Frame>(new Frame(_id, abs_filename, hdu, _selected_file_info_extended, _verbose_logging));
         if (frame->IsValid()) {
             // Check if the old _frames[file_id] object exists. If so, delete it.
             if (_frames.count(file_id) > 0) {

--- a/Util.h
+++ b/Util.h
@@ -132,4 +132,15 @@ struct RegionState {
     }
 };
 
+struct ZProfileWidget {
+    int stokes_index;
+    std::vector<int> stats_types;
+
+    ZProfileWidget() {}
+    ZProfileWidget(int stokes_index_, std::vector<int> stats_types_) {
+        stokes_index = stokes_index_;
+        stats_types = stats_types_;
+    }
+};
+
 #endif // CARTA_BACKEND__UTIL_H_

--- a/Util.h
+++ b/Util.h
@@ -132,32 +132,4 @@ struct RegionState {
     }
 };
 
-struct RegionRequest {
-    std::vector<CARTA::SetSpectralRequirements_SpectralConfig> config;
-    RegionRequest() {}
-    RegionRequest(std::vector<CARTA::SetSpectralRequirements_SpectralConfig> config_) {
-        config = config_;
-    }
-    void UpdateRequest(std::vector<CARTA::SetSpectralRequirements_SpectralConfig> config_) {
-        config.clear();
-        config = config_;
-    }
-    bool IsAmong(int profile_index, std::vector<int> other_stats) {
-        if (config.size() > profile_index) {
-            std::vector<int> requested_stats(config[profile_index].stats_types().begin(), config[profile_index].stats_types().end());
-            if (requested_stats.size() != other_stats.size()) {
-                return false;
-            }
-            for (int i = 0; i < requested_stats.size(); ++i) {
-                if (requested_stats[i] != other_stats[i]) {
-                    return false;
-                }
-            }
-        } else {
-            return false;
-        }
-        return true;
-    }
-};
-
 #endif // CARTA_BACKEND__UTIL_H_

--- a/Util.h
+++ b/Util.h
@@ -132,14 +132,17 @@ struct RegionState {
     }
 };
 
-struct ZProfileWidget {
+struct SpectralConfig {
     int stokes_index;
     std::vector<int> stats_types;
 
-    ZProfileWidget() {}
-    ZProfileWidget(int stokes_index_, std::vector<int> stats_types_) {
+    SpectralConfig() {}
+    SpectralConfig(int stokes_index_, std::vector<int> stats_types_) {
         stokes_index = stokes_index_;
         stats_types = stats_types_;
+    }
+    bool operator==(const SpectralConfig& rhs) const {
+        return ((stokes_index == rhs.stokes_index) && (stats_types == rhs.stats_types));
     }
 };
 


### PR DESCRIPTION
For issue #298, building on mark/refactor_profile_cancellation branch.  My brief testing of this branch did not reproduce these issues.

The functionality is basically the same as Mark's, but instead of accessing spectral profiles by an index into the profile vector, the requested profile is found by its stokes index (the int equivalent of the string coordinate: I=0, Q=1, etc., CURRENT_STOKES=-1).  This means that the Frame has to keep track of two stokes index values:  `config_stokes` is the stokes_index in the spectral config, and `profile_stokes` is the stokes index for slicing the image data (equal to `config_stokes` except when CURRENT_STOKES must be replaced by the current stokes index).

This is still not perfect, but I hesitated to make greater changes just before the pre-release.  There are no safeguards to prevent one thread from replacing the vector while another is searching it for the requested profile.  To minimize this, the vector is retrieved before the search when possible to make it more atomic.  Another inefficiency is that the current profile calculations in progress are interrupted if the spectral config for the stokes index changes (even if the change is to add another stats type).  However, if the first stat is complete and sent before the requirements change, then it is not re-sent.  These issues can be improved in the next release.