### PR TITLE
Fix export region seg faults for image with no direction coordinate

### DIFF
--- a/Ds9Parser.cc
+++ b/Ds9Parser.cc
@@ -667,7 +667,9 @@ void Ds9Parser::PrintBoxRegion(const RegionProperties& properties, std::ostream&
         casacore::Quantity cx(points[0]), cy(points[1]);
         casacore::Quantity width(points[2]), height(points[3]);
         // adjust width by cosine(declination) for correct export
-        width *= cos(cy);
+        if (width.isConform("rad")) {
+            width *= cos(cy);
+        }
         os << std::fixed << std::setprecision(6) << cx.get("deg").getValue() << ",";
         os << std::fixed << std::setprecision(6) << cy.get("deg").getValue() << ",";
 

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -958,89 +958,86 @@ casacore::CountedPtr<const casa::AnnotationBase> Region::AnnotationRegion(bool p
     casa::AnnRegion* ann_region(nullptr);
     casa::AnnSymbol* ann_symbol(nullptr); // not a region
     if (!_control_points.empty()) {
-        try {
-            casacore::Vector<casacore::Stokes::StokesTypes> stokes_types = GetStokesTypes();
-            bool require_region(false);
-            switch (_type) {
-                case CARTA::POINT: {
-                    casacore::Quantity x, y;
-                    if (pixel_coord) {
-                        x = casacore::Quantity(_control_points[0].x(), "pix");
-                        y = casacore::Quantity(_control_points[0].y(), "pix");
-                    } else {
-                        x = _control_points_wcs[0];
-                        y = _control_points_wcs[1];
-                    }
-                    ann_symbol = new casa::AnnSymbol(x, y, _coord_sys, casa::AnnSymbol::POINT, stokes_types);
-                    break;
+        casacore::Vector<casacore::Stokes::StokesTypes> stokes_types = GetStokesTypes();
+        bool require_region(false);
+        switch (_type) {
+            case CARTA::POINT: {
+                casacore::Quantity x, y;
+                if (pixel_coord) {
+                    x = casacore::Quantity(_control_points[0].x(), "pix");
+                    y = casacore::Quantity(_control_points[0].y(), "pix");
+                } else {
+                    x = _control_points_wcs[0];
+                    y = _control_points_wcs[1];
                 }
-                case CARTA::RECTANGLE: {
-                    casacore::Quantity cx, cy, xwidth, ywidth;
-                    if (pixel_coord) {
-                        cx = casacore::Quantity(_control_points[0].x(), "pix");
-                        cy = casacore::Quantity(_control_points[0].y(), "pix");
-                        xwidth = casacore::Quantity(_control_points[1].x(), "pix");
-                        ywidth = casacore::Quantity(_control_points[1].y(), "pix");
-                    } else {
-                        cx = _control_points_wcs[0];
-                        cy = _control_points_wcs[1];
-                        xwidth = _control_points_wcs[2];
-                        ywidth = _control_points_wcs[3];
-                        // adjust width by cosine(declination) for correct import
-                        xwidth *= cos(cy);
-                    }
-                    if (_rotation == 0.0) {
-                        ann_region = new casa::AnnCenterBox(cx, cy, xwidth, ywidth, _coord_sys, _image_shape, stokes_types, require_region);
-                    } else {
-                        casacore::Quantity position_angle(_rotation, "deg");
-                        ann_region = new casa::AnnRotBox(
-                            cx, cy, xwidth, ywidth, position_angle, _coord_sys, _image_shape, stokes_types, require_region);
-                    }
-                    break;
-                }
-                case CARTA::POLYGON: {
-                    size_t npoints(_control_points.size());
-                    casacore::Vector<casacore::Quantity> x_coords(npoints), y_coords(npoints);
-                    if (pixel_coord) {
-                        for (size_t i = 0; i < npoints; ++i) {
-                            x_coords(i) = casacore::Quantity(_control_points[i].x(), "pix");
-                            y_coords(i) = casacore::Quantity(_control_points[i].y(), "pix");
-                        }
-                    } else {
-                        int point_index(0);
-                        for (size_t i = 0; i < npoints; ++i) {
-                            x_coords(i) = _control_points_wcs[point_index++];
-                            y_coords(i) = _control_points_wcs[point_index++];
-                        }
-                    }
-                    ann_region = new casa::AnnPolygon(x_coords, y_coords, _coord_sys, _image_shape, stokes_types, require_region);
-                    break;
-                }
-                case CARTA::ELLIPSE: {
-                    casacore::Quantity cx, cy, bmaj, bmin;
-                    if (pixel_coord) {
-                        cx = casacore::Quantity(_control_points[0].x(), "pix");
-                        cy = casacore::Quantity(_control_points[0].y(), "pix");
-                        bmaj = casacore::Quantity(_control_points[1].x(), "pix");
-                        bmin = casacore::Quantity(_control_points[1].y(), "pix");
-                    } else {
-                        cx = _control_points_wcs[0];
-                        cy = _control_points_wcs[1];
-                        bmaj = _control_points_wcs[2];
-                        bmin = _control_points_wcs[3];
-                    }
-                    casacore::Quantity position_angle(_rotation, "deg");
-                    ann_region =
-                        new casa::AnnEllipse(cx, cy, bmaj, bmin, position_angle, _coord_sys, _image_shape, stokes_types, require_region);
-                    break;
-                }
-                default:
-                    break;
+                ann_symbol = new casa::AnnSymbol(x, y, _coord_sys, casa::AnnSymbol::POINT, stokes_types);
+                break;
             }
-        } catch (casacore::AipsError& err) {
-            std::cerr << "Export carta region type " << _type << " failed: " << err.getMesg() << std::endl;
+            case CARTA::RECTANGLE: {
+                casacore::Quantity cx, cy, xwidth, ywidth;
+                if (pixel_coord) {
+                    cx = casacore::Quantity(_control_points[0].x(), "pix");
+                    cy = casacore::Quantity(_control_points[0].y(), "pix");
+                    xwidth = casacore::Quantity(_control_points[1].x(), "pix");
+                    ywidth = casacore::Quantity(_control_points[1].y(), "pix");
+                } else {
+                    cx = _control_points_wcs[0];
+                    cy = _control_points_wcs[1];
+                    xwidth = _control_points_wcs[2];
+                    ywidth = _control_points_wcs[3];
+                    // adjust width by cosine(declination) for correct import
+                    xwidth *= cos(cy);
+                }
+                if (_rotation == 0.0) {
+                    ann_region = new casa::AnnCenterBox(cx, cy, xwidth, ywidth, _coord_sys, _image_shape, stokes_types, require_region);
+                } else {
+                    casacore::Quantity position_angle(_rotation, "deg");
+                    ann_region = new casa::AnnRotBox(
+                        cx, cy, xwidth, ywidth, position_angle, _coord_sys, _image_shape, stokes_types, require_region);
+                }
+                break;
+            }
+            case CARTA::POLYGON: {
+                size_t npoints(_control_points.size());
+                casacore::Vector<casacore::Quantity> x_coords(npoints), y_coords(npoints);
+                if (pixel_coord) {
+                    for (size_t i = 0; i < npoints; ++i) {
+                        x_coords(i) = casacore::Quantity(_control_points[i].x(), "pix");
+                        y_coords(i) = casacore::Quantity(_control_points[i].y(), "pix");
+                    }
+                } else {
+                    int point_index(0);
+                    for (size_t i = 0; i < npoints; ++i) {
+                        x_coords(i) = _control_points_wcs[point_index++];
+                        y_coords(i) = _control_points_wcs[point_index++];
+                    }
+                }
+                ann_region = new casa::AnnPolygon(x_coords, y_coords, _coord_sys, _image_shape, stokes_types, require_region);
+                break;
+            }
+            case CARTA::ELLIPSE: {
+                casacore::Quantity cx, cy, bmaj, bmin;
+                if (pixel_coord) {
+                    cx = casacore::Quantity(_control_points[0].x(), "pix");
+                    cy = casacore::Quantity(_control_points[0].y(), "pix");
+                    bmaj = casacore::Quantity(_control_points[1].x(), "pix");
+                    bmin = casacore::Quantity(_control_points[1].y(), "pix");
+                } else {
+                    cx = _control_points_wcs[0];
+                    cy = _control_points_wcs[1];
+                    bmaj = _control_points_wcs[2];
+                    bmin = _control_points_wcs[3];
+                }
+                casacore::Quantity position_angle(_rotation, "deg");
+                ann_region =
+                    new casa::AnnEllipse(cx, cy, bmaj, bmin, position_angle, _coord_sys, _image_shape, stokes_types, require_region);
+                break;
+            }
+            default:
+                break;
         }
     }
+
     if (ann_region != nullptr) {
         ann_region->setAnnotationOnly(false);
     }

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -994,8 +994,8 @@ casacore::CountedPtr<const casa::AnnotationBase> Region::AnnotationRegion(bool p
                     ann_region = new casa::AnnCenterBox(cx, cy, xwidth, ywidth, _coord_sys, _image_shape, stokes_types, require_region);
                 } else {
                     casacore::Quantity position_angle(_rotation, "deg");
-                    ann_region = new casa::AnnRotBox(
-                        cx, cy, xwidth, ywidth, position_angle, _coord_sys, _image_shape, stokes_types, require_region);
+                    ann_region =
+                        new casa::AnnRotBox(cx, cy, xwidth, ywidth, position_angle, _coord_sys, _image_shape, stokes_types, require_region);
                 }
                 break;
             }

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -985,8 +985,10 @@ casacore::CountedPtr<const casa::AnnotationBase> Region::AnnotationRegion(bool p
                     cy = _control_points_wcs[1];
                     xwidth = _control_points_wcs[2];
                     ywidth = _control_points_wcs[3];
-                    // adjust width by cosine(declination) for correct import
-                    xwidth *= cos(cy);
+                    // adjust width by cosine(declination) for correct import if not linear
+                    if (xwidth.isConform("rad")) {
+                        xwidth *= cos(cy);
+                    }
                 }
                 if (_rotation == 0.0) {
                     ann_region = new casa::AnnCenterBox(cx, cy, xwidth, ywidth, _coord_sys, _image_shape, stokes_types, require_region);


### PR DESCRIPTION
For issue #334 , patched into release/1.2.  Fixes DS9 exports only, and backend no longer seg faults.

CRTF import/exports and DS9 imports still fail with a "image coordinate system has no direction coordinate" error message.  Will need to fix/workaround this imageanalysis Annotation exception in next release.