### PR TITLE
Region import failures

### DIFF
--- a/Ds9Parser.cc
+++ b/Ds9Parser.cc
@@ -667,7 +667,9 @@ void Ds9Parser::PrintBoxRegion(const RegionProperties& properties, std::ostream&
         casacore::Quantity cx(points[0]), cy(points[1]);
         casacore::Quantity width(points[2]), height(points[3]);
         // adjust width by cosine(declination) for correct export
-        width *= cos(cy);
+        if (width.isConform("rad")) {
+            width *= cos(cy);
+        }
         os << std::fixed << std::setprecision(6) << cx.get("deg").getValue() << ",";
         os << std::fixed << std::setprecision(6) << cy.get("deg").getValue() << ",";
 

--- a/Ds9Parser.cc
+++ b/Ds9Parser.cc
@@ -192,11 +192,13 @@ bool Ds9Parser::SetDirectionRefFrame(std::string& ds9_coord) {
 
 void Ds9Parser::InitializeDirectionReferenceFrame() {
     // Set _direction_reference_frame attribute to image coord sys direction frame
-    casacore::MDirection::Types reference_frame(casacore::MDirection::DEFAULT);
     if (_coord_sys.hasDirectionCoordinate()) {
+        casacore::MDirection::Types reference_frame;
         reference_frame = _coord_sys.directionCoordinate().directionType();
+        _direction_ref_frame = casacore::MDirection::showType(reference_frame);
+    } else if (_coord_sys.hasLinearCoordinate()) {
+        _direction_ref_frame = "linear";
     }
-    _direction_ref_frame = casacore::MDirection::showType(reference_frame);
 }
 
 // Create Annotation region
@@ -698,18 +700,18 @@ void Ds9Parser::PrintEllipseRegion(const RegionProperties& properties, std::ostr
         }
     } else {
         os << "ellipse(";
+        // angle measured from x-axis
+        float angle = properties.rotation + 90.0;
+        if (angle > 360.0) {
+            angle -= 360.0;
+        }
         if (_pixel_coord) {
             os << std::fixed << std::setprecision(2) << points[0].getValue();
             for (size_t i = 1; i < points.size(); ++i) {
                 os << "," << points[i].getValue();
             }
-            os << "," << std::defaultfloat << std::setprecision(8) << properties.rotation << ")";
+            os << "," << std::defaultfloat << std::setprecision(8) << angle << ")";
         } else {
-            // angle measured from x-axis
-            float angle = properties.rotation + 90.0;
-            if (angle > 360.0) {
-                angle -= 360.0;
-            }
             os << std::fixed << std::setprecision(6) << points[0].get("deg").getValue() << ",";
             os << std::fixed << std::setprecision(6) << points[1].get("deg").getValue() << ",";
             os << std::fixed << std::setprecision(2) << points[2].get("arcsec").getValue() << "\""

--- a/Ds9Parser.cc
+++ b/Ds9Parser.cc
@@ -26,24 +26,21 @@ Ds9Parser::Ds9Parser(std::string& filename, const casacore::CoordinateSystem& im
     InitDs9CoordMap();
 
     // Create vector of file lines, delimited with newline or semicolon
-    std::ifstream ds9_file(filename);
-    if (ds9_file.is_open()) {
-        std::vector<std::string> file_lines;
-        while (!ds9_file.eof()) {
-            std::string single_line;
-            getline(ds9_file, single_line); // get by newline
-            std::vector<std::string> lines;
-            SplitString(single_line, ';', lines); // split by semicolon
-            for (auto& line : lines) {
-                file_lines.push_back(line);
-            }
+    std::ifstream ds9_file;
+    ds9_file.open(filename);
+    std::vector<std::string> file_lines;
+    while (!ds9_file.eof()) {
+        std::string single_line;
+        getline(ds9_file, single_line); // get by newline
+        std::vector<std::string> lines;
+        SplitString(single_line, ';', lines); // split by semicolon
+        for (auto& line : lines) {
+            file_lines.push_back(line);
         }
-        ds9_file.close();
-        // Process into annotation lines
-        ProcessFileLines(file_lines);
-    } else {
-        throw casacore::AipsError("Cannot open file");
     }
+    ds9_file.close();
+    // Process into annotation lines
+    ProcessFileLines(file_lines);
 }
 
 Ds9Parser::Ds9Parser(const casacore::CoordinateSystem& image_coord_sys, std::string& contents, casacore::IPosition& image_shape)
@@ -104,6 +101,9 @@ void Ds9Parser::InitDs9CoordMap() {
     _coord_map["galactic"] = "GALACTIC";
     _coord_map["ecliptic"] = "ECLIPTIC";
     _coord_map["icrs"] = "ICRS";
+    _coord_map["wcs"] = "UNSUPPORTED";
+    _coord_map["wcsa"] = "UNSUPPORTED";
+    _coord_map["linear"] = "UNSUPPORTED";
 }
 
 // public accessors
@@ -147,11 +147,13 @@ void Ds9Parser::ProcessFileLines(std::vector<std::string>& lines) {
             continue;
         }
 
-        // process coordinate system
+        // process coordinate system; global or for a region definition
         if (IsDs9CoordSysKeyword(line)) {
             ds9_coord_sys_ok = SetDirectionRefFrame(line);
             if (!ds9_coord_sys_ok) {
-                std::cerr << "Cannot process DS9 coordinate system: " << line << std::endl;
+                std::string csys_error = "coord sys " + line + " not supported";
+                AddImportError(csys_error);
+                std::cerr << "Ds9Parser import error: " << csys_error << std::endl;
             }
             continue;
         }
@@ -180,13 +182,20 @@ bool Ds9Parser::SetDirectionRefFrame(std::string& ds9_coord) {
     // Returns whether conversion was successful or undefined/not supported
     bool converted_coord(false);
     std::transform(ds9_coord.begin(), ds9_coord.end(), ds9_coord.begin(), ::tolower); // convert in-place to lowercase
+
     if (_coord_map.count(ds9_coord)) {
-        converted_coord = true;
+        if (_coord_map[ds9_coord] == "UNSUPPORTED") {
+            return converted_coord;
+        }
+
         if ((ds9_coord != "physical") && (ds9_coord != "image")) { // pixel coordinates
-            _direction_ref_frame = _coord_map[ds9_coord];
             _pixel_coord = false;
         }
+
+        _direction_ref_frame = _coord_map[ds9_coord];
+        converted_coord = true;
     }
+
     return converted_coord;
 }
 
@@ -198,6 +207,8 @@ void Ds9Parser::InitializeDirectionReferenceFrame() {
         _direction_ref_frame = casacore::MDirection::showType(reference_frame);
     } else if (_coord_sys.hasLinearCoordinate()) {
         _direction_ref_frame = "linear";
+    } else {
+        _direction_ref_frame = "physical";
     }
 }
 
@@ -206,76 +217,75 @@ void Ds9Parser::InitializeDirectionReferenceFrame() {
 void Ds9Parser::SetAnnotationRegion(std::string& region_description) {
     // Convert ds9 region description into AsciiAnnotationFileLine and add to RegionTextList.
 
-    // Split into region parts: definition [0], properties [1]
-    std::vector<string> region_parts;
-    SplitString(region_description, '#', region_parts);
-
-    // Split definition to check for annulus (e.g. "ellipse1 & !ellipse2")
-    std::vector<string> region_definitions;
-    SplitString(region_parts[0], '&', region_definitions);
-    if (region_definitions.size() == 2) {
-        std::cerr << "Import error: Ellipse Annulus and Box Annulus not supported" << std::endl;
-        return;
+    // Split into region definition, properties
+    std::string region_definition(region_description), region_properties;
+    if (region_description.find("#") != std::string::npos) {
+        std::vector<string> region_parts;
+        SplitString(region_description, '#', region_parts);
+        region_definition = region_parts[0];
+        region_properties = region_parts[1];
     }
 
-    // Process region definition
-    // DS9 can have 3 formats: optional commas, and optional parentheses
-    // Ex: "circle 100 100 10", "circle(100 100 10)", "circle(100,100,10)"
+    // Process region definition include/exclude
     bool exclude_region(false);
-    casacore::String formatted_region(region_definitions[0]); // handy utilities: trim, gsub (global substitution)
-    formatted_region.trim();                                  // remove beginning and ending whitespace
-    formatted_region.ltrim('+');                              // remove 'include' property
+    casacore::String formatted_region(region_definition); // handy utilities: trim, gsub (global substitution)
+    formatted_region.trim();                              // remove beginning and ending whitespace
+    formatted_region.ltrim('+');                          // remove 'include' property
     if ((formatted_region[0] == '!') || (formatted_region[0] == '-')) {
         exclude_region = true;
         formatted_region.ltrim('!'); // remove 'exclude' property
         formatted_region.ltrim('-'); // remove 'exclude' property
     }
 
-    // normalize all formats into space delimiter "circle 100 100 10":
-    formatted_region.gsub("(", " "); // replace left parenthesis with space
-    formatted_region.gsub(")", "");  // remove right parenthesis
-    formatted_region.gsub(",", " "); // replace commas with space
-
-    // split definition into parts (region type and parameters) e.g. ["circle", "100", "100", "10"]
-    std::vector<std::string> region_parameters;
-    SplitString(formatted_region, ' ', region_parameters);
-    if (region_parameters.size() < 3) {
+    // Get Annotation type from region definition
+    casa::AnnotationBase::Type ann_region_type;
+    if (!GetAnnotationRegionType(region_definition, ann_region_type)) {
+        std::string unsupported_type("unknown/unsupported keyword " + region_definition);
+        AddImportError(unsupported_type);
+        std::cerr << "Ds9Parser import error: " << unsupported_type << std::endl;
         return;
     }
-    ConvertDs9UnitToCasacore(region_parameters);
 
-    // process region properties (currently text only)
-    casacore::String label;
-    if (region_parts.size() > 1) {
-        label = GetRegionName(region_parts[1]);
-    }
+    // Retrieve label from region properties
+    casacore::String label = GetRegionName(region_properties);
 
-    ProcessRegionDefinition(region_parameters, label, exclude_region);
+    // Create Annotation Region based on type
+    ProcessRegionDefinition(ann_region_type, region_definition, label, exclude_region);
 }
 
-void Ds9Parser::ConvertDs9UnitToCasacore(std::vector<std::string>& region_parameters) {
-    // replace ds9 units with casacore units in value-unit parameter string
-    for (size_t i = 1; i < region_parameters.size(); ++i) {
-        std::string casacore_unit;
-        if (region_parameters[i].back() == 'd') {
-            casacore_unit = "deg";
-        } else if (region_parameters[i].back() == 'r') {
-            casacore_unit = "rad";
-        } else if (region_parameters[i].back() == 'p') {
-            casacore_unit = "pix";
-        } else if (region_parameters[i].back() == 'i') {
-            casacore_unit = "pix";
-        }
-        if (!casacore_unit.empty()) {
-            region_parameters[i].pop_back();
-            region_parameters[i].append(casacore_unit);
+bool Ds9Parser::GetAnnotationRegionType(std::string& ds9_region, casa::AnnotationBase::Type& type) {
+    // Convert DS9 region type to annotation region type.
+    // Returns whether conversion was successful; there is no AnnotationBase::Type::UNKNOWN
+    bool found_type(false);
+    std::unordered_map<std::string, casa::AnnotationBase::Type> region_type_map = {{"circle", casa::AnnotationBase::Type::CIRCLE},
+        {"ellipse", casa::AnnotationBase::Type::ELLIPSE}, {"box", casa::AnnotationBase::Type::ROTATED_BOX},
+        {"polygon", casa::AnnotationBase::Type::POLYGON}, {"point", casa::AnnotationBase::Type::SYMBOL},
+        {"line", casa::AnnotationBase::Type::LINE}, {"vector", casa::AnnotationBase::Type::VECTOR},
+        {"text", casa::AnnotationBase::Type::TEXT}, {"annulus", casa::AnnotationBase::Type::ANNULUS}};
+
+    // search for "point" first, could be "circle point", "box point", etc.
+    if (ds9_region.find("point") != std::string::npos) {
+        type = region_type_map["point"];
+        found_type = true;
+    } else {
+        for (auto& region_type : region_type_map) {
+            if (ds9_region.find(region_type.first) != std::string::npos) {
+                type = region_type.second;
+                found_type = true;
+                break;
+            }
         }
     }
+    return found_type;
 }
 
 casacore::String Ds9Parser::GetRegionName(std::string& region_properties) {
     // Parse region properties (everything after '#') for text, used as region name
     casacore::String text_label;
+    if (region_properties.empty()) {
+        return text_label;
+    }
+
     if (region_properties.find("text") != std::string::npos) {
         casacore::String properties(region_properties);
         text_label = properties.after("text=");
@@ -290,46 +300,53 @@ casacore::String Ds9Parser::GetRegionName(std::string& region_properties) {
     return text_label;
 }
 
-void Ds9Parser::ProcessRegionDefinition(std::vector<std::string>& region_definition, casacore::String& label, bool exclude_region) {
-    // Process region definition vector (e.g. ["circle", "100", "100", "20"]) into AnnRegion
-    std::string region_type = region_definition[0];
-    // point can have symbol descriptor, e.g. ""circle point", "diamond point", etc.
-    if (region_definition[1].find("point") != std::string::npos) {
-        region_type = "point";
-    }
-    // Get Annotation type from region type
-    casa::AnnotationBase::Type ann_region_type;
-    if (!GetAnnotationRegionType(region_type, ann_region_type)) {
-        return;
-    }
-
-    // process region type parameters into AnnRegion or AnnSymbol
-    std::string error_message;
+void Ds9Parser::ProcessRegionDefinition(
+    casa::AnnotationBase::Type ann_region_type, std::string& region_definition, casacore::String& label, bool exclude_region) {
+    // Process region definition arguments into AnnRegion or AnnSymbol
+    std::string error_message, region_type;
     casa::AnnRegion* ann_region(nullptr);
     casa::AnnSymbol* ann_symbol(nullptr); // not a region, handle separately
     try {
         switch (ann_region_type) {
-            case casa::AnnotationBase::Type::CIRCLE:
+            case casa::AnnotationBase::Type::CIRCLE: {
+                region_type = "circle";
                 ann_region = CreateCircleRegion(region_definition);
                 break;
-            case casa::AnnotationBase::Type::ELLIPSE:
+            }
+            case casa::AnnotationBase::Type::ELLIPSE: {
+                region_type = "ellipse";
                 ann_region = CreateEllipseRegion(region_definition);
                 break;
-            case casa::AnnotationBase::Type::ROTATED_BOX: // or a CENTER_BOX if angle==0
+            }
+            case casa::AnnotationBase::Type::ROTATED_BOX: { // or a CENTER_BOX if angle==0
+                region_type = "box";
                 ann_region = CreateBoxRegion(region_definition);
                 break;
-            case casa::AnnotationBase::Type::POLYGON:
+            }
+            case casa::AnnotationBase::Type::POLYGON: {
+                region_type = "polygon";
                 ann_region = CreatePolygonRegion(region_definition);
                 break;
-            case casa::AnnotationBase::Type::SYMBOL: // used for carta point region
+            }
+            case casa::AnnotationBase::Type::SYMBOL: { // used for carta point region
+                region_type = "point";
                 ann_symbol = CreateSymbolRegion(region_definition);
                 break;
-            case casa::AnnotationBase::Type::ANNULUS:
-            case casa::AnnotationBase::Type::LINE:
+            }
+            case casa::AnnotationBase::Type::ANNULUS: {
+                region_type = "annulus";
                 error_message = "Import region '" + region_type + "' failed:  not supported yet.";
                 break;
-            case casa::AnnotationBase::Type::TEXT:
-                error_message = "Import region '" + region_type + "' failed:  annotations not supported yet.";
+            }
+            case casa::AnnotationBase::Type::LINE: {
+                region_type = "line";
+                error_message = "Import region '" + region_type + "' failed:  not supported yet.";
+                break;
+            }
+            case casa::AnnotationBase::Type::TEXT: {
+                region_type = "text";
+                error_message = "Import '" + region_type + "' failed:  annotations not supported yet.";
+            }
             default:
                 break;
         }
@@ -337,6 +354,11 @@ void Ds9Parser::ProcessRegionDefinition(std::vector<std::string>& region_definit
         std::ostringstream oss;
         oss << "Import region '" << region_type << "' failed: " << err.getMesg();
         error_message = oss.str();
+    }
+
+    if (!error_message.empty()) {
+        AddImportError(error_message);
+        std::cerr << "Ds9Parser import error: " << error_message << std::endl;
     }
 
     // Add AsciiAnnotationFileLine for Annotation to RegionTextList
@@ -349,100 +371,193 @@ void Ds9Parser::ProcessRegionDefinition(std::vector<std::string>& region_definit
         ann_region->setDifference(exclude_region);
         annotation_region = casacore::CountedPtr<const casa::AnnotationBase>(ann_region);
     } else {
-        std::cerr << error_message << std::endl;
         return;
     }
+
     casa::AsciiAnnotationFileLine file_line = casa::AsciiAnnotationFileLine(annotation_region);
     _region_list.addLine(file_line);
 }
 
-bool Ds9Parser::GetAnnotationRegionType(std::string& ds9_region, casa::AnnotationBase::Type& type) {
-    // Convert ds9 region type (everything but "ruler") to annotation region type.
-    // Returns whether conversion was successful, there is no AnnotationBase::Type::UNKNOWN!
-    bool found_type(false);
-    std::unordered_map<std::string, casa::AnnotationBase::Type> region_type_map = {{"circle", casa::AnnotationBase::Type::CIRCLE},
-        {"annulus", casa::AnnotationBase::Type::ANNULUS}, {"ellipse", casa::AnnotationBase::Type::ELLIPSE},
-        {"box", casa::AnnotationBase::Type::ROTATED_BOX}, // or a CENTER_BOX if angle==0
-        {"polygon", casa::AnnotationBase::Type::POLYGON}, {"line", casa::AnnotationBase::Type::LINE},
-        {"text", casa::AnnotationBase::Type::TEXT}, {"point", casa::AnnotationBase::Type::SYMBOL}};
+bool Ds9Parser::CheckAndConvertParameter(std::string& parameter, const std::string& region_type) {
+    // Replace ds9 unit with casacore unit in value-unit parameter string, for casacore::Quantity.
+    // Returns whether valid ds9 parameter
+    std::string error_prefix(region_type + " invalid parameter ");
 
-    for (auto& region_type : region_type_map) {
-        if (ds9_region.find(region_type.first) != std::string::npos) {
-            type = region_type.second;
-            found_type = true;
-            break;
-        }
+    // use stod to find index of unit in string (after numeric value)
+    size_t idx;
+    try {
+        double val = stod(parameter, &idx); // string to double
+    } catch (std::invalid_argument& err) {
+        std::string invalid_arg(error_prefix + parameter + ", not a numeric value");
+        AddImportError(invalid_arg);
+        std::cerr << "Ds9Parser import error: " << invalid_arg << std::endl;
+        return false;
     }
-    return found_type;
+
+    size_t param_length(parameter.length());
+    if (param_length == idx) { // no unit
+        return true;
+    }
+
+    if (param_length > idx + 1) {
+        // check for hms, dms formats
+        const char* param_carray = parameter.c_str();
+        float h, m, s;
+        if ((sscanf(param_carray, "%f:%f:%f", &h, &m, &s) == 3) || (sscanf(param_carray, "%fh%fm%fs", &h, &m, &s) == 3) ||
+            (sscanf(param_carray, "%fd%fm%fs", &h, &m, &s) == 3)) { // time format ok
+            return true;
+        }
+
+        // DS9 units are a single character
+        std::string invalid_unit(error_prefix + "unit " + parameter);
+        AddImportError(invalid_unit);
+        std::cerr << "Ds9Parser import error: " << invalid_unit << std::endl;
+        return false;
+    }
+
+    const char unit = parameter.back();
+    std::string casacore_unit;
+    if (unit == 'd') {
+        casacore_unit = "deg";
+    } else if (unit == 'r') {
+        casacore_unit = "rad";
+    } else if (unit == 'p') {
+        casacore_unit = "pix";
+    } else if (unit == 'i') {
+        casacore_unit = "pix";
+    } else if ((unit == '"') || (unit == '\'')) {
+        // casacore unit is the same, no error
+    } else {
+        std::string invalid_unit(error_prefix + "unit " + parameter);
+        AddImportError(invalid_unit);
+        std::cerr << "Ds9Parser import error: " << invalid_unit << std::endl;
+        return false;
+    }
+
+    if (!casacore_unit.empty()) {
+        parameter.pop_back();
+        parameter.append(casacore_unit);
+    }
+
+    // parameter unit validated
+    return true;
 }
 
-casacore::String Ds9Parser::ConvertTimeFormatToDeg(std::string& parameter_string) {
+casacore::String Ds9Parser::ConvertTimeFormatToDeg(std::string& parameter) {
     // If parameter is in sexagesimal format dd:mm::ss.ssss, convert to angle format dd.mm.ss.ssss for readQuantity
-    casacore::String converted_format(parameter_string);
+    casacore::String converted_format(parameter);
     if (converted_format.contains(":")) {
         converted_format.gsub(":", ".");
     }
     return converted_format;
 }
 
-casa::AnnRegion* Ds9Parser::CreateBoxRegion(std::vector<std::string>& region_definition) {
+bool Ds9Parser::ParseRegion(std::string& region_definition, std::vector<std::string>& parameters, int nparams) {
+    // Parse region definition into known number of parameters; first is region type.
+    // DS9 can have 3 formats: optional commas, and optional parentheses
+    // Ex: "circle 100 100 10", "circle(100 100 10)", "circle(100,100,10)"
+    // nparams = 0 for variable number of params.
+    // Returns whether syntax was parsed into nparams.
+    casacore::String definition(region_definition);
+    if (definition.freq('(') != definition.freq(')')) {
+        return false;
+    }
+
+    definition.gsub("(", " "); // replace ( with space
+    definition.gsub(")", " "); // replace ) with space
+    definition.gsub(",", " "); // replace , with space
+    SplitString(definition, ' ', parameters);
+    if (nparams > 0) {
+        return (parameters.size() == nparams);
+    } else {
+        return true;
+    }
+}
+
+casa::AnnRegion* Ds9Parser::CreateBoxRegion(std::string& region_definition) {
     // Create AnnCenterBox or AnnRotBox from DS9 region definition
+    // box x y width height angle
     casa::AnnRegion* ann_region(nullptr);
-    size_t nparams(region_definition.size());
-    if (nparams == 6) { // box x y width height angle
+    std::vector<std::string> params;
+    if (ParseRegion(region_definition, params, 6)) {
         // convert strings to Quantities
-        std::vector<casacore::Quantity> parameters;
+        std::vector<casacore::Quantity> param_quantities;
         std::vector<casacore::String> units = {"", "deg", "deg", "arcsec", "arcsec", "deg"};
+        size_t nparams(params.size());
         for (size_t i = 1; i < nparams; ++i) {
-            casacore::String param_string(region_definition[i]);
-            if (i == 2) {
-                param_string = ConvertTimeFormatToDeg(param_string);
-            }
-            casacore::Quantity param_quantity;
-            if (readQuantity(param_quantity, param_string)) {
-                if (param_quantity.getUnit().empty()) {
-                    if ((i == nparams - 1) || !_pixel_coord) {
-                        param_quantity.setUnit(units[i]);
-                    } else {
-                        param_quantity.setUnit("pix");
-                    }
+            std::string param(params[i]);
+            if (CheckAndConvertParameter(param, "box")) {
+                casacore::String param_string(param);
+                if (i == 2) { // degree format, not time
+                    param_string = ConvertTimeFormatToDeg(param);
                 }
-                parameters.push_back(param_quantity);
+                casacore::Quantity param_quantity;
+                if (readQuantity(param_quantity, param_string)) {
+                    if (param_quantity.getUnit().empty()) {
+                        if ((i == nparams - 1) || !_pixel_coord) {
+                            param_quantity.setUnit(units[i]);
+                        } else {
+                            param_quantity.setUnit("pix");
+                        }
+                    }
+                    param_quantities.push_back(param_quantity);
+                } else {
+                    std::string invalid_param("invalid box parameter " + param);
+                    AddImportError(invalid_param);
+                    std::cerr << "Ds9Parser import error: " << invalid_param << std::endl;
+                    return ann_region;
+                }
             } else {
-                std::cerr << "ERROR: cannot process box parameter " << region_definition[i] << std::endl;
-                return ann_region; // nullptr, cannot process parameters
+                return ann_region;
             }
         }
 
-        // AnnCenterBox / AnnRotBox arguments
         casacore::Quantity begin_freq, end_freq, rest_freq;
         casacore::String freq_ref_frame, doppler;
         casacore::Vector<casacore::Stokes::StokesTypes> stokes_types;
-
-        if (parameters[4].getValue() == 0.0) { // angle parameter; no rotation
-            ann_region = new casa::AnnCenterBox(parameters[0], parameters[1], parameters[2], parameters[3], _direction_ref_frame,
-                _coord_sys, _image_shape, begin_freq, end_freq, freq_ref_frame, doppler, rest_freq, stokes_types, false, false);
+        if (param_quantities[4].getValue() == 0.0) { // angle parameter; no rotation
+            ann_region = new casa::AnnCenterBox(param_quantities[0], param_quantities[1], param_quantities[2], param_quantities[3],
+                _direction_ref_frame, _coord_sys, _image_shape, begin_freq, end_freq, freq_ref_frame, doppler, rest_freq, stokes_types,
+                false, false);
         } else {
-            ann_region =
-                new casa::AnnRotBox(parameters[0], parameters[1], parameters[2], parameters[3], parameters[4], _direction_ref_frame,
-                    _coord_sys, _image_shape, begin_freq, end_freq, freq_ref_frame, doppler, rest_freq, stokes_types, false, false);
+            ann_region = new casa::AnnRotBox(param_quantities[0], param_quantities[1], param_quantities[2], param_quantities[3],
+                param_quantities[4], _direction_ref_frame, _coord_sys, _image_shape, begin_freq, end_freq, freq_ref_frame, doppler,
+                rest_freq, stokes_types, false, false);
         }
+    } else if (ParseRegion(region_definition, params, 0)) {
+        // unsupported box annulus: box x y w1 h1 w2 h2 [angle]
+        std::string invalid_params = "unsupported box definition " + region_definition;
+        AddImportError(invalid_params);
+        std::cerr << "Ds9Parser import error: " << invalid_params << std::endl;
+    } else {
+        std::string syntax_error = "box syntax error " + region_definition;
+        AddImportError(syntax_error);
+        std::cerr << "Ds9Parser import error: " << syntax_error << std::endl;
     }
     return ann_region;
 }
 
-casa::AnnRegion* Ds9Parser::CreateCircleRegion(std::vector<std::string>& region_definition) {
+casa::AnnRegion* Ds9Parser::CreateCircleRegion(std::string& region_definition) {
     // Create AnnCircle from DS9 region definition
+    // circle x y radius
     casa::AnnRegion* ann_region(nullptr);
-    size_t nparams(region_definition.size());
-    if (nparams == 4) { // circle x y radius
-        // convert strings to Quantities
-        std::vector<casacore::Quantity> parameters;
-        std::vector<casacore::String> units = {"", "deg", "deg", "arcsec"};
-        for (size_t i = 1; i < nparams; ++i) {
-            casacore::String param_string(region_definition[i]);
-            if (i == 2) {
-                param_string = ConvertTimeFormatToDeg(param_string);
+    std::vector<std::string> params;
+    if (!ParseRegion(region_definition, params, 4)) {
+        std::string syntax_error = "circle syntax error " + region_definition;
+        AddImportError(syntax_error);
+        std::cerr << "Ds9Parser import error: " << syntax_error << std::endl;
+        return ann_region;
+    }
+
+    // convert strings to Quantities
+    std::vector<casacore::Quantity> param_quantities;
+    std::vector<casacore::String> units = {"", "deg", "deg", "arcsec"};
+    for (size_t i = 1; i < params.size(); ++i) {
+        std::string param(params[i]);
+        if (CheckAndConvertParameter(param, "circle")) {
+            casacore::String param_string(param);
+            if (i == 2) { // degree format, not time
+                param_string = ConvertTimeFormatToDeg(param);
             }
             casacore::Quantity param_quantity;
             if (readQuantity(param_quantity, param_string)) {
@@ -453,77 +568,111 @@ casa::AnnRegion* Ds9Parser::CreateCircleRegion(std::vector<std::string>& region_
                         param_quantity.setUnit(units[i]);
                     }
                 }
-                parameters.push_back(param_quantity);
+                param_quantities.push_back(param_quantity);
             } else {
-                std::cerr << "ERROR: cannot process circle parameter " << region_definition[i] << std::endl;
-                return ann_region; // nullptr, cannot process parameters
+                std::string invalid_param("invalid circle parameter " + param);
+                AddImportError(invalid_param);
+                std::cerr << "Ds9Parser import error: " << invalid_param << std::endl;
+                return ann_region;
             }
+        } else {
+            return ann_region;
         }
-
-        // AnnCircle arguments
-        casacore::Quantity begin_freq, end_freq, rest_freq;
-        casacore::String freq_ref_frame, doppler;
-        casacore::Vector<casacore::Stokes::StokesTypes> stokes_types;
-
-        ann_region = new casa::AnnCircle(parameters[0], parameters[1], parameters[2], _direction_ref_frame, _coord_sys, _image_shape,
-            begin_freq, end_freq, freq_ref_frame, doppler, rest_freq, stokes_types, false, false);
     }
 
+    casacore::Quantity begin_freq, end_freq, rest_freq;
+    casacore::String freq_ref_frame, doppler;
+    casacore::Vector<casacore::Stokes::StokesTypes> stokes_types;
+    ann_region = new casa::AnnCircle(param_quantities[0], param_quantities[1], param_quantities[2], _direction_ref_frame, _coord_sys,
+        _image_shape, begin_freq, end_freq, freq_ref_frame, doppler, rest_freq, stokes_types, false, false);
     return ann_region;
 }
 
-casa::AnnRegion* Ds9Parser::CreateEllipseRegion(std::vector<std::string>& region_definition) {
+casa::AnnRegion* Ds9Parser::CreateEllipseRegion(std::string& region_definition) {
     // Create AnnEllipse from DS9 region definition
+    // ellipse x y radius radius angle
     casa::AnnRegion* ann_region(nullptr);
-    size_t nparams(region_definition.size());
-    if (nparams == 6) { // ellipse x y radius radius angle
+    std::vector<std::string> params;
+    if (ParseRegion(region_definition, params, 6)) {
         // convert strings to Quantities
-        std::vector<casacore::Quantity> parameters;
+        std::vector<casacore::Quantity> param_quantities;
         std::vector<casacore::String> units = {"", "deg", "deg", "arcsec", "arcsec", "deg"};
+        size_t nparams(params.size());
         for (size_t i = 1; i < nparams; ++i) {
-            casacore::String param_string(region_definition[i]);
-            if (i == 2) {
-                param_string = ConvertTimeFormatToDeg(param_string);
-            }
-            casacore::Quantity param_quantity;
-            if (readQuantity(param_quantity, param_string)) {
-                if (param_quantity.getUnit().empty()) {
-                    if ((i == nparams - 1) || !_pixel_coord) {
-                        param_quantity.setUnit(units[i]);
-                    } else {
-                        param_quantity.setUnit("pix");
-                    }
+            std::string param(params[i]);
+            if (CheckAndConvertParameter(param, "ellipse")) {
+                casacore::String param_string(param);
+                if (i == 2) { // degree format, not time
+                    param_string = ConvertTimeFormatToDeg(param);
                 }
-                parameters.push_back(param_quantity);
+                casacore::Quantity param_quantity;
+                if (readQuantity(param_quantity, param_string)) {
+                    if (param_quantity.getUnit().empty()) {
+                        if ((i == nparams - 1) || !_pixel_coord) {
+                            param_quantity.setUnit(units[i]);
+                        } else {
+                            param_quantity.setUnit("pix");
+                        }
+                    }
+                    param_quantities.push_back(param_quantity);
+                } else {
+                    std::string invalid_param("invalid ellipse parameter " + param);
+                    AddImportError(invalid_param);
+                    std::cerr << "Ds9Parser import error: " << invalid_param << std::endl;
+                    return ann_region;
+                }
             } else {
-                std::cerr << "ERROR: cannot process ellipse parameter " << region_definition[i] << std::endl;
-                return ann_region; // nullptr, cannot process parameters
+                return ann_region;
             }
         }
 
-        // AnnEllipse arguments
         casacore::Quantity begin_freq, end_freq, rest_freq;
         casacore::String freq_ref_frame, doppler;
         casacore::Vector<casacore::Stokes::StokesTypes> stokes_types;
         // adjust angle (from x-axis)
-        casacore::Quantity position_angle(parameters[4]);
+        casacore::Quantity position_angle(param_quantities[4]);
         position_angle -= 90.0;
-
-        ann_region = new casa::AnnEllipse(parameters[0], parameters[1], parameters[2], parameters[3], position_angle, _direction_ref_frame,
-            _coord_sys, _image_shape, begin_freq, end_freq, freq_ref_frame, doppler, rest_freq, stokes_types, false, false);
+        ann_region = new casa::AnnEllipse(param_quantities[0], param_quantities[1], param_quantities[2], param_quantities[3],
+            position_angle, _direction_ref_frame, _coord_sys, _image_shape, begin_freq, end_freq, freq_ref_frame, doppler, rest_freq,
+            stokes_types, false, false);
+    } else if (ParseRegion(region_definition, params, 0)) {
+        // unsupported ellipse annulus: ellipse x y r11 r12 r21 r22 [angle]
+        std::string invalid_params = "unsupported ellipse definition " + region_definition;
+        AddImportError(invalid_params);
+        std::cerr << "Ds9Parser import error: " << invalid_params << std::endl;
+    } else {
+        std::string syntax_error = "ellipse syntax error " + region_definition;
+        AddImportError(syntax_error);
+        std::cerr << "Ds9Parser import error: " << syntax_error << std::endl;
     }
-
     return ann_region;
 }
 
-casa::AnnRegion* Ds9Parser::CreatePolygonRegion(std::vector<std::string>& region_definition) {
+casa::AnnRegion* Ds9Parser::CreatePolygonRegion(std::string& region_definition) {
     // Create AnnPolygon from DS9 region definition
+    // polygon x1 y1 x2 y2 x3 y3 ...
     casa::AnnRegion* ann_region(nullptr);
-    if (region_definition.size() % 2 == 1) { // polygon x1 y1 x2 y2 x3 y3 ...
-        // convert strings to Quantities
-        std::vector<casacore::Quantity> parameters;
-        for (size_t i = 1; i < region_definition.size(); i++) {
-            casacore::String param_string(region_definition[i]);
+    std::vector<std::string> params;
+    if (!ParseRegion(region_definition, params, 0)) {
+        std::string syntax_error = "polygon syntax error " + region_definition;
+        AddImportError(syntax_error);
+        std::cerr << "Ds9Parser import error: " << syntax_error << std::endl;
+        return ann_region;
+    }
+
+    if (params.size() % 2 != 1) {
+        std::string syntax_error = "polygon syntax error " + region_definition;
+        AddImportError(syntax_error);
+        std::cerr << "Ds9Parser import error: " << syntax_error << std::endl;
+        return ann_region;
+    }
+
+    // convert strings to Quantities
+    std::vector<casacore::Quantity> param_quantities;
+    for (size_t i = 1; i < params.size(); ++i) {
+        std::string param(params[i]);
+        if (CheckAndConvertParameter(param, "polygon")) {
+            casacore::String param_string(param);
             if ((i % 2) == 0) {
                 param_string = ConvertTimeFormatToDeg(param_string);
             }
@@ -536,39 +685,56 @@ casa::AnnRegion* Ds9Parser::CreatePolygonRegion(std::vector<std::string>& region
                         param_quantity.setUnit("deg");
                     }
                 }
-                parameters.push_back(param_quantity);
+                param_quantities.push_back(param_quantity);
             } else {
-                std::cerr << "ERROR: cannot process polygon parameter " << region_definition[i] << std::endl;
-                return ann_region; // nullptr, cannot process parameters
+                std::string invalid_param("invalid polygon parameter " + param);
+                AddImportError(invalid_param);
+                std::cerr << "Ds9Parser import error: " << invalid_param << std::endl;
+                return ann_region;
             }
+        } else {
+            return ann_region;
         }
-
-        // AnnPolygon arguments
-        std::vector<casacore::Quantity> xPositions, yPositions;
-        for (size_t i = 0; i < parameters.size(); i += 2) {
-            xPositions.push_back(parameters[i]);
-            yPositions.push_back(parameters[i + 1]);
-        }
-        casacore::Quantity begin_freq, end_freq, rest_freq;
-        casacore::String freq_ref_frame, doppler;
-        casacore::Vector<casacore::Stokes::StokesTypes> stokes_types;
-
-        ann_region = new casa::AnnPolygon(xPositions, yPositions, _direction_ref_frame, _coord_sys, _image_shape, begin_freq, end_freq,
-            freq_ref_frame, doppler, rest_freq, stokes_types, false, false);
     }
 
+    // AnnPolygon arguments
+    std::vector<casacore::Quantity> xPositions, yPositions;
+    for (size_t i = 0; i < param_quantities.size(); i += 2) {
+        xPositions.push_back(param_quantities[i]);
+        yPositions.push_back(param_quantities[i + 1]);
+    }
+    casacore::Quantity begin_freq, end_freq, rest_freq;
+    casacore::String freq_ref_frame, doppler;
+    casacore::Vector<casacore::Stokes::StokesTypes> stokes_types;
+
+    ann_region = new casa::AnnPolygon(xPositions, yPositions, _direction_ref_frame, _coord_sys, _image_shape, begin_freq, end_freq,
+        freq_ref_frame, doppler, rest_freq, stokes_types, false, false);
     return ann_region;
 }
 
-casa::AnnSymbol* Ds9Parser::CreateSymbolRegion(std::vector<std::string>& region_definition) {
+casa::AnnSymbol* Ds9Parser::CreateSymbolRegion(std::string& region_definition) {
     // Create AnnSymbol from DS9 region definition
+    // point x y, circle point x y
     casa::AnnSymbol* ann_symbol(nullptr);
-    if (region_definition.size() == 3) { // point x y
-        // convert strings to Quantities
-        std::vector<casacore::Quantity> parameters;
-        for (size_t i = 1; i < region_definition.size(); ++i) {
-            casacore::String param_string(region_definition[i]);
-            if (i == 2) {
+    std::vector<std::string> params;
+    int first_param;
+    if (ParseRegion(region_definition, params, 3)) {
+        first_param = 1;
+    } else if (ParseRegion(region_definition, params, 4)) {
+        first_param = 2;
+    } else {
+        std::string syntax_error = "point syntax error " + region_definition;
+        AddImportError(syntax_error);
+        std::cerr << "Ds9Parser import error: " << syntax_error << std::endl;
+        return ann_symbol;
+    }
+
+    std::vector<casacore::Quantity> param_quantities;
+    for (size_t i = first_param; i < params.size(); ++i) {
+        std::string param(params[i]);
+        if (CheckAndConvertParameter(param, "point")) {
+            casacore::String param_string(param);
+            if (i == first_param + 1) {
                 param_string = ConvertTimeFormatToDeg(param_string);
             }
             casacore::Quantity param_quantity;
@@ -580,23 +746,34 @@ casa::AnnSymbol* Ds9Parser::CreateSymbolRegion(std::vector<std::string>& region_
                         param_quantity.setUnit("deg");
                     }
                 }
-                parameters.push_back(param_quantity);
+                param_quantities.push_back(param_quantity);
             } else {
-                std::cerr << "ERROR: cannot process point parameter " << region_definition[i] << std::endl;
-                return ann_symbol; // nullptr, cannot process parameters
+                std::string invalid_param("invalid point parameter " + param);
+                AddImportError(invalid_param);
+                std::cerr << "Ds9Parser import error: " << invalid_param << std::endl;
+                return ann_symbol;
             }
+        } else {
+            return ann_symbol;
         }
-
-        // AnnSymbol arguments
-        casacore::Quantity begin_freq, end_freq, rest_freq;
-        casacore::String freq_ref_frame, doppler;
-        casacore::Vector<casacore::Stokes::StokesTypes> stokes_types;
-
-        ann_symbol = new casa::AnnSymbol(parameters[0], parameters[1], _direction_ref_frame, _coord_sys, '.', begin_freq, end_freq,
-            freq_ref_frame, doppler, rest_freq, stokes_types);
     }
 
+    casacore::Quantity begin_freq, end_freq, rest_freq;
+    casacore::String freq_ref_frame, doppler;
+    casacore::Vector<casacore::Stokes::StokesTypes> stokes_types;
+    ann_symbol = new casa::AnnSymbol(param_quantities[0], param_quantities[1], _direction_ref_frame, _coord_sys, '.', begin_freq, end_freq,
+        freq_ref_frame, doppler, rest_freq, stokes_types);
     return ann_symbol;
+}
+
+void Ds9Parser::AddImportError(std::string& error) {
+    // append error string
+    if (_import_errors.empty()) {
+        _import_errors.append("Ds9Parser warning: ");
+    } else {
+        _import_errors.append(", ");
+    }
+    _import_errors.append(error);
 }
 
 // For export

--- a/Ds9Parser.h
+++ b/Ds9Parser.h
@@ -55,6 +55,9 @@ public:
     unsigned int NumLines(); // AsciiAnnotationFileLines stored in RegionTextList
     const casacore::Vector<casa::AsciiAnnotationFileLine> GetLines();
     casa::AsciiAnnotationFileLine LineAt(unsigned int i);
+    inline std::string GetImportErrors() {
+        return _import_errors;
+    }
 
     // export regions
     void AddRegion(const std::string& name, CARTA::RegionType type, const std::vector<casacore::Quantity>& control_points, float rotation);
@@ -76,18 +79,23 @@ private:
     bool SetDirectionRefFrame(std::string& ds9_coord);
     void InitializeDirectionReferenceFrame(); // using input image_coord_sys
 
-    // region creation
+    // Import region creation
     void SetAnnotationRegion(std::string& region_description);
-    void ConvertDs9UnitToCasacore(std::vector<std::string>& region_parameters);
-    casacore::String GetRegionName(std::string& region_properties);
-    void ProcessRegionDefinition(std::vector<std::string>& region_definition, casacore::String& label, bool exclude_region);
     bool GetAnnotationRegionType(std::string& ds9_region, casa::AnnotationBase::Type& type);
-    casacore::String ConvertTimeFormatToDeg(std::string& parameter_string);
-    casa::AnnRegion* CreateBoxRegion(std::vector<std::string>& region_definition);
-    casa::AnnRegion* CreateCircleRegion(std::vector<std::string>& region_definition);
-    casa::AnnRegion* CreateEllipseRegion(std::vector<std::string>& region_definition);
-    casa::AnnRegion* CreatePolygonRegion(std::vector<std::string>& region_definition);
-    casa::AnnSymbol* CreateSymbolRegion(std::vector<std::string>& region_definition);
+    casacore::String GetRegionName(std::string& region_properties);
+    void ProcessRegionDefinition(
+        casa::AnnotationBase::Type ann_region_type, std::string& region_definition, casacore::String& label, bool exclude_region);
+    bool CheckAndConvertParameter(std::string& parameter, const std::string& region_type);
+    casacore::String ConvertTimeFormatToDeg(std::string& parameter);
+    bool ParseRegion(std::string& region_definition, std::vector<std::string>& parameters, int nparams);
+    casa::AnnRegion* CreateBoxRegion(std::string& region_definition);
+    casa::AnnRegion* CreateCircleRegion(std::string& region_definition);
+    casa::AnnRegion* CreateEllipseRegion(std::string& region_definition);
+    casa::AnnRegion* CreatePolygonRegion(std::string& region_definition);
+    casa::AnnSymbol* CreateSymbolRegion(std::string& region_definition);
+
+    // Import region errors
+    void AddImportError(std::string& error);
 
     // region export
     void PrintBoxRegion(const RegionProperties& properties, std::ostream& os);
@@ -100,6 +108,9 @@ private:
     std::unordered_map<std::string, std::string> _coord_map;
     std::string _direction_ref_frame;
     bool _pixel_coord;
+
+    // capture errors
+    std::string _import_errors;
 
     casa::RegionTextList _region_list; // import
     std::vector<RegionProperties> _regions;

--- a/Frame.cc
+++ b/Frame.cc
@@ -258,13 +258,7 @@ void Frame::RemoveRegion(int region_id) {
 
 void Frame::ImportRegion(
     CARTA::FileType file_type, std::string& filename, std::vector<std::string>& contents, CARTA::ImportRegionAck& import_ack) {
-    // Import region from file
-    if (filename.empty() && contents.empty()) {
-        import_ack.set_success(false);
-        import_ack.set_message("Import region failed: no region file contents.");
-        import_ack.add_regions();
-        return;
-    }
+    // Import region from file or contents
 
     // cannot create annotation regions with no direction coordinate
     const casacore::CoordinateSystem coord_sys = _loader->LoadData(FileInfo::Data::Image)->coordinates();
@@ -275,6 +269,7 @@ void Frame::ImportRegion(
         return;
     }
 
+    // concat contents vector into one string delimited by newline
     std::string file_contents;
     if (!contents.empty()) {
         // concat contents into one string delimited by newline

--- a/Frame.cc
+++ b/Frame.cc
@@ -498,21 +498,41 @@ void Frame::ExportCrtfRegions(
         if (_regions.count(region_id)) {
             auto& region = _regions[region_id];
             if (region->IsValid()) {
-                casacore::CountedPtr<const casa::AnnotationBase> annotation_region = region->AnnotationRegion(pixel_coord);
-                casa::AsciiAnnotationFileLine file_line = casa::AsciiAnnotationFileLine(annotation_region);
-                region_list.addLine(file_line);
+                try {
+                    casacore::CountedPtr<const casa::AnnotationBase> annotation_region = region->AnnotationRegion(pixel_coord);
+                    if (!annotation_region.null()) {
+                        casa::AsciiAnnotationFileLine file_line = casa::AsciiAnnotationFileLine(annotation_region);
+                        region_list.addLine(file_line);
+                    }
+                } catch (casacore::AipsError& err) {
+                    std::ostringstream oss;
+                    oss << " Region " << region_id << " export failed: ";
+                    if (err.getMesg().contains("no direction coordinate")) {
+                        oss << "image coordinate system has no direction coordinate.";
+                    } else {
+                        oss << err.getMesg();
+                    }
+                    message += oss.str();
+                }
             } else {
-                message += " Region " + std::to_string(region_id) + " export failed: region is not valid for this image.";
+                std::ostringstream oss;
+                oss << " Region " << region_id << " export failed: region is not valid for this image.";
+                message += oss.str();
             }
         } else {
-            message += " Region " + std::to_string(region_id) + " export failed: does not exist.";
+            std::ostringstream oss;
+            oss << " Region " << region_id << " export failed: no longer exists.";
+            message += oss.str();
         }
     }
 
     // check if file lines created
     if (region_list.nLines() == 0) {
         export_ack.set_success(false);
-        export_ack.set_message("Export region failed: no regions to export.");
+        if (message.empty()) {
+            message = "Export region failed: no regions to export.";
+        }
+        export_ack.set_message(message);
         export_ack.add_contents();
         return;
     }

--- a/Frame.cc
+++ b/Frame.cc
@@ -469,6 +469,16 @@ void Frame::ExportRegion(CARTA::FileType file_type, CARTA::CoordinateType coord_
         }
     }
 
+    if (coord_type == CARTA::CoordinateType::WORLD) {
+        const casacore::CoordinateSystem coord_sys = _loader->LoadData(FileInfo::Data::Image)->coordinates();
+        if (!coord_sys.hasDirectionCoordinate()) {
+            export_ack.set_success(false);
+            export_ack.set_message("Export region failed: image coordinate system has no direction coordinate.");
+            export_ack.add_contents();
+            return;
+        }
+    }
+
     // export according to type
     switch (file_type) {
         case CARTA::FileType::CRTF:

--- a/Frame.cc
+++ b/Frame.cc
@@ -275,19 +275,19 @@ void Frame::ImportRegion(
         return;
     }
 
-    // concat contents into one string delimited by newline
     std::string file_contents;
     if (!contents.empty()) {
+        // concat contents into one string delimited by newline
         for (auto& line : contents) {
             file_contents.append(line + "\n");
         }
     }
 
-    std::string message;
-    switch (file_type) {
-        case CARTA::FileType::CRTF: {
-            try {
-                // use RegionTextList to import file and create annotation file lines
+    std::string error_prefix("Import region failed: "), message;
+    try {
+        switch (file_type) {
+            case CARTA::FileType::CRTF: {
+                // use casa RegionTextList to import file and create annotation file lines
                 casa::RegionTextList region_list;
                 bool require_region(false); // import regions outside image
                 if (!filename.empty()) {
@@ -296,47 +296,60 @@ void Frame::ImportRegion(
                 } else {
                     region_list = casa::RegionTextList(coord_sys, file_contents, _image_shape, "", "", "", true, require_region);
                 }
-                // iterate through annotations to create regions if valid
+
+                // iterate through annotations to create regions if valid and add to ack message
                 for (unsigned int iline = 0; iline < region_list.nLines(); ++iline) {
                     casa::AsciiAnnotationFileLine file_line = region_list.lineAt(iline);
                     ImportAnnotationFileLine(file_line, coord_sys, file_type, import_ack, message);
                 }
-            } catch (casacore::AipsError& err) {
-                if (_verbose) {
-                    std::cerr << "Import region failed: " << err.getMesg() << std::endl;
+                break;
+            }
+            case CARTA::FileType::REG: {
+                carta::Ds9Parser parser;
+                if (!filename.empty()) {
+                    parser = carta::Ds9Parser(filename, coord_sys, _image_shape);
+                } else {
+                    parser = carta::Ds9Parser(coord_sys, file_contents, _image_shape);
                 }
-                import_ack.set_success(false);
-                import_ack.set_message("CRTF region file import failed.");
-                import_ack.add_regions();
+
+                // check for failed regions
+                message = parser.GetImportErrors();
+
+                // iterate through annotations to create regions if valid and add to ack message
+                for (unsigned int iline = 0; iline < parser.NumLines(); ++iline) {
+                    casa::AsciiAnnotationFileLine file_line = parser.LineAt(iline);
+                    ImportAnnotationFileLine(file_line, coord_sys, file_type, import_ack, message);
+                }
+                break;
             }
-            break;
-        }
-        case CARTA::FileType::REG: {
-            carta::Ds9Parser parser;
-            if (!filename.empty()) {
-                parser = carta::Ds9Parser(filename, coord_sys, _image_shape);
-            } else {
-                parser = carta::Ds9Parser(coord_sys, file_contents, _image_shape);
+            default: {
+                message = error_prefix + "file type not supported.";
+                break;
             }
-            // iterate through annotations to create regions if valid
-            for (unsigned int iline = 0; iline < parser.NumLines(); ++iline) {
-                casa::AsciiAnnotationFileLine file_line = parser.LineAt(iline);
-                ImportAnnotationFileLine(file_line, coord_sys, file_type, import_ack, message);
-            }
-            break;
         }
-        default: {
-            message = "Import region failed: file type not supported.";
-            break;
+    } catch (casacore::AipsError& err) {
+        casacore::String error_message(err.getMesg());
+        if (_verbose) {
+            std::cerr << error_prefix << error_message << std::endl;
         }
+
+        // shorten error message to user
+        error_message = error_message.before("... thrown by"); // remove casacode file
+        error_message = error_message.before(" at File");      // remove casacode file
+        if (!filename.empty()) {
+            casacore::Path full_path(filename);
+            error_message.gsub(filename, full_path.baseName()); // remove filename path
+        }
+        std::ostringstream oss;
+        oss << error_prefix << error_message;
+        message = oss.str();
     }
 
     // determine success
-    bool success(true);
-    if (import_ack.regions_size() == 0) {
-        success = false;
+    bool success(import_ack.regions_size() > 0);
+    if (!success) {
         if (message.empty()) {
-            message = "Region file import failed: zero regions set";
+            message = error_prefix + "zero regions set";
         }
         import_ack.add_regions();
     }

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -962,89 +962,88 @@ casacore::CountedPtr<const casa::AnnotationBase> Region::AnnotationRegion(bool p
     casa::AnnRegion* ann_region(nullptr);
     casa::AnnSymbol* ann_symbol(nullptr); // not a region
     if (!_control_points.empty()) {
-        try {
-            casacore::Vector<casacore::Stokes::StokesTypes> stokes_types = GetStokesTypes();
-            bool require_region(false);
-            switch (_type) {
-                case CARTA::POINT: {
-                    casacore::Quantity x, y;
-                    if (pixel_coord) {
-                        x = casacore::Quantity(_control_points[0].x(), "pix");
-                        y = casacore::Quantity(_control_points[0].y(), "pix");
-                    } else {
-                        x = _control_points_wcs[0];
-                        y = _control_points_wcs[1];
-                    }
-                    ann_symbol = new casa::AnnSymbol(x, y, _coord_sys, casa::AnnSymbol::POINT, stokes_types);
-                    break;
+        casacore::Vector<casacore::Stokes::StokesTypes> stokes_types = GetStokesTypes();
+        bool require_region(false);
+        switch (_type) {
+            case CARTA::POINT: {
+                casacore::Quantity x, y;
+                if (pixel_coord) {
+                    x = casacore::Quantity(_control_points[0].x(), "pix");
+                    y = casacore::Quantity(_control_points[0].y(), "pix");
+                } else {
+                    x = _control_points_wcs[0];
+                    y = _control_points_wcs[1];
                 }
-                case CARTA::RECTANGLE: {
-                    casacore::Quantity cx, cy, xwidth, ywidth;
-                    if (pixel_coord) {
-                        cx = casacore::Quantity(_control_points[0].x(), "pix");
-                        cy = casacore::Quantity(_control_points[0].y(), "pix");
-                        xwidth = casacore::Quantity(_control_points[1].x(), "pix");
-                        ywidth = casacore::Quantity(_control_points[1].y(), "pix");
-                    } else {
-                        cx = _control_points_wcs[0];
-                        cy = _control_points_wcs[1];
-                        xwidth = _control_points_wcs[2];
-                        ywidth = _control_points_wcs[3];
-                        // adjust width by cosine(declination) for correct import
+                ann_symbol = new casa::AnnSymbol(x, y, _coord_sys, casa::AnnSymbol::POINT, stokes_types);
+                break;
+            }
+            case CARTA::RECTANGLE: {
+                casacore::Quantity cx, cy, xwidth, ywidth;
+                if (pixel_coord) {
+                    cx = casacore::Quantity(_control_points[0].x(), "pix");
+                    cy = casacore::Quantity(_control_points[0].y(), "pix");
+                    xwidth = casacore::Quantity(_control_points[1].x(), "pix");
+                    ywidth = casacore::Quantity(_control_points[1].y(), "pix");
+                } else {
+                    cx = _control_points_wcs[0];
+                    cy = _control_points_wcs[1];
+                    xwidth = _control_points_wcs[2];
+                    ywidth = _control_points_wcs[3];
+                    // adjust width by cosine(declination) for correct import if not linear
+                    if (xwidth.isConform("rad")) {
                         xwidth *= cos(cy);
                     }
-                    if (_rotation == 0.0) {
-                        ann_region = new casa::AnnCenterBox(cx, cy, xwidth, ywidth, _coord_sys, _image_shape, stokes_types, require_region);
-                    } else {
-                        casacore::Quantity position_angle(_rotation, "deg");
-                        ann_region = new casa::AnnRotBox(
-                            cx, cy, xwidth, ywidth, position_angle, _coord_sys, _image_shape, stokes_types, require_region);
-                    }
-                    break;
                 }
-                case CARTA::POLYGON: {
-                    size_t npoints(_control_points.size());
-                    casacore::Vector<casacore::Quantity> x_coords(npoints), y_coords(npoints);
-                    if (pixel_coord) {
-                        for (size_t i = 0; i < npoints; ++i) {
-                            x_coords(i) = casacore::Quantity(_control_points[i].x(), "pix");
-                            y_coords(i) = casacore::Quantity(_control_points[i].y(), "pix");
-                        }
-                    } else {
-                        int point_index(0);
-                        for (size_t i = 0; i < npoints; ++i) {
-                            x_coords(i) = _control_points_wcs[point_index++];
-                            y_coords(i) = _control_points_wcs[point_index++];
-                        }
-                    }
-                    ann_region = new casa::AnnPolygon(x_coords, y_coords, _coord_sys, _image_shape, stokes_types, require_region);
-                    break;
-                }
-                case CARTA::ELLIPSE: {
-                    casacore::Quantity cx, cy, bmaj, bmin;
-                    if (pixel_coord) {
-                        cx = casacore::Quantity(_control_points[0].x(), "pix");
-                        cy = casacore::Quantity(_control_points[0].y(), "pix");
-                        bmaj = casacore::Quantity(_control_points[1].x(), "pix");
-                        bmin = casacore::Quantity(_control_points[1].y(), "pix");
-                    } else {
-                        cx = _control_points_wcs[0];
-                        cy = _control_points_wcs[1];
-                        bmaj = _control_points_wcs[2];
-                        bmin = _control_points_wcs[3];
-                    }
+                if (_rotation == 0.0) {
+                    ann_region = new casa::AnnCenterBox(cx, cy, xwidth, ywidth, _coord_sys, _image_shape, stokes_types, require_region);
+                } else {
                     casacore::Quantity position_angle(_rotation, "deg");
                     ann_region =
-                        new casa::AnnEllipse(cx, cy, bmaj, bmin, position_angle, _coord_sys, _image_shape, stokes_types, require_region);
-                    break;
+                        new casa::AnnRotBox(cx, cy, xwidth, ywidth, position_angle, _coord_sys, _image_shape, stokes_types, require_region);
                 }
-                default:
-                    break;
+                break;
             }
-        } catch (casacore::AipsError& err) {
-            std::cerr << "Export carta region type " << _type << " failed: " << err.getMesg() << std::endl;
+            case CARTA::POLYGON: {
+                size_t npoints(_control_points.size());
+                casacore::Vector<casacore::Quantity> x_coords(npoints), y_coords(npoints);
+                if (pixel_coord) {
+                    for (size_t i = 0; i < npoints; ++i) {
+                        x_coords(i) = casacore::Quantity(_control_points[i].x(), "pix");
+                        y_coords(i) = casacore::Quantity(_control_points[i].y(), "pix");
+                    }
+                } else {
+                    int point_index(0);
+                    for (size_t i = 0; i < npoints; ++i) {
+                        x_coords(i) = _control_points_wcs[point_index++];
+                        y_coords(i) = _control_points_wcs[point_index++];
+                    }
+                }
+                ann_region = new casa::AnnPolygon(x_coords, y_coords, _coord_sys, _image_shape, stokes_types, require_region);
+                break;
+            }
+            case CARTA::ELLIPSE: {
+                casacore::Quantity cx, cy, bmaj, bmin;
+                if (pixel_coord) {
+                    cx = casacore::Quantity(_control_points[0].x(), "pix");
+                    cy = casacore::Quantity(_control_points[0].y(), "pix");
+                    bmaj = casacore::Quantity(_control_points[1].x(), "pix");
+                    bmin = casacore::Quantity(_control_points[1].y(), "pix");
+                } else {
+                    cx = _control_points_wcs[0];
+                    cy = _control_points_wcs[1];
+                    bmaj = _control_points_wcs[2];
+                    bmin = _control_points_wcs[3];
+                }
+                casacore::Quantity position_angle(_rotation, "deg");
+                ann_region =
+                    new casa::AnnEllipse(cx, cy, bmaj, bmin, position_angle, _coord_sys, _image_shape, stokes_types, require_region);
+                break;
+            }
+            default:
+                break;
         }
     }
+
     if (ann_region != nullptr) {
         ann_region->setAnnotationOnly(false);
     }

--- a/Session.cc
+++ b/Session.cc
@@ -505,6 +505,11 @@ void Session::OnImportRegion(const CARTA::ImportRegion& message, uint32_t reques
                 contents = {message.contents().begin(), message.contents().end()};
             }
             _frames.at(file_id)->ImportRegion(file_type, abs_filename, contents, import_ack);
+            std::string ack_message(import_ack.message());
+            if (!ack_message.empty()) { // send message to log
+                CARTA::ErrorSeverity level = (import_ack.success() == true ? CARTA::ErrorSeverity::WARNING : CARTA::ErrorSeverity::ERROR);
+                SendLogEvent(ack_message, {"import"}, level);
+            }
             SendFileEvent(file_id, CARTA::EventType::IMPORT_REGION_ACK, request_id, import_ack);
         } catch (std::out_of_range& range_error) {
             std::string error = fmt::format("File id {} closed", file_id);


### PR DESCRIPTION
Issues #334 and #343 

- Importing regions with no direction coordinate causes an exception (even for pixel imports, for now).  The image's coordinate system is checked and a warning issued, and the region import fails.
- When a region's syntax or definition fails, the import fails for CRTF region files but succeeds for DS9 region files if any regions are successfully imported; warnings are issued for the failed regions.
- If the region file does not exist, the import fails.