### PR TITLE
Angus/contouring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ set(LINK_LIBS
         crypto
         z
         zfp
+        zstd
         tbb
         casa_casa
         casa_coordinates

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,12 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 # processes only, set EnableAvx to ON
 #set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=native")
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
-option(EnableAvx "Enable AVX codepaths instead of SSE2" OFF)
+option(EnableAvx "Enable AVX codepaths instead of SSE4" OFF)
+
 if (EnableAvx)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx")
+else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4")
 endif()
 
 # use -DAuthServer:BOOL=ON to link mongodb and jsonccpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,9 @@ set(SOURCE_FILES
         Util.cc
         FileListHandler.cc
         Tile.cc
-        Ds9Parser.cc Contouring.cc Contouring.h Smoothing.cc Smoothing.h)
+        Ds9Parser.cc
+        Contouring.cc
+        Smoothing.cc)
 
 add_definitions(-DHAVE_HDF5)
 add_executable(carta_backend ${SOURCE_FILES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,10 +5,16 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_INCLUDE_DIRECTORIES_BEFORE ON)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+
 # Use the -march=native flags when building on the same architecture as deploying to get a slight performance
-# increase when running CPU intensive tasks such as compression and down-sampling of data
+# increase when running CPU intensive tasks such as compression and down-sampling of data. If targeting AVX-capable
+# processes only, set EnableAvx to ON
 #set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=native")
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+option(EnableAvx "Enable AVX codepaths instead of SSE2" OFF)
+if (EnableAvx)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx")
+endif()
 
 # use -DAuthServer:BOOL=ON to link mongodb and jsonccpp
 option(AuthServer "AuthServer" OFF)
@@ -83,7 +89,7 @@ set(SOURCE_FILES
         Util.cc
         FileListHandler.cc
         Tile.cc
-        Ds9Parser.cc)
+        Ds9Parser.cc Contouring.cc Contouring.h Smoothing.cc Smoothing.h)
 
 add_definitions(-DHAVE_HDF5)
 add_executable(carta_backend ${SOURCE_FILES})

--- a/Compression.cc
+++ b/Compression.cc
@@ -168,14 +168,23 @@ void EncodeIntegers(std::vector<int32_t>& array, bool strided) {
 
     if (strided) {
         // Delta-encoding of neighbouring vertices to improve compression
-        for (size_t i = 0; i < N - 3; i += 2) {
-            array[i] = array[i + 2] - array[i];
-            array[i + 1] = array[i + 3] - array[i + 1];
+        int lastX = 0;
+        int lastY = 0;
+        for (size_t i = 0; i < N - 1; i += 2) {
+            int currentX = array[i];
+            int currentY = array[i + 1];
+            array[i] = currentX - lastX;
+            array[i + 1] = currentY - lastY;
+            lastX = currentX;
+            lastY = currentY;
         }
     } else {
         // Delta-encoding of neighbouring integers to improve compression
-        for (size_t i = 0; i < N - 1; i++) {
-            array[i] = array[i + 1] - array[i];
+        int last = 0;
+        for (size_t i = 0; i < N; i++) {
+            int current = array[i];
+            array[i] = current - last;
+            last = current;
         }
     }
 

--- a/Compression.cc
+++ b/Compression.cc
@@ -46,38 +46,6 @@ int Compress(vector<float>& array, size_t offset, vector<char>& compression_buff
     return status;
 }
 
-int Decompress(
-    vector<float>& array, vector<char>& compression_buffer, size_t& compressed_size, uint32_t nx, uint32_t ny, uint32_t precision) {
-    int status = 0;    /* return value: 0 = success */
-    zfp_type type;     /* array scalar type */
-    zfp_field* field;  /* array meta data */
-    zfp_stream* zfp;   /* compressed stream */
-    bitstream* stream; /* bit stream to write to or read from */
-
-    /* allocate meta data for the 3D array a[nz][ny][nx] */
-    type = zfp_type_float;
-    field = zfp_field_2d(array.data(), type, nx, ny);
-
-    /* allocate meta data for a compressed stream */
-    zfp = zfp_stream_open(nullptr);
-    zfp_stream_set_precision(zfp, precision);
-
-    stream = stream_open(compression_buffer.data(), compressed_size);
-    zfp_stream_set_bit_stream(zfp, stream);
-    zfp_stream_rewind(zfp);
-
-    if (!zfp_decompress(zfp, field)) {
-        // fmt::print("decompression failed\n");
-        status = 1;
-    }
-    /* clean up */
-    zfp_field_free(field);
-    zfp_stream_close(zfp);
-    stream_close(stream);
-
-    return status;
-}
-
 // Removes NaNs from an array and returns run-length encoded list of NaNs
 vector<int32_t> GetNanEncodingsSimple(vector<float>& array, int offset, int length) {
     int32_t prev_index = offset;

--- a/Compression.cc
+++ b/Compression.cc
@@ -164,7 +164,7 @@ void RoundAndEncodeVertices(const std::vector<float>& array, std::vector<int32_t
 void EncodeIntegers(std::vector<int32_t>& array, bool strided) {
     const int num_values = array.size();
     const int blocked_length = 4 * (num_values / 4);
-    std::array<uint8_t, 16> shuffle_vals = {0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15};
+    const std::array<uint8_t, 16> shuffle_vals = {0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15};
 
     if (strided) {
         // Delta-encoding of neighbouring vertices to improve compression

--- a/Compression.cc
+++ b/Compression.cc
@@ -140,11 +140,11 @@ vector<int32_t> GetNanEncodingsBlock(vector<float>& array, int offset, int w, in
 
 // This function transforms an array of 2D vertices from contour data in order to improve compression ratios
 void RoundAndEncodeVertices(const std::vector<float>& array, std::vector<int32_t>& dest, float rounding_factor) {
-    const int N = array.size();
-    dest.resize(N);
+    const int num_values = array.size();
+    dest.resize(num_values);
     int i = 0;
 
-    const int blocked_length = 4 * (N / 4);
+    const int blocked_length = 4 * (num_values / 4);
     // Run through the vertices in groups of 4, rounding to the nearest Nth of a pixel
     for (i = 0; i < blocked_length; i += 4) {
         __m128 vertices_vector = _mm_loadu_ps(&array[i]);
@@ -154,7 +154,7 @@ void RoundAndEncodeVertices(const std::vector<float>& array, std::vector<int32_t
     }
 
     // Round the remaining pixels
-    for (i = blocked_length; i < N; i++) {
+    for (i = blocked_length; i < num_values; i++) {
         dest[i] = round(array[i] * rounding_factor);
     }
 
@@ -162,15 +162,15 @@ void RoundAndEncodeVertices(const std::vector<float>& array, std::vector<int32_t
 }
 
 void EncodeIntegers(std::vector<int32_t>& array, bool strided) {
-    const int N = array.size();
-    const int blocked_length = 4 * (N / 4);
+    const int num_values = array.size();
+    const int blocked_length = 4 * (num_values / 4);
     std::array<uint8_t, 16> shuffle_vals = {0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15};
 
     if (strided) {
         // Delta-encoding of neighbouring vertices to improve compression
         int last_x = 0;
         int last_y = 0;
-        for (size_t i = 0; i < N - 1; i += 2) {
+        for (size_t i = 0; i < num_values - 1; i += 2) {
             int current_x = array[i];
             int current_y = array[i + 1];
             array[i] = current_x - last_x;
@@ -181,7 +181,7 @@ void EncodeIntegers(std::vector<int32_t>& array, bool strided) {
     } else {
         // Delta-encoding of neighbouring integers to improve compression
         int last = 0;
-        for (size_t i = 0; i < N; i++) {
+        for (size_t i = 0; i < num_values; i++) {
             int current = array[i];
             array[i] = current - last;
             last = current;

--- a/Compression.cc
+++ b/Compression.cc
@@ -168,15 +168,15 @@ void EncodeIntegers(std::vector<int32_t>& array, bool strided) {
 
     if (strided) {
         // Delta-encoding of neighbouring vertices to improve compression
-        int lastX = 0;
-        int lastY = 0;
+        int last_x = 0;
+        int last_y = 0;
         for (size_t i = 0; i < N - 1; i += 2) {
-            int currentX = array[i];
-            int currentY = array[i + 1];
-            array[i] = currentX - lastX;
-            array[i + 1] = currentY - lastY;
-            lastX = currentX;
-            lastY = currentY;
+            int current_x = array[i];
+            int current_y = array[i + 1];
+            array[i] = current_x - last_x;
+            array[i + 1] = current_y - last_y;
+            last_x = current_x;
+            last_y = current_y;
         }
     } else {
         // Delta-encoding of neighbouring integers to improve compression

--- a/Compression.cc
+++ b/Compression.cc
@@ -3,13 +3,13 @@
 #include <array>
 #include <cmath>
 
-#include <zfp.h>
 #include <x86intrin.h>
+#include <zfp.h>
 
 using namespace std;
 
 int Compress(vector<float>& array, size_t offset, vector<char>& compression_buffer, size_t& compressed_size, uint32_t nx, uint32_t ny,
-             uint32_t precision) {
+    uint32_t precision) {
     int status = 0;     /* return value: 0 = success */
     zfp_type type;      /* array scalar type */
     zfp_field* field;   /* array meta data */
@@ -150,7 +150,7 @@ void RoundAndEncodeVertices(const std::vector<float>& array, std::vector<int32_t
         __m128 vertices_vector = _mm_loadu_ps(&array[i]);
         // If we prefer truncation, then _mm_cvttps_epi32 should be used instead
         __m128i rounded_vals = _mm_cvtps_epi32(vertices_vector * rounding_factor);
-        _mm_store_si128((__m128i*) &dest[i], rounded_vals);
+        _mm_store_si128((__m128i*)&dest[i], rounded_vals);
     }
 
     // Round the remaining pixels
@@ -190,8 +190,8 @@ void EncodeIntegers(std::vector<int32_t>& array, bool strided) {
 
     // Shuffle bytes in blocks of 126 bits (4 floats). The remaining bytes are left along
     for (size_t i = 0; i < blocked_length; i += 4) {
-        __m128i vals = _mm_loadu_si128((__m128i*) &array[i]);
-        vals = _mm_shuffle_epi8(vals, *(__m128i*) shuffle_vals.data());
-        _mm_store_si128((__m128i*) &array[i], vals);
+        __m128i vals = _mm_loadu_si128((__m128i*)&array[i]);
+        vals = _mm_shuffle_epi8(vals, *(__m128i*)shuffle_vals.data());
+        _mm_store_si128((__m128i*)&array[i], vals);
     }
 }

--- a/Compression.h
+++ b/Compression.h
@@ -7,8 +7,6 @@
 
 int Compress(std::vector<float>& array, size_t offset, std::vector<char>& compression_buffer, std::size_t& compressed_size, uint32_t nx,
     uint32_t ny, uint32_t precision);
-int Decompress(std::vector<float>& array, std::vector<char>& compression_buffer, std::size_t& compressed_size, uint32_t nx, uint32_t ny,
-    uint32_t precision);
 std::vector<int32_t> GetNanEncodingsSimple(std::vector<float>& array, int offset, int length);
 std::vector<int32_t> GetNanEncodingsBlock(std::vector<float>& array, int offset, int w, int h);
 

--- a/Compression.h
+++ b/Compression.h
@@ -10,4 +10,6 @@ int Compress(std::vector<float>& array, size_t offset, std::vector<char>& compre
 std::vector<int32_t> GetNanEncodingsSimple(std::vector<float>& array, int offset, int length);
 std::vector<int32_t> GetNanEncodingsBlock(std::vector<float>& array, int offset, int w, int h);
 
+void RoundAndEncodeVertices(const std::vector<float>& array, std::vector<int32_t>& dest, float rounding_factor);
+void EncodeIntegers(std::vector<int32_t>& array, bool strided = false);
 #endif // CARTA_BACKEND__COMPRESSION_H_

--- a/Contouring.cc
+++ b/Contouring.cc
@@ -13,8 +13,8 @@ using namespace std;
 // Contour tracing code adapted from SAOImage DS9: https://github.com/SAOImageDS9/SAOImageDS9
 void traceSegment(const float* image,
                   std::vector<bool>& visited,
-                  int width,
-                  int height,
+                  int64_t width,
+                  int64_t height,
                   double scale,
                   double offset,
                   double level,
@@ -22,8 +22,8 @@ void traceSegment(const float* image,
                   int y_cell,
                   int side,
                   vector<float>& vertices) {
-    int i = x_cell;
-    int j = y_cell;
+    int64_t i = x_cell;
+    int64_t j = y_cell;
     int orig_side = side;
 
     bool first_iteration = true;
@@ -124,10 +124,10 @@ void traceSegment(const float* image,
     }
 }
 
-void traceLevel(const float* image, int width, int height, double scale, double offset, double level, vector<float>& vertices, vector<int32_t>& indices) {
-    int N = width * height;
+void traceLevel(const float* image, int64_t width, int64_t height, double scale, double offset, double level, vector<float>& vertices, vector<int32_t>& indices) {
+    int64_t N = width * height;
     vector<bool> visited(N);
-    int i, j;
+    int64_t i, j;
 
     // Search TopEdge
     for (j = 0, i = 0; i < width - 1; i++) {
@@ -172,8 +172,8 @@ void traceLevel(const float* image, int width, int height, double scale, double 
     }
 }
 
-void TraceSingleContour(float* image, int width, int height, double scale, double offset, double level, std::vector<float>& vertex_data, std::vector<int32_t>& indices) {
-    int N = width * height;
+void TraceSingleContour(float* image, int64_t width, int64_t height, double scale, double offset, double level, std::vector<float>& vertex_data, std::vector<int32_t>& indices) {
+    int64_t N = width * height;
     vertex_data.clear();
     indices.clear();
 
@@ -185,28 +185,28 @@ void TraceSingleContour(float* image, int width, int height, double scale, doubl
     traceLevel(image, width, height, scale, offset, level, vertex_data, indices);
 }
 
-void TraceContours(float* image, int width, int height, double scale, double offset, const std::vector<double>& levels, std::vector<std::vector<float>>& vertex_data,
+void TraceContours(float* image, int64_t width, int64_t height, double scale, double offset, const std::vector<double>& levels, std::vector<std::vector<float>>& vertex_data,
                    std::vector<std::vector<int32_t>>& index_data) {
     auto t_start_contours = std::chrono::high_resolution_clock::now();
     vertex_data.resize(levels.size());
     index_data.resize(levels.size());
 
-    size_t N = width * height;
-    for (size_t i = 0; i < N; i++) {
+    int64_t N = width * height;
+    for (int64_t i = 0; i < N; i++) {
         if (isnan(image[i])) {
             image[i] = -std::numeric_limits<float>::max();
         }
     }
 
-    auto loop = [&](const tbb::blocked_range<int>& r) {
-        for (int l = r.begin(); l < r.end(); l++) {
+    auto loop = [&](const tbb::blocked_range<int64_t>& r) {
+        for (int64_t l = r.begin(); l < r.end(); l++) {
             vertex_data[l].clear();
             index_data[l].clear();
             traceLevel(image, width, height, scale, offset, levels[l], vertex_data[l], index_data[l]);
         }
     };
 
-    tbb::parallel_for(tbb::blocked_range<int>(0, levels.size()), loop);
+    tbb::parallel_for(tbb::blocked_range<int64_t>(0, levels.size()), loop);
     auto t_end_contours = std::chrono::high_resolution_clock::now();
     auto dt_contours = std::chrono::duration_cast<std::chrono::microseconds>(t_end_contours - t_start_contours).count();
     auto rate_contours = width * height / (double) dt_contours;

--- a/Contouring.cc
+++ b/Contouring.cc
@@ -186,7 +186,7 @@ void TraceSingleContour(float* image, int64_t width, int64_t height, double scal
 }
 
 void TraceContours(float* image, int64_t width, int64_t height, double scale, double offset, const std::vector<double>& levels, std::vector<std::vector<float>>& vertex_data,
-                   std::vector<std::vector<int32_t>>& index_data) {
+                   std::vector<std::vector<int32_t>>& index_data, bool verbose_logging) {
     auto t_start_contours = std::chrono::high_resolution_clock::now();
     vertex_data.resize(levels.size());
     index_data.resize(levels.size());
@@ -207,18 +207,21 @@ void TraceContours(float* image, int64_t width, int64_t height, double scale, do
     };
 
     tbb::parallel_for(tbb::blocked_range<int64_t>(0, levels.size()), loop);
-    auto t_end_contours = std::chrono::high_resolution_clock::now();
-    auto dt_contours = std::chrono::duration_cast<std::chrono::microseconds>(t_end_contours - t_start_contours).count();
-    auto rate_contours = width * height / (double) dt_contours;
-    int vertex_count = 0;
-    int segment_count = 0;
-    for (auto& vertices : vertex_data) {
-        vertex_count += vertices.size();
-    }
-    for (auto& indices : index_data) {
-        segment_count += indices.size();
-    }
 
-    fmt::print("Contoured {}x{} image in {} ms at {} MPix/s. Found {} vertices in {} segments across {} levels\n", width, height,
-               dt_contours * 1e-3, rate_contours, vertex_count, segment_count, levels.size());
+    if (verbose_logging) {
+        auto t_end_contours = std::chrono::high_resolution_clock::now();
+        auto dt_contours = std::chrono::duration_cast<std::chrono::microseconds>(t_end_contours - t_start_contours).count();
+        auto rate_contours = width * height / (double) dt_contours;
+        int vertex_count = 0;
+        int segment_count = 0;
+        for (auto& vertices : vertex_data) {
+            vertex_count += vertices.size();
+        }
+        for (auto& indices : index_data) {
+            segment_count += indices.size();
+        }
+
+        fmt::print("Contoured {}x{} image in {} ms at {} MPix/s. Found {} vertices in {} segments across {} levels\n", width, height,
+                   dt_contours * 1e-3, rate_contours, vertex_count, segment_count, levels.size());
+    }
 }

--- a/Contouring.cc
+++ b/Contouring.cc
@@ -124,8 +124,8 @@ void TraceSegment(const float* image, std::vector<bool>& visited, int64_t width,
 
 void TraceLevel(const float* image, int64_t width, int64_t height, double scale, double offset, double level, vector<float>& vertices,
     vector<int32_t>& indices) {
-    int64_t N = width * height;
-    vector<bool> visited(N);
+    int64_t num_pixels = width * height;
+    vector<bool> visited(num_pixels);
     int64_t i, j;
 
     // Search TopEdge
@@ -173,11 +173,11 @@ void TraceLevel(const float* image, int64_t width, int64_t height, double scale,
 
 void TraceSingleContour(float* image, int64_t width, int64_t height, double scale, double offset, double level,
     std::vector<float>& vertex_data, std::vector<int32_t>& indices) {
-    int64_t N = width * height;
+    int64_t num_pixels = width * height;
     vertex_data.clear();
     indices.clear();
 
-    for (auto i = 0; i < N; i++) {
+    for (auto i = 0; i < num_pixels; i++) {
         if (isnan(image[i])) {
             image[i] = -std::numeric_limits<float>::max();
         }
@@ -191,8 +191,8 @@ void TraceContours(float* image, int64_t width, int64_t height, double scale, do
     vertex_data.resize(levels.size());
     index_data.resize(levels.size());
 
-    int64_t N = width * height;
-    for (int64_t i = 0; i < N; i++) {
+    int64_t num_pixels = width * height;
+    for (int64_t i = 0; i < num_pixels; i++) {
         if (isnan(image[i])) {
             image[i] = -std::numeric_limits<float>::max();
         }

--- a/Contouring.cc
+++ b/Contouring.cc
@@ -1,0 +1,224 @@
+#include "Contouring.h"
+
+#include <chrono>
+#include <cmath>
+#include <limits>
+#include <vector>
+
+#include <fmt/format.h>
+#include <tbb/tbb.h>
+
+using namespace std;
+
+// Contour tracing code adapted from SAOImage DS9: https://github.com/SAOImageDS9/SAOImageDS9
+void traceSegment(const float* image,
+                  std::vector<bool>& visited,
+                  int width,
+                  int height,
+                  double scale,
+                  double offset,
+                  double level,
+                  int x_cell,
+                  int y_cell,
+                  int side,
+                  vector<float>& vertices) {
+    int i = x_cell;
+    int j = y_cell;
+    int orig_side = side;
+
+    bool first_iteration = true;
+    bool done = (i < 0 || i >= width - 1 || (j < 0 && j >= height - 1));
+
+    while (!done) {
+        bool flag = false;
+        double a = image[(j) * width + i];
+        double b = image[(j) * width + i + 1];
+        double c = image[(j + 1) * width + i + 1];
+        double d = image[(j + 1) * width + i];
+
+        double X = 0, Y = 0;
+        if (first_iteration) {
+            first_iteration = false;
+            switch (side) {
+                case Edge::TopEdge:X = (level - a) / (b - a) + i;
+                    Y = j;
+                    break;
+                case Edge::RightEdge:X = i + 1;
+                    Y = (level - b) / (c - b) + j;
+                    break;
+                case Edge::BottomEdge:X = (level - c) / (d - c) + i;
+                    Y = j + 1;
+                    break;
+                case Edge::LeftEdge:X = i;
+                    Y = (level - a) / (d - a) + j;
+                    break;
+                default:break;
+            }
+
+        } else {
+            if (side == Edge::TopEdge) {
+                visited[j * width + i] = true;
+            }
+
+            do {
+                if (++side == Edge::None) {
+                    side = Edge::TopEdge;
+                }
+
+                switch (side) {
+                    case Edge::TopEdge:
+                        if (a >= level && level > b) {
+                            flag = true;
+                            X = (level - a) / (b - a) + i;
+                            Y = j;
+                            j--;
+                        }
+                        break;
+                    case Edge::RightEdge:
+                        if (b >= level && level > c) {
+                            flag = true;
+                            X = i + 1;
+                            Y = (level - b) / (c - b) + j;
+                            i++;
+                        }
+                        break;
+                    case Edge::BottomEdge:
+                        if (c >= level && level > d) {
+                            flag = true;
+                            X = (level - d) / (c - d) + i;
+                            Y = j + 1;
+                            j++;
+                        }
+                        break;
+                    case Edge::LeftEdge:
+                        if (d >= level && level > a) {
+                            flag = true;
+                            X = i;
+                            Y = (level - a) / (d - a) + j;
+                            i--;
+                        }
+                        break;
+                    default:break;
+                }
+            } while (!flag);
+
+            if (++side == Edge::None) {
+                side = Edge::TopEdge;
+            }
+            if (++side == Edge::None) {
+                side = Edge::TopEdge;
+            }
+            if (i == x_cell && j == y_cell && side == orig_side) {
+                done = true;
+            }
+            if (i < 0 || i >= width - 1 || j < 0 || j >= height - 1) {
+                done = true;
+            }
+        }
+
+        // Shift to pixel center
+        double xVal = X + 0.5;
+        double yVal = Y + 0.5;
+        vertices.push_back(scale * xVal + offset);
+        vertices.push_back(scale * yVal + offset);
+    }
+}
+
+void traceLevel(const float* image, int width, int height, double scale, double offset, double level, vector<float>& vertices, vector<int32_t>& indices) {
+    int N = width * height;
+    vector<bool> visited(N);
+    int i, j;
+
+    // Search TopEdge
+    for (j = 0, i = 0; i < width - 1; i++) {
+        if (image[(j) * width + i] < level && level <= image[(j) * width + i + 1]) {
+            indices.push_back(vertices.size());
+            traceSegment(image, visited, width, height, scale, offset, level, i, j, Edge::TopEdge, vertices);
+        }
+    }
+
+    // Search RightEdge
+    for (j = 0; j < height - 1; j++) {
+        if (image[(j) * width + i] < level && level <= image[(j + 1) * width + i]) {
+            indices.push_back(vertices.size());
+            traceSegment(image, visited, width, height, scale, offset, level, i - 1, j, Edge::RightEdge, vertices);
+        }
+    }
+
+    // Search Bottom
+    for (i--; i >= 0; i--) {
+        if (image[(j) * width + i + 1] < level && level <= image[(j) * width + i]) {
+            indices.push_back(vertices.size());
+            traceSegment(image, visited, width, height, scale, offset, level, i, j - 1, Edge::BottomEdge, vertices);
+        }
+    }
+
+    // Search Left
+    for (i = 0, j--; j >= 0; j--) {
+        if (image[(j + 1) * width + i] < level && level <= image[(j) * width + i]) {
+            indices.push_back(vertices.size());
+            traceSegment(image, visited, width, height, scale, offset, level, i, j, Edge::LeftEdge, vertices);
+        }
+    }
+
+    // Search each row of the image
+    for (j = 1; j < height - 1; j++) {
+        for (i = 0; i < width - 1; i++) {
+            if (!visited[j * width + i] && image[(j) * width + i] < level && level <= image[(j) * width + i + 1]) {
+                indices.push_back(vertices.size());
+                traceSegment(image, visited, width, height, scale, offset, level, i, j, TopEdge, vertices);
+            }
+        }
+    }
+}
+
+void TraceSingleContour(float* image, int width, int height, double scale, double offset, double level, std::vector<float>& vertex_data, std::vector<int32_t>& indices) {
+    int N = width * height;
+    vertex_data.clear();
+    indices.clear();
+
+    for (auto i = 0; i < N; i++) {
+        if (isnan(image[i])) {
+            image[i] = -std::numeric_limits<float>::max();
+        }
+    }
+    traceLevel(image, width, height, scale, offset, level, vertex_data, indices);
+}
+
+void TraceContours(float* image, int width, int height, double scale, double offset, const std::vector<double>& levels, std::vector<std::vector<float>>& vertex_data,
+                   std::vector<std::vector<int32_t>>& index_data) {
+    auto t_start_contours = std::chrono::high_resolution_clock::now();
+    vertex_data.resize(levels.size());
+    index_data.resize(levels.size());
+
+    size_t N = width * height;
+    for (size_t i = 0; i < N; i++) {
+        if (isnan(image[i])) {
+            image[i] = -std::numeric_limits<float>::max();
+        }
+    }
+
+    auto loop = [&](const tbb::blocked_range<int>& r) {
+        for (int l = r.begin(); l < r.end(); l++) {
+            vertex_data[l].clear();
+            index_data[l].clear();
+            traceLevel(image, width, height, scale, offset, levels[l], vertex_data[l], index_data[l]);
+        }
+    };
+
+    tbb::parallel_for(tbb::blocked_range<int>(0, levels.size()), loop);
+    auto t_end_contours = std::chrono::high_resolution_clock::now();
+    auto dt_contours = std::chrono::duration_cast<std::chrono::microseconds>(t_end_contours - t_start_contours).count();
+    auto rate_contours = width * height / (double) dt_contours;
+    int vertex_count = 0;
+    int segment_count = 0;
+    for (auto& vertices : vertex_data) {
+        vertex_count += vertices.size();
+    }
+    for (auto& indices : index_data) {
+        segment_count += indices.size();
+    }
+
+    fmt::print("Contoured {}x{} image in {} ms at {} MPix/s. Found {} vertices in {} segments across {} levels\n", width, height,
+               dt_contours * 1e-3, rate_contours, vertex_count, segment_count, levels.size());
+}

--- a/Contouring.cc
+++ b/Contouring.cc
@@ -11,7 +11,7 @@
 using namespace std;
 
 // Contour tracing code adapted from SAOImage DS9: https://github.com/SAOImageDS9/SAOImageDS9
-void traceSegment(const float* image, std::vector<bool>& visited, int64_t width, int64_t height, double scale, double offset, double level,
+void TraceSegment(const float* image, std::vector<bool>& visited, int64_t width, int64_t height, double scale, double offset, double level,
     int x_cell, int y_cell, int side, vector<float>& vertices) {
     int64_t i = x_cell;
     int64_t j = y_cell;
@@ -27,25 +27,26 @@ void traceSegment(const float* image, std::vector<bool>& visited, int64_t width,
         double c = image[(j + 1) * width + i + 1];
         double d = image[(j + 1) * width + i];
 
-        double X = 0, Y = 0;
+        double x = 0;
+        double y = 0;
         if (first_iteration) {
             first_iteration = false;
             switch (side) {
                 case Edge::TopEdge:
-                    X = (level - a) / (b - a) + i;
-                    Y = j;
+                    x = (level - a) / (b - a) + i;
+                    y = j;
                     break;
                 case Edge::RightEdge:
-                    X = i + 1;
-                    Y = (level - b) / (c - b) + j;
+                    x = i + 1;
+                    y = (level - b) / (c - b) + j;
                     break;
                 case Edge::BottomEdge:
-                    X = (level - c) / (d - c) + i;
-                    Y = j + 1;
+                    x = (level - c) / (d - c) + i;
+                    y = j + 1;
                     break;
                 case Edge::LeftEdge:
-                    X = i;
-                    Y = (level - a) / (d - a) + j;
+                    x = i;
+                    y = (level - a) / (d - a) + j;
                     break;
                 default:
                     break;
@@ -65,32 +66,32 @@ void traceSegment(const float* image, std::vector<bool>& visited, int64_t width,
                     case Edge::TopEdge:
                         if (a >= level && level > b) {
                             flag = true;
-                            X = (level - a) / (b - a) + i;
-                            Y = j;
+                            x = (level - a) / (b - a) + i;
+                            y = j;
                             j--;
                         }
                         break;
                     case Edge::RightEdge:
                         if (b >= level && level > c) {
                             flag = true;
-                            X = i + 1;
-                            Y = (level - b) / (c - b) + j;
+                            x = i + 1;
+                            y = (level - b) / (c - b) + j;
                             i++;
                         }
                         break;
                     case Edge::BottomEdge:
                         if (c >= level && level > d) {
                             flag = true;
-                            X = (level - d) / (c - d) + i;
-                            Y = j + 1;
+                            x = (level - d) / (c - d) + i;
+                            y = j + 1;
                             j++;
                         }
                         break;
                     case Edge::LeftEdge:
                         if (d >= level && level > a) {
                             flag = true;
-                            X = i;
-                            Y = (level - a) / (d - a) + j;
+                            x = i;
+                            y = (level - a) / (d - a) + j;
                             i--;
                         }
                         break;
@@ -114,14 +115,14 @@ void traceSegment(const float* image, std::vector<bool>& visited, int64_t width,
         }
 
         // Shift to pixel center
-        double xVal = X + 0.5;
-        double yVal = Y + 0.5;
-        vertices.push_back(scale * xVal + offset);
-        vertices.push_back(scale * yVal + offset);
+        double x_val = x + 0.5;
+        double y_val = y + 0.5;
+        vertices.push_back(scale * x_val + offset);
+        vertices.push_back(scale * y_val + offset);
     }
 }
 
-void traceLevel(const float* image, int64_t width, int64_t height, double scale, double offset, double level, vector<float>& vertices,
+void TraceLevel(const float* image, int64_t width, int64_t height, double scale, double offset, double level, vector<float>& vertices,
     vector<int32_t>& indices) {
     int64_t N = width * height;
     vector<bool> visited(N);
@@ -131,7 +132,7 @@ void traceLevel(const float* image, int64_t width, int64_t height, double scale,
     for (j = 0, i = 0; i < width - 1; i++) {
         if (image[(j)*width + i] < level && level <= image[(j)*width + i + 1]) {
             indices.push_back(vertices.size());
-            traceSegment(image, visited, width, height, scale, offset, level, i, j, Edge::TopEdge, vertices);
+            TraceSegment(image, visited, width, height, scale, offset, level, i, j, Edge::TopEdge, vertices);
         }
     }
 
@@ -139,7 +140,7 @@ void traceLevel(const float* image, int64_t width, int64_t height, double scale,
     for (j = 0; j < height - 1; j++) {
         if (image[(j)*width + i] < level && level <= image[(j + 1) * width + i]) {
             indices.push_back(vertices.size());
-            traceSegment(image, visited, width, height, scale, offset, level, i - 1, j, Edge::RightEdge, vertices);
+            TraceSegment(image, visited, width, height, scale, offset, level, i - 1, j, Edge::RightEdge, vertices);
         }
     }
 
@@ -147,7 +148,7 @@ void traceLevel(const float* image, int64_t width, int64_t height, double scale,
     for (i--; i >= 0; i--) {
         if (image[(j)*width + i + 1] < level && level <= image[(j)*width + i]) {
             indices.push_back(vertices.size());
-            traceSegment(image, visited, width, height, scale, offset, level, i, j - 1, Edge::BottomEdge, vertices);
+            TraceSegment(image, visited, width, height, scale, offset, level, i, j - 1, Edge::BottomEdge, vertices);
         }
     }
 
@@ -155,7 +156,7 @@ void traceLevel(const float* image, int64_t width, int64_t height, double scale,
     for (i = 0, j--; j >= 0; j--) {
         if (image[(j + 1) * width + i] < level && level <= image[(j)*width + i]) {
             indices.push_back(vertices.size());
-            traceSegment(image, visited, width, height, scale, offset, level, i, j, Edge::LeftEdge, vertices);
+            TraceSegment(image, visited, width, height, scale, offset, level, i, j, Edge::LeftEdge, vertices);
         }
     }
 
@@ -164,7 +165,7 @@ void traceLevel(const float* image, int64_t width, int64_t height, double scale,
         for (i = 0; i < width - 1; i++) {
             if (!visited[j * width + i] && image[(j)*width + i] < level && level <= image[(j)*width + i + 1]) {
                 indices.push_back(vertices.size());
-                traceSegment(image, visited, width, height, scale, offset, level, i, j, TopEdge, vertices);
+                TraceSegment(image, visited, width, height, scale, offset, level, i, j, TopEdge, vertices);
             }
         }
     }
@@ -181,7 +182,7 @@ void TraceSingleContour(float* image, int64_t width, int64_t height, double scal
             image[i] = -std::numeric_limits<float>::max();
         }
     }
-    traceLevel(image, width, height, scale, offset, level, vertex_data, indices);
+    TraceLevel(image, width, height, scale, offset, level, vertex_data, indices);
 }
 
 void TraceContours(float* image, int64_t width, int64_t height, double scale, double offset, const std::vector<double>& levels,
@@ -201,7 +202,7 @@ void TraceContours(float* image, int64_t width, int64_t height, double scale, do
         for (int64_t l = r.begin(); l < r.end(); l++) {
             vertex_data[l].clear();
             index_data[l].clear();
-            traceLevel(image, width, height, scale, offset, levels[l], vertex_data[l], index_data[l]);
+            TraceLevel(image, width, height, scale, offset, levels[l], vertex_data[l], index_data[l]);
         }
     };
 

--- a/Contouring.cc
+++ b/Contouring.cc
@@ -11,17 +11,8 @@
 using namespace std;
 
 // Contour tracing code adapted from SAOImage DS9: https://github.com/SAOImageDS9/SAOImageDS9
-void traceSegment(const float* image,
-                  std::vector<bool>& visited,
-                  int64_t width,
-                  int64_t height,
-                  double scale,
-                  double offset,
-                  double level,
-                  int x_cell,
-                  int y_cell,
-                  int side,
-                  vector<float>& vertices) {
+void traceSegment(const float* image, std::vector<bool>& visited, int64_t width, int64_t height, double scale, double offset, double level,
+    int x_cell, int y_cell, int side, vector<float>& vertices) {
     int64_t i = x_cell;
     int64_t j = y_cell;
     int orig_side = side;
@@ -31,8 +22,8 @@ void traceSegment(const float* image,
 
     while (!done) {
         bool flag = false;
-        double a = image[(j) * width + i];
-        double b = image[(j) * width + i + 1];
+        double a = image[(j)*width + i];
+        double b = image[(j)*width + i + 1];
         double c = image[(j + 1) * width + i + 1];
         double d = image[(j + 1) * width + i];
 
@@ -40,19 +31,24 @@ void traceSegment(const float* image,
         if (first_iteration) {
             first_iteration = false;
             switch (side) {
-                case Edge::TopEdge:X = (level - a) / (b - a) + i;
+                case Edge::TopEdge:
+                    X = (level - a) / (b - a) + i;
                     Y = j;
                     break;
-                case Edge::RightEdge:X = i + 1;
+                case Edge::RightEdge:
+                    X = i + 1;
                     Y = (level - b) / (c - b) + j;
                     break;
-                case Edge::BottomEdge:X = (level - c) / (d - c) + i;
+                case Edge::BottomEdge:
+                    X = (level - c) / (d - c) + i;
                     Y = j + 1;
                     break;
-                case Edge::LeftEdge:X = i;
+                case Edge::LeftEdge:
+                    X = i;
                     Y = (level - a) / (d - a) + j;
                     break;
-                default:break;
+                default:
+                    break;
             }
 
         } else {
@@ -98,7 +94,8 @@ void traceSegment(const float* image,
                             i--;
                         }
                         break;
-                    default:break;
+                    default:
+                        break;
                 }
             } while (!flag);
 
@@ -124,14 +121,15 @@ void traceSegment(const float* image,
     }
 }
 
-void traceLevel(const float* image, int64_t width, int64_t height, double scale, double offset, double level, vector<float>& vertices, vector<int32_t>& indices) {
+void traceLevel(const float* image, int64_t width, int64_t height, double scale, double offset, double level, vector<float>& vertices,
+    vector<int32_t>& indices) {
     int64_t N = width * height;
     vector<bool> visited(N);
     int64_t i, j;
 
     // Search TopEdge
     for (j = 0, i = 0; i < width - 1; i++) {
-        if (image[(j) * width + i] < level && level <= image[(j) * width + i + 1]) {
+        if (image[(j)*width + i] < level && level <= image[(j)*width + i + 1]) {
             indices.push_back(vertices.size());
             traceSegment(image, visited, width, height, scale, offset, level, i, j, Edge::TopEdge, vertices);
         }
@@ -139,7 +137,7 @@ void traceLevel(const float* image, int64_t width, int64_t height, double scale,
 
     // Search RightEdge
     for (j = 0; j < height - 1; j++) {
-        if (image[(j) * width + i] < level && level <= image[(j + 1) * width + i]) {
+        if (image[(j)*width + i] < level && level <= image[(j + 1) * width + i]) {
             indices.push_back(vertices.size());
             traceSegment(image, visited, width, height, scale, offset, level, i - 1, j, Edge::RightEdge, vertices);
         }
@@ -147,7 +145,7 @@ void traceLevel(const float* image, int64_t width, int64_t height, double scale,
 
     // Search Bottom
     for (i--; i >= 0; i--) {
-        if (image[(j) * width + i + 1] < level && level <= image[(j) * width + i]) {
+        if (image[(j)*width + i + 1] < level && level <= image[(j)*width + i]) {
             indices.push_back(vertices.size());
             traceSegment(image, visited, width, height, scale, offset, level, i, j - 1, Edge::BottomEdge, vertices);
         }
@@ -155,7 +153,7 @@ void traceLevel(const float* image, int64_t width, int64_t height, double scale,
 
     // Search Left
     for (i = 0, j--; j >= 0; j--) {
-        if (image[(j + 1) * width + i] < level && level <= image[(j) * width + i]) {
+        if (image[(j + 1) * width + i] < level && level <= image[(j)*width + i]) {
             indices.push_back(vertices.size());
             traceSegment(image, visited, width, height, scale, offset, level, i, j, Edge::LeftEdge, vertices);
         }
@@ -164,7 +162,7 @@ void traceLevel(const float* image, int64_t width, int64_t height, double scale,
     // Search each row of the image
     for (j = 1; j < height - 1; j++) {
         for (i = 0; i < width - 1; i++) {
-            if (!visited[j * width + i] && image[(j) * width + i] < level && level <= image[(j) * width + i + 1]) {
+            if (!visited[j * width + i] && image[(j)*width + i] < level && level <= image[(j)*width + i + 1]) {
                 indices.push_back(vertices.size());
                 traceSegment(image, visited, width, height, scale, offset, level, i, j, TopEdge, vertices);
             }
@@ -172,7 +170,8 @@ void traceLevel(const float* image, int64_t width, int64_t height, double scale,
     }
 }
 
-void TraceSingleContour(float* image, int64_t width, int64_t height, double scale, double offset, double level, std::vector<float>& vertex_data, std::vector<int32_t>& indices) {
+void TraceSingleContour(float* image, int64_t width, int64_t height, double scale, double offset, double level,
+    std::vector<float>& vertex_data, std::vector<int32_t>& indices) {
     int64_t N = width * height;
     vertex_data.clear();
     indices.clear();
@@ -185,8 +184,8 @@ void TraceSingleContour(float* image, int64_t width, int64_t height, double scal
     traceLevel(image, width, height, scale, offset, level, vertex_data, indices);
 }
 
-void TraceContours(float* image, int64_t width, int64_t height, double scale, double offset, const std::vector<double>& levels, std::vector<std::vector<float>>& vertex_data,
-                   std::vector<std::vector<int32_t>>& index_data, bool verbose_logging) {
+void TraceContours(float* image, int64_t width, int64_t height, double scale, double offset, const std::vector<double>& levels,
+    std::vector<std::vector<float>>& vertex_data, std::vector<std::vector<int32_t>>& index_data, bool verbose_logging) {
     auto t_start_contours = std::chrono::high_resolution_clock::now();
     vertex_data.resize(levels.size());
     index_data.resize(levels.size());
@@ -211,7 +210,7 @@ void TraceContours(float* image, int64_t width, int64_t height, double scale, do
     if (verbose_logging) {
         auto t_end_contours = std::chrono::high_resolution_clock::now();
         auto dt_contours = std::chrono::duration_cast<std::chrono::microseconds>(t_end_contours - t_start_contours).count();
-        auto rate_contours = width * height / (double) dt_contours;
+        auto rate_contours = width * height / (double)dt_contours;
         int vertex_count = 0;
         int segment_count = 0;
         for (auto& vertices : vertex_data) {
@@ -222,6 +221,6 @@ void TraceContours(float* image, int64_t width, int64_t height, double scale, do
         }
 
         fmt::print("Contoured {}x{} image in {} ms at {} MPix/s. Found {} vertices in {} segments across {} levels\n", width, height,
-                   dt_contours * 1e-3, rate_contours, vertex_count, segment_count, levels.size());
+            dt_contours * 1e-3, rate_contours, vertex_count, segment_count, levels.size());
     }
 }

--- a/Contouring.h
+++ b/Contouring.h
@@ -1,0 +1,13 @@
+#ifndef CARTA_BACKEND__CONTOURING_H_
+#define CARTA_BACKEND__CONTOURING_H_
+
+#include <vector>
+#include <cstdint>
+
+enum Edge { TopEdge, RightEdge, BottomEdge, LeftEdge, None };
+
+void TraceContourLevel(float* image, int width, int height, double scale, double offset, double level, std::vector<double>& vertex_data, std::vector<int32_t>& indices);
+void TraceContours(float* image, int width, int height, double scale, double offset, const std::vector<double>& levels, std::vector<std::vector<float>>& vertex_data,
+    std::vector<std::vector<int32_t>>& index_data);
+
+#endif // CARTA_BACKEND__CONTOURING_H_

--- a/Contouring.h
+++ b/Contouring.h
@@ -8,6 +8,6 @@ enum Edge { TopEdge, RightEdge, BottomEdge, LeftEdge, None };
 
 void TraceContourLevel(float* image, int64_t width, int64_t height, double scale, double offset, double level, std::vector<double>& vertex_data, std::vector<int32_t>& indices);
 void TraceContours(float* image, int64_t width, int64_t height, double scale, double offset, const std::vector<double>& levels, std::vector<std::vector<float>>& vertex_data,
-    std::vector<std::vector<int32_t>>& index_data);
+    std::vector<std::vector<int32_t>>& index_data, bool verbose_logging = false);
 
 #endif // CARTA_BACKEND__CONTOURING_H_

--- a/Contouring.h
+++ b/Contouring.h
@@ -1,13 +1,14 @@
 #ifndef CARTA_BACKEND__CONTOURING_H_
 #define CARTA_BACKEND__CONTOURING_H_
 
-#include <vector>
 #include <cstdint>
+#include <vector>
 
 enum Edge { TopEdge, RightEdge, BottomEdge, LeftEdge, None };
 
-void TraceContourLevel(float* image, int64_t width, int64_t height, double scale, double offset, double level, std::vector<double>& vertex_data, std::vector<int32_t>& indices);
-void TraceContours(float* image, int64_t width, int64_t height, double scale, double offset, const std::vector<double>& levels, std::vector<std::vector<float>>& vertex_data,
-    std::vector<std::vector<int32_t>>& index_data, bool verbose_logging = false);
+void TraceContourLevel(float* image, int64_t width, int64_t height, double scale, double offset, double level,
+    std::vector<double>& vertex_data, std::vector<int32_t>& indices);
+void TraceContours(float* image, int64_t width, int64_t height, double scale, double offset, const std::vector<double>& levels,
+    std::vector<std::vector<float>>& vertex_data, std::vector<std::vector<int32_t>>& index_data, bool verbose_logging = false);
 
 #endif // CARTA_BACKEND__CONTOURING_H_

--- a/Contouring.h
+++ b/Contouring.h
@@ -6,8 +6,8 @@
 
 enum Edge { TopEdge, RightEdge, BottomEdge, LeftEdge, None };
 
-void TraceContourLevel(float* image, int width, int height, double scale, double offset, double level, std::vector<double>& vertex_data, std::vector<int32_t>& indices);
-void TraceContours(float* image, int width, int height, double scale, double offset, const std::vector<double>& levels, std::vector<std::vector<float>>& vertex_data,
+void TraceContourLevel(float* image, int64_t width, int64_t height, double scale, double offset, double level, std::vector<double>& vertex_data, std::vector<int32_t>& indices);
+void TraceContours(float* image, int64_t width, int64_t height, double scale, double offset, const std::vector<double>& levels, std::vector<std::vector<float>>& vertex_data,
     std::vector<std::vector<int32_t>>& index_data);
 
 #endif // CARTA_BACKEND__CONTOURING_H_

--- a/EventHeader.h
+++ b/EventHeader.h
@@ -2,7 +2,7 @@
 #define CARTA_BACKEND__EVENTHEADER_H_
 
 namespace carta {
-const uint16_t ICD_VERSION = 7;
+const uint16_t ICD_VERSION = 9;
 struct EventHeader {
     uint16_t type;
     uint16_t icd_version;

--- a/Frame.cc
+++ b/Frame.cc
@@ -19,7 +19,7 @@
 using namespace carta;
 
 Frame::Frame(uint32_t session_id, const std::string& filename, const std::string& hdu, const CARTA::FileInfoExtended* info, bool verbose,
-             int default_channel)
+    int default_channel)
     : _session_id(session_id),
       _valid(true),
       _z_profile_count(0),
@@ -160,7 +160,7 @@ bool Frame::ChannelsChanged(int channel, int stokes) {
 // Set regions
 
 bool Frame::SetRegion(int region_id, const std::string& name, CARTA::RegionType type, std::vector<CARTA::Point>& points, float rotation,
-                      std::string& message) {
+    std::string& message) {
     // Create or update Region
     bool region_set(false);
 
@@ -349,7 +349,7 @@ void Frame::ImportRegion(
 }
 
 void Frame::ImportAnnotationFileLine(casa::AsciiAnnotationFileLine& file_line, const casacore::CoordinateSystem& coord_sys,
-                                     CARTA::FileType file_type, CARTA::ImportRegionAck& import_ack, std::string message) {
+    CARTA::FileType file_type, CARTA::ImportRegionAck& import_ack, std::string message) {
     // Process a single CRTF annotation file line to set region; adds region to frame regions.
     // Completes ack message with region properties or appends to message if failed.
     switch (file_line.getType()) {
@@ -425,26 +425,32 @@ casacore::String Frame::AnnTypeToDs9String(casa::AnnotationBase::Type annotation
         case casa::AnnotationBase::LINE:
         case casa::AnnotationBase::CIRCLE:
         case casa::AnnotationBase::ELLIPSE:
-        case casa::AnnotationBase::ANNULUS:ds9_type = casa::AnnotationBase::typeToString(annotation_type);
+        case casa::AnnotationBase::ANNULUS:
+            ds9_type = casa::AnnotationBase::typeToString(annotation_type);
             break;
-        case casa::AnnotationBase::TEXT:ds9_type = "text";
+        case casa::AnnotationBase::TEXT:
+            ds9_type = "text";
             break;
-        case casa::AnnotationBase::SYMBOL:ds9_type = "point";
+        case casa::AnnotationBase::SYMBOL:
+            ds9_type = "point";
             break;
         case casa::AnnotationBase::RECT_BOX:
         case casa::AnnotationBase::CENTER_BOX:
-        case casa::AnnotationBase::ROTATED_BOX:ds9_type = "box";
+        case casa::AnnotationBase::ROTATED_BOX:
+            ds9_type = "box";
             break;
-        case casa::AnnotationBase::POLYGON:ds9_type = "polygon";
+        case casa::AnnotationBase::POLYGON:
+            ds9_type = "polygon";
             break;
         case casa::AnnotationBase::POLYLINE:
-        case casa::AnnotationBase::VECTOR:break; // no equivalent
+        case casa::AnnotationBase::VECTOR:
+            break; // no equivalent
     }
     return ds9_type;
 }
 
 void Frame::ExportRegion(CARTA::FileType file_type, CARTA::CoordinateType coord_type, std::vector<int>& region_ids, std::string& filename,
-                         CARTA::ExportRegionAck& export_ack) {
+    CARTA::ExportRegionAck& export_ack) {
     // Export regions to file with filename; if no filename, add contents to ack message for client-side export.
     // Check if regions to export
     if (region_ids.empty()) {
@@ -467,9 +473,11 @@ void Frame::ExportRegion(CARTA::FileType file_type, CARTA::CoordinateType coord_
 
     // export according to type
     switch (file_type) {
-        case CARTA::FileType::CRTF:ExportCrtfRegions(region_ids, coord_type, filename, export_ack);
+        case CARTA::FileType::CRTF:
+            ExportCrtfRegions(region_ids, coord_type, filename, export_ack);
             break;
-        case CARTA::FileType::REG:ExportDs9Regions(region_ids, coord_type, filename, export_ack);
+        case CARTA::FileType::REG:
+            ExportDs9Regions(region_ids, coord_type, filename, export_ack);
             break;
         default: {
             export_ack.set_success(false);
@@ -877,7 +885,7 @@ bool Frame::FillRasterImageData(CARTA::RasterImageData& raster_image_data, std::
                     nan_encodings[i] =
                         GetNanEncodingsBlock(image_data, subset_element_start, row_length, subset_row_end - subset_row_start);
                     Compress(image_data, subset_element_start, compression_buffers[i], compressed_sizes[i], row_length,
-                             subset_row_end - subset_row_start, precision);
+                        subset_row_end - subset_row_start, precision);
                 }
             };
             tbb::parallel_for(range, loop);
@@ -885,7 +893,7 @@ bool Frame::FillRasterImageData(CARTA::RasterImageData& raster_image_data, std::
             // Complete message
             for (auto i = 0; i < num_subsets_setting; i++) {
                 raster_image_data.add_image_data(compression_buffers[i].data(), compressed_sizes[i]);
-                raster_image_data.add_nan_encodings((char*) nan_encodings[i].data(), nan_encodings[i].size() * sizeof(int));
+                raster_image_data.add_nan_encodings((char*)nan_encodings[i].data(), nan_encodings[i].size() * sizeof(int));
             }
             raster_data_ok = true;
         } else {
@@ -975,7 +983,7 @@ bool Frame::GetRasterData(std::vector<float>& image_data, CARTA::ImageBounds& bo
 
 // Tile data
 bool Frame::FillRasterTileData(CARTA::RasterTileData& raster_tile_data, const Tile& tile, int channel, int stokes,
-                               CARTA::CompressionType compression_type, float compression_quality) {
+    CARTA::CompressionType compression_type, float compression_quality) {
     // Early exit if channel has changed
     if (ChannelsChanged(channel, stokes)) {
         return false;
@@ -1033,9 +1041,9 @@ bool Frame::GetRasterTileData(std::vector<float>& tile_data, const Tile& tile, i
     CARTA::ImageBounds bounds;
     // crop to image size
     bounds.set_x_min(std::max(0, tile.x * tile_size_original));
-    bounds.set_x_max(std::min((int) _image_shape(0), (tile.x + 1) * tile_size_original));
+    bounds.set_x_max(std::min((int)_image_shape(0), (tile.x + 1) * tile_size_original));
     bounds.set_y_min(std::max(0, tile.y * tile_size_original));
-    bounds.set_y_max(std::min((int) _image_shape(1), (tile.y + 1) * tile_size_original));
+    bounds.set_y_max(std::min((int)_image_shape(1), (tile.y + 1) * tile_size_original));
 
     const int req_height = bounds.y_max() - bounds.y_min();
     const int req_width = bounds.x_max() - bounds.x_min();
@@ -1361,7 +1369,7 @@ bool Frame::FillSpectralProfileData(
                     // if region mask is valid, then check is swizzled data available
                     if (_loader->UseRegionSpectralData(mask, _image_mutex)) {
                         profile_ok = _loader->GetRegionSpectralData(region_id, config_stokes, profile_stokes, mask, region->XyOrigin(),
-                                                                    _image_mutex, [&](std::map<CARTA::StatsType, std::vector<double>>* stats_values_map, float progress) {
+                            _image_mutex, [&](std::map<CARTA::StatsType, std::vector<double>>* stats_values_map, float progress) {
                                 CARTA::SpectralProfileData profile_message;
                                 profile_message.set_stokes(curr_stokes);
                                 profile_message.set_progress(progress);
@@ -1371,14 +1379,14 @@ bool Frame::FillSpectralProfileData(
                             });
                     } else {
                         profile_ok = GetRegionSpectralData(region_id, config_stokes, profile_stokes,
-                                                           [&](std::map<CARTA::StatsType, std::vector<double>> results, float progress) {
-                                                               CARTA::SpectralProfileData profile_message;
-                                                               profile_message.set_stokes(curr_stokes);
-                                                               profile_message.set_progress(progress);
-                                                               region->FillSpectralProfileDataMessage(profile_message, config_stokes, results);
-                                                               // send (partial) result to Session
-                                                               cb(profile_message);
-                                                           });
+                            [&](std::map<CARTA::StatsType, std::vector<double>> results, float progress) {
+                                CARTA::SpectralProfileData profile_message;
+                                profile_message.set_stokes(curr_stokes);
+                                profile_message.set_progress(progress);
+                                region->FillSpectralProfileDataMessage(profile_message, config_stokes, results);
+                                // send (partial) result to Session
+                                cb(profile_message);
+                            });
                     }
                 }
             }
@@ -1660,7 +1668,7 @@ bool Frame::GetPointSpectralData(
                     guard.unlock();
                     memcpy(&data[start(_spectral_axis)], buffer.data(), count(_spectral_axis) * sizeof(float));
                     start(_spectral_axis) += count(_spectral_axis);
-                    progress = (float) start(_spectral_axis) / profile_size;
+                    progress = (float)start(_spectral_axis) / profile_size;
 
                     // get the time elapse for this step
                     auto t_end = std::chrono::high_resolution_clock::now();
@@ -1699,7 +1707,7 @@ bool Frame::GetPointSpectralData(
 }
 
 bool Frame::GetRegionSpectralData(int region_id, int config_stokes, int profile_stokes,
-                                  const std::function<void(std::map<CARTA::StatsType, std::vector<double>>, float)>& partial_results_callback) {
+    const std::function<void(std::map<CARTA::StatsType, std::vector<double>>, float)>& partial_results_callback) {
     // get starting spectral config
     SpectralConfig start_config_stats;
     if (!GetRegionSpectralConfig(region_id, config_stokes, start_config_stats)) {
@@ -1779,7 +1787,7 @@ bool Frame::GetRegionSpectralData(int region_id, int config_stokes, int profile_
             }
 
             start += count;
-            progress = (float) start / profile_size;
+            progress = (float)start / profile_size;
 
             // get the time elapse for this step
             auto t_end = std::chrono::high_resolution_clock::now();
@@ -1811,21 +1819,21 @@ bool Frame::GetRegionSpectralData(int region_id, int config_stokes, int profile_
     return data_ok;
 }
 
-bool Frame::ContourImage(CARTA::SmoothingMode smoothing_mode, int smoothing_factor, const std::vector<double>& levels,
-                         std::vector<std::vector<float>>& vertex_data, std::vector<std::vector<int32_t>>& index_data) {
+bool Frame::ContourImage(std::vector<std::vector<float>>& vertex_data, std::vector<std::vector<int32_t>>& index_data) {
     double scale = 1.0;
     double offset = 0;
     bool smooth_successful = false;
     tbb::queuing_rw_mutex::scoped_lock cache_lock(_cache_mutex, false);
 
-    if (smoothing_mode == CARTA::SmoothingMode::NoSmoothing || smoothing_factor <= 1) {
-        TraceContours(_image_cache.data(), _image_shape(0), _image_shape(1), scale, offset, levels, vertex_data, index_data, _verbose);
+    if (_contour_settings.smoothing_mode == CARTA::SmoothingMode::NoSmoothing || _contour_settings.smoothing_factor <= 1) {
+        TraceContours(_image_cache.data(), _image_shape(0), _image_shape(1), scale, offset, _contour_settings.levels, vertex_data,
+            index_data, _verbose);
         return true;
-    } else if (smoothing_mode == CARTA::SmoothingMode::GaussianBlur) {
+    } else if (_contour_settings.smoothing_mode == CARTA::SmoothingMode::GaussianBlur) {
         // Smooth the image from cache
-        float sigma = smoothing_factor / 2.0f;
-        int mask_size = smoothing_factor * 2 + 1;
-        const int apron_height = smoothing_factor;
+        float sigma = _contour_settings.smoothing_factor / 2.0f;
+        int mask_size = _contour_settings.smoothing_factor * 2 + 1;
+        const int apron_height = _contour_settings.smoothing_factor;
         std::vector<float> kernel(mask_size);
         int64_t kernel_width = (kernel.size() - 1) / 2;
         MakeKernel(kernel, sigma);
@@ -1835,13 +1843,15 @@ bool Frame::ContourImage(CARTA::SmoothingMode smoothing_mode, int smoothing_fact
         int64_t dest_width = _image_shape(0) - 2 * kernel_width;
         int64_t dest_height = _image_shape(1) - 2 * kernel_width;
         std::unique_ptr<float[]> dest_array(new float[dest_width * dest_height]);
-        smooth_successful = GaussianSmooth(_image_cache.data(), dest_array.get(), source_width, source_height, dest_width, dest_height, smoothing_factor, _verbose);
+        smooth_successful = GaussianSmooth(_image_cache.data(), dest_array.get(), source_width, source_height, dest_width, dest_height,
+            _contour_settings.smoothing_factor, _verbose);
         // Can release lock early, as we're no longer using the image cache
         cache_lock.release();
         if (smooth_successful) {
             // Perform contouring with an offset based on the Gaussian smoothing apron size
-            offset = smoothing_factor;
-            TraceContours(dest_array.get(), dest_width, dest_height, scale, offset, levels, vertex_data, index_data, _verbose);
+            offset = _contour_settings.smoothing_factor;
+            TraceContours(
+                dest_array.get(), dest_width, dest_height, scale, offset, _contour_settings.levels, vertex_data, index_data, _verbose);
             return true;
         }
     } else {
@@ -1852,14 +1862,15 @@ bool Frame::ContourImage(CARTA::SmoothingMode smoothing_mode, int smoothing_fact
         image_bounds.set_x_max(_image_shape(0));
         image_bounds.set_y_max(_image_shape(1));
         std::vector<float> dest_vector;
-        smooth_successful = GetRasterData(dest_vector, image_bounds, smoothing_factor, true);
+        smooth_successful = GetRasterData(dest_vector, image_bounds, _contour_settings.smoothing_factor, true);
         if (smooth_successful) {
             // Perform contouring with an offset based on the block size, and a scale factor equal to block size
             offset = 0;
-            scale = smoothing_factor;
-            size_t dest_width = image_bounds.x_max() / smoothing_factor;
-            size_t dest_height = image_bounds.y_max() / smoothing_factor;
-            TraceContours(dest_vector.data(), dest_width, dest_height, scale, offset, levels, vertex_data, index_data, _verbose);
+            scale = _contour_settings.smoothing_factor;
+            size_t dest_width = image_bounds.x_max() / _contour_settings.smoothing_factor;
+            size_t dest_height = image_bounds.y_max() / _contour_settings.smoothing_factor;
+            TraceContours(
+                dest_vector.data(), dest_width, dest_height, scale, offset, _contour_settings.levels, vertex_data, index_data, _verbose);
             return true;
         }
         fmt::print("Smoothing mode not implemented yet!\n");
@@ -1976,6 +1987,16 @@ bool Frame::GetRegionState(int region_id, RegionState& region_state) {
 bool Frame::GetRegionSpectralConfig(int region_id, int config_stokes, SpectralConfig& config_stats) {
     if (_regions.count(region_id)) {
         return _regions[region_id]->GetSpectralConfig(config_stokes, config_stats);
+    }
+    return false;
+}
+bool Frame::SetContourParameters(const CARTA::SetContourParameters& message) {
+    ContourSettings new_settings = {std::vector<double>(message.levels().begin(), message.levels().end()), message.smoothing_mode(),
+        message.smoothing_factor(), message.decimation_factor(), message.compression_level(), message.reference_file_id()};
+
+    if (_contour_settings != new_settings) {
+        _contour_settings = new_settings;
+        return true;
     }
     return false;
 }

--- a/Frame.h
+++ b/Frame.h
@@ -15,6 +15,7 @@
 #include <tbb/atomic.h>
 #include <tbb/queuing_rw_mutex.h>
 
+#include <carta-protobuf/contour.pb.h>
 #include <carta-protobuf/defs.pb.h>
 #include <carta-protobuf/export_region.pb.h>
 #include <carta-protobuf/import_region.pb.h>
@@ -35,6 +36,38 @@ struct ViewSettings {
     CARTA::CompressionType compression_type;
     float quality;
     int num_subsets;
+};
+
+struct ContourSettings {
+    std::vector<double> levels;
+    CARTA::SmoothingMode smoothing_mode;
+    int smoothing_factor;
+    int decimation;
+    int compression_level;
+    uint32_t reference_file_id;
+
+    // Equality operator for checking if contour settings have changed
+    bool operator==(const ContourSettings& rhs) const {
+        if (this->smoothing_mode != rhs.smoothing_mode || this->decimation != rhs.decimation ||
+            this->compression_level != rhs.compression_level || this->reference_file_id != rhs.reference_file_id) {
+            return false;
+        }
+        if (this->levels.size() != rhs.levels.size()) {
+            return false;
+        }
+
+        for (auto i = 0; i < this->levels.size(); i++) {
+            if (this->levels[i] != rhs.levels[i]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    bool operator!=(const ContourSettings& rhs) const {
+        return !(*this == rhs);
+    }
 };
 
 class Frame {
@@ -91,8 +124,11 @@ public:
     bool FillRegionStatsData(int region_id, CARTA::RegionStatsData& stats_data);
 
     // Functions used for smoothing and contouring
-    bool ContourImage(CARTA::SmoothingMode smoothing_mode, int smoothing_factor, const std::vector<double>& levels,
-        std::vector<std::vector<float>>& vertex_data, std::vector<std::vector<int>>& index_data);
+    bool SetContourParameters(const CARTA::SetContourParameters& message);
+    inline ContourSettings& GetContourParameters() {
+        return _contour_settings;
+    };
+    bool ContourImage(std::vector<std::vector<float>>& vertex_data, std::vector<std::vector<int>>& index_data);
 
     // histogram only (not full data message) : get if stored, else can calculate
     bool GetRegionMinMax(int region_id, int channel, int stokes, float& min_val, float& max_val);
@@ -215,6 +251,9 @@ private:
 
     // Image settings
     ViewSettings _view_settings;
+
+    // Contour settings
+    ContourSettings _contour_settings;
 
     // Image data handling
     std::vector<float> _image_cache;    // image data for current channelIndex, stokesIndex

--- a/Frame.h
+++ b/Frame.h
@@ -90,6 +90,10 @@ public:
     bool FillRegionHistogramData(int region_id, CARTA::RegionHistogramData* histogram_data, bool channel_changed = false);
     bool FillRegionStatsData(int region_id, CARTA::RegionStatsData& stats_data);
 
+    // Functions used for smoothing and contouring
+    bool ContourImage(CARTA::SmoothingMode smoothing_mode, int smoothing_factor, const std::vector<double>& levels,
+        std::vector<std::vector<float>>& vertex_data, std::vector<std::vector<int>>& index_data);
+
     // histogram only (not full data message) : get if stored, else can calculate
     bool GetRegionMinMax(int region_id, int channel, int stokes, float& min_val, float& max_val);
     bool CalcRegionMinMax(int region_id, int channel, int stokes, float& min_val, float& max_val);

--- a/Main.cc
+++ b/Main.cc
@@ -1,5 +1,3 @@
-
-
 #if _AUTH_SERVER_
 #include <jsoncpp/json/json.h>
 #include <jsoncpp/json/value.h>
@@ -292,6 +290,12 @@ void OnMessage(uWS::WebSocket<uWS::SERVER>* ws, char* raw_message, size_t length
                     } else {
                         fmt::print("Bad EXPORT_REGION message!\n");
                     }
+                    break;
+                }
+                case CARTA::EventType::SET_CONTOUR_PARAMETERS: {
+                    CARTA::SetContourParameters message;
+                    message.ParseFromArray(event_buf, event_length);
+                    tsk = new (tbb::task::allocate_root(session->Context())) OnSetContourParametersTask(session, message);
                     break;
                 }
                 default: {

--- a/OnMessageTask.cc
+++ b/OnMessageTask.cc
@@ -121,3 +121,8 @@ tbb::task* OnAddRequiredTilesTask::execute() {
     _session->OnAddRequiredTiles(_message);
     return nullptr;
 }
+
+tbb::task* OnSetContourParametersTask::execute() {
+    _session->OnSetContourParameters(_message);
+    return nullptr;
+}

--- a/OnMessageTask.h
+++ b/OnMessageTask.h
@@ -7,6 +7,7 @@
 #include <tuple>
 #include <vector>
 
+#include <carta-protobuf/contour.pb.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/task.h>
 
@@ -111,6 +112,18 @@ public:
         _message = message;
     }
     ~OnAddRequiredTilesTask() = default;
+};
+
+class OnSetContourParametersTask : public OnMessageTask {
+    tbb::task* execute() override;
+    CARTA::SetContourParameters _message;
+    int _start, _stride, _end;
+
+public:
+    OnSetContourParametersTask(Session* session, CARTA::SetContourParameters message) : OnMessageTask(session) {
+        _message = message;
+    }
+    ~OnSetContourParametersTask() = default;
 };
 
 #endif // CARTA_BACKEND__ONMESSAGETASK_H_

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ folder       Set folder for data files, default current directory
 ## External dependencies
 The server build depends on the following libraries: 
 * [casacore](https://github.com/casacore/casacore) for CASA image libraries. Build and install from git repo.  casacore requires casa data (https://open-bitbucket.nrao.edu/scm/casa/casa-data.git); follow the sparse checkout instructions.
-* [zfp](https://github.com/LLNL/zfp) for data compression. The same library is used on the client, after being compiled to WebAssembly. Build and install from git repo. For best performance, build with AVX extensions. 
+* [zfp](https://github.com/LLNL/zfp) for data compression. The same library is used on the client, after being compiled to WebAssembly. Build and install from git repo. For best performance, build with AVX extensions.
+* [Zstd](https://github.com/facebook/zstd) for data compression. Debian package `libzstd-dev`.
 * [fmt](https://github.com/fmtlib/fmt) for python-style (and safe printf-style) string formatting and printing. Debian package `libfmt3-dev`. 
 * [protobuf](https://developers.google.com/protocol-buffers) for client-side communication using specific message formats. Debian package `libprotobuf-dev` (> 3.0 required. Can use [PPA](https://launchpad.net/~maarten-fonville/+archive/ubuntu/protobuf) for earlier versions of Ubuntu) 
 * [HDF5](https://support.hdfgroup.org/HDF5/) C++ library for HDF5 support. Debian packages `libhdf5-dev` and `libhdf5-cpp-100`. By default, the serial version of the HDF5 library is targeted.

--- a/Session.cc
+++ b/Session.cc
@@ -691,6 +691,7 @@ void Session::OnSetContourParameters(const CARTA::SetContourParameters& message)
                     tmp_data[1] = vertices[v + 1] * pixel_rounding;
                     tmp_data[2] = vertices[v + 2] * pixel_rounding;
                     tmp_data[3] = vertices[v + 3] * pixel_rounding;
+
                     data_shuffled_ptr[0] = data_ptr[0];
                     data_shuffled_ptr[1] = data_ptr[4];
                     data_shuffled_ptr[2] = data_ptr[8];

--- a/Session.cc
+++ b/Session.cc
@@ -17,6 +17,7 @@
 #include <carta-protobuf/error.pb.h>
 #include <carta-protobuf/raster_tile.pb.h>
 #include <carta-protobuf/contour_image.pb.h>
+#include <zstd.h>
 
 #include "Carta.h"
 #include "EventHeader.h"
@@ -660,6 +661,7 @@ void Session::OnSetContourParameters(const CARTA::SetContourParameters& message)
             response.set_file_id(message.file_id());
             response.set_channel(message.channel());
             response.set_stokes(message.stokes());
+
             // TODO: handle image bounds correctly
             for (auto i = 0; i < levels.size(); i++) {
                 auto& vertices = vertex_data[i];
@@ -673,8 +675,57 @@ void Session::OnSetContourParameters(const CARTA::SetContourParameters& message)
                 // Fill contour set
                 auto contour_set = response.add_contour_sets();
                 contour_set->set_level(levels[i]);
-                contour_set->set_raw_coordinates_fp32(vertices.data(), vertices.size() * sizeof(float));
-                contour_set->set_raw_start_indices_i32(indices.data(), indices.size() * sizeof(int32_t));
+
+                // decimate vertices and shuffle bytes for better compression
+                const int N = vertices.size();
+                const int pixel_rounding = 8;
+                std::vector<int32_t> vertices_shuffled(N);
+                int v = 0;
+                std::array<int32_t, 4> tmp_data;
+                char* data_shuffled_ptr = (char*) vertices_shuffled.data();
+                char* data_ptr = (char*) tmp_data.data();
+
+                // TODO: This could definitely be improved by SSE/AVX
+                for (v = 0; v < 4 * (N / 4); v += 4) {
+                    tmp_data[0] = vertices[v + 0] * pixel_rounding;
+                    tmp_data[1] = vertices[v + 1] * pixel_rounding;
+                    tmp_data[2] = vertices[v + 2] * pixel_rounding;
+                    tmp_data[3] = vertices[v + 3] * pixel_rounding;
+                    data_shuffled_ptr[0] = data_ptr[0];
+                    data_shuffled_ptr[1] = data_ptr[4];
+                    data_shuffled_ptr[2] = data_ptr[8];
+                    data_shuffled_ptr[3] = data_ptr[12];
+
+                    data_shuffled_ptr[4] = data_ptr[1];
+                    data_shuffled_ptr[5] = data_ptr[5];
+                    data_shuffled_ptr[6] = data_ptr[9];
+                    data_shuffled_ptr[7] = data_ptr[13];
+
+                    data_shuffled_ptr[8] = data_ptr[2];
+                    data_shuffled_ptr[9] = data_ptr[6];
+                    data_shuffled_ptr[10] = data_ptr[10];
+                    data_shuffled_ptr[11] = data_ptr[14];
+
+                    data_shuffled_ptr[12] = data_ptr[3];
+                    data_shuffled_ptr[13] = data_ptr[7];
+                    data_shuffled_ptr[14] = data_ptr[11];
+                    data_shuffled_ptr[15] = data_ptr[15];
+
+                    data_shuffled_ptr += 16;
+                }
+
+                for (; v < N; v++) {
+                    vertices_shuffled[v] = vertices[v] * pixel_rounding;
+                }
+
+                // Compress using Zstd library
+                char* buffer = new char[N * 4];
+                size_t compressed_size = ZSTD_compress(buffer, N * 4, vertices_shuffled.data(), vertices_shuffled.size() * sizeof(int32_t), 1);
+
+                contour_set->set_raw_coordinates(buffer, compressed_size);
+                contour_set->set_raw_start_indices(indices.data(), indices.size() * sizeof(int32_t));
+                contour_set->set_decimation_factor(pixel_rounding);
+                delete[] buffer;
             }
             SendFileEvent(response.file_id(), CARTA::EventType::CONTOUR_IMAGE_DATA, 0, response);
         } else {

--- a/Session.cc
+++ b/Session.cc
@@ -701,16 +701,17 @@ void Session::OnSetContourParameters(const CARTA::SetContourParameters& message)
                 total_src_size += src_size;
                 total_compressed_size += compressed_size;
             }
-            auto t_end = std::chrono::high_resolution_clock::now();
-            auto dt = std::chrono::duration_cast<std::chrono::microseconds>(t_end - t_start).count();
-            double ratio = ((double) total_compressed_size) / total_src_size;
-            fmt::print("Encoded and compressed {:.2f} kB to {:.2f} kB ({:.2f}%) in {} ms using compression level {}\n",
-                       total_src_size * 1.0e-3,
-                       total_compressed_size * 1.0e-3,
-                       ratio * 100,
-                       dt * 1.0e-3,
-                       compression_level);
-
+            if (_verbose_logging) {
+                auto t_end = std::chrono::high_resolution_clock::now();
+                auto dt = std::chrono::duration_cast<std::chrono::microseconds>(t_end - t_start).count();
+                double ratio = ((double) total_compressed_size) / total_src_size;
+                fmt::print("Encoded and compressed {:.2f} kB to {:.2f} kB ({:.2f}%) in {} ms using compression level {}\n",
+                           total_src_size * 1.0e-3,
+                           total_compressed_size * 1.0e-3,
+                           ratio * 100,
+                           dt * 1.0e-3,
+                           compression_level);
+            }
             SendFileEvent(response.file_id(), CARTA::EventType::CONTOUR_IMAGE_DATA, 0, response);
         } else {
             SendLogEvent("Error processing contours", {"contours"}, CARTA::ErrorSeverity::WARNING);

--- a/Session.cc
+++ b/Session.cc
@@ -679,7 +679,7 @@ void Session::OnSetContourParameters(const CARTA::SetContourParameters& message)
                 contour_set->set_level(levels[i]);
 
                 const int N = vertices.size();
-                const float pixel_rounding = 8;
+                const float pixel_rounding = 2;
 
                 std::vector<int32_t> vertices_shuffled;
                 RoundAndEncodeVertices(vertices, vertices_shuffled, pixel_rounding);

--- a/Session.h
+++ b/Session.h
@@ -155,6 +155,9 @@ public:
     }
     static void SetInitExitTimeout(int secs);
 
+    inline uint32_t GetId() {
+        return _id;
+    }
     // TODO: should these be public? NO!!!!!!!!
     uint32_t _id;
     FileSettings _file_settings;
@@ -183,6 +186,7 @@ private:
     bool SendSpectralProfileData(int file_id, int region_id, bool channel_changed = false, bool stokes_changed = false);
     bool SendRegionHistogramData(int file_id, int region_id, bool channel_changed = false);
     bool SendRegionStatsData(int file_id, int region_id); // update stats in all cases
+    bool SendContourData(int file_id);
     void UpdateRegionData(int file_id, bool send_image_histogram = true, bool channel_changed = false, bool stokes_changed = false);
 
     // Send protobuf messages

--- a/Session.h
+++ b/Session.h
@@ -20,6 +20,7 @@
 #include <casacore/casa/aips.h>
 
 #include <carta-protobuf/close_file.pb.h>
+#include <carta-protobuf/contour.pb.h>
 #include <carta-protobuf/file_info.pb.h>
 #include <carta-protobuf/file_list.pb.h>
 #include <carta-protobuf/open_file.pb.h>
@@ -63,6 +64,7 @@ public:
     void OnSetHistogramRequirements(const CARTA::SetHistogramRequirements& message, uint32_t request_id);
     void OnSetSpectralRequirements(const CARTA::SetSpectralRequirements& message);
     void OnSetStatsRequirements(const CARTA::SetStatsRequirements& message);
+    void OnSetContourParameters(const CARTA::SetContourParameters& message);
     void OnRegionListRequest(const CARTA::RegionListRequest& request, uint32_t request_id);
     void OnRegionFileInfoRequest(const CARTA::RegionFileInfoRequest& request, uint32_t request_id);
 

--- a/Smoothing.cc
+++ b/Smoothing.cc
@@ -106,7 +106,7 @@ bool RunKernel(const vector<float>& kernel, const float* src_data, float* dest_d
 }
 
 bool GaussianSmooth(const float* src_data, float* dest_data, int64_t src_width, int64_t src_height, int64_t dest_width, int64_t dest_height,
-    int smoothing_factor) {
+    int smoothing_factor, bool verbose_logging) {
     float sigma = round(smoothing_factor / 2.0f);
     int mask_size = smoothing_factor * 2 + 1;
     const int apron_height = smoothing_factor;
@@ -149,10 +149,12 @@ bool GaussianSmooth(const float* src_data, float* dest_data, int64_t src_width, 
         source_ptr += num_lines * src_width;
         dest_ptr += num_lines * dest_width;
     }
-    auto t_end = std::chrono::high_resolution_clock::now();
-    auto dt = std::chrono::duration_cast<std::chrono::microseconds>(t_end - t_start).count();
-    auto rate = dest_width * dest_height / (double)dt;
-    fmt::print(
-        "Smoothed with smoothing factor of {} and kernel size of {} in {} ms at {} MPix/s\n", smoothing_factor, mask_size, dt * 1e-3, rate);
+    if (verbose_logging) {
+        auto t_end = std::chrono::high_resolution_clock::now();
+        auto dt = std::chrono::duration_cast<std::chrono::microseconds>(t_end - t_start).count();
+        auto rate = dest_width * dest_height / (double) dt;
+        fmt::print(
+            "Smoothed with smoothing factor of {} and kernel size of {} in {} ms at {} MPix/s\n", smoothing_factor, mask_size, dt * 1e-3, rate);
+    }
     return true;
 }

--- a/Smoothing.cc
+++ b/Smoothing.cc
@@ -1,0 +1,158 @@
+#include "Smoothing.h"
+
+#include <chrono>
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+#include <fmt/ostream.h>
+#include <tbb/tbb.h>
+
+using namespace std;
+
+double NormPdf(double x, double sigma) {
+    return exp(-0.5 * x * x / (sigma * sigma)) / sigma;
+}
+
+void MakeKernel(vector<float>& kernel, double sigma) {
+    const int kernel_radius = (kernel.size() - 1) / 2;
+    for (int j = 0; j <= kernel_radius; ++j) {
+        kernel[kernel_radius + j] = kernel[kernel_radius - j] = NormPdf(j, sigma);
+    }
+}
+
+bool RunKernel(const vector<float>& kernel, const float* src_data, float* dest_data, const int64_t src_width, const int64_t src_height,
+    const int64_t dest_width, const int64_t dest_height, const bool vertical) {
+    const int64_t kernel_radius = (kernel.size() - 1) / 2;
+
+    if (vertical && dest_height < src_height - kernel_radius * 2) {
+        return false;
+    } else if (dest_width < src_width - kernel_radius * 2) {
+        return false;
+    }
+
+    const int64_t jump_size = vertical ? src_width : 1;
+    const int64_t dest_block_limit = SIMD_WIDTH * ((dest_width) / SIMD_WIDTH);
+    const int64_t x_offset = vertical ? 0 : kernel_radius;
+    const int64_t y_offset = vertical ? kernel_radius : 0;
+
+    auto loop = [&](const tbb::blocked_range<int>& r) {
+        for (int64_t dest_y = r.begin(); dest_y < r.end(); dest_y++) {
+            int64_t src_y = dest_y + y_offset;
+            // Handle row in steps of 4 or 8 using SSE or AVX
+            for (int64_t dest_x = 0; dest_x < dest_block_limit; dest_x += SIMD_WIDTH) {
+                int64_t dest_index = dest_x + dest_width * dest_y;
+                int64_t src_x = dest_x + x_offset;
+#ifdef __AVX__
+                __m256 sum = _mm256_setzero_ps();
+                __m256 weight = _mm256_setzero_ps();
+                for (int64_t i = -kernel_radius; i <= kernel_radius; i++) {
+                    int64_t src_index = src_x + i * jump_size + src_width * src_y;
+                    __m256 val = _mm256_loadu_ps(src_data + src_index);
+                    __m256 w = _mm256_set1_ps(kernel[i + kernel_radius]);
+                    __m256 mask = _mm256_andnot_ps(is_infinity(val), _mm256_cmp_ps(val, val, _CMP_EQ_OQ));
+                    w = _mm256_and_ps(w, mask);
+                    val = _mm256_and_ps(val, mask);
+                    sum += val * w;
+                    weight += w;
+                }
+                sum /= weight;
+                _mm256_storeu_ps(dest_data + dest_index, sum);
+#else
+                __m128 sum = _mm_setzero_ps();
+                __m128 weight = _mm_setzero_ps();
+                for (int64_t i = -kernel_radius; i <= kernel_radius; i++) {
+                    int64_t src_index = src_x + i * jump_size + src_width * src_y;
+                    __m128 val = _mm_loadu_ps(src_data + src_index);
+                    __m128 w = _mm_set_ps1(kernel[i + kernel_radius]);
+                    __m128 mask = _mm_andnot_ps(is_infinity(val), _mm_cmpeq_ps(val, val));
+                    w = _mm_and_ps(w, mask);
+                    val = _mm_and_ps(val, mask);
+                    sum += val * w;
+                    weight += w;
+                }
+                sum /= weight;
+                _mm_storeu_ps(dest_data + dest_index, sum);
+#endif
+            }
+
+            // Handle remainder of each block
+            for (int64_t dest_x = dest_block_limit; dest_x < dest_width; dest_x++) {
+                int64_t dest_index = dest_x + dest_width * dest_y;
+                int64_t src_x = dest_x + x_offset;
+                float sum = 0.0;
+                float weight = 0.0;
+                for (int64_t i = -kernel_radius; i <= kernel_radius; i++) {
+                    int64_t src_index = src_x + i * jump_size + src_width * src_y;
+                    float val = src_data[src_index];
+                    if (!isnan(val)) {
+                        float w = kernel[i + kernel_radius];
+                        sum += val * w;
+                        weight += w;
+                    }
+                }
+                if (weight > 0.0) {
+                    sum /= weight;
+                } else {
+                    sum = NAN;
+                }
+                dest_data[dest_index] = sum;
+            }
+        }
+    };
+    tbb::parallel_for(tbb::blocked_range<int>(0, dest_height), loop);
+
+    return true;
+}
+
+bool GaussianSmooth(const float* src_data, float* dest_data, int64_t src_width, int64_t src_height, int64_t dest_width, int64_t dest_height,
+    int smoothing_factor) {
+    float sigma = round(smoothing_factor / 2.0f);
+    int mask_size = smoothing_factor * 2 + 1;
+    const int apron_height = smoothing_factor;
+    int64_t calculated_dest_width = src_width - 2 * smoothing_factor;
+    int64_t calculated_dest_height = src_height - 2 * smoothing_factor;
+
+    if (dest_width * dest_height < calculated_dest_width * calculated_dest_height) {
+        fmt::print(std::cerr, "Incorrectly sized destination array. Should be at least{}x{} (got {}x{})\n", calculated_dest_width,
+            calculated_dest_height, dest_width, dest_height);
+        return false;
+    }
+
+    vector<float> kernel(mask_size);
+    MakeKernel(kernel, sigma);
+
+    double target_pixels = (SMOOTHING_TEMP_BUFFER_SIZE_MB * 1e6) / sizeof(float);
+    int64_t target_buffer_height = target_pixels / dest_width;
+    if (target_buffer_height < 4 * apron_height) {
+        target_buffer_height = 4 * apron_height;
+    }
+    int64_t buffer_height = min(target_buffer_height, src_height);
+
+    int64_t line_offset = 0;
+    auto t_start = std::chrono::high_resolution_clock::now();
+    unique_ptr<float> temp_array(new float[dest_width * buffer_height]);
+    auto source_ptr = src_data;
+    auto dest_ptr = dest_data;
+    const auto temp_ptr = temp_array.get();
+
+    while (line_offset < dest_height) {
+        int64_t num_lines = buffer_height - 2 * apron_height;
+        // clamp last iteration
+        if (line_offset + num_lines > dest_height) {
+            num_lines = dest_height - line_offset;
+        }
+        RunKernel(kernel, source_ptr, temp_ptr, src_width, src_height, dest_width, num_lines + 2 * apron_height, false);
+        RunKernel(kernel, temp_array.get(), dest_ptr, dest_width, num_lines + 2 * apron_height, dest_width, num_lines, true);
+
+        line_offset += num_lines;
+        source_ptr += num_lines * src_width;
+        dest_ptr += num_lines * dest_width;
+    }
+    auto t_end = std::chrono::high_resolution_clock::now();
+    auto dt = std::chrono::duration_cast<std::chrono::microseconds>(t_end - t_start).count();
+    auto rate = dest_width * dest_height / (double)dt;
+    fmt::print(
+        "Smoothed with smoothing factor of {} and kernel size of {} in {} ms at {} MPix/s\n", smoothing_factor, mask_size, dt * 1e-3, rate);
+    return true;
+}

--- a/Smoothing.cc
+++ b/Smoothing.cc
@@ -152,9 +152,9 @@ bool GaussianSmooth(const float* src_data, float* dest_data, int64_t src_width, 
     if (verbose_logging) {
         auto t_end = std::chrono::high_resolution_clock::now();
         auto dt = std::chrono::duration_cast<std::chrono::microseconds>(t_end - t_start).count();
-        auto rate = dest_width * dest_height / (double) dt;
-        fmt::print(
-            "Smoothed with smoothing factor of {} and kernel size of {} in {} ms at {} MPix/s\n", smoothing_factor, mask_size, dt * 1e-3, rate);
+        auto rate = dest_width * dest_height / (double)dt;
+        fmt::print("Smoothed with smoothing factor of {} and kernel size of {} in {} ms at {} MPix/s\n", smoothing_factor, mask_size,
+            dt * 1e-3, rate);
     }
     return true;
 }

--- a/Smoothing.cc
+++ b/Smoothing.cc
@@ -27,7 +27,9 @@ bool RunKernel(const vector<float>& kernel, const float* src_data, float* dest_d
 
     if (vertical && dest_height < src_height - kernel_radius * 2) {
         return false;
-    } else if (dest_width < src_width - kernel_radius * 2) {
+    }
+
+    if (dest_width < src_width - kernel_radius * 2) {
         return false;
     }
 
@@ -50,7 +52,7 @@ bool RunKernel(const vector<float>& kernel, const float* src_data, float* dest_d
                     int64_t src_index = src_x + i * jump_size + src_width * src_y;
                     __m256 val = _mm256_loadu_ps(src_data + src_index);
                     __m256 w = _mm256_set1_ps(kernel[i + kernel_radius]);
-                    __m256 mask = _mm256_andnot_ps(is_infinity(val), _mm256_cmp_ps(val, val, _CMP_EQ_OQ));
+                    __m256 mask = _mm256_andnot_ps(IsInfinity(val), _mm256_cmp_ps(val, val, _CMP_EQ_OQ));
                     w = _mm256_and_ps(w, mask);
                     val = _mm256_and_ps(val, mask);
                     sum += val * w;
@@ -65,7 +67,7 @@ bool RunKernel(const vector<float>& kernel, const float* src_data, float* dest_d
                     int64_t src_index = src_x + i * jump_size + src_width * src_y;
                     __m128 val = _mm_loadu_ps(src_data + src_index);
                     __m128 w = _mm_set_ps1(kernel[i + kernel_radius]);
-                    __m128 mask = _mm_andnot_ps(is_infinity(val), _mm_cmpeq_ps(val, val));
+                    __m128 mask = _mm_andnot_ps(IsInfinity(val), _mm_cmpeq_ps(val, val));
                     w = _mm_and_ps(w, mask);
                     val = _mm_and_ps(val, mask);
                     sum += val * w;

--- a/Smoothing.h
+++ b/Smoothing.h
@@ -15,22 +15,22 @@
 #ifdef __AVX__
 #define SIMD_WIDTH 8
 
-static inline __m256 is_infinity(__m256 x) {
-    const __m256 SIGN_MASK = _mm256_set1_ps(-0.0);
-    const __m256 INF = _mm256_set1_ps(std::numeric_limits<float>::infinity());
-    x = _mm256_andnot_ps(SIGN_MASK, x);
-    x = _mm256_cmp_ps(x, INF, _CMP_EQ_OQ);
+static inline __m256 IsInfinity(__m256 x) {
+    const __m256 sign_mask = _mm256_set1_ps(-0.0);
+    const __m256 inf = _mm256_set1_ps(std::numeric_limits<float>::infinity());
+    x = _mm256_andnot_ps(sign_mask, x);
+    x = _mm256_cmp_ps(x, inf, _CMP_EQ_OQ);
     return x;
 }
 #else
 #define SIMD_WIDTH 4
 
-static inline __m128 is_infinity(__m128 x) {
-    const __m128 SIGN_MASK = _mm_set_ps1(-0.0f);
-    const __m128 INF = _mm_set_ps1(std::numeric_limits<float>::infinity());
+static inline __m128 IsInfinity(__m128 x) {
+    const __m128 sign_mask = _mm_set_ps1(-0.0f);
+    const __m128 inf = _mm_set_ps1(std::numeric_limits<float>::infinity());
 
-    x = _mm_andnot_ps(SIGN_MASK, x);
-    x = _mm_cmpeq_ps(x, INF);
+    x = _mm_andnot_ps(sign_mask, x);
+    x = _mm_cmpeq_ps(x, inf);
     return x;
 }
 #endif

--- a/Smoothing.h
+++ b/Smoothing.h
@@ -39,5 +39,5 @@ void MakeKernel(std::vector<float>& kernel, double sigma);
 bool RunKernel(const std::vector<float>& kernel, const float* src_data, float* dest_data, int64_t src_width, int64_t src_height,
     int64_t dest_width, int64_t dest_height, bool vertical);
 bool GaussianSmooth(const float* src_data, float* dest_data, int64_t src_width, int64_t src_height, int64_t dest_width, int64_t dest_height,
-    int smoothing_factor);
+    int smoothing_factor, bool verbose_logging = false);
 #endif // CARTA_BACKEND__SMOOTHING_H_

--- a/Smoothing.h
+++ b/Smoothing.h
@@ -1,0 +1,43 @@
+//
+// Created by angus on 2019/09/23.
+//
+
+#ifndef CARTA_BACKEND__SMOOTHING_H_
+#define CARTA_BACKEND__SMOOTHING_H_
+
+#include <x86intrin.h>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+#define SMOOTHING_TEMP_BUFFER_SIZE_MB 200
+
+#ifdef __AVX__
+#define SIMD_WIDTH 8
+
+static inline __m256 is_infinity(__m256 x) {
+    const __m256 SIGN_MASK = _mm256_set1_ps(-0.0);
+    const __m256 INF = _mm256_set1_ps(std::numeric_limits<float>::infinity());
+    x = _mm256_andnot_ps(SIGN_MASK, x);
+    x = _mm256_cmp_ps(x, INF, _CMP_EQ_OQ);
+    return x;
+}
+#else
+#define SIMD_WIDTH 4
+
+static inline __m128 is_infinity(__m128 x) {
+    const __m128 SIGN_MASK = _mm_set_ps1(-0.0f);
+    const __m128 INF = _mm_set_ps1(std::numeric_limits<float>::infinity());
+
+    x = _mm_andnot_ps(SIGN_MASK, x);
+    x = _mm_cmpeq_ps(x, INF);
+    return x;
+}
+#endif
+
+void MakeKernel(std::vector<float>& kernel, double sigma);
+bool RunKernel(const std::vector<float>& kernel, const float* src_data, float* dest_data, int64_t src_width, int64_t src_height,
+    int64_t dest_width, int64_t dest_height, bool vertical);
+bool GaussianSmooth(const float* src_data, float* dest_data, int64_t src_width, int64_t src_height, int64_t dest_width, int64_t dest_height,
+    int smoothing_factor);
+#endif // CARTA_BACKEND__SMOOTHING_H_


### PR DESCRIPTION
Note: This is a companion PR of [carta-frontend/#567](https://github.com/CARTAvis/carta-frontend/pull/567). The two should only be merged into `dev` once both are approved.

This PR adds basic contouring support. Contours are calculated after the image has been smoothed, either using a block averaging or Gaussian smoothing filter. The contour implementation is adapted from SAOImage DS9 (a note has been added in the source code to indicate this). However, there are a number of differences:
- The Gaussian blur step is completely different, and uses `parallel_for` and  SSE4/AVX to speed up the filter
- The code is C++11-compliant
- The code uses `std::vector<bool>` instead of char arrays, to reduce memory consumption
- The tracing is performed in parallel (one thread per level)

After tracing, the contour poly-lines are quantized to a specified fraction of a pixel, then delta-encoded and shuffled, before compressing using the Zstd library. As such, `libzstd-dev` is now required.

Contours are re-calculated when the backend recieves a `SET_CONTOUR_PARAMETERS` message, or when the channel changes. At the moment, the `reference_file_id` must be the same as the `file_id`, but in future, we could use the AST library to transform between coordinate systems. 

Animations work, but animating across Stokes parameters is currently nonsensical, because the contour levels don't change during animation. 

There's still a lot more to do in terms of contours, but this is a decent starting point, and it shouldn't break anything _else_. 