### PR TITLE
Fix backend crash from incomplete coordinate system axes

### DIFF
--- a/FileInfoLoader.cc
+++ b/FileInfoLoader.cc
@@ -1061,6 +1061,9 @@ void FileInfoLoader::FindChanStokesAxis(const casacore::IPosition& data_shape, c
     const casacore::String& axis_type_2, const casacore::String& axis_type_3, const casacore::String& axis_type_4, int& chan_axis,
     int& stokes_axis) {
     // Use CTYPE values to find axes and set nchan, nstokes
+    chan_axis = -1;
+    stokes_axis = -1;
+
     // Note header axes are 1-based but shape is 0-based
     casacore::String c_type1(axis_type_1), c_type2(axis_type_2), c_type3(axis_type_3), c_type4(axis_type_4);
     // uppercase for string comparisons
@@ -1069,37 +1072,20 @@ void FileInfoLoader::FindChanStokesAxis(const casacore::IPosition& data_shape, c
     c_type3.upcase();
     c_type4.upcase();
 
-    // find spectral axis
-    if (!c_type1.empty() && (c_type1.contains("FELO") || c_type1.contains("FREQ") || c_type1.contains("VELO") || c_type1.contains("VOPT") ||
-                                c_type1.contains("VRAD") || c_type1.contains("WAVE") || c_type1.contains("AWAV"))) {
-        chan_axis = 0;
-    } else if (!c_type2.empty() &&
-               (c_type2.contains("FELO") || c_type2.contains("FREQ") || c_type2.contains("VELO") || c_type2.contains("VOPT") ||
-                   c_type2.contains("VRAD") || c_type2.contains("WAVE") || c_type2.contains("AWAV"))) {
-        chan_axis = 1;
-    } else if (!c_type3.empty() &&
-               (c_type3.contains("FELO") || c_type3.contains("FREQ") || c_type3.contains("VELO") || c_type3.contains("VOPT") ||
-                   c_type3.contains("VRAD") || c_type3.contains("WAVE") || c_type3.contains("AWAV"))) {
-        chan_axis = 2;
-    } else if (!c_type4.empty() &&
-               (c_type4.contains("FELO") || c_type4.contains("FREQ") || c_type4.contains("VELO") || c_type4.contains("VOPT") ||
-                   c_type4.contains("VRAD") || c_type4.contains("WAVE") || c_type4.contains("AWAV"))) {
-        chan_axis = 3;
-    } else {
-        chan_axis = -1;
+    size_t ntypes(4);
+    const casacore::String ctypes[] = {c_type1, c_type2, c_type3, c_type4};
+    const casacore::String spectral_types[] = {"FELO", "FREQ", "VELO", "VOPT", "VRAD", "WAVE", "AWAV"};
+    const casacore::String stokes_type = "STOKES";
+    for (size_t i = 0; i < ntypes; ++i) {
+        for (auto& spectral_type : spectral_types) {
+            if (ctypes[i].contains(spectral_type)) {
+                chan_axis = i;
+            }
+        }
+        if (ctypes[i] == stokes_type) {
+            stokes_axis = i;
+        }
     }
-
-    // find stokes axis
-    if (c_type1 == "STOKES")
-        stokes_axis = 0;
-    else if (c_type2 == "STOKES")
-        stokes_axis = 1;
-    else if (c_type3 == "STOKES")
-        stokes_axis = 2;
-    else if (c_type4 == "STOKES")
-        stokes_axis = 3;
-    else
-        stokes_axis = -1;
 }
 
 // ***** FITS keyword conversion *****

--- a/Frame.cc
+++ b/Frame.cc
@@ -56,7 +56,7 @@ Frame::Frame(uint32_t session_id, const std::string& filename, const std::string
 
     // Get shape and axis values from the loader
     std::string log_message;
-    if (!_loader->FindShape(_image_shape, _spectral_axis, _stokes_axis, log_message)) {
+    if (!_loader->FindShape(info, _image_shape, _spectral_axis, _stokes_axis, log_message)) {
         _open_image_error = fmt::format("Problem loading file {}: {}", filename_only, log_message);
         if (_verbose) {
             Log(session_id, _open_image_error);

--- a/ImageData/FileLoader.cc
+++ b/ImageData/FileLoader.cc
@@ -37,8 +37,9 @@ FileLoader* FileLoader::GetLoader(const std::string& filename) {
 }
 
 bool FileLoader::FindShape(const CARTA::FileInfoExtended* info, IPos& shape, int& spectral_axis, int& stokes_axis, std::string& message) {
-    // Find image shape, spectral axis, and stokes axis from image data, coordinate system, and extended file info
-    // set defaults
+    // Return image shape, spectral axis, and stokes axis from image data, coordinate system, and extended file info.
+
+    // set defaults: undefined
     spectral_axis = -1;
     stokes_axis = -1;
 
@@ -52,6 +53,7 @@ bool FileLoader::FindShape(const CARTA::FileInfoExtended* info, IPos& shape, int
         message = "Image must be 2D, 3D, or 4D.";
         return false;
     }
+    _channel_size = shape(0) * shape(1);
 
     casacore::CoordinateSystem coord_sys;
     if (!GetCoordinateSystem(coord_sys)) {
@@ -59,7 +61,7 @@ bool FileLoader::FindShape(const CARTA::FileInfoExtended* info, IPos& shape, int
         return false;
     }
     if (coord_sys.nPixelAxes() != _num_dims) {
-        message = "Problem loading image: incomplete header.";
+        message = "Problem loading image: cannot determine coordinate axes from incomplete header.";
         return false;
     }
 
@@ -94,10 +96,28 @@ bool FileLoader::FindShape(const CARTA::FileInfoExtended* info, IPos& shape, int
         // workaround when header incomplete or invalid values for creating proper coordinate system
         FindCoordinates(info, spectral_axis, stokes_axis);
     }
-
+    if ((spectral_axis < 0) || (stokes_axis < 0)) {
+        if ((spectral_axis < 0) && (stokes_axis >= 0)) { // stokes is known
+            spectral_axis = (stokes_axis == 3 ? 2 : 3);
+        } else if ((spectral_axis >= 0) && (stokes_axis < 0)) { // spectral is known
+            stokes_axis = (spectral_axis == 3 ? 2 : 3);
+        }
+        if ((spectral_axis < 0) && (stokes_axis < 0)) { // neither is known, guess by shape (max 4 stokes)
+            if (shape(2) > 4) {
+                spectral_axis = 2;
+                stokes_axis = 3;
+            } else if (shape(3) > 4) {
+                spectral_axis = 3;
+                stokes_axis = 2;
+            }
+        }
+        if ((spectral_axis < 0) && (stokes_axis < 0)) { // neither is known, give up
+            message = "Problem loading image: cannot determine coordinate axes from incomplete header.";
+            return false;
+        }
+    }
     _num_channels = (spectral_axis == -1 ? 1 : shape(spectral_axis));
     _num_stokes = (stokes_axis == -1 ? 1 : shape(stokes_axis));
-    _channel_size = shape(0) * shape(1);
 
     return true;
 }

--- a/ImageData/FileLoader.cc
+++ b/ImageData/FileLoader.cc
@@ -36,53 +36,12 @@ FileLoader* FileLoader::GetLoader(const std::string& filename) {
     return nullptr;
 }
 
-void FileLoader::FindCoords(int& spectral_axis, int& stokes_axis) {
-    // use CoordinateSystem to determine axis coordinate types
+bool FileLoader::FindShape(const CARTA::FileInfoExtended* info, IPos& shape, int& spectral_axis, int& stokes_axis, std::string& message) {
+    // Find image shape, spectral axis, and stokes axis from image data, coordinate system, and extended file info
+    // set defaults
     spectral_axis = -1;
     stokes_axis = -1;
-    casacore::CoordinateSystem coord_sys;
-    if (GetCoordinateSystem(coord_sys)) {
-        // spectral axis
-        spectral_axis = casacore::CoordinateUtil::findSpectralAxis(coord_sys);
-        if (spectral_axis < 0) {
-            int tab_coord = coord_sys.findCoordinate(casacore::Coordinate::TABULAR);
-            if (tab_coord >= 0) {
-                casacore::Vector<casacore::Int> pixel_axes = coord_sys.pixelAxes(tab_coord);
-                for (casacore::uInt i = 0; i < pixel_axes.size(); ++i) {
-                    casacore::String axis_name = coord_sys.worldAxisNames()(pixel_axes(i));
-                    if (axis_name == "Frequency" || axis_name == "Velocity")
-                        spectral_axis = pixel_axes(i);
-                }
-            }
-        }
-        // stokes axis
-        int pixel, world, coord;
-        casacore::CoordinateUtil::findStokesAxis(pixel, world, coord, coord_sys);
-        if (coord >= 0)
-            stokes_axis = pixel;
 
-        // not found!
-        if (spectral_axis < 2) {   // spectral not found or is xy
-            if (stokes_axis < 2) { // stokes not found or is xy, use defaults
-                spectral_axis = 2;
-                stokes_axis = 3;
-            } else { // stokes found, set spectral to other one
-                if (stokes_axis == 2)
-                    spectral_axis = 3;
-                else
-                    spectral_axis = 2;
-            }
-        } else if (stokes_axis < 2) { // stokes not found
-            // set stokes to the other one
-            if (spectral_axis == 2)
-                stokes_axis = 3;
-            else
-                stokes_axis = 2;
-        }
-    }
-}
-
-bool FileLoader::FindShape(IPos& shape, int& spectral_axis, int& stokes_axis, std::string& message) {
     if (!HasData(FileInfo::Data::Image))
         return false;
 
@@ -115,30 +74,69 @@ bool FileLoader::FindShape(IPos& shape, int& spectral_axis, int& stokes_axis, st
         return false;
     }
 
-    // spectral axis not defined if CTYPE is not "FREQ" (e.g. "FREQUENC" will fail)
-    if ((spectral_axis == -1) && (_num_dims > 2)) {
-        if ((_num_dims == 3) || (stokes_axis == 3)) {
-            spectral_axis = 2;
-        } else {
-            spectral_axis = 3;
-        }
-    }
-
-    if (spectral_axis == -1) {
+    // 2D image
+    if (_num_dims == 2) {
         _num_channels = 1;
-    } else {
-        _num_channels = shape(spectral_axis);
-    }
-
-    if (stokes_axis == -1) {
         _num_stokes = 1;
-    } else {
-        _num_stokes = shape(stokes_axis);
+        return true;
     }
 
+    // 3D image
+    if (_num_dims == 3) {
+        spectral_axis = (spectral_axis < 0 ? 2 : spectral_axis);
+        _num_channels = shape(spectral_axis);
+        _num_stokes = 1;
+        return true;
+    }
+
+    // 4D image
+    if ((spectral_axis < 0) || (stokes_axis < 0)) {
+        // workaround when header incomplete or invalid values for creating proper coordinate system
+        FindCoordinates(info, spectral_axis, stokes_axis);
+    }
+
+    _num_channels = (spectral_axis == -1 ? 1 : shape(spectral_axis));
+    _num_stokes = (stokes_axis == -1 ? 1 : shape(stokes_axis));
     _channel_size = shape(0) * shape(1);
 
     return true;
+}
+
+void FileLoader::FindCoordinates(const CARTA::FileInfoExtended* info, int& spectral_axis, int& stokes_axis) {
+    // read ctypes from file info header entries to determine spectral and stokes axes
+    casacore::String ctype1, ctype2, ctype3, ctype4;
+    for (int i = 0; i < info->header_entries_size(); ++i) {
+        CARTA::HeaderEntry entry = info->header_entries(i);
+        if (entry.name() == "CTYPE1") {
+            ctype1 = casacore::String(entry.value());
+            ctype1.upcase();
+        } else if (entry.name() == "CTYPE2") {
+            ctype2 = casacore::String(entry.value());
+            ctype2.upcase();
+        } else if (entry.name() == "CTYPE3") {
+            ctype3 = casacore::String(entry.value());
+            ctype3.upcase();
+        } else if (entry.name() == "CTYPE4") {
+            ctype4 = casacore::String(entry.value());
+            ctype4.upcase();
+        }
+    }
+
+    // find axes from ctypes
+    size_t ntypes(4);
+    const casacore::String ctypes[] = {ctype1, ctype2, ctype3, ctype4};
+    const casacore::String spectral_types[] = {"FELO", "FREQ", "VELO", "VOPT", "VRAD", "WAVE", "AWAV"};
+    const casacore::String stokes_type = "STOKES";
+    for (size_t i = 0; i < ntypes; ++i) {
+        for (auto& spectral_type : spectral_types) {
+            if (ctypes[i].contains(spectral_type)) {
+                spectral_axis = i;
+            }
+        }
+        if (ctypes[i] == stokes_type) {
+            stokes_axis = i;
+        }
+    }
 }
 
 const FileLoader::IPos FileLoader::GetStatsDataShape(FileInfo::Data ds) {

--- a/ImageData/FileLoader.h
+++ b/ImageData/FileLoader.h
@@ -130,11 +130,11 @@ public:
     virtual ~FileLoader() = default;
 
     static FileLoader* GetLoader(const std::string& filename);
-    // return coordinates for axis types
-    virtual void FindCoords(int& spectral_axis, int& stokes_axis);
 
-    // get shape and axis information from image
-    virtual bool FindShape(IPos& shape, int& spectral_axis, int& stokes_axis, std::string& message);
+    // get shape and axis information from image data and coordinate system
+    bool FindShape(const CARTA::FileInfoExtended* info, IPos& shape, int& spectral_axis, int& stokes_axis, std::string& message);
+    // use extended file info if coord sys fails
+    void FindCoordinates(const CARTA::FileInfoExtended* info, int& spectral_axis, int& stokes_axis);
 
     // Load image statistics, if they exist, from the file
     virtual void LoadImageStats(bool load_percentiles = false);

--- a/Session.cc
+++ b/Session.cc
@@ -42,7 +42,6 @@ Session::Session(uWS::WebSocket<uWS::SERVER>* ws, uint32_t id, std::string root,
       _selected_file_info_extended(nullptr),
       _outgoing_async(outgoing_async),
       _file_list_handler(file_list_handler),
-      _new_frame(false),
       _image_channel_task_active(false),
       _file_settings(this) {
     _histogram_progress = HISTOGRAM_COMPLETE;
@@ -301,7 +300,6 @@ void Session::OnOpenFile(const CARTA::OpenFile& message, uint32_t request_id) {
             std::unique_lock<std::mutex> lock(_frame_mutex); // open/close lock
             _frames[file_id] = move(frame);
             lock.unlock();
-            _new_frame = true;
             // copy file info, extended file info
             CARTA::FileInfo* response_file_info = new CARTA::FileInfo();
             response_file_info->set_name(_selected_file_info->name());

--- a/Session.h
+++ b/Session.h
@@ -203,7 +203,6 @@ private:
     // Frame
     std::unordered_map<int, std::unique_ptr<Frame>> _frames; // <file_id, Frame>: one frame per image file
     std::mutex _frame_mutex;                                 // lock frames to create/destroy
-    bool _new_frame;                                         // flag to send histogram with data
 
     // State for animation functions.
     std::unique_ptr<AnimationObject> _animation_object;


### PR DESCRIPTION
"Forward-port" fix #337 in release branch.

If header is incomplete or has unexpected values, the FileLoader attempts to use extended file info to determine spectral/stokes axes, then resorts to guessing.