### PR TITLE
Reject pv image as "not supported"

### DIFF
--- a/Frame.cc
+++ b/Frame.cc
@@ -48,7 +48,7 @@ Frame::Frame(uint32_t session_id, const std::string& filename, const std::string
 
     // Get shape and axis values from the loader
     if (!_loader->FindShape(_image_shape, _num_channels, _num_stokes, _spectral_axis, _stokes_axis)) {
-        Log(session_id, "Problem loading file {}: could not determine image shape", filename);
+        Log(session_id, "Problem loading file {}: could not determine image shape or coordinate system axes", filename);
         _valid = false;
         return;
     }

--- a/Frame.h
+++ b/Frame.h
@@ -43,8 +43,10 @@ public:
         int default_channel = DEFAULT_CHANNEL);
     ~Frame();
 
-    // frame info
     bool IsValid();
+    std::string GetErrorMessage();
+
+    // frame info
     std::vector<int> GetRegionIds();
     int GetMaxRegionId();
     size_t NumChannels(); // if no channel axis, nchan=1
@@ -188,6 +190,7 @@ private:
     // setup
     uint32_t _session_id;
     bool _valid;
+    std::string _open_image_error;
 
     // spectral profile counter, which is used to determine whether the Frame object can be destroyed (_z_profile_count == 0 ?).
     tbb::atomic<int> _z_profile_count;

--- a/ImageData/FileLoader.cc
+++ b/ImageData/FileLoader.cc
@@ -93,16 +93,27 @@ bool FileLoader::FindShape(IPos& shape, size_t& num_channels, size_t& num_stokes
         return false;
     }
 
-    // determine axis order (0-based)
-    if (num_dims == 3) { // use defaults
-        spectral_axis = 2;
-        stokes_axis = -1;
-    } else if (num_dims == 4) { // find spectral and stokes axes
-        FindCoords(spectral_axis, stokes_axis);
+    casacore::CoordinateSystem coord_sys;
+    if (!GetCoordinateSystem(coord_sys)) {
+        return false;
+    }
+    if (coord_sys.nPixelAxes() != num_dims) {
+        return false;
     }
 
-    num_channels = (spectral_axis >= 0 ? shape(spectral_axis) : 1);
-    num_stokes = (stokes_axis >= 0 ? shape(stokes_axis) : 1);
+    spectral_axis = coord_sys.spectralAxisNumber();
+    if (spectral_axis == -1) {
+        num_channels = 1;
+    } else {
+        num_channels = shape(spectral_axis);
+    }
+
+    stokes_axis = coord_sys.polarizationAxisNumber();
+    if (stokes_axis == -1) {
+        num_stokes = 1;
+    } else {
+        num_stokes = shape(stokes_axis);
+    }
 
     _num_dims = num_dims;
     _num_channels = num_channels;

--- a/ImageData/FileLoader.cc
+++ b/ImageData/FileLoader.cc
@@ -109,8 +109,8 @@ bool FileLoader::FindShape(IPos& shape, int& spectral_axis, int& stokes_axis, st
     spectral_axis = coord_sys.spectralAxisNumber();
     stokes_axis = coord_sys.polarizationAxisNumber();
 
-    // pv images not supported (yet)
-    if ((spectral_axis == 0) && !linear_axes.empty() && (linear_axes(0) == 1)) { // pv image
+    // pv images not supported (yet); spectral axis is 0 or 1, and the other is linear
+    if (!linear_axes.empty() && (((spectral_axis == 0) && (linear_axes(0) == 1)) || ((spectral_axis == 1) && (linear_axes(0) == 0)))) {
         message = "Position-velocity (pv) images not supported.";
         return false;
     }

--- a/ImageData/FileLoader.cc
+++ b/ImageData/FileLoader.cc
@@ -87,7 +87,7 @@ bool FileLoader::FindShape(IPos& shape, int& spectral_axis, int& stokes_axis, st
         return false;
 
     shape = LoadData(FileInfo::Data::Image)->shape();
-    size_t _num_dims = shape.size();
+    _num_dims = shape.size();
 
     if (_num_dims < 2 || _num_dims > 4) {
         message = "Image must be 2D, 3D, or 4D.";

--- a/ImageData/FileLoader.h
+++ b/ImageData/FileLoader.h
@@ -134,7 +134,7 @@ public:
     virtual void FindCoords(int& spectral_axis, int& stokes_axis);
 
     // get shape and axis information from image
-    virtual bool FindShape(IPos& shape, size_t& num_channels, size_t& num_stokes, int& spectral_axis, int& stokes_axis);
+    virtual bool FindShape(IPos& shape, int& spectral_axis, int& stokes_axis, std::string& message);
 
     // Load image statistics, if they exist, from the file
     virtual void LoadImageStats(bool load_percentiles = false);

--- a/Session.cc
+++ b/Session.cc
@@ -321,13 +321,15 @@ void Session::OnOpenFile(const CARTA::OpenFile& message, uint32_t request_id) {
 
             success = true;
         } else {
-            err_message = "Could not load image";
+            err_message = frame->GetErrorMessage();
         }
     }
     ack.set_success(success);
     ack.set_message(err_message);
     SendEvent(CARTA::EventType::OPEN_FILE_ACK, request_id, ack);
-    UpdateRegionData(file_id);
+    if (success) {
+        UpdateRegionData(file_id);
+    }
 }
 
 void Session::OnCloseFile(const CARTA::CloseFile& message) {

--- a/Session.cc
+++ b/Session.cc
@@ -968,7 +968,6 @@ void Session::UpdateRegionData(int file_id, bool send_image_histogram, bool chan
         std::vector<int> regions(_frames.at(file_id)->GetRegionIds());
         for (auto region_id : regions) {
             // CHECK FOR CANCEL HERE ??
-            _frames.at(file_id)->IncreaseZProfileCount(region_id);
             SendRegionStatsData(file_id, region_id);
             SendSpatialProfileData(file_id, region_id, stokes_changed);
             if ((region_id == IMAGE_REGION_ID) && send_image_histogram) {
@@ -976,6 +975,7 @@ void Session::UpdateRegionData(int file_id, bool send_image_histogram, bool chan
             } else if (region_id != IMAGE_REGION_ID) {
                 SendRegionHistogramData(file_id, region_id, channel_changed);
             }
+            _frames.at(file_id)->IncreaseZProfileCount(region_id);
             SendSpectralProfileData(file_id, region_id, channel_changed, stokes_changed);
             _frames.at(file_id)->DecreaseZProfileCount(region_id);
         }
@@ -1002,8 +1002,9 @@ void Session::SendEvent(CARTA::EventType event_type, uint32_t event_id, google::
 
 void Session::SendFileEvent(int32_t file_id, CARTA::EventType event_type, uint32_t event_id, google::protobuf::MessageLite& message) {
     // do not send if file is closed
-    if (_frames.count(file_id))
+    if (_frames.count(file_id)) {
         SendEvent(event_type, event_id, message);
+    }
 }
 
 void Session::SendPendingMessages() {


### PR DESCRIPTION
Use image coordinate system to detect pv image, then return open file ack message with success = false and error message.  Also check that coord sys number of pixel axes == image dimensions, else this will fail later when creating a region (including image and default cursor) and converting between pixel/world coordinates.  The number of pixel axes can be incorrect when header keywords describing each axis are missing.

Also check open file success before calling method to send data streams.

There may still be an issue in the frontend.