### PR TITLE
Fix import region file contents

### DIFF
--- a/Frame.cc
+++ b/Frame.cc
@@ -279,8 +279,8 @@ void Frame::ImportRegion(
         case CARTA::FileType::CRTF: {
             try {
                 // use RegionTextList to import file and create annotation file lines
-		casa::RegionTextList region_list;
-		if (!filename.empty()) {
+                casa::RegionTextList region_list;
+                if (!filename.empty()) {
                     region_list = casa::RegionTextList(filename, coord_sys, _image_shape);
                 } else {
                     region_list = casa::RegionTextList(coord_sys, file_contents, _image_shape);

--- a/Frame.h
+++ b/Frame.h
@@ -132,7 +132,7 @@ private:
     void SetDefaultCursor();            // using center point of image
 
     // Region import/export helpers
-    bool ImportCrtfFileLine(casa::AsciiAnnotationFileLine& file_line, const casacore::CoordinateSystem& coord_sys,
+    void ImportCrtfFileLine(casa::AsciiAnnotationFileLine& file_line, const casacore::CoordinateSystem& coord_sys,
         CARTA::ImportRegionAck& import_ack, std::string message);
     void ExportCrtfRegion(
         std::vector<int>& region_ids, CARTA::CoordinateType coord_type, std::string& filename, CARTA::ExportRegionAck& export_ack);

--- a/Frame.h
+++ b/Frame.h
@@ -63,8 +63,8 @@ public:
     }
     bool RegionChanged(int region_id);
     void RemoveRegion(int region_id);
-    void ImportRegionFile(CARTA::FileType file_type, std::string& filename, CARTA::ImportRegionAck& import_ack);
-    void ImportRegionContents(CARTA::FileType file_type, std::vector<std::string>& contents, CARTA::ImportRegionAck& import_ack);
+    void ImportRegion(
+        CARTA::FileType file_type, std::string& filename, std::vector<std::string>& contents, CARTA::ImportRegionAck& import_ack);
     void ExportRegion(CARTA::FileType file_type, CARTA::CoordinateType coord_type, std::vector<int>& region_ids, std::string& filename,
         CARTA::ExportRegionAck& export_ack);
 

--- a/Session.cc
+++ b/Session.cc
@@ -495,19 +495,19 @@ void Session::OnImportRegion(const CARTA::ImportRegion& message, uint32_t reques
             CARTA::ImportRegionAck import_ack; // response
             std::string directory(message.directory()), filename(message.file());
             CARTA::FileType file_type(message.type());
+	    std::string abs_filename;
+            std::vector<std::string> contents;
             if (!directory.empty() && !filename.empty()) {
                 // form path with filename
                 casacore::Path root_path(_root_folder);
                 root_path.append(directory);
                 root_path.append(filename);
-                std::string abs_filename(root_path.resolvedName());
-                _frames.at(file_id)->ImportRegionFile(file_type, abs_filename, import_ack);
-                SendFileEvent(file_id, CARTA::EventType::IMPORT_REGION_ACK, request_id, import_ack);
+                abs_filename = root_path.resolvedName();
             } else {
-                std::vector<std::string> contents = {message.contents().begin(), message.contents().end()};
-                _frames.at(file_id)->ImportRegionContents(file_type, contents, import_ack);
-                SendFileEvent(file_id, CARTA::EventType::IMPORT_REGION_ACK, request_id, import_ack);
+                contents = {message.contents().begin(), message.contents().end()};
             }
+            _frames.at(file_id)->ImportRegion(file_type, abs_filename, contents, import_ack);
+            SendFileEvent(file_id, CARTA::EventType::IMPORT_REGION_ACK, request_id, import_ack);
         } catch (std::out_of_range& range_error) {
             std::string error = fmt::format("File id {} closed", file_id);
             SendLogEvent(error, {"import"}, CARTA::ErrorSeverity::DEBUG);

--- a/Session.cc
+++ b/Session.cc
@@ -495,7 +495,7 @@ void Session::OnImportRegion(const CARTA::ImportRegion& message, uint32_t reques
             CARTA::ImportRegionAck import_ack; // response
             std::string directory(message.directory()), filename(message.file());
             CARTA::FileType file_type(message.type());
-	    std::string abs_filename;
+            std::string abs_filename;
             std::vector<std::string> contents;
             if (!directory.empty() && !filename.empty()) {
                 // form path with filename


### PR DESCRIPTION
While thinking about how to handle global properties in the ds9 parser, I realized that importing crtf file contents was incorrect.  This led to some refactoring to use common code for the various region import options.  Tested to make sure I didn't break server-side crtf file imports.