### PR TITLE
Implement DS9 region import/export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ set(SOURCE_FILES
         Util.cc
         FileListHandler.cc
         Tile.cc
-	DS9Parser.cc)
+        DS9Parser.cc)
 
 add_definitions(-DHAVE_HDF5)
 add_executable(carta_backend ${SOURCE_FILES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ set(SOURCE_FILES
         Util.cc
         FileListHandler.cc
         Tile.cc
-        DS9Parser.cc)
+        Ds9Parser.cc)
 
 add_definitions(-DHAVE_HDF5)
 add_executable(carta_backend ${SOURCE_FILES})

--- a/Ds9Parser.cc
+++ b/Ds9Parser.cc
@@ -69,8 +69,7 @@ Ds9Parser::Ds9Parser(const casacore::CoordinateSystem& image_coord_sys, std::str
 }
 
 Ds9Parser::Ds9Parser(const casacore::CoordinateSystem& image_coord_sys, bool pixel_coord)
-    : _coord_sys(image_coord_sys),
-      _pixel_coord(pixel_coord) {
+    : _coord_sys(image_coord_sys), _pixel_coord(pixel_coord) {
     // Used for exporting regions
     InitDs9CoordMap();
 
@@ -148,7 +147,7 @@ void Ds9Parser::ProcessFileLines(std::vector<std::string>& lines) {
         }
 
         // process coordinate system
-        if (IsDs9CoordSysKeyword(line)) { 
+        if (IsDs9CoordSysKeyword(line)) {
             ds9_coord_sys_ok = SetDirectionRefFrame(line);
             if (!ds9_coord_sys_ok) {
                 std::cerr << "Cannot process DS9 coordinate system: " << line << std::endl;
@@ -234,7 +233,7 @@ void Ds9Parser::SetAnnotationRegion(std::string& region_description) {
     formatted_region.gsub(")", "");  // remove right parenthesis
     formatted_region.gsub(",", " "); // replace commas with space
 
-    // split definition into parts (region type and parameters) e.g. ["circle", "100", "100", "10"] 
+    // split definition into parts (region type and parameters) e.g. ["circle", "100", "100", "10"]
     std::vector<std::string> region_parameters;
     SplitString(formatted_region, ' ', region_parameters);
     if (region_parameters.size() < 3) {
@@ -275,15 +274,15 @@ casacore::String Ds9Parser::GetRegionName(std::string& region_properties) {
     // Parse region properties (everything after '#') for text, used as region name
     casacore::String text_label;
     if (region_properties.find("text") != std::string::npos) {
-       casacore::String properties(region_properties);
-       text_label = properties.after("text=");
-       // strip delimiters
-       char text_delim = text_label[0];
-       text_label.ltrim(text_delim);
-       if (text_delim == '{') {
-           text_delim = '}';
-       }
-       text_label = text_label.before(text_delim); // e.g. "Region X"
+        casacore::String properties(region_properties);
+        text_label = properties.after("text=");
+        // strip delimiters
+        char text_delim = text_label[0];
+        text_label.ltrim(text_delim);
+        if (text_delim == '{') {
+            text_delim = '}';
+        }
+        text_label = text_label.before(text_delim); // e.g. "Region X"
     }
     return text_label;
 }
@@ -358,22 +357,17 @@ bool Ds9Parser::GetAnnotationRegionType(std::string& ds9_region, casa::Annotatio
     // Convert ds9 region type (everything but "ruler") to annotation region type.
     // Returns whether conversion was successful, there is no AnnotationBase::Type::UNKNOWN!
     bool found_type(false);
-    std::unordered_map<std::string, casa::AnnotationBase::Type> region_type_map = {
-        {"circle", casa::AnnotationBase::Type::CIRCLE},
-        {"annulus", casa::AnnotationBase::Type::ANNULUS},
-        {"ellipse", casa::AnnotationBase::Type::ELLIPSE},
-        {"box", casa::AnnotationBase::Type::ROTATED_BOX}, // or a CENTER_BOX if angle==0
-        {"polygon", casa::AnnotationBase::Type::POLYGON},
-        {"line", casa::AnnotationBase::Type::LINE},
-        {"text", casa::AnnotationBase::Type::TEXT},
-        {"point", casa::AnnotationBase::Type::SYMBOL}
-    };
+    std::unordered_map<std::string, casa::AnnotationBase::Type> region_type_map = {{"circle", casa::AnnotationBase::Type::CIRCLE},
+        {"annulus", casa::AnnotationBase::Type::ANNULUS}, {"ellipse", casa::AnnotationBase::Type::ELLIPSE},
+	{"box", casa::AnnotationBase::Type::ROTATED_BOX}, // or a CENTER_BOX if angle==0
+        {"polygon", casa::AnnotationBase::Type::POLYGON}, {"line", casa::AnnotationBase::Type::LINE},
+        {"text", casa::AnnotationBase::Type::TEXT}, {"point", casa::AnnotationBase::Type::SYMBOL}};
 
     for (auto& region_type : region_type_map) {
         if (ds9_region.find(region_type.first) != std::string::npos) {
             type = region_type.second;
             found_type = true;
-	    break;
+            break;
         }
     }
     return found_type;
@@ -413,9 +407,9 @@ casa::AnnRegion* Ds9Parser::CreateBoxRegion(std::vector<std::string>& region_def
             ann_region = new casa::AnnCenterBox(parameters[0], parameters[1], parameters[2], parameters[3], _direction_ref_frame,
                 _coord_sys, _image_shape, begin_freq, end_freq, freq_ref_frame, doppler, rest_freq, stokes_types, false, false);
         } else {
-            ann_region = new casa::AnnRotBox(parameters[0], parameters[1], parameters[2], parameters[3], parameters[4],
-                _direction_ref_frame, _coord_sys, _image_shape, begin_freq, end_freq, freq_ref_frame, doppler, rest_freq, stokes_types,
-                false, false);
+            ann_region =
+                new casa::AnnRotBox(parameters[0], parameters[1], parameters[2], parameters[3], parameters[4], _direction_ref_frame,
+                    _coord_sys, _image_shape, begin_freq, end_freq, freq_ref_frame, doppler, rest_freq, stokes_types, false, false);
         }
     }
     return ann_region;
@@ -531,7 +525,7 @@ casa::AnnRegion* Ds9Parser::CreatePolygonRegion(std::vector<std::string>& region
         ann_region = new casa::AnnPolygon(xPositions, yPositions, _direction_ref_frame, _coord_sys, _image_shape, begin_freq, end_freq,
             freq_ref_frame, doppler, rest_freq, stokes_types, false, false);
     }
- 
+
     return ann_region;
 }
 
@@ -582,9 +576,9 @@ void Ds9Parser::PrintHeader(std::ostream& os) {
     // print file format, globals, and coord sys
     os << "# Region file format: DS9 CARTA " << VERSION_ID << std::endl;
     Ds9Properties globals;
-    os << "global color=" << globals.color << " delete=" << globals.delete_region << " edit=" << globals.edit_region << " fixed="
-       << globals.fixed_region << " font=\"" << globals.font << "\" highlite=" << globals.highlite_region << " include="
-       << globals.include_region << " move=" << globals.move_region << " select=" << globals.select_region << std::endl;
+    os << "global color=" << globals.color << " delete=" << globals.delete_region << " edit=" << globals.edit_region
+       << " fixed=" << globals.fixed_region << " font=\"" << globals.font << "\" highlite=" << globals.highlite_region
+       << " include=" << globals.include_region << " move=" << globals.move_region << " select=" << globals.select_region << std::endl;
     os << _direction_ref_frame << std::endl;
 }
 
@@ -614,7 +608,7 @@ void Ds9Parser::PrintRegion(unsigned int i, std::ostream& os) {
         if (!region.name.empty()) {
             os << " # text={" << region.name << "}";
         }
-        os << std::endl;    
+        os << std::endl;
     }
 }
 
@@ -639,8 +633,10 @@ void Ds9Parser::PrintBoxRegion(const RegionProperties& properties, std::ostream&
     } else {
         os << std::fixed << std::setprecision(6) << points[0].get("deg").getValue() << ",";
         os << std::fixed << std::setprecision(6) << points[1].get("deg").getValue() << ",";
-        os << std::fixed << std::setprecision(2) << points[2].get("arcsec").getValue() << "\"" << ",";
-        os << std::fixed << std::setprecision(2) << points[3].get("arcsec").getValue() << "\"" << ",";
+        os << std::fixed << std::setprecision(2) << points[2].get("arcsec").getValue() << "\""
+           << ",";
+        os << std::fixed << std::setprecision(2) << points[3].get("arcsec").getValue() << "\""
+           << ",";
         os << std::defaultfloat << std::setprecision(8) << properties.rotation << ")";
     }
 }
@@ -671,8 +667,10 @@ void Ds9Parser::PrintEllipseRegion(const RegionProperties& properties, std::ostr
         } else {
             os << std::fixed << std::setprecision(6) << points[0].get("deg").getValue() << ",";
             os << std::fixed << std::setprecision(6) << points[1].get("deg").getValue() << ",";
-            os << std::fixed << std::setprecision(2) << points[2].get("arcsec").getValue() << "\"" << ",";
-            os << std::fixed << std::setprecision(2) << points[3].get("arcsec").getValue() << "\"" << ",";
+            os << std::fixed << std::setprecision(2) << points[2].get("arcsec").getValue() << "\""
+               << ",";
+            os << std::fixed << std::setprecision(2) << points[3].get("arcsec").getValue() << "\""
+               << ",";
             os << std::defaultfloat << std::setprecision(8) << properties.rotation << ")";
         }
     }

--- a/Ds9Parser.cc
+++ b/Ds9Parser.cc
@@ -2,8 +2,8 @@
 
 #include <iomanip>
 
-#include <casacore/coordinates/Coordinates/DirectionCoordinate.h>
 #include <casacore/casa/Quanta/QMath.h>
+#include <casacore/coordinates/Coordinates/DirectionCoordinate.h>
 #include <imageanalysis/Annotations/AnnCenterBox.h>
 #include <imageanalysis/Annotations/AnnCircle.h>
 #include <imageanalysis/Annotations/AnnEllipse.h>

--- a/Ds9Parser.cc
+++ b/Ds9Parser.cc
@@ -13,7 +13,7 @@
 
 using namespace carta;
 
-Ds9Parser::Ds9Parser(std::string& filename, const casacore::CoordinateSystem& image_coord_sys, casacore::IPosition& image_shape) 
+Ds9Parser::Ds9Parser(std::string& filename, const casacore::CoordinateSystem& image_coord_sys, casacore::IPosition& image_shape)
     : _coord_sys(image_coord_sys),
       _image_shape(image_shape),
       _direction_ref_frame(""),
@@ -54,7 +54,7 @@ Ds9Parser::Ds9Parser(const casacore::CoordinateSystem& image_coord_sys, std::str
     // Create vector of file lines, delimited with newline or semicolon
     std::vector<std::string> file_lines, input_lines;
     SplitString(contents, '\n', input_lines); // split by newline
-    for (auto single_line : input_lines) { 
+    for (auto single_line : input_lines) {
         std::vector<std::string> lines;
         SplitString(single_line, ';', lines); // split by semicolon
         for (auto& line : lines) {
@@ -79,7 +79,6 @@ casa::AsciiAnnotationFileLine Ds9Parser::LineAt(unsigned int i) {
     // region list throws exception if index out of range
     return _region_list.lineAt(i);
 }
-
 
 // Process or ignore each file line
 
@@ -148,10 +147,10 @@ void Ds9Parser::SetAnnotationRegion(std::string& region_description) {
         }
 
         // normalize all formats into space delimiter "circle 100 100 10":
-        formatted_region.gsub("(", " ");   // replace left parenthesis
-        formatted_region.gsub(")", "");    // remove right parenthesis
-        formatted_region.gsub(",", " ");   // replace commas
-	// replace with casacore units
+        formatted_region.gsub("(", " "); // replace left parenthesis
+        formatted_region.gsub(")", "");  // remove right parenthesis
+        formatted_region.gsub(",", " "); // replace commas
+        // replace with casacore units
         formatted_region.gsub("d", "deg");
         formatted_region.gsub("r", "rad");
         formatted_region.gsub("p", "pix");
@@ -174,8 +173,8 @@ void Ds9Parser::SetAnnotationRegion(std::string& region_description) {
 // Coordinate system helpers
 
 bool Ds9Parser::IsDs9CoordSysKeyword(std::string& input) {
-    const std::string ds9_coordsys_keywords[] = {"PHYSICAL", "IMAGE", "FK4", "B1950", "FK5", "J2000", "GALACTIC", "ECLIPTIC", "ICRS", "LINEAR",
-        "AMPLIFIER", "DETECTOR"};
+    const std::string ds9_coordsys_keywords[] = {
+        "PHYSICAL", "IMAGE", "FK4", "B1950", "FK5", "J2000", "GALACTIC", "ECLIPTIC", "ICRS", "LINEAR", "AMPLIFIER", "DETECTOR"};
     std::transform(input.begin(), input.end(), input.begin(), ::toupper); // convert in-place to uppercase
     for (auto& keyword : ds9_coordsys_keywords) {
         if (keyword == input) {
@@ -319,8 +318,7 @@ casa::AnnRegion* Ds9Parser::CreateCircleRegion(std::vector<std::string>& region_
     if (region_definition.size() == 4) { // circle x y radius
         // convert strings to Quantities
         std::vector<casacore::Quantity> parameters;
-	for (size_t i = 1; i < region_definition.size(); ++i) {
-            std::string param_string(region_definition[i]);
+        for (auto& param_string : region_definition) {
             casacore::Quantity param_quantity;
             if (readQuantity(param_quantity, param_string)) {
                 if (param_quantity.getUnit().empty()) {
@@ -353,7 +351,7 @@ casa::AnnRegion* Ds9Parser::CreateEllipseRegion(std::vector<std::string>& region
     if (nparams == 6) { // ellipse x y radius radius angle
         // convert strings to Quantities
         std::vector<casacore::Quantity> parameters;
-	for (size_t i = 1; i < nparams; ++i) {
+        for (size_t i = 1; i < nparams; ++i) {
             std::string param_string(region_definition[i]);
             casacore::Quantity param_quantity;
             if (readQuantity(param_quantity, param_string)) {
@@ -391,8 +389,8 @@ casa::AnnRegion* Ds9Parser::CreateBoxRegion(std::vector<std::string>& region_def
     if (nparams == 6) { // box x y width height angle
         // convert strings to Quantities
         std::vector<casacore::Quantity> parameters;
-	// x and y
-	for (size_t i = 1; i < nparams; ++i) {
+        // x and y
+        for (size_t i = 1; i < nparams; ++i) {
             std::string xy_string(region_definition[i]);
             casacore::Quantity xy_quantity;
             if (readQuantity(xy_quantity, xy_string)) {

--- a/Ds9Parser.cc
+++ b/Ds9Parser.cc
@@ -1,0 +1,499 @@
+//# Ds9Parser: parses lines of input ds9 region file into CARTA::RegionInfo for import
+
+#include <casacore/coordinates/Coordinates/DirectionCoordinate.h>
+#include <imageanalysis/Annotations/AnnCenterBox.h>
+#include <imageanalysis/Annotations/AnnCircle.h>
+#include <imageanalysis/Annotations/AnnEllipse.h>
+#include <imageanalysis/Annotations/AnnPolygon.h>
+#include <imageanalysis/Annotations/AnnRegion.h>
+#include <imageanalysis/Annotations/AnnRotBox.h>
+
+#include "Ds9Parser.h"
+#include "Util.h"
+
+using namespace carta;
+
+Ds9Parser::Ds9Parser(std::string& filename, const casacore::CoordinateSystem& image_coord_sys, casacore::IPosition& image_shape) 
+    : _coord_sys(image_coord_sys),
+      _image_shape(image_shape),
+      _direction_ref_frame(""),
+      _pixel_coords(false),
+      _region_list(image_coord_sys, image_shape) {
+    // Parse given file into casa::AsciiAnnotationFileLines
+
+    // Create vector of file lines, delimited with newline or semicolon
+    std::ifstream ds9_file(filename);
+    if (ds9_file.is_open()) {
+        std::vector<std::string> file_lines;
+        while (!ds9_file.eof()) {
+            std::string single_line;
+            getline(ds9_file, single_line); // get by newline
+            std::vector<std::string> lines;
+            SplitString(single_line, ';', lines); // split by semicolon
+            for (auto& line : lines) {
+                file_lines.push_back(line);
+            }
+        }
+        ds9_file.close();
+        // Process into annotation lines
+        ProcessFileLines(file_lines);
+    } else {
+        throw casacore::AipsError("Cannot open file");
+    }
+}
+
+Ds9Parser::Ds9Parser(const casacore::CoordinateSystem& image_coord_sys, std::string& contents, casacore::IPosition& image_shape)
+    : _coord_sys(image_coord_sys),
+      _image_shape(image_shape),
+      _direction_ref_frame(""),
+      _pixel_coords(false),
+      _region_list(image_coord_sys, image_shape) {
+    // Convert given file contents into casa::AsciiAnnotationFileLines
+    InitializeDirectionReferenceFrame();
+
+    // Create vector of file lines, delimited with newline or semicolon
+    std::vector<std::string> file_lines, input_lines;
+    SplitString(contents, '\n', input_lines); // split by newline
+    for (auto single_line : input_lines) { 
+        std::vector<std::string> lines;
+        SplitString(single_line, ';', lines); // split by semicolon
+        for (auto& line : lines) {
+            file_lines.push_back(line);
+        }
+    }
+    // Process into annotation lines
+    ProcessFileLines(file_lines);
+}
+
+// public accessors
+
+unsigned int Ds9Parser::NumLines() {
+    return _region_list.nLines();
+}
+
+const casacore::Vector<casa::AsciiAnnotationFileLine> Ds9Parser::GetLines() {
+    return _region_list.getLines();
+}
+
+casa::AsciiAnnotationFileLine Ds9Parser::LineAt(unsigned int i) {
+    // region list throws exception if index out of range
+    return _region_list.lineAt(i);
+}
+
+
+// Process or ignore each file line
+
+void Ds9Parser::ProcessFileLines(std::vector<std::string>& lines) {
+    if (lines.empty()) {
+        return;
+    }
+
+    for (auto& line : lines) {
+        // skip blank line
+        if (line.empty()) {
+            continue;
+        }
+        // skip comment
+        if (line[0] == '#') {
+            continue;
+        }
+        // skip regions excluded for later analysis (annotation-only)
+        if (line[0] == '-') {
+            continue;
+        }
+        // skip global settings not used in carta
+        if (line.find("global") != std::string::npos) {
+            continue;
+        }
+
+        // process coordinate system
+        if (IsDs9CoordSysKeyword(line)) { 
+            if (SetDirectionRefFrame(line)) {
+                continue;
+            } else {
+                // TODO: skip lines until new csys definition?
+                throw casacore::AipsError("Cannot process DS9 coordinate system.");
+            }
+        }
+
+        // direction frame required to set regions
+        if (_direction_ref_frame.empty()) {
+            InitializeDirectionReferenceFrame();
+        }
+        // process region
+        SetAnnotationRegion(line);
+    }
+}
+
+void Ds9Parser::SetAnnotationRegion(std::string& region_description) {
+    // Convert ds9 region description into AsciiAnnotationFileLine and add to RegionTextList.
+    // Split into region definition, properties
+    std::vector<string> region_parts;
+    SplitString(region_description, '#', region_parts);
+
+    // Split definition in case it is an annulus (e.g. "ellipse1 & !ellipse2")
+    std::vector<string> region_definitions;
+    SplitString(region_parts[0], '&', region_definitions);
+
+    // Process region definitions
+    // DS9 can have 3 formats: optional commas, and optional parentheses
+    // Ex: "circle 100 100 10", "circle(100 100 10)", "circle(100,100,10)"
+    for (auto& region_definition : region_definitions) {
+        casacore::String formatted_region(region_definition); // handy utilities: trim, gsub (global substitution)
+        formatted_region.trim();                              // remove beginning and ending whitespace
+        std::string crtf_prefix;
+        if (formatted_region[0] == '!') { // NOT
+            crtf_prefix = "-";
+            formatted_region.ltrim('!');
+        }
+
+        // normalize all formats into space delimiter "circle 100 100 10":
+        formatted_region.gsub("(", " ");   // replace left parenthesis
+        formatted_region.gsub(")", "");    // remove right parenthesis
+        formatted_region.gsub(",", " ");   // replace commas
+	// replace with casacore units
+        formatted_region.gsub("d", "deg");
+        formatted_region.gsub("r", "rad");
+        formatted_region.gsub("p", "pix");
+        formatted_region.gsub("i", "pix");
+        formatted_region.gsub("'", "arcmin");
+        formatted_region.gsub("\"", "arcsec");
+        // TODO: hms, dms
+
+        // split definition into parts (region type and parameters)
+        std::vector<std::string> region_parameters;
+        SplitString(formatted_region, ' ', region_parameters);
+        if (region_parameters.size() < 3) {
+            return;
+        }
+
+        ProcessRegionDefinition(region_parameters, crtf_prefix);
+    }
+}
+
+// Coordinate system helpers
+
+bool Ds9Parser::IsDs9CoordSysKeyword(std::string& input) {
+    const std::string ds9_coordsys_keywords[] = {"PHYSICAL", "IMAGE", "FK4", "B1950", "FK5", "J2000", "GALACTIC", "ECLIPTIC", "ICRS", "LINEAR",
+        "AMPLIFIER", "DETECTOR"};
+    std::transform(input.begin(), input.end(), input.begin(), ::toupper); // convert in-place to uppercase
+    for (auto& keyword : ds9_coordsys_keywords) {
+        if (keyword == input) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool Ds9Parser::SetDirectionRefFrame(std::string& ds9_coord) {
+    // Convert coord sys string to CRTF-defined reference frame
+    // Returns whether conversion was successful
+    bool converted_coord(false);
+    if ((ds9_coord == "PHYSICAL") || (ds9_coord == "IMAGE")) { // pixel
+        _pixel_coords = true;
+        converted_coord = true;
+    } else if ((ds9_coord == "FK4") || (ds9_coord == "B1950")) {
+        _direction_ref_frame = "B1950";
+        converted_coord = true;
+    } else if ((ds9_coord == "FK5") || (ds9_coord == "J2000")) {
+        _direction_ref_frame = "J2000";
+        converted_coord = true;
+    } else if ((ds9_coord == "GALACTIC") || (ds9_coord == "ECLIPTIC") || (ds9_coord == "ICRS")) {
+        _direction_ref_frame = ds9_coord;
+        converted_coord = true;
+    }
+    return converted_coord;
+}
+
+void Ds9Parser::InitializeDirectionReferenceFrame() {
+    // Set _direction_reference_frame attribute to image coord sys direction frame
+    casacore::MDirection::Types reference_frame_type(casacore::MDirection::DEFAULT);
+    if (_coord_sys.hasDirectionCoordinate()) {
+        _coord_sys.directionCoordinate().getReferenceConversion(reference_frame_type);
+    }
+    _direction_ref_frame = casacore::MDirection::showType(reference_frame_type);
+}
+
+// Region helpers
+
+void Ds9Parser::ProcessRegionDefinition(std::vector<std::string>& region_definition, std::string& crtf_prefix) {
+    // Process region definition vector (e.g. ["circle", "100", "100", "20"]) into AnnRegion
+    std::string region_type = region_definition[0];
+    size_t first_param_index(1);
+    // point can have symbol descriptor, e.g. ""circle point", "diamond point", etc.
+    if (region_definition[1] == "point") {
+        region_type = "POINT";
+        first_param_index = 2;
+    }
+    // Get Annotation type from region type
+    casa::AnnotationBase::Type ann_region_type;
+    bool valid_ann_region = GetAnnotationRegionType(region_type, ann_region_type);
+    if (!valid_ann_region) {
+        return;
+    }
+
+    // process region type parameters into AnnRegion or AnnSymbol
+    std::string error_message;
+    casa::AnnRegion* ann_region(nullptr);
+    casa::AnnSymbol* ann_symbol(nullptr); // not a region, handle separately
+    try {
+        switch (ann_region_type) {
+            case casa::AnnotationBase::Type::CIRCLE:
+                ann_region = CreateCircleRegion(region_definition, crtf_prefix);
+                break;
+            case casa::AnnotationBase::Type::ELLIPSE:
+                ann_region = CreateEllipseRegion(region_definition, crtf_prefix);
+                break;
+            case casa::AnnotationBase::Type::ROTATED_BOX: // or a CENTER_BOX if angle==0
+                ann_region = CreateBoxRegion(region_definition, crtf_prefix);
+                break;
+            case casa::AnnotationBase::Type::POLYGON:
+                ann_region = CreatePolygonRegion(region_definition, crtf_prefix);
+                break;
+            case casa::AnnotationBase::Type::SYMBOL: // used for carta point region
+                ann_symbol = CreateSymbolRegion(region_definition, crtf_prefix);
+                break;
+            case casa::AnnotationBase::Type::ANNULUS:
+            case casa::AnnotationBase::Type::LINE:
+                error_message = "Import region " + region_type + " failed:  not supported yet.";
+                break;
+            case casa::AnnotationBase::Type::TEXT:
+                error_message = "Import region " + region_type + " failed:  annotations not supported yet.";
+            default:
+                break;
+        }
+    } catch (casacore::AipsError& err) {
+        std::ostringstream oss;
+        oss << "Import region " << region_type << " failed: " << err.getMesg();
+        error_message = oss.str();
+    }
+
+    // Add AsciiAnnotationFileLine for Annotation to RegionTextList
+    casacore::CountedPtr<const casa::AnnotationBase> annotation_region;
+    if (ann_symbol != nullptr) {
+        annotation_region = casacore::CountedPtr<const casa::AnnotationBase>(ann_symbol);
+    } else if (ann_region != nullptr) {
+        annotation_region = casacore::CountedPtr<const casa::AnnotationBase>(ann_region);
+    } else {
+        return;
+    }
+    casa::AsciiAnnotationFileLine file_line = casa::AsciiAnnotationFileLine(annotation_region);
+    _region_list.addLine(file_line);
+}
+
+bool Ds9Parser::GetAnnotationRegionType(std::string& ds9_region, casa::AnnotationBase::Type& type) {
+    // Convert ds9 region type (everything but "ruler") to annotation region type.
+    // Returns whether conversion was successful, there is no AnnotationBase::Type::UNKNOWN!
+    bool found_type(false);
+    if (ds9_region == "CIRCLE") {
+        type = casa::AnnotationBase::Type::CIRCLE;
+        found_type = true;
+    } else if (ds9_region == "ANNULUS") {
+        type = casa::AnnotationBase::Type::ANNULUS;
+        found_type = true;
+    } else if (ds9_region == "ELLIPSE") {
+        type = casa::AnnotationBase::Type::ELLIPSE;
+        found_type = true;
+    } else if (ds9_region == "BOX") {
+        type = casa::AnnotationBase::Type::ROTATED_BOX; // or a CENTER_BOX if angle=0
+        found_type = true;
+    } else if (ds9_region == "POLYGON") {
+        type = casa::AnnotationBase::Type::POLYGON;
+        found_type = true;
+    } else if (ds9_region == "LINE") {
+        type = casa::AnnotationBase::Type::LINE;
+        found_type = true;
+    } else if (ds9_region == "TEXT") {
+        type = casa::AnnotationBase::Type::TEXT;
+        found_type = true;
+    } else if (ds9_region == "POINT") {
+        type = casa::AnnotationBase::Type::SYMBOL;
+        found_type = true;
+    }
+    return found_type;
+}
+
+casa::AnnRegion* Ds9Parser::CreateCircleRegion(std::vector<std::string>& region_definition, std::string& crtf_prefix) {
+    // Create AnnCircle from DS9 region definition
+    casa::AnnRegion* ann_region(nullptr);
+    if (region_definition.size() == 4) { // circle x y radius
+        // convert strings to Quantities
+        std::vector<casacore::Quantity> parameters;
+	for (size_t i = 1; i < region_definition.size(); ++i) {
+            std::string param_string(region_definition[i]);
+            casacore::Quantity param_quantity;
+            if (readQuantity(param_quantity, param_string)) {
+                if (param_quantity.getUnit().empty()) {
+                    param_quantity.setUnit("pix");
+                }
+                parameters.push_back(param_quantity);
+            } else {
+                std::cerr << "ERROR: cannot process circle parameter " << param_string << std::endl;
+                return ann_region; // nullptr, cannot process parameters
+            }
+        }
+
+        // AnnCircle arguments
+        casacore::Quantity begin_freq, end_freq, rest_freq;
+        casacore::String freq_ref_frame, doppler;
+        casacore::Vector<casacore::Stokes::StokesTypes> stokes_types;
+        bool annotation_only(false);
+
+        ann_region = new casa::AnnCircle(parameters[0], parameters[1], parameters[2], _direction_ref_frame, _coord_sys, _image_shape,
+            begin_freq, end_freq, freq_ref_frame, doppler, rest_freq, stokes_types, annotation_only);
+    }
+
+    return ann_region;
+}
+
+casa::AnnRegion* Ds9Parser::CreateEllipseRegion(std::vector<std::string>& region_definition, std::string& crtf_prefix) {
+    // Create AnnEllipse from DS9 region definition
+    casa::AnnRegion* ann_region(nullptr);
+    size_t nparams(region_definition.size());
+    if (nparams == 6) { // ellipse x y radius radius angle
+        // convert strings to Quantities
+        std::vector<casacore::Quantity> parameters;
+	for (size_t i = 1; i < nparams; ++i) {
+            std::string param_string(region_definition[i]);
+            casacore::Quantity param_quantity;
+            if (readQuantity(param_quantity, param_string)) {
+                if (param_quantity.getUnit().empty()) {
+                    if (i == nparams - 1) {
+                        param_quantity.setUnit("deg");
+                    } else {
+                        param_quantity.setUnit("pix");
+                    }
+                }
+                parameters.push_back(param_quantity);
+            } else {
+                std::cerr << "ERROR: cannot process ellipse parameter " << param_string << std::endl;
+                return ann_region; // nullptr, cannot process parameters
+            }
+        }
+
+        // AnnEllipse arguments
+        casacore::Quantity begin_freq, end_freq, rest_freq;
+        casacore::String freq_ref_frame, doppler;
+        casacore::Vector<casacore::Stokes::StokesTypes> stokes_types;
+        bool annotation_only(false);
+
+        ann_region = new casa::AnnEllipse(parameters[0], parameters[1], parameters[2], parameters[3], parameters[4], _direction_ref_frame,
+            _coord_sys, _image_shape, begin_freq, end_freq, freq_ref_frame, doppler, rest_freq, stokes_types, annotation_only);
+    }
+
+    return ann_region;
+}
+
+casa::AnnRegion* Ds9Parser::CreateBoxRegion(std::vector<std::string>& region_definition, std::string& crtf_prefix) {
+    // Create AnnCenterBox or AnnRotBox from DS9 region definition
+    casa::AnnRegion* ann_region(nullptr);
+    size_t nparams(region_definition.size());
+    if (nparams == 6) { // box x y width height angle
+        // convert strings to Quantities
+        std::vector<casacore::Quantity> parameters;
+	// x and y
+	for (size_t i = 1; i < nparams; ++i) {
+            std::string xy_string(region_definition[i]);
+            casacore::Quantity xy_quantity;
+            if (readQuantity(xy_quantity, xy_string)) {
+                if (xy_quantity.getUnit().empty()) {
+                    if (i == nparams - 1) {
+                        xy_quantity.setUnit("deg");
+                    } else {
+                        xy_quantity.setUnit("pix");
+                    }
+                }
+                parameters.push_back(xy_quantity);
+            } else {
+                std::cerr << "ERROR: cannot process box parameter " << xy_string << std::endl;
+                return ann_region; // nullptr, cannot process parameters
+            }
+        }
+
+        // AnnCenterBox / AnnRotBox arguments
+        casacore::Quantity begin_freq, end_freq, rest_freq;
+        casacore::String freq_ref_frame, doppler;
+        casacore::Vector<casacore::Stokes::StokesTypes> stokes_types;
+        bool annotation_only(false);
+
+        if (parameters[4].getValue() == 0.0) { // angle parameter; no rotation
+            ann_region = new casa::AnnCenterBox(parameters[0], parameters[1], parameters[2], parameters[3], _direction_ref_frame,
+                _coord_sys, _image_shape, begin_freq, end_freq, freq_ref_frame, doppler, rest_freq, stokes_types, annotation_only);
+        } else {
+            ann_region = new casa::AnnRotBox(parameters[0], parameters[1], parameters[2], parameters[3], parameters[4],
+                _direction_ref_frame, _coord_sys, _image_shape, begin_freq, end_freq, freq_ref_frame, doppler, rest_freq, stokes_types,
+                annotation_only);
+        }
+    }
+    return ann_region;
+}
+
+casa::AnnRegion* Ds9Parser::CreatePolygonRegion(std::vector<std::string>& region_definition, std::string& crtf_prefix) {
+    // Create AnnPolygon from DS9 region definition
+    casa::AnnRegion* ann_region(nullptr);
+    if (region_definition.size() % 2 == 1) { // "polygon" + pairs of x,y points
+        // convert strings to Quantities
+        std::vector<casacore::Quantity> parameters;
+        for (size_t i = 1; i < region_definition.size(); i++) {
+            std::string xy_string(region_definition[i]);
+            casacore::Quantity xy_quantity;
+            if (readQuantity(xy_quantity, xy_string)) {
+                if (xy_quantity.getUnit().empty()) {
+                    xy_quantity.setUnit("pix");
+                }
+                parameters.push_back(xy_quantity);
+            } else {
+                std::cerr << "ERROR: cannot process polygon parameter " << xy_string << std::endl;
+                return ann_region; // nullptr, cannot process parameters
+            }
+        }
+
+        // AnnPolygon arguments
+        std::vector<casacore::Quantity> xPositions, yPositions;
+        for (size_t i = 0; i < parameters.size(); i += 2) {
+            xPositions.push_back(parameters[i]);
+            yPositions.push_back(parameters[i + 1]);
+        }
+        casacore::Quantity begin_freq, end_freq, rest_freq;
+        casacore::String freq_ref_frame, doppler;
+        casacore::Vector<casacore::Stokes::StokesTypes> stokes_types;
+        bool annotation_only(false);
+
+        ann_region = new casa::AnnPolygon(xPositions, yPositions, _direction_ref_frame, _coord_sys, _image_shape, begin_freq, end_freq,
+            freq_ref_frame, doppler, rest_freq, stokes_types, annotation_only);
+    }
+ 
+    return ann_region;
+}
+
+casa::AnnSymbol* Ds9Parser::CreateSymbolRegion(std::vector<std::string>& region_definition, std::string& crtf_prefix) {
+    // Create AnnSymbol from DS9 region definition
+    casa::AnnSymbol* ann_symbol(nullptr);
+    if (region_definition.size() == 3) { // point x y
+        // convert strings to Quantities
+        std::vector<casacore::Quantity> parameters;
+        for (size_t i = 1; i < region_definition.size(); ++i) {
+            std::string xy_string(region_definition[i]);
+            casacore::Quantity xy_quantity;
+            if (readQuantity(xy_quantity, xy_string)) {
+                if (xy_quantity.getUnit().empty()) {
+                    xy_quantity.setUnit("pix");
+                }
+                parameters.push_back(xy_quantity);
+            } else {
+                std::cerr << "ERROR: cannot process point parameter " << xy_string << std::endl;
+                return ann_symbol; // nullptr, cannot process parameters
+            }
+        }
+
+        // AnnSymbol arguments
+        casacore::Quantity begin_freq, end_freq, rest_freq;
+        casacore::String freq_ref_frame, doppler;
+        casacore::Vector<casacore::Stokes::StokesTypes> stokes_types;
+
+        ann_symbol = new casa::AnnSymbol(parameters[0], parameters[1], _direction_ref_frame, _coord_sys, '.', begin_freq, end_freq,
+            freq_ref_frame, doppler, rest_freq, stokes_types);
+    }
+
+    return ann_symbol;
+}

--- a/Ds9Parser.cc
+++ b/Ds9Parser.cc
@@ -292,7 +292,7 @@ void Ds9Parser::ProcessRegionDefinition(std::vector<std::string>& region_definit
     // Process region definition vector (e.g. ["circle", "100", "100", "20"]) into AnnRegion
     std::string region_type = region_definition[0];
     // point can have symbol descriptor, e.g. ""circle point", "diamond point", etc.
-    if (region_definition[1] == "point") {
+    if (region_definition[1].find("point") != std::string::npos) {
         region_type = "point";
     }
     // Get Annotation type from region type
@@ -369,9 +369,12 @@ bool Ds9Parser::GetAnnotationRegionType(std::string& ds9_region, casa::Annotatio
         {"point", casa::AnnotationBase::Type::SYMBOL}
     };
 
-    if (region_type_map.count(ds9_region)) {
-        type = region_type_map[ds9_region];
-        found_type = true;
+    for (auto& region_type : region_type_map) {
+        if (ds9_region.find(region_type.first) != std::string::npos) {
+            type = region_type.second;
+            found_type = true;
+	    break;
+        }
     }
     return found_type;
 }

--- a/Ds9Parser.cc
+++ b/Ds9Parser.cc
@@ -359,7 +359,7 @@ bool Ds9Parser::GetAnnotationRegionType(std::string& ds9_region, casa::Annotatio
     bool found_type(false);
     std::unordered_map<std::string, casa::AnnotationBase::Type> region_type_map = {{"circle", casa::AnnotationBase::Type::CIRCLE},
         {"annulus", casa::AnnotationBase::Type::ANNULUS}, {"ellipse", casa::AnnotationBase::Type::ELLIPSE},
-	{"box", casa::AnnotationBase::Type::ROTATED_BOX}, // or a CENTER_BOX if angle==0
+        {"box", casa::AnnotationBase::Type::ROTATED_BOX}, // or a CENTER_BOX if angle==0
         {"polygon", casa::AnnotationBase::Type::POLYGON}, {"line", casa::AnnotationBase::Type::LINE},
         {"text", casa::AnnotationBase::Type::TEXT}, {"point", casa::AnnotationBase::Type::SYMBOL}};
 

--- a/Ds9Parser.h
+++ b/Ds9Parser.h
@@ -12,45 +12,94 @@
 
 namespace carta{
 
+struct Ds9Properties {
+    std::string text;
+    std::string color = "green";
+    std::string font = "helvetica 10 normal roman";
+    bool select_region = true;
+    bool edit_region = true;
+    bool move_region = true;
+    bool delete_region =true;
+    bool highlite_region =true;
+    bool include_region = true;
+    bool fixed_region = false;
+};
+
+struct RegionProperties {
+    std::string name;
+    CARTA::RegionType type;
+    std::vector<casacore::Quantity> control_points;
+    float rotation;
+
+    RegionProperties() {}
+    RegionProperties(std::string name_, CARTA::RegionType type_, std::vector<casacore::Quantity> control_points_, float rotation_) {
+        name = name_;
+        type = type_;
+        control_points = control_points_;
+        rotation = rotation_;
+    }
+};
+
 class Ds9Parser {
 public:
     Ds9Parser() {}
+    // constructors for import
     Ds9Parser(std::string& filename, const casacore::CoordinateSystem& image_coord_sys, casacore::IPosition& image_shape);
     Ds9Parser(const casacore::CoordinateSystem& image_coord_sys, std::string& contents, casacore::IPosition& image_shape);
+    // constructor for export
+    Ds9Parser(const casacore::CoordinateSystem& image_coord_sys, bool pixel_coord);
 
-    unsigned int NumLines();
+    // retrieve imported regions from RegionTextList
+    unsigned int NumLines(); // AsciiAnnotationFileLines stored in RegionTextList
     const casacore::Vector<casa::AsciiAnnotationFileLine> GetLines();
     casa::AsciiAnnotationFileLine LineAt(unsigned int i);
 
+    // export regions
+    void AddRegion(const std::string& name, CARTA::RegionType type, const std::vector<casacore::Quantity>& control_points, float rotation);
+    inline unsigned int NumRegions() {
+        return _regions.size();
+    }
+    void PrintHeader(std::ostream& os);
+    void PrintRegion(unsigned int i, std::ostream& os);
+    void PrintRegionsToFile(std::ofstream& ofs);
+
 private:
+    void InitDs9CoordMap();
+
     void ProcessFileLines(std::vector<std::string>& lines);
     bool SetCoordinateSystem(std::string& ds9_coord);
-    void SetAnnotationRegion(std::string& region_description);
 
     // coordinate system helpers
     bool IsDs9CoordSysKeyword(std::string& input);
     bool SetDirectionRefFrame(std::string& ds9_coord);
     void InitializeDirectionReferenceFrame(); // using input image_coord_sys
 
-    // parse region properties for text
-    casacore::String GetTextLabel(std::string& region_properties);
-
     // region creation
-    void ConvertUnits(std::vector<std::string>& region_parameters);
+    void SetAnnotationRegion(std::string& region_description);
+    void ConvertDs9UnitToCasacore(std::vector<std::string>& region_parameters);
+    casacore::String GetRegionName(std::string& region_properties);
     void ProcessRegionDefinition(std::vector<std::string>& region_definition, casacore::String& label, bool exclude_region);
     bool GetAnnotationRegionType(std::string& ds9_region, casa::AnnotationBase::Type& type);
+    casa::AnnRegion* CreateBoxRegion(std::vector<std::string>& region_definition);
     casa::AnnRegion* CreateCircleRegion(std::vector<std::string>& region_definition);
     casa::AnnRegion* CreateEllipseRegion(std::vector<std::string>& region_definition);
-    casa::AnnRegion* CreateBoxRegion(std::vector<std::string>& region_definition);
     casa::AnnRegion* CreatePolygonRegion(std::vector<std::string>& region_definition);
     casa::AnnSymbol* CreateSymbolRegion(std::vector<std::string>& region_definition);
 
+    // region export
+    void PrintBoxRegion(const RegionProperties& properties, std::ostream& os);
+    void PrintEllipseRegion(const RegionProperties& properties, std::ostream& os);
+    void PrintPointRegion(const RegionProperties& properties, std::ostream& os);
+    void PrintPolygonRegion(const RegionProperties& properties, std::ostream& os);
+
     casacore::CoordinateSystem _coord_sys;
     casacore::IPosition _image_shape;
+    std::unordered_map<std::string, std::string> _coord_map;
     std::string _direction_ref_frame;
-    std::string _DEFAULT_UNIT; // "deg" in astropy regions DS9Parser
     bool _pixel_coord;
-    casa::RegionTextList _region_list;
+
+    casa::RegionTextList _region_list; // import
+    std::vector<RegionProperties> _regions;
 };
 
 } // namespace carta

--- a/Ds9Parser.h
+++ b/Ds9Parser.h
@@ -4,6 +4,7 @@
 #define CARTA_BACKEND__DS9PARSER_H_
 
 #include <unordered_map>
+
 #include <casacore/coordinates/Coordinates/CoordinateSystem.h>
 #include <imageanalysis/Annotations/AnnSymbol.h>
 #include <imageanalysis/Annotations/RegionTextList.h>

--- a/Ds9Parser.h
+++ b/Ds9Parser.h
@@ -3,6 +3,7 @@
 #ifndef CARTA_BACKEND__DS9PARSER_H_
 #define CARTA_BACKEND__DS9PARSER_H_
 
+#include <unordered_map>
 #include <casacore/coordinates/Coordinates/CoordinateSystem.h>
 #include <imageanalysis/Annotations/AnnSymbol.h>
 #include <imageanalysis/Annotations/RegionTextList.h>

--- a/Ds9Parser.h
+++ b/Ds9Parser.h
@@ -32,19 +32,24 @@ private:
     bool SetDirectionRefFrame(std::string& ds9_coord);
     void InitializeDirectionReferenceFrame(); // using input image_coord_sys
 
-    // region helpers
-    void ProcessRegionDefinition(std::vector<std::string>& region_definition, std::string& crtf_prefix);
+    // parse region properties for text
+    casacore::String GetTextLabel(std::string& region_properties);
+
+    // region creation
+    void ConvertUnits(std::vector<std::string>& region_parameters);
+    void ProcessRegionDefinition(std::vector<std::string>& region_definition, casacore::String& label, bool exclude_region);
     bool GetAnnotationRegionType(std::string& ds9_region, casa::AnnotationBase::Type& type);
-    casa::AnnRegion* CreateCircleRegion(std::vector<std::string>& region_definition, std::string& crtf_prefix);
-    casa::AnnRegion* CreateEllipseRegion(std::vector<std::string>& region_definition, std::string& crtf_prefix);
-    casa::AnnRegion* CreateBoxRegion(std::vector<std::string>& region_definition, std::string& crtf_prefix);
-    casa::AnnRegion* CreatePolygonRegion(std::vector<std::string>& region_definition, std::string& crtf_prefix);
-    casa::AnnSymbol* CreateSymbolRegion(std::vector<std::string>& region_definition, std::string& crtf_prefix);
+    casa::AnnRegion* CreateCircleRegion(std::vector<std::string>& region_definition);
+    casa::AnnRegion* CreateEllipseRegion(std::vector<std::string>& region_definition);
+    casa::AnnRegion* CreateBoxRegion(std::vector<std::string>& region_definition);
+    casa::AnnRegion* CreatePolygonRegion(std::vector<std::string>& region_definition);
+    casa::AnnSymbol* CreateSymbolRegion(std::vector<std::string>& region_definition);
 
     casacore::CoordinateSystem _coord_sys;
     casacore::IPosition _image_shape;
     std::string _direction_ref_frame;
-    bool _pixel_coords;
+    std::string _DEFAULT_UNIT; // "deg" in astropy regions DS9Parser
+    bool _pixel_coord;
     casa::RegionTextList _region_list;
 };
 

--- a/Ds9Parser.h
+++ b/Ds9Parser.h
@@ -80,6 +80,7 @@ private:
     casacore::String GetRegionName(std::string& region_properties);
     void ProcessRegionDefinition(std::vector<std::string>& region_definition, casacore::String& label, bool exclude_region);
     bool GetAnnotationRegionType(std::string& ds9_region, casa::AnnotationBase::Type& type);
+    casacore::String ConvertTimeFormatToDeg(std::string& parameter_string);
     casa::AnnRegion* CreateBoxRegion(std::vector<std::string>& region_definition);
     casa::AnnRegion* CreateCircleRegion(std::vector<std::string>& region_definition);
     casa::AnnRegion* CreateEllipseRegion(std::vector<std::string>& region_definition);

--- a/Ds9Parser.h
+++ b/Ds9Parser.h
@@ -19,8 +19,8 @@ struct Ds9Properties {
     bool select_region = true;
     bool edit_region = true;
     bool move_region = true;
-    bool delete_region =true;
-    bool highlite_region =true;
+    bool delete_region = true;
+    bool highlite_region = true;
     bool include_region = true;
     bool fixed_region = false;
 };

--- a/Ds9Parser.h
+++ b/Ds9Parser.h
@@ -1,0 +1,53 @@
+//# Ds9Parser.h: parse ds9 region file to get CARTA::RegionInfo
+
+#ifndef CARTA_BACKEND__DS9PARSER_H_
+#define CARTA_BACKEND__DS9PARSER_H_
+
+#include <casacore/coordinates/Coordinates/CoordinateSystem.h>
+#include <imageanalysis/Annotations/AnnSymbol.h>
+#include <imageanalysis/Annotations/RegionTextList.h>
+#include <imageanalysis/IO/AsciiAnnotationFileLine.h>
+
+#include <carta-protobuf/defs.pb.h>
+
+namespace carta{
+
+class Ds9Parser {
+public:
+    Ds9Parser() {}
+    Ds9Parser(std::string& filename, const casacore::CoordinateSystem& image_coord_sys, casacore::IPosition& image_shape);
+    Ds9Parser(const casacore::CoordinateSystem& image_coord_sys, std::string& contents, casacore::IPosition& image_shape);
+
+    unsigned int NumLines();
+    const casacore::Vector<casa::AsciiAnnotationFileLine> GetLines();
+    casa::AsciiAnnotationFileLine LineAt(unsigned int i);
+
+private:
+    void ProcessFileLines(std::vector<std::string>& lines);
+    bool SetCoordinateSystem(std::string& ds9_coord);
+    void SetAnnotationRegion(std::string& region_description);
+
+    // coordinate system helpers
+    bool IsDs9CoordSysKeyword(std::string& input);
+    bool SetDirectionRefFrame(std::string& ds9_coord);
+    void InitializeDirectionReferenceFrame(); // using input image_coord_sys
+
+    // region helpers
+    void ProcessRegionDefinition(std::vector<std::string>& region_definition, std::string& crtf_prefix);
+    bool GetAnnotationRegionType(std::string& ds9_region, casa::AnnotationBase::Type& type);
+    casa::AnnRegion* CreateCircleRegion(std::vector<std::string>& region_definition, std::string& crtf_prefix);
+    casa::AnnRegion* CreateEllipseRegion(std::vector<std::string>& region_definition, std::string& crtf_prefix);
+    casa::AnnRegion* CreateBoxRegion(std::vector<std::string>& region_definition, std::string& crtf_prefix);
+    casa::AnnRegion* CreatePolygonRegion(std::vector<std::string>& region_definition, std::string& crtf_prefix);
+    casa::AnnSymbol* CreateSymbolRegion(std::vector<std::string>& region_definition, std::string& crtf_prefix);
+
+    casacore::CoordinateSystem _coord_sys;
+    casacore::IPosition _image_shape;
+    std::string _direction_ref_frame;
+    bool _pixel_coords;
+    casa::RegionTextList _region_list;
+};
+
+} // namespace carta
+
+#endif // CARTA_BACKEND__DS9PARSER_H_

--- a/Ds9Parser.h
+++ b/Ds9Parser.h
@@ -10,7 +10,7 @@
 
 #include <carta-protobuf/defs.pb.h>
 
-namespace carta{
+namespace carta {
 
 struct Ds9Properties {
     std::string text;

--- a/Frame.cc
+++ b/Frame.cc
@@ -557,18 +557,18 @@ void Frame::ExportDs9Regions(
             if (pixel_coord) {
                 RegionState region_state = region->GetRegionState();
                 std::vector<CARTA::Point> carta_points(region_state.control_points);
-		std::vector<casacore::Quantity> points_quantities;
-		for (auto& point : carta_points) {
+                std::vector<casacore::Quantity> points_quantities;
+                for (auto& point : carta_points) {
                     points_quantities.push_back(casacore::Quantity(point.x(), "pix"));
                     points_quantities.push_back(casacore::Quantity(point.y(), "pix"));
                 }
                 parser.AddRegion(region_state.name, region_state.type, points_quantities, region_state.rotation);
             } else {
                 std::string name(region->Name());
-		CARTA::RegionType type(region->Type());
-		std::vector<casacore::Quantity> control_points(region->GetControlPointsWcs());
-		float rotation(region->Rotation());
-		parser.AddRegion(name, type, control_points, rotation);
+                CARTA::RegionType type(region->Type());
+                std::vector<casacore::Quantity> control_points(region->GetControlPointsWcs());
+                float rotation(region->Rotation());
+                parser.AddRegion(name, type, control_points, rotation);
             }
         }
     }

--- a/Frame.cc
+++ b/Frame.cc
@@ -279,8 +279,8 @@ void Frame::ImportRegion(
         case CARTA::FileType::CRTF: {
             try {
                 // use RegionTextList to import file and create annotation file lines
-		casa::RegionTextList region_list;
-		if (!filename.empty()) {
+                casa::RegionTextList region_list;
+                if (!filename.empty()) {
                     region_list = casa::RegionTextList(filename, coord_sys, _image_shape);
                 } else {
                     region_list = casa::RegionTextList(coord_sys, file_contents, _image_shape);

--- a/Frame.h
+++ b/Frame.h
@@ -132,7 +132,7 @@ private:
     void SetDefaultCursor();            // using center point of image
 
     // Region import/export helpers
-    bool ImportCrtfFileLine(casa::AsciiAnnotationFileLine& file_line, const casacore::CoordinateSystem& coord_sys,
+    void ImportCrtfFileLine(casa::AsciiAnnotationFileLine& file_line, const casacore::CoordinateSystem& coord_sys,
         CARTA::ImportRegionAck& import_ack, std::string message);
     void ExportCrtfRegion(
         std::vector<int>& region_ids, CARTA::CoordinateType coord_type, std::string& filename, CARTA::ExportRegionAck& export_ack);

--- a/Frame.h
+++ b/Frame.h
@@ -134,8 +134,8 @@ private:
     // Region import/export helpers
     void ImportAnnotationFileLine(casa::AsciiAnnotationFileLine& file_line, const casacore::CoordinateSystem& coord_sys,
         CARTA::FileType file_type, CARTA::ImportRegionAck& import_ack, std::string message);
-    casacore::String AnnTypeToDs9String(casa::AnnotationBase::Type ann_type);
-    void ExportCrtfRegion(
+    casacore::String AnnTypeToDs9String(casa::AnnotationBase::Type annotation_type);
+    void ExportRegion(
         std::vector<int>& region_ids, CARTA::CoordinateType coord_type, std::string& filename, CARTA::ExportRegionAck& export_ack);
 
     // Image view settings

--- a/Frame.h
+++ b/Frame.h
@@ -132,8 +132,9 @@ private:
     void SetDefaultCursor();            // using center point of image
 
     // Region import/export helpers
-    void ImportCrtfFileLine(casa::AsciiAnnotationFileLine& file_line, const casacore::CoordinateSystem& coord_sys,
-        CARTA::ImportRegionAck& import_ack, std::string message);
+    void ImportAnnotationFileLine(casa::AsciiAnnotationFileLine& file_line, const casacore::CoordinateSystem& coord_sys,
+        CARTA::FileType file_type, CARTA::ImportRegionAck& import_ack, std::string message);
+    casacore::String AnnTypeToDs9String(casa::AnnotationBase::Type ann_type);
     void ExportCrtfRegion(
         std::vector<int>& region_ids, CARTA::CoordinateType coord_type, std::string& filename, CARTA::ExportRegionAck& export_ack);
 

--- a/Frame.h
+++ b/Frame.h
@@ -135,7 +135,9 @@ private:
     void ImportAnnotationFileLine(casa::AsciiAnnotationFileLine& file_line, const casacore::CoordinateSystem& coord_sys,
         CARTA::FileType file_type, CARTA::ImportRegionAck& import_ack, std::string message);
     casacore::String AnnTypeToDs9String(casa::AnnotationBase::Type annotation_type);
-    void ExportRegion(
+    void ExportCrtfRegions(
+        std::vector<int>& region_ids, CARTA::CoordinateType coord_type, std::string& filename, CARTA::ExportRegionAck& export_ack);
+    void ExportDs9Regions(
         std::vector<int>& region_ids, CARTA::CoordinateType coord_type, std::string& filename, CARTA::ExportRegionAck& export_ack);
 
     // Image view settings

--- a/Frame.h
+++ b/Frame.h
@@ -63,8 +63,8 @@ public:
     }
     bool RegionChanged(int region_id);
     void RemoveRegion(int region_id);
-    void ImportRegionFile(CARTA::FileType file_type, std::string& filename, CARTA::ImportRegionAck& import_ack);
-    void ImportRegionContents(CARTA::FileType file_type, std::vector<std::string>& contents, CARTA::ImportRegionAck& import_ack);
+    void ImportRegion(
+        CARTA::FileType file_type, std::string& filename, std::vector<std::string>& contents, CARTA::ImportRegionAck& import_ack);
     void ExportRegion(CARTA::FileType file_type, CARTA::CoordinateType coord_type, std::vector<int>& region_ids, std::string& filename,
         CARTA::ExportRegionAck& export_ack);
 

--- a/InterfaceConstants.h
+++ b/InterfaceConstants.h
@@ -3,6 +3,9 @@
 #ifndef CARTA_BACKEND__INTERFACECONSTANTS_H_
 #define CARTA_BACKEND__INTERFACECONSTANTS_H_
 
+// version
+#define VERSION_ID "1.2.1"
+
 // file ids
 #define ALL_FILES -1
 

--- a/Main.cc
+++ b/Main.cc
@@ -46,7 +46,7 @@ static uint32_t session_number;
 static uWS::Hub websocket_hub;
 
 // command-line arguments
-static string root_folder("/"), base_folder("."), version_id("1.2");
+static string root_folder("/"), base_folder(".");
 static bool verbose, use_permissions, use_mongodb;
 namespace CARTA {
 string token;
@@ -354,7 +354,7 @@ int main(int argc, const char* argv[]) {
         { // get values then let Input go out of scope
             casacore::Input inp;
             string json_fname;
-            inp.version(version_id);
+            inp.version(VERSION_ID);
             inp.create("verbose", "False", "display verbose logging", "Bool");
             inp.create("permissions", "False", "use a permissions file for determining access", "Bool");
             inp.create("token", CARTA::token, "only accept connections with this authorization token", "String");

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -275,16 +275,6 @@ Region::Region(casacore::CountedPtr<const casa::AnnotationBase> annotation_regio
     }
 }
 
-void Region::SplitString(std::string& input, char delim, std::vector<std::string>& parts) {
-    // util to split input string into parts by delimiter
-    parts.clear();
-    std::stringstream ss(input);
-    std::string item;
-    while (std::getline(ss, item, delim)) {
-        parts.push_back(item);
-    }
-}
-
 // *************************************************************************
 // Region settings
 

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -746,8 +746,9 @@ casacore::WCRegion* Region::MakeEllipseRegion(const std::vector<CARTA::Point>& p
         _control_points_wcs.clear();
         _control_points_wcs.push_back(center_world(0));
         _control_points_wcs.push_back(center_world(1));
-        _control_points_wcs.push_back(major_axis);
-        _control_points_wcs.push_back(minor_axis);
+        // convert npixels to length on given pixel axis
+        _control_points_wcs.push_back(_coord_sys.toWorldLength(major_axis.getValue(), 0));
+        _control_points_wcs.push_back(_coord_sys.toWorldLength(minor_axis.getValue(), 1));
     }
     return ellipse;
 }

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -699,7 +699,7 @@ casacore::WCRegion* Region::MakeRectangleRegion(const std::vector<CARTA::Point>&
             }
         }
 
-	// Create rectangle polygon from vertices
+        // Create rectangle polygon from vertices
         std::unique_lock<std::mutex> guard(_casacore_region_mutex);
         box_polygon = new casacore::WCPolygon(x_world, y_world, _xy_axes, _coord_sys);
         guard.unlock();

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -8,6 +8,7 @@
 
 #include <casacore/casa/Arrays/ArrayLogical.h>
 #include <casacore/casa/Quanta/Quantum.h>
+#include <casacore/casa/Quanta/QMath.h>
 #include <casacore/coordinates/Coordinates/DirectionCoordinate.h>
 #include <casacore/images/Regions/WCEllipsoid.h>
 #include <casacore/images/Regions/WCExtension.h>
@@ -80,22 +81,31 @@ Region::Region(casacore::CountedPtr<const casa::AnnotationBase> annotation_regio
                     // all rectangles are polygons
                     const casa::AnnPolygon* polygon = dynamic_cast<const casa::AnnPolygon*>(annotation_region.get());
                     if (polygon != nullptr) {
+                        // store WCRegion
                         std::atomic_store(&_xy_region, polygon->getRegion2());
-                        // get polygon vertices for control points
+
+                        // get polygon pixel vertices, control points
+                        double cx_pix, cy_pix, width_pix, height_pix;
                         std::vector<casacore::Double> x, y;
                         polygon->pixelVertices(x, y);
-                        double xmin = *std::min_element(x.begin(), x.end());
-                        double xmax = *std::max_element(x.begin(), x.end());
-                        double ymin = *std::min_element(y.begin(), y.end());
-                        double ymax = *std::max_element(y.begin(), y.end());
-                        // set carta rectangle control points
+                        GetRectangleControlPointsFromVertices(x, y, cx_pix, cy_pix, width_pix, height_pix);
                         CARTA::Point point;
-                        point.set_x((xmin + xmax) / 2.0); // cx
-                        point.set_y((ymin + ymax) / 2.0); // cy
+                        point.set_x(cx_pix);
+                        point.set_y(cy_pix);
                         _control_points.push_back(point);
-                        point.set_x(xmax - xmin); // width
-                        point.set_y(ymax - ymin); // height
+                        point.set_x(width_pix);
+                        point.set_y(height_pix);
                         _control_points.push_back(point);
+
+                        // get polygon world vertices, wcs control points
+                        casacore::Quantity cx_wcs, cy_wcs, width_wcs, height_wcs;
+                        std::vector<casacore::Quantity> x_wcs, y_wcs;
+                        polygon->worldVertices(x_wcs, y_wcs);
+                        GetRectangleControlPointsFromVertices(x_wcs, y_wcs, cx_wcs, cy_wcs, width_wcs, height_wcs);
+                        _control_points_wcs.push_back(cx_wcs);
+                        _control_points_wcs.push_back(cy_wcs);
+                        _control_points_wcs.push_back(width_wcs);
+                        _control_points_wcs.push_back(height_wcs);
                         _valid = true;
                     }
                     break;
@@ -106,8 +116,9 @@ Region::Region(casacore::CountedPtr<const casa::AnnotationBase> annotation_regio
                     // cannot get original rectangle and rotation from AnnRotBox, it is a polygon
                     const casa::AnnRotBox* rotbox = dynamic_cast<const casa::AnnRotBox*>(annotation_region.get());
                     if (rotbox != nullptr) {
+                        // store WCRegion
                         std::atomic_store(&_xy_region, rotbox->getRegion2());
-                        // Create center box to get region control points, then add rotation
+
                         // parse printed string (known format) to get rotbox input params
                         std::ostringstream rotbox_output;
                         rotbox->print(rotbox_output);
@@ -115,6 +126,7 @@ Region::Region(casacore::CountedPtr<const casa::AnnotationBase> annotation_regio
                         // create comma-delimited string of quantities
                         casacore::String params(outputstr.after("rotbox ")); // remove rotbox
                         params.gsub("[", "");                                // remove [
+                        params.gsub("] ", "],");                             // add comma delimiter
                         params.gsub("]", "");                                // remove ]
                         // split string into string vector
                         std::vector<std::string> quantities;
@@ -126,23 +138,34 @@ Region::Region(casacore::CountedPtr<const casa::AnnotationBase> annotation_regio
                         casacore::readQuantity(xwidth, quantities[2]);
                         casacore::readQuantity(ywidth, quantities[3]);
                         casacore::readQuantity(rotang, quantities[4]);
-                        // make centerbox from quantities
+
+                        // make (unrotated) centerbox from parsed quantities
                         casacore::Vector<casacore::Stokes::StokesTypes> stokes_types = GetStokesTypes();
                         casa::AnnCenterBox cbox = casa::AnnCenterBox(cx, cy, xwidth, ywidth, _coord_sys, _image_shape, stokes_types);
-                        // get pixel vertices to calculate center point, pixel width/height
+
+                        // get polygon pixel vertices, control points
+                        double cx_pix, cy_pix, width_pix, height_pix;
                         std::vector<casacore::Double> x, y;
                         cbox.pixelVertices(x, y);
-                        double xmin = *std::min_element(x.begin(), x.end());
-                        double xmax = *std::max_element(x.begin(), x.end());
-                        double ymin = *std::min_element(y.begin(), y.end());
-                        double ymax = *std::max_element(y.begin(), y.end());
+                        GetRectangleControlPointsFromVertices(x, y, cx_pix, cy_pix, width_pix, height_pix);
                         CARTA::Point point;
-                        point.set_x((xmin + xmax) / 2.0); // cx
-                        point.set_y((ymin + ymax) / 2.0); // cy
+                        point.set_x(cx_pix);
+                        point.set_y(cy_pix);
                         _control_points.push_back(point);
-                        point.set_x(xmax - xmin); // width
-                        point.set_y(ymax - ymin); // height
+                        point.set_x(width_pix);
+                        point.set_y(height_pix);
                         _control_points.push_back(point);
+
+                        // get polygon world vertices, control points
+                        casacore::Quantity cx_wcs, cy_wcs, width_wcs, height_wcs;
+                        std::vector<casacore::Quantity> x_wcs, y_wcs;
+                        cbox.worldVertices(x_wcs, y_wcs);
+                        GetRectangleControlPointsFromVertices(x_wcs, y_wcs, cx_wcs, cy_wcs, width_wcs, height_wcs);
+                        _control_points_wcs.push_back(cx_wcs);
+                        _control_points_wcs.push_back(cy_wcs);
+                        _control_points_wcs.push_back(width_wcs);
+                        _control_points_wcs.push_back(height_wcs);
+
                         // convert rotang to deg
                         rotang.convert("deg");
                         _rotation = rotang.getValue();
@@ -155,15 +178,21 @@ Region::Region(casacore::CountedPtr<const casa::AnnotationBase> annotation_regio
                     _type = CARTA::RegionType::POLYGON;
                     const casa::AnnPolygon* polygon = dynamic_cast<const casa::AnnPolygon*>(annotation_region.get());
                     if (polygon != nullptr) {
+                        // store WCRegion
                         std::atomic_store(&_xy_region, polygon->getRegion2());
-                        // get polygon vertices for control points
-                        std::vector<casacore::Double> x, y;
-                        polygon->pixelVertices(x, y);
-                        for (size_t i = 0; i < x.size(); ++i) {
+
+                        // get polygon vertices (pixel and world) for control points
+                        std::vector<casacore::Double> xpix, ypix;
+                        std::vector<casacore::Quantity> xworld, yworld;
+                        polygon->pixelVertices(xpix, ypix);
+                        polygon->worldVertices(xworld, yworld);
+                        for (size_t i = 0; i < xpix.size(); ++i) {
                             CARTA::Point point;
-                            point.set_x(x[i]);
-                            point.set_y(y[i]);
+                            point.set_x(xpix[i]);
+                            point.set_y(ypix[i]);
                             _control_points.push_back(point);
+                            _control_points_wcs.push_back(xworld[i]);
+                            _control_points_wcs.push_back(yworld[i]);
                         }
                         _valid = true;
                     }
@@ -181,7 +210,10 @@ Region::Region(casacore::CountedPtr<const casa::AnnotationBase> annotation_regio
                     if (ann_type == casa::AnnotationBase::CIRCLE) {
                         const casa::AnnCircle* circle = dynamic_cast<const casa::AnnCircle*>(annotation_region.get());
                         if (circle != nullptr) {
+                            // store WCRegion
                             std::atomic_store(&_xy_region, circle->getRegion2());
+
+                            // get parameters
                             center_position = circle->getCenter();
                             bmaj = circle->getRadius();
                             bmin = bmaj;
@@ -192,7 +224,10 @@ Region::Region(casacore::CountedPtr<const casa::AnnotationBase> annotation_regio
                         // if pixels not square, circle is an AnnEllipse
                         const casa::AnnEllipse* ellipse = dynamic_cast<const casa::AnnEllipse*>(annotation_region.get());
                         if (ellipse != nullptr) {
+                            // store WCRegion
                             std::atomic_store(&_xy_region, ellipse->getRegion2());
+
+                            // get parameters
                             center_position = ellipse->getCenter();
                             bmaj = ellipse->getSemiMajorAxis();
                             bmin = ellipse->getSemiMinorAxis();
@@ -212,21 +247,30 @@ Region::Region(casacore::CountedPtr<const casa::AnnotationBase> annotation_regio
                             world_coords.resize(_coord_sys.nPixelAxes(), true);
                             _coord_sys.toPixel(pixel_coords, world_coords);
                         }
-
                         CARTA::Point point;
                         point.set_x(pixel_coords[0]);
                         point.set_y(pixel_coords[1]);
                         _control_points.push_back(point);
-                        // set control point: bmaj, bmin in npixels
+
+                        // convert bmaj, bmin to pixel length
                         double bmaj_pixel = AngleToLength(bmaj, 0);
                         double bmin_pixel = AngleToLength(bmin, 1);
                         point.set_x(bmaj_pixel);
                         point.set_y(bmin_pixel);
                         _control_points.push_back(point);
-                        if (is_ellipse) { // set rotation
+
+                        // set rotation for ellipse
+                        if (is_ellipse) {
                             position_angle.convert("deg");
                             _rotation = position_angle.getValue();
                         }
+
+                        // set control points in Quantities
+                        casacore::Quantum<casacore::Vector<casacore::Double>> angle = center_position.getAngle();
+                        _control_points_wcs.push_back(casacore::Quantity(angle.getValue()[0], angle.getUnit()));
+                        _control_points_wcs.push_back(casacore::Quantity(angle.getValue()[1], angle.getUnit()));
+                        _control_points_wcs.push_back(bmaj);
+                        _control_points_wcs.push_back(bmin);
                         _valid = true;
                     }
                     break;
@@ -234,9 +278,14 @@ Region::Region(casacore::CountedPtr<const casa::AnnotationBase> annotation_regio
                 case casa::AnnotationBase::SYMBOL: {
                     const casa::AnnSymbol* point = dynamic_cast<const casa::AnnSymbol*>(annotation_region.get());
                     if (point != nullptr) {
-                        // set region with control point since symbol is not a region
-                        // set CARTA point x, y in pixel coords
+                        // wcs position of point
                         casacore::MDirection position = point->getDirection();
+                        // set control points as Quantities
+                        casacore::Quantum<casacore::Vector<casacore::Double>> angle = position.getAngle();
+                        _control_points_wcs.push_back(casacore::Quantity(angle.getValue()[0], angle.getUnit()));
+                        _control_points_wcs.push_back(casacore::Quantity(angle.getValue()[1], angle.getUnit()));
+
+                        // Convert wcs position to pixel coordinates
                         casacore::Vector<casacore::Double> pixel_coords;
                         if (_coord_sys.hasDirectionCoordinate()) {
                             casacore::DirectionCoordinate dir_coord = _coord_sys.directionCoordinate();
@@ -247,16 +296,18 @@ Region::Region(casacore::CountedPtr<const casa::AnnotationBase> annotation_regio
                             world_coords.resize(_coord_sys.nPixelAxes(), true);
                             _coord_sys.toPixel(pixel_coords, world_coords);
                         }
+
+                        // Set CARTA point
                         CARTA::Point point;
                         point.set_x(pixel_coords[0]);
                         point.set_y(pixel_coords[1]);
                         std::vector<CARTA::Point> points;
                         points.push_back(point);
-                        // other region parameters
+                        // Set other region parameters
                         std::string name = annotation_region->getLabel();
                         CARTA::RegionType type = CARTA::RegionType::POINT;
-                        float rotation(0.0);
-                        _valid = UpdateRegionParameters(name, type, points, rotation);
+                        // Set region properties and xy region
+                        _valid = UpdateRegionParameters(name, type, points, _rotation);
                     }
                     break;
                 }
@@ -378,6 +429,35 @@ bool Region::XyPixelsToWorld(casacore::Vector<casacore::Double> x_pixel, casacor
     }
     return converted;
 }
+
+void Region::GetRectangleControlPointsFromVertices(
+    std::vector<casacore::Double>& x, std::vector<casacore::Double>& y, double& cx, double& cy, double& width, double& height) {
+    // Input: pixel vertices x and y
+    // Returns: rectangle center point cx and cy, width, and height
+    double xmin = *std::min_element(x.begin(), x.end());
+    double xmax = *std::max_element(x.begin(), x.end());
+    double ymin = *std::min_element(y.begin(), y.end());
+    double ymax = *std::max_element(y.begin(), y.end());
+    cx = (xmin + xmax) / 2.0;
+    cy = (ymin + ymax) / 2.0;
+    width = xmax - xmin;
+    height = ymax - ymin;
+}
+
+void Region::GetRectangleControlPointsFromVertices(std::vector<casacore::Quantity>& x, std::vector<casacore::Quantity>& y,
+    casacore::Quantity& cx, casacore::Quantity& cy, casacore::Quantity& width, casacore::Quantity& height) {
+    // Input: world vertices x and y
+    // Returns: rectangle center point cx and cy, width, and height as wcs Quantities
+    casacore::Quantity xmin = *std::min_element(x.begin(), x.end());
+    casacore::Quantity xmax = *std::max_element(x.begin(), x.end());
+    casacore::Quantity ymin = *std::min_element(y.begin(), y.end());
+    casacore::Quantity ymax = *std::max_element(y.begin(), y.end());
+    cx = (xmin + xmax) / 2.0;
+    cy = (ymin + ymax) / 2.0;
+    width = xmax - xmin;
+    height = ymax - ymin;
+}
+
 // *************************************************************************
 // Parameter checking
 
@@ -531,6 +611,10 @@ casacore::WCRegion* Region::MakePointRegion(const std::vector<CARTA::Point>& poi
         std::unique_lock<std::mutex> guard(_casacore_region_mutex);
         box = new casacore::WCBox(world_point, world_point, _xy_axes, _coord_sys, abs_rel);
         guard.unlock();
+        // set control points as quantities
+        _control_points_wcs.clear();
+        _control_points_wcs.push_back(world_point(0));
+        _control_points_wcs.push_back(world_point(1));
     }
     return box;
 }
@@ -547,22 +631,47 @@ casacore::WCRegion* Region::MakeRectangleRegion(const std::vector<CARTA::Point>&
         // 4 corner points
         int num_points(4);
         casacore::Vector<casacore::Double> x(num_points), y(num_points);
-        if (rotation == 0.0f) {
-            float x_min(center_x - width / 2.0f), x_max(center_x + width / 2.0f);
-            float y_min(center_y - height / 2.0f), y_max(center_y + height / 2.0f);
-            // Bottom left
-            x(0) = x_min;
-            y(0) = y_min;
-            // Bottom right
-            x(1) = x_max;
-            y(1) = y_min;
-            // Top right
-            x(2) = x_max;
-            y(2) = y_max;
-            // Top left
-            x(3) = x_min;
-            y(3) = y_max;
-        } else {
+        float x_min(center_x - width / 2.0f), x_max(center_x + width / 2.0f);
+        float y_min(center_y - height / 2.0f), y_max(center_y + height / 2.0f);
+        // Bottom left
+        x(0) = x_min;
+        y(0) = y_min;
+        // Bottom right
+        x(1) = x_max;
+        y(1) = y_min;
+        // Top right
+        x(2) = x_max;
+        y(2) = y_max;
+        // Top left
+        x(3) = x_min;
+        y(3) = y_max;
+
+        // Set control points (for unrotated box) as quantities in wcs
+	// Convert pixel coords to world coords
+        casacore::Quantum<casacore::Vector<casacore::Double>> x_world, y_world;
+        if (!XyPixelsToWorld(x, y, x_world, y_world)) {
+            return box_polygon; // nullptr, conversion failed
+        }
+        // Convert Quantum<Vector<Double>> to Vector<Quantum<Double>>
+        std::vector<casacore::Quantum<casacore::Double>> x_world_vector, y_world_vector;
+        casacore::Vector<casacore::Double> x_world_values = x_world.getValue();
+        casacore::Vector<casacore::Double> y_world_values = y_world.getValue();
+        casacore::String x_unit = x_world.getUnit();
+        casacore::String y_unit = y_world.getUnit();
+        for (size_t i = 0; i < x_world_values.size(); ++i) {
+            x_world_vector.push_back(casacore::Quantity(x_world_values[i], x_unit));
+            y_world_vector.push_back(casacore::Quantity(y_world_values[i], y_unit));
+        }
+        // calculate center point, width, height in world coordinates
+        casacore::Quantity cx_wcs, cy_wcs, width_wcs, height_wcs;
+        GetRectangleControlPointsFromVertices(x_world_vector, y_world_vector, cx_wcs, cy_wcs, width_wcs, height_wcs);
+        _control_points_wcs.clear();
+        _control_points_wcs.push_back(cx_wcs);
+        _control_points_wcs.push_back(cy_wcs);
+        _control_points_wcs.push_back(width_wcs);
+        _control_points_wcs.push_back(height_wcs);
+
+        if (rotation != 0.0f) {
             // Apply rotation matrix to get width and height vectors in rotated basis
             float cos_x = cos(rotation * M_PI / 180.0f);
             float sin_x = sin(rotation * M_PI / 180.0f);
@@ -583,14 +692,14 @@ casacore::WCRegion* Region::MakeRectangleRegion(const std::vector<CARTA::Point>&
             // Top left
             x(3) = center_x + (-width_vector_x + height_vector_x) / 2.0f;
             y(3) = center_y + (-width_vector_y + height_vector_y) / 2.0f;
+
+            // Convert pixel coords to world coords vertices
+            if (!XyPixelsToWorld(x, y, x_world, y_world)) {
+                return box_polygon; // nullptr, conversion failed
+            }
         }
 
-        // Convert pixel coords to world coords
-        casacore::Quantum<casacore::Vector<casacore::Double>> x_world, y_world;
-        if (!XyPixelsToWorld(x, y, x_world, y_world)) {
-            return box_polygon; // nullptr, conversion failed
-        }
-
+	// Create rectangle polygon from vertices
         std::unique_lock<std::mutex> guard(_casacore_region_mutex);
         box_polygon = new casacore::WCPolygon(x_world, y_world, _xy_axes, _coord_sys);
         guard.unlock();
@@ -629,6 +738,13 @@ casacore::WCRegion* Region::MakeEllipseRegion(const std::vector<CARTA::Point>& p
         ellipse = new casacore::WCEllipsoid(
             center_world(0), center_world(1), major_axis, minor_axis, theta, _xy_axes(0), _xy_axes(1), _coord_sys);
         guard.unlock();
+
+        // Set control points as quantities in wcs
+        _control_points_wcs.clear();
+        _control_points_wcs.push_back(center_world(0));
+        _control_points_wcs.push_back(center_world(1));
+        _control_points_wcs.push_back(major_axis);
+        _control_points_wcs.push_back(minor_axis);
     }
     return ellipse;
 }
@@ -652,6 +768,18 @@ casacore::WCRegion* Region::MakePolygonRegion(const std::vector<CARTA::Point>& p
     std::unique_lock<std::mutex> guard(_casacore_region_mutex);
     polygon = new casacore::WCPolygon(x_world, y_world, _xy_axes, _coord_sys);
     guard.unlock();
+
+    // Set control points as quantities in wcs
+    _control_points_wcs.clear();
+    casacore::Vector<casacore::Double> x_world_values = x_world.getValue();
+    casacore::Vector<casacore::Double> y_world_values = y_world.getValue();
+    casacore::String x_unit = x_world.getUnit();
+    casacore::String y_unit = y_world.getUnit();
+    for (size_t i = 0; i < x_world_values.size(); ++i) {
+        _control_points_wcs.push_back(casacore::Quantity(x_world_values(i), x_unit));
+        _control_points_wcs.push_back(casacore::Quantity(y_world_values(i), y_unit));
+    }
+
     return polygon;
 }
 
@@ -834,32 +962,29 @@ casacore::CountedPtr<const casa::AnnotationBase> Region::AnnotationRegion(bool p
             casacore::Vector<casacore::Stokes::StokesTypes> stokes_types = GetStokesTypes();
             switch (_type) {
                 case CARTA::POINT: {
-                    casacore::Quantity x = casacore::Quantity(_control_points[0].x(), "pix");
-                    casacore::Quantity y = casacore::Quantity(_control_points[0].y(), "pix");
-                    if (!pixel_coord) {
-                        casacore::Vector<casacore::Quantity> world_point;
-                        if (CartaPointToWorld(_control_points[0], world_point)) {
-                            x = world_point(0);
-                            y = world_point(1);
-                        }
+                    casacore::Quantity x, y;
+                    if (pixel_coord) {
+                        x = casacore::Quantity(_control_points[0].x(), "pix");
+                        y = casacore::Quantity(_control_points[0].y(), "pix");
+                    } else {
+                        x = _control_points_wcs[0];
+                        y = _control_points_wcs[1];
                     }
                     ann_symbol = new casa::AnnSymbol(x, y, _coord_sys, casa::AnnSymbol::POINT, stokes_types);
                     break;
                 }
                 case CARTA::RECTANGLE: {
                     casacore::Quantity cx, cy, xwidth, ywidth;
-                    cx = casacore::Quantity(_control_points[0].x(), "pix");
-                    cy = casacore::Quantity(_control_points[0].y(), "pix");
-                    xwidth = casacore::Quantity(_control_points[1].x(), "pix");
-                    ywidth = casacore::Quantity(_control_points[1].y(), "pix");
-                    if (!pixel_coord) {
-                        casacore::Vector<casacore::Quantity> world_point;
-                        if (CartaPointToWorld(_control_points[0], world_point)) {
-                            cx = world_point[0];
-                            cy = world_point[1];
-                            xwidth = _coord_sys.toWorldLength(_control_points[1].x(), 0);
-                            ywidth = _coord_sys.toWorldLength(_control_points[1].y(), 1);
-                        }
+                    if (pixel_coord) {
+                        cx = casacore::Quantity(_control_points[0].x(), "pix");
+                        cy = casacore::Quantity(_control_points[0].y(), "pix");
+                        xwidth = casacore::Quantity(_control_points[1].x(), "pix");
+                        ywidth = casacore::Quantity(_control_points[1].y(), "pix");
+                    } else {
+                        cx = _control_points_wcs[0];
+                        cy = _control_points_wcs[1];
+                        xwidth = _control_points_wcs[2];
+                        ywidth = _control_points_wcs[3];
                     }
                     if (_rotation == 0.0) {
                         ann_region = new casa::AnnCenterBox(cx, cy, xwidth, ywidth, _coord_sys, _image_shape, stokes_types);
@@ -872,28 +997,16 @@ casacore::CountedPtr<const casa::AnnotationBase> Region::AnnotationRegion(bool p
                 case CARTA::POLYGON: {
                     size_t npoints(_control_points.size());
                     casacore::Vector<casacore::Quantity> x_coords(npoints), y_coords(npoints);
-                    for (size_t i = 0; i < npoints; ++i) {
-                        x_coords(i) = casacore::Quantity(_control_points[i].x(), "pix");
-                        y_coords(i) = casacore::Quantity(_control_points[i].y(), "pix");
-                    }
-                    if (!pixel_coord) {
-                        casacore::Vector<casacore::Double> x_pixel(npoints), y_pixel(npoints);
+                    if (pixel_coord) {
                         for (size_t i = 0; i < npoints; ++i) {
-                            x_pixel(i) = _control_points[i].x();
-                            y_pixel(i) = _control_points[i].y();
+                            x_coords(i) = casacore::Quantity(_control_points[i].x(), "pix");
+                            y_coords(i) = casacore::Quantity(_control_points[i].y(), "pix");
                         }
-                        casacore::Quantum<casacore::Vector<casacore::Double>> x_world, y_world;
-                        if (XyPixelsToWorld(x_pixel, y_pixel, x_world, y_world)) {
-                            // Unfortunately, constructors for WCPolygon and AnnPolygon differ;
-                            // convert Quantum<Vector> to Vector<Quantum>
-                            casacore::Vector<casacore::Double> x_values(x_world.getValue());
-                            casacore::Unit x_unit(x_world.getUnit());
-                            casacore::Vector<casacore::Double> y_values(y_world.getValue());
-                            casacore::Unit y_unit(y_world.getUnit());
-                            for (size_t i = 0; i < x_values.size(); ++i) {
-                                x_coords(i) = casacore::Quantity(x_values[i], x_unit);
-                                y_coords(i) = casacore::Quantity(y_values[i], y_unit);
-                            }
+                    } else {
+                        int point_index(0);
+                        for (size_t i = 0; i < npoints; ++i) {
+                            x_coords(i) = _control_points_wcs[point_index++];
+                            y_coords(i) = _control_points_wcs[point_index++];
                         }
                     }
                     ann_region = new casa::AnnPolygon(x_coords, y_coords, _coord_sys, _image_shape, stokes_types);
@@ -901,18 +1014,16 @@ casacore::CountedPtr<const casa::AnnotationBase> Region::AnnotationRegion(bool p
                 }
                 case CARTA::ELLIPSE: {
                     casacore::Quantity cx, cy, bmaj, bmin;
-                    cx = casacore::Quantity(_control_points[0].x(), "pix");
-                    cy = casacore::Quantity(_control_points[0].y(), "pix");
-                    bmaj = casacore::Quantity(_control_points[1].x(), "pix");
-                    bmin = casacore::Quantity(_control_points[1].y(), "pix");
-                    if (!pixel_coord) {
-                        casacore::Vector<casacore::Quantity> world_point;
-                        if (CartaPointToWorld(_control_points[0], world_point)) { // will use pixel coords if conversion fails
-                            cx = world_point[0];
-                            cy = world_point[1];
-                            bmaj = _coord_sys.toWorldLength(_control_points[1].x(), 0);
-                            bmin = _coord_sys.toWorldLength(_control_points[1].y(), 1);
-                        }
+                    if (pixel_coord) {
+                        cx = casacore::Quantity(_control_points[0].x(), "pix");
+                        cy = casacore::Quantity(_control_points[0].y(), "pix");
+                        bmaj = casacore::Quantity(_control_points[1].x(), "pix");
+                        bmin = casacore::Quantity(_control_points[1].y(), "pix");
+                    } else {
+                        cx = _control_points_wcs[0];
+                        cy = _control_points_wcs[1];
+                        bmaj = _control_points_wcs[2];
+                        bmin = _control_points_wcs[3];
                     }
                     casacore::Quantity position_angle(_rotation, "deg");
                     ann_region = new casa::AnnEllipse(cx, cy, bmaj, bmin, position_angle, _coord_sys, _image_shape, stokes_types);

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -7,8 +7,8 @@
 #include <cmath>     // round
 
 #include <casacore/casa/Arrays/ArrayLogical.h>
-#include <casacore/casa/Quanta/Quantum.h>
 #include <casacore/casa/Quanta/QMath.h>
+#include <casacore/casa/Quanta/Quantum.h>
 #include <casacore/coordinates/Coordinates/DirectionCoordinate.h>
 #include <casacore/images/Regions/WCEllipsoid.h>
 #include <casacore/images/Regions/WCExtension.h>
@@ -647,7 +647,7 @@ casacore::WCRegion* Region::MakeRectangleRegion(const std::vector<CARTA::Point>&
         y(3) = y_max;
 
         // Set control points (for unrotated box) as quantities in wcs
-	// Convert pixel coords to world coords
+        // Convert pixel coords to world coords
         casacore::Quantum<casacore::Vector<casacore::Double>> x_world, y_world;
         if (!XyPixelsToWorld(x, y, x_world, y_world)) {
             return box_polygon; // nullptr, conversion failed

--- a/Region/Region.h
+++ b/Region/Region.h
@@ -65,9 +65,14 @@ public:
     inline std::vector<CARTA::Point> GetControlPoints() {
         return _control_points;
     };
+    inline std::vector<casacore::Quantity> GetControlPointsWcs() {
+        return _control_points_wcs;
+    }
+
     inline float Rotation() {
         return _rotation;
     };
+
     casacore::IPosition XyShape();
     casacore::IPosition XyOrigin();
     std::shared_ptr<casacore::ArrayLattice<casacore::Bool>> XyMask();
@@ -166,6 +171,12 @@ private:
     bool XyPixelsToWorld(casacore::Vector<casacore::Double> x, casacore::Vector<casacore::Double> y,
         casacore::Quantum<casacore::Vector<casacore::Double>>& x_world, casacore::Quantum<casacore::Vector<casacore::Double>>& y_world);
 
+    // Imported rectangles are polygon vertices; calculate center point, width, and height
+    void GetRectangleControlPointsFromVertices(
+        std::vector<casacore::Double>& x, std::vector<casacore::Double>& y, double& cx, double& cy, double& width, double& height);
+    void GetRectangleControlPointsFromVertices(std::vector<casacore::Quantity>& x, std::vector<casacore::Quantity>& y,
+        casacore::Quantity& cx, casacore::Quantity& cy, casacore::Quantity& width, casacore::Quantity& height);
+
     // For region export, need stokes types from coordinate system
     casacore::Vector<casacore::Stokes::StokesTypes> GetStokesTypes();
 
@@ -196,6 +207,7 @@ private:
     std::string _name;
     CARTA::RegionType _type;
     std::vector<CARTA::Point> _control_points;
+    std::vector<casacore::Quantity> _control_points_wcs;
     float _rotation;
 
     // region flags

--- a/Region/Region.h
+++ b/Region/Region.h
@@ -178,9 +178,6 @@ private:
 
     void SetConnectionFlag(bool connected);
 
-    // util to split input string into parts by delimiter
-    void SplitString(std::string& input, char delim, std::vector<std::string>& parts);
-
     // region definition (ICD SET_REGION parameters)
     std::string _name;
     CARTA::RegionType _type;

--- a/Session.cc
+++ b/Session.cc
@@ -495,19 +495,19 @@ void Session::OnImportRegion(const CARTA::ImportRegion& message, uint32_t reques
             CARTA::ImportRegionAck import_ack; // response
             std::string directory(message.directory()), filename(message.file());
             CARTA::FileType file_type(message.type());
+	    std::string abs_filename;
+            std::vector<std::string> contents;
             if (!directory.empty() && !filename.empty()) {
                 // form path with filename
                 casacore::Path root_path(_root_folder);
                 root_path.append(directory);
                 root_path.append(filename);
-                std::string abs_filename(root_path.resolvedName());
-                _frames.at(file_id)->ImportRegionFile(file_type, abs_filename, import_ack);
-                SendFileEvent(file_id, CARTA::EventType::IMPORT_REGION_ACK, request_id, import_ack);
+                abs_filename = root_path.resolvedName();
             } else {
-                std::vector<std::string> contents = {message.contents().begin(), message.contents().end()};
-                _frames.at(file_id)->ImportRegionContents(file_type, contents, import_ack);
-                SendFileEvent(file_id, CARTA::EventType::IMPORT_REGION_ACK, request_id, import_ack);
+                contents = {message.contents().begin(), message.contents().end()};
             }
+            _frames.at(file_id)->ImportRegion(file_type, abs_filename, contents, import_ack);
+            SendFileEvent(file_id, CARTA::EventType::IMPORT_REGION_ACK, request_id, import_ack);
         } catch (std::out_of_range& range_error) {
             std::string error = fmt::format("File id {} closed", file_id);
             SendLogEvent(error, {"import"}, CARTA::ErrorSeverity::DEBUG);

--- a/Session.cc
+++ b/Session.cc
@@ -495,7 +495,7 @@ void Session::OnImportRegion(const CARTA::ImportRegion& message, uint32_t reques
             CARTA::ImportRegionAck import_ack; // response
             std::string directory(message.directory()), filename(message.file());
             CARTA::FileType file_type(message.type());
-	    std::string abs_filename;
+            std::string abs_filename;
             std::vector<std::string> contents;
             if (!directory.empty() && !filename.empty()) {
                 // form path with filename

--- a/Util.cc
+++ b/Util.cc
@@ -114,6 +114,8 @@ void SplitString(std::string& input, char delim, std::vector<std::string>& parts
     std::stringstream ss(input);
     std::string item;
     while (std::getline(ss, item, delim)) {
-        parts.push_back(item);
+        if (!item.empty()) {
+            parts.push_back(item);
+        }
     }
 }

--- a/Util.cc
+++ b/Util.cc
@@ -107,3 +107,13 @@ bool CheckRootBaseFolders(string& root, string& base) {
     }
     return true;
 }
+
+void SplitString(std::string& input, char delim, std::vector<std::string>& parts) {
+    // util to split input string into parts by delimiter
+    parts.clear();
+    std::stringstream ss(input);
+    std::string item;
+    while (std::getline(ss, item, delim)) {
+        parts.push_back(item);
+    }
+}

--- a/Util.h
+++ b/Util.h
@@ -34,6 +34,8 @@ inline void Log(uint32_t id, const std::string& template_string, Args... args) {
 void ReadPermissions(const std::string& filename, std::unordered_map<std::string, std::vector<std::string>>& permissions_map);
 bool CheckRootBaseFolders(std::string& root, std::string& base);
 
+// split input string into a vector of strings by delimiter
+void SplitString(std::string& input, char delim, std::vector<std::string>& parts);
 //
 // Usage of the ChannelRange:
 //


### PR DESCRIPTION
Issue #287 , also fixes rotbox angle bug #342 .  Increases version number from 1.2 to 1.2.1.

Creating a Region now sets the control points in pixel coordinates as well as wcs coordinates, which can be retrieved for world coordinate export to CRTF and DS9 files.

Added Ds9Parser to import DS9 region files by parsing region strings to set imageanalysis AnnRegions, which can be used to retrieve the (possibly world-converted) parameters and to be  applied to the image to get the resulting casacore::WCRegion.  Export uses the Region parameters directly to form the DS9 region strings.

