### PR TITLE
Add region spectral profile cache for non-HDF5 images

### DIFF
--- a/Frame.cc
+++ b/Frame.cc
@@ -1595,14 +1595,20 @@ bool Frame::GetRegionSpectralData(int region_id, int config_stokes, int profile_
 
         // initialize the spectral data
         std::map<CARTA::StatsType, std::vector<double>> results;
+        size_t start;
         size_t profile_size = NumChannels(); // total number of channels
-        if (!region->InitSpectralData(config_stokes, profile_size, results)) {
+        if (!region->InitSpectralData(profile_stokes, profile_size, results, start)) {
             // config removed or no unsent stats
             return false;
         }
 
-        // initialize the variables
-        size_t start = 0;
+        // If stats cache is available and completed, don't need to recalculate spectral profiles.
+        if (start == profile_size) {
+            partial_results_callback(results, 1.0f);
+            return true;
+        }
+
+        // Initialize variables and calculate spectral profiles
         size_t count, end;
         float progress = 0;
         casacore::SubImage<float> sub_image;
@@ -1617,6 +1623,10 @@ bool Frame::GetRegionSpectralData(int region_id, int config_stokes, int profile_
 
             // check if region, current stokes, spectral requirements changed
             if (Interrupt(region_id, profile_stokes, start_region_state, start_config_stats)) {
+                // Save stats cache if region state is not changed
+                if (IsSameRegionState(region_id, start_region_state)) {
+                    region->SetStatsCache(profile_stokes, results, start);
+                }
                 return data_ok; // false until complete
             }
 
@@ -1670,6 +1680,11 @@ bool Frame::GetRegionSpectralData(int region_id, int config_stokes, int profile_
             if (dt_partial_profile > TARGET_PARTIAL_REGION_TIME || progress >= 1.0f) {
                 t_partial_profile_start = std::chrono::high_resolution_clock::now();
                 partial_results_callback(results, progress);
+            }
+
+            // Save stats cache while spectral profiles are completed and region state is not changed
+            if (progress == 1.0f && IsSameRegionState(region_id, start_region_state)) {
+                region->SetStatsCache(profile_stokes, results, start);
             }
         }
         data_ok = true;

--- a/Frame.cc
+++ b/Frame.cc
@@ -1592,15 +1592,12 @@ bool Frame::GetRegionSpectralData(int region_id, int config_stokes, int profile_
     bool data_ok(false);
     if (_regions.count(region_id)) {
         auto& region = _regions[region_id];
-
-        // initialize the spectral data
         std::map<CARTA::StatsType, std::vector<double>> results;
         size_t start;
         size_t profile_size = NumChannels(); // total number of channels
-        if (!region->InitSpectralData(profile_stokes, profile_size, results, start)) {
-            // config removed or no unsent stats
-            return false;
-        }
+
+        // Try to get the cache or initialize spectral profiles to NaN
+        region->InitSpectralData(profile_stokes, profile_size, results, start);
 
         // If stats cache is available and completed, don't need to recalculate spectral profiles.
         if (start == profile_size) {
@@ -1640,7 +1637,7 @@ bool Frame::GetRegionSpectralData(int region_id, int config_stokes, int profile_
             if (has_subimage) {
                 std::map<CARTA::StatsType, std::vector<double>> buffers;
                 std::unique_lock<std::mutex> ulock2(_image_mutex);
-                bool has_data = region->GetSpectralProfileData(buffers, config_stokes, sub_image);
+                bool has_data = region->GetSpectralProfileData(buffers, sub_image);
                 ulock2.unlock();
                 if (has_data) {
                     for (const auto& buffer : buffers) {

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -1373,12 +1373,6 @@ bool Region::GetStatsCache(
 }
 
 void Region::ResetStatsCache() {
-    // Reset channel end index to 0 for all stats with their stokes, in order to recalculate all spectral profiles.
     std::unique_lock<std::mutex> lock(_stats_cache_mutex);
-    for (const auto& stats_stoke_elem : _stats_cache) {
-        int profile_stokes = stats_stoke_elem.first;
-        for (auto& stats_type_elem : _stats_cache[profile_stokes]) {
-            stats_type_elem.second.channel_end = 0;
-        }
-    }
+    _stats_cache.clear();
 }

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -303,8 +303,12 @@ bool Region::UpdateRegionParameters(
 
     // region changed if xy params changed and points validated
     _xy_region_changed = xy_params_changed && points_set;
-    if (_xy_region_changed && _region_stats)
+    if (_xy_region_changed && _region_stats) {
         _region_stats->ClearStats(); // recalculate everything
+        if (type != CARTA::RegionType::POINT) {
+            ResetStatsCache(); // Reset stats cache for non-point region
+        }
+    }
 
     return points_set;
 }
@@ -1207,14 +1211,11 @@ void Region::SetAllSpectralProfilesUnsent() {
 
 bool Region::GetSpectralProfileData(
     std::map<CARTA::StatsType, std::vector<double>>& spectral_data, int config_stokes, casacore::ImageInterface<float>& image) {
-    // Return spectral data for unsent stats in spectral config
+    // Return spectral data for all stats in spectral config
     bool have_stats(false);
     if (_region_profiler) {
-        std::vector<int> unsent_stats;
-        if (_region_profiler->GetUnsentStatsForProfile(config_stokes, unsent_stats)) {
-            if (!unsent_stats.empty() && _region_stats) {
-                have_stats = _region_stats->CalcStatsValues(spectral_data, unsent_stats, image);
-            }
+        if (!_all_stats.empty() && _region_stats) {
+            have_stats = _region_stats->CalcStatsValues(spectral_data, _all_stats, image);
         }
     }
     return have_stats;
@@ -1299,20 +1300,33 @@ void Region::FillNaNSpectralProfileDataMessage(CARTA::SpectralProfileData& profi
     }
 }
 
-bool Region::InitSpectralData(int config_stokes, size_t profile_size, std::map<CARTA::StatsType, std::vector<double>>& spectral_data) {
-    // Initialize spectral data map for unsent stats to NaN
+bool Region::InitSpectralData(
+    int profile_stokes, size_t profile_size, std::map<CARTA::StatsType, std::vector<double>>& spectral_data, size_t& channel_start) {
+    // Initialize spectral data map for all stats
     bool data_init(false);
+    channel_start = std::numeric_limits<size_t>::max();
     if (_region_profiler) {
-        std::vector<int> unsent_stats;
-        if (_region_profiler->GetUnsentStatsForProfile(config_stokes, unsent_stats)) { // true if profile still exists
-            if (!unsent_stats.empty()) {
-                for (size_t i = 0; i < unsent_stats.size(); ++i) {
-                    auto stats_type = static_cast<CARTA::StatsType>(unsent_stats[i]);
+        if (!_all_stats.empty()) {
+            for (size_t i = 0; i < _all_stats.size(); ++i) {
+                auto stats_type = static_cast<CARTA::StatsType>(_all_stats[i]);
+                std::vector<double> buffer;
+                size_t tmp_channel_start;
+                if (GetStatsCache(profile_stokes, profile_size, stats_type, buffer, tmp_channel_start)) {
+                    // Stats cache is available, reuse it.
+                    spectral_data.emplace(stats_type, buffer);
+                } else {
+                    // Initialize spectral data map for the stats to NaN
                     std::vector<double> init_spectral_data(profile_size, std::numeric_limits<double>::quiet_NaN());
                     spectral_data.emplace(stats_type, init_spectral_data);
+                    tmp_channel_start = 0;
                 }
-                data_init = true;
+                // Use the minimum of channel_start for all stats types (to be conservative),
+                // which is used to determine the start channel of spectral profile calculations.
+                if (tmp_channel_start < channel_start) {
+                    channel_start = tmp_channel_start;
+                }
             }
+            data_init = true;
         }
     }
     return data_init;
@@ -1333,4 +1347,47 @@ void Region::DisconnectCalled() {
     while (_z_profile_count) {
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     } // wait for the jobs finished
+}
+
+void Region::SetStatsCache(int profile_stokes, std::map<CARTA::StatsType, std::vector<double>>& stats_data, size_t channel_end) {
+    std::unique_lock<std::mutex> lock(_stats_cache_mutex);
+    for (auto& stats_data_elem : stats_data) {
+        auto& stats_type = stats_data_elem.first;
+        std::vector<double>& stats_values = stats_data_elem.second;
+        // Set stats cache
+        StatsCacheData& stats_cache_data = _stats_cache[profile_stokes][stats_type];
+        stats_cache_data.stats_values = std::move(stats_values);
+        stats_cache_data.channel_end = channel_end;
+    }
+}
+
+bool Region::GetStatsCache(
+    int profile_stokes, size_t profile_size, CARTA::StatsType stats_type, std::vector<double>& stats_data, size_t& channel_start) {
+    bool cache_ok(false);
+    channel_start = std::numeric_limits<size_t>::max();
+    std::unique_lock<std::mutex> lock(_stats_cache_mutex);
+    if (_stats_cache.count(profile_stokes)) {
+        auto& stats_cache_stoke = _stats_cache[profile_stokes];
+        if (stats_cache_stoke.count(stats_type)) {
+            StatsCacheData& stats_cache_stoke_type = stats_cache_stoke[stats_type];
+            stats_data = stats_cache_stoke_type.stats_values;
+            channel_start = stats_cache_stoke_type.channel_end;
+            // Check does stats cache fit requirements
+            if ((channel_start > 0 && channel_start <= profile_size) && (stats_data.size() == profile_size)) {
+                cache_ok = true;
+            }
+        }
+    }
+    return cache_ok;
+}
+
+void Region::ResetStatsCache() {
+    // Reset channel end index to 0 for all stats with their stokes, in order to recalculate all spectral profiles.
+    std::unique_lock<std::mutex> lock(_stats_cache_mutex);
+    for (const auto& stats_stoke_elem : _stats_cache) {
+        int profile_stokes = stats_stoke_elem.first;
+        for (auto& stats_type_elem : _stats_cache[profile_stokes]) {
+            stats_type_elem.second.channel_end = 0;
+        }
+    }
 }

--- a/Region/Region.h
+++ b/Region/Region.h
@@ -235,8 +235,9 @@ private:
     // Lock when stats cache is being read or written
     std::mutex _stats_cache_mutex;
 
-    // Define all stats types to calculate: {Sum, Mean, RMS, Sigma, SumSq, Min, Max}
-    std::vector<int> _all_stats = {2, 4, 5, 6, 7, 8, 9};
+    // Define all stats types to calculate
+    std::vector<int> _all_stats = {CARTA::StatsType::Sum, CARTA::StatsType::Mean, CARTA::StatsType::RMS, CARTA::StatsType::Sigma,
+        CARTA::StatsType::SumSq, CARTA::StatsType::Min, CARTA::StatsType::Max};
 };
 
 } // namespace carta

--- a/Region/Region.h
+++ b/Region/Region.h
@@ -114,14 +114,13 @@ public:
     void SetAllSpectralProfilesUnsent();
 
     // Spectral data
-    bool GetSpectralProfileData(
-        std::map<CARTA::StatsType, std::vector<double>>& spectral_data, int config_stokes, casacore::ImageInterface<float>& image);
+    bool GetSpectralProfileData(std::map<CARTA::StatsType, std::vector<double>>& spectral_data, casacore::ImageInterface<float>& image);
     void FillPointSpectralProfileDataMessage(
         CARTA::SpectralProfileData& profile_message, int config_stokes, std::vector<float>& spectral_data);
     void FillSpectralProfileDataMessage(
         CARTA::SpectralProfileData& profile_message, int config_stokes, std::map<CARTA::StatsType, std::vector<double>>& spectral_data);
     void FillNaNSpectralProfileDataMessage(CARTA::SpectralProfileData& profile_message, int config_stokes);
-    bool InitSpectralData(
+    void InitSpectralData(
         int profile_stokes, size_t profile_size, std::map<CARTA::StatsType, std::vector<double>>& stats_data, size_t& channel_start);
 
     // Stats: pass through to RegionStats


### PR DESCRIPTION
This mechanism is similar to the stats cache for HDF5 images, which calculates all stats types, including `Sum`, `Mean`, `RMS`, `Sigma`, `SumSq`, `Min` and `Max` a time, and then stores the results in the `Region` object. If there is an interruption during the calculation, say, we change settings of region spectral profile widgets, the unfinished results also stored in the cache and can be reused to continue the calculation next time, if the region's state is not changed. 

The advantage is that no matter how we change the number of spectral profile widgets and their settings, the calculations will not be repeated. Although at the start it will spend more time to calculate all stats types. If the region's state changed, the `Region` object will reset the stats cache by `ResetStatsCache()` function, which will start new spectral profile calculations.