### PR TITLE
Angus/contour stream

### DIFF
--- a/Compression.cc
+++ b/Compression.cc
@@ -170,7 +170,7 @@ void EncodeIntegers(std::vector<int32_t>& array, bool strided) {
         // Delta-encoding of neighbouring vertices to improve compression
         int last_x = 0;
         int last_y = 0;
-        for (size_t i = 0; i < num_values - 1; i += 2) {
+        for (int64_t i = 0; i < num_values - 1; i += 2) {
             int current_x = array[i];
             int current_y = array[i + 1];
             array[i] = current_x - last_x;
@@ -181,7 +181,7 @@ void EncodeIntegers(std::vector<int32_t>& array, bool strided) {
     } else {
         // Delta-encoding of neighbouring integers to improve compression
         int last = 0;
-        for (size_t i = 0; i < num_values; i++) {
+        for (int64_t i = 0; i < num_values; i++) {
             int current = array[i];
             array[i] = current - last;
             last = current;
@@ -189,7 +189,7 @@ void EncodeIntegers(std::vector<int32_t>& array, bool strided) {
     }
 
     // Shuffle bytes in blocks of 126 bits (4 floats). The remaining bytes are left along
-    for (size_t i = 0; i < blocked_length; i += 4) {
+    for (int64_t i = 0; i < blocked_length; i += 4) {
         __m128i vals = _mm_loadu_si128((__m128i*)&array[i]);
         vals = _mm_shuffle_epi8(vals, *(__m128i*)shuffle_vals.data());
         _mm_store_si128((__m128i*)&array[i], vals);

--- a/Contouring.cc
+++ b/Contouring.cc
@@ -130,17 +130,21 @@ void TraceLevel(const float* image, int64_t width, int64_t height, double scale,
     vector<bool> visited(num_pixels);
     int64_t i, j;
 
+    auto test_for_chunk_overflow = [&]() {
+        if (vertex_cutoff && vertices.size() > vertex_cutoff) {
+            double progress = std::min(0.99, checked_pixels / double(num_pixels));
+            partial_callback(level, progress, vertices, indices);
+            vertices.clear();
+            indices.clear();
+        }
+    };
+
     // Search TopEdge
     for (j = 0, i = 0; i < width - 1; i++) {
         if (image[(j)*width + i] < level && level <= image[(j)*width + i + 1]) {
             indices.push_back(vertices.size());
             TraceSegment(image, visited, width, height, scale, offset, level, i, j, Edge::TopEdge, vertices);
-            if (vertex_cutoff && vertices.size() > vertex_cutoff) {
-                double progress = std::min(0.99, checked_pixels / double(num_pixels));
-                partial_callback(level, progress, vertices, indices);
-                vertices.clear();
-                indices.clear();
-            }
+            test_for_chunk_overflow();
         }
         checked_pixels++;
     }
@@ -150,12 +154,7 @@ void TraceLevel(const float* image, int64_t width, int64_t height, double scale,
         if (image[(j)*width + i] < level && level <= image[(j + 1) * width + i]) {
             indices.push_back(vertices.size());
             TraceSegment(image, visited, width, height, scale, offset, level, i - 1, j, Edge::RightEdge, vertices);
-            if (vertex_cutoff && vertices.size() > vertex_cutoff) {
-                double progress = std::min(0.99, checked_pixels / double(num_pixels));
-                partial_callback(level, progress, vertices, indices);
-                vertices.clear();
-                indices.clear();
-            }
+            test_for_chunk_overflow();
         }
         checked_pixels++;
     }
@@ -165,12 +164,7 @@ void TraceLevel(const float* image, int64_t width, int64_t height, double scale,
         if (image[(j)*width + i + 1] < level && level <= image[(j)*width + i]) {
             indices.push_back(vertices.size());
             TraceSegment(image, visited, width, height, scale, offset, level, i, j - 1, Edge::BottomEdge, vertices);
-            if (vertex_cutoff && vertices.size() > vertex_cutoff) {
-                double progress = std::min(0.99, checked_pixels / double(num_pixels));
-                partial_callback(level, progress, vertices, indices);
-                vertices.clear();
-                indices.clear();
-            }
+            test_for_chunk_overflow();
         }
         checked_pixels++;
     }
@@ -180,12 +174,7 @@ void TraceLevel(const float* image, int64_t width, int64_t height, double scale,
         if (image[(j + 1) * width + i] < level && level <= image[(j)*width + i]) {
             indices.push_back(vertices.size());
             TraceSegment(image, visited, width, height, scale, offset, level, i, j, Edge::LeftEdge, vertices);
-            if (vertex_cutoff && vertices.size() > vertex_cutoff) {
-                double progress = std::min(0.99, checked_pixels / double(num_pixels));
-                partial_callback(level, progress, vertices, indices);
-                vertices.clear();
-                indices.clear();
-            }
+            test_for_chunk_overflow();
         }
         checked_pixels++;
     }
@@ -196,12 +185,7 @@ void TraceLevel(const float* image, int64_t width, int64_t height, double scale,
             if (!visited[j * width + i] && image[(j)*width + i] < level && level <= image[(j)*width + i + 1]) {
                 indices.push_back(vertices.size());
                 TraceSegment(image, visited, width, height, scale, offset, level, i, j, TopEdge, vertices);
-                if (vertex_cutoff && vertices.size() > vertex_cutoff) {
-                    double progress = std::min(0.99, checked_pixels / double(num_pixels));
-                    partial_callback(level, progress, vertices, indices);
-                    vertices.clear();
-                    indices.clear();
-                }
+                test_for_chunk_overflow();
             }
             checked_pixels++;
         }

--- a/Contouring.cc
+++ b/Contouring.cc
@@ -123,8 +123,10 @@ void TraceSegment(const float* image, std::vector<bool>& visited, int64_t width,
 }
 
 void TraceLevel(const float* image, int64_t width, int64_t height, double scale, double offset, double level, vector<float>& vertices,
-    vector<int32_t>& indices) {
-    int64_t num_pixels = width * height;
+    vector<int32_t>& indices, int chunk_size, ContourCallback& partial_callback) {
+    const int64_t num_pixels = width * height;
+    const size_t vertex_cutoff = 2 * chunk_size;
+    int64_t checked_pixels = 0;
     vector<bool> visited(num_pixels);
     int64_t i, j;
 
@@ -133,7 +135,14 @@ void TraceLevel(const float* image, int64_t width, int64_t height, double scale,
         if (image[(j)*width + i] < level && level <= image[(j)*width + i + 1]) {
             indices.push_back(vertices.size());
             TraceSegment(image, visited, width, height, scale, offset, level, i, j, Edge::TopEdge, vertices);
+            if (vertex_cutoff && vertices.size() > vertex_cutoff) {
+                double progress = std::min(0.99, checked_pixels / double(num_pixels));
+                partial_callback(level, progress, vertices, indices);
+                vertices.clear();
+                indices.clear();
+            }
         }
+        checked_pixels++;
     }
 
     // Search RightEdge
@@ -141,7 +150,14 @@ void TraceLevel(const float* image, int64_t width, int64_t height, double scale,
         if (image[(j)*width + i] < level && level <= image[(j + 1) * width + i]) {
             indices.push_back(vertices.size());
             TraceSegment(image, visited, width, height, scale, offset, level, i - 1, j, Edge::RightEdge, vertices);
+            if (vertex_cutoff && vertices.size() > vertex_cutoff) {
+                double progress = std::min(0.99, checked_pixels / double(num_pixels));
+                partial_callback(level, progress, vertices, indices);
+                vertices.clear();
+                indices.clear();
+            }
         }
+        checked_pixels++;
     }
 
     // Search Bottom
@@ -149,7 +165,14 @@ void TraceLevel(const float* image, int64_t width, int64_t height, double scale,
         if (image[(j)*width + i + 1] < level && level <= image[(j)*width + i]) {
             indices.push_back(vertices.size());
             TraceSegment(image, visited, width, height, scale, offset, level, i, j - 1, Edge::BottomEdge, vertices);
+            if (vertex_cutoff && vertices.size() > vertex_cutoff) {
+                double progress = std::min(0.99, checked_pixels / double(num_pixels));
+                partial_callback(level, progress, vertices, indices);
+                vertices.clear();
+                indices.clear();
+            }
         }
+        checked_pixels++;
     }
 
     // Search Left
@@ -157,7 +180,14 @@ void TraceLevel(const float* image, int64_t width, int64_t height, double scale,
         if (image[(j + 1) * width + i] < level && level <= image[(j)*width + i]) {
             indices.push_back(vertices.size());
             TraceSegment(image, visited, width, height, scale, offset, level, i, j, Edge::LeftEdge, vertices);
+            if (vertex_cutoff && vertices.size() > vertex_cutoff) {
+                double progress = std::min(0.99, checked_pixels / double(num_pixels));
+                partial_callback(level, progress, vertices, indices);
+                vertices.clear();
+                indices.clear();
+            }
         }
+        checked_pixels++;
     }
 
     // Search each row of the image
@@ -166,27 +196,22 @@ void TraceLevel(const float* image, int64_t width, int64_t height, double scale,
             if (!visited[j * width + i] && image[(j)*width + i] < level && level <= image[(j)*width + i + 1]) {
                 indices.push_back(vertices.size());
                 TraceSegment(image, visited, width, height, scale, offset, level, i, j, TopEdge, vertices);
+                if (vertex_cutoff && vertices.size() > vertex_cutoff) {
+                    double progress = std::min(0.99, checked_pixels / double(num_pixels));
+                    partial_callback(level, progress, vertices, indices);
+                    vertices.clear();
+                    indices.clear();
+                }
             }
+            checked_pixels++;
         }
     }
-}
-
-void TraceSingleContour(float* image, int64_t width, int64_t height, double scale, double offset, double level,
-    std::vector<float>& vertex_data, std::vector<int32_t>& indices) {
-    int64_t num_pixels = width * height;
-    vertex_data.clear();
-    indices.clear();
-
-    for (auto i = 0; i < num_pixels; i++) {
-        if (isnan(image[i])) {
-            image[i] = -std::numeric_limits<float>::max();
-        }
-    }
-    TraceLevel(image, width, height, scale, offset, level, vertex_data, indices);
+    partial_callback(level, 1.0, vertices, indices);
 }
 
 void TraceContours(float* image, int64_t width, int64_t height, double scale, double offset, const std::vector<double>& levels,
-    std::vector<std::vector<float>>& vertex_data, std::vector<std::vector<int32_t>>& index_data, bool verbose_logging) {
+    std::vector<std::vector<float>>& vertex_data, std::vector<std::vector<int32_t>>& index_data, int chunk_size,
+    ContourCallback& partial_callback, bool verbose_logging) {
     auto t_start_contours = std::chrono::high_resolution_clock::now();
     vertex_data.resize(levels.size());
     index_data.resize(levels.size());
@@ -202,7 +227,7 @@ void TraceContours(float* image, int64_t width, int64_t height, double scale, do
         for (int64_t l = r.begin(); l < r.end(); l++) {
             vertex_data[l].clear();
             index_data[l].clear();
-            TraceLevel(image, width, height, scale, offset, levels[l], vertex_data[l], index_data[l]);
+            TraceLevel(image, width, height, scale, offset, levels[l], vertex_data[l], index_data[l], chunk_size, partial_callback);
         }
     };
 

--- a/Contouring.h
+++ b/Contouring.h
@@ -2,13 +2,17 @@
 #define CARTA_BACKEND__CONTOURING_H_
 
 #include <cstdint>
+#include <functional>
 #include <vector>
+
+typedef const std::function<void(double, double, const std::vector<float>&, const std::vector<int32_t>&)> ContourCallback;
 
 enum Edge { TopEdge, RightEdge, BottomEdge, LeftEdge, None };
 
 void TraceContourLevel(float* image, int64_t width, int64_t height, double scale, double offset, double level,
     std::vector<double>& vertex_data, std::vector<int32_t>& indices);
 void TraceContours(float* image, int64_t width, int64_t height, double scale, double offset, const std::vector<double>& levels,
-    std::vector<std::vector<float>>& vertex_data, std::vector<std::vector<int32_t>>& index_data, bool verbose_logging = false);
+    std::vector<std::vector<float>>& vertex_data, std::vector<std::vector<int32_t>>& index_data, int chunk_size,
+    ContourCallback& partial_callback, bool verbose_logging = false);
 
 #endif // CARTA_BACKEND__CONTOURING_H_

--- a/EventHeader.h
+++ b/EventHeader.h
@@ -2,7 +2,7 @@
 #define CARTA_BACKEND__EVENTHEADER_H_
 
 namespace carta {
-const uint16_t ICD_VERSION = 9;
+const uint16_t ICD_VERSION = 10;
 struct EventHeader {
     uint16_t type;
     uint16_t icd_version;

--- a/Frame.cc
+++ b/Frame.cc
@@ -1871,12 +1871,8 @@ bool Frame::ContourImage(ContourCallback& partial_contour_callback) {
         return true;
     } else if (_contour_settings.smoothing_mode == CARTA::SmoothingMode::GaussianBlur) {
         // Smooth the image from cache
-        float sigma = _contour_settings.smoothing_factor / 2.0f;
-        int mask_size = _contour_settings.smoothing_factor * 2 + 1;
-        const int apron_height = _contour_settings.smoothing_factor;
-        std::vector<float> kernel(mask_size);
-        int64_t kernel_width = (kernel.size() - 1) / 2;
-        MakeKernel(kernel, sigma);
+        int mask_size = (_contour_settings.smoothing_factor - 1) * 2 + 1;
+        int64_t kernel_width = (mask_size - 1) / 2;
 
         int64_t source_width = _image_shape(0);
         int64_t source_height = _image_shape(1);
@@ -1889,7 +1885,7 @@ bool Frame::ContourImage(ContourCallback& partial_contour_callback) {
         cache_lock.release();
         if (smooth_successful) {
             // Perform contouring with an offset based on the Gaussian smoothing apron size
-            offset = _contour_settings.smoothing_factor;
+            offset = _contour_settings.smoothing_factor - 1;
             TraceContours(dest_array.get(), dest_width, dest_height, scale, offset, _contour_settings.levels, vertex_data, index_data,
                 _contour_settings.chunk_size, partial_contour_callback, _verbose);
             return true;

--- a/Frame.cc
+++ b/Frame.cc
@@ -1857,11 +1857,12 @@ bool Frame::GetRegionSpectralData(int region_id, int config_stokes, int profile_
     return data_ok;
 }
 
-bool Frame::ContourImage(std::vector<std::vector<float>>& vertex_data, std::vector<std::vector<int32_t>>& index_data,
-    ContourCallback& partial_contour_callback) {
+bool Frame::ContourImage(ContourCallback& partial_contour_callback) {
     double scale = 1.0;
     double offset = 0;
     bool smooth_successful = false;
+    std::vector<std::vector<float>> vertex_data;
+    std::vector<std::vector<int>> index_data;
     tbb::queuing_rw_mutex::scoped_lock cache_lock(_cache_mutex, false);
 
     if (_contour_settings.smoothing_mode == CARTA::SmoothingMode::NoSmoothing || _contour_settings.smoothing_factor <= 1) {

--- a/Frame.h
+++ b/Frame.h
@@ -131,8 +131,7 @@ public:
     inline ContourSettings& GetContourParameters() {
         return _contour_settings;
     };
-    bool ContourImage(
-        std::vector<std::vector<float>>& vertex_data, std::vector<std::vector<int>>& index_data, ContourCallback& partial_contour_callback);
+    bool ContourImage(ContourCallback& partial_contour_callback);
 
     // histogram only (not full data message) : get if stored, else can calculate
     bool GetRegionMinMax(int region_id, int channel, int stokes, float& min_val, float& max_val);

--- a/Frame.h
+++ b/Frame.h
@@ -25,6 +25,7 @@
 #include <carta-protobuf/spatial_profile.pb.h>
 #include <carta-protobuf/spectral_profile.pb.h>
 
+#include "Contouring.h"
 #include "ImageData/FileLoader.h"
 #include "InterfaceConstants.h"
 #include "Region/Region.h"
@@ -44,12 +45,14 @@ struct ContourSettings {
     int smoothing_factor;
     int decimation;
     int compression_level;
+    int chunk_size;
     uint32_t reference_file_id;
 
     // Equality operator for checking if contour settings have changed
     bool operator==(const ContourSettings& rhs) const {
         if (this->smoothing_mode != rhs.smoothing_mode || this->decimation != rhs.decimation ||
-            this->compression_level != rhs.compression_level || this->reference_file_id != rhs.reference_file_id) {
+            this->compression_level != rhs.compression_level || this->reference_file_id != rhs.reference_file_id ||
+            this->chunk_size != rhs.chunk_size) {
             return false;
         }
         if (this->levels.size() != rhs.levels.size()) {
@@ -128,7 +131,8 @@ public:
     inline ContourSettings& GetContourParameters() {
         return _contour_settings;
     };
-    bool ContourImage(std::vector<std::vector<float>>& vertex_data, std::vector<std::vector<int>>& index_data);
+    bool ContourImage(
+        std::vector<std::vector<float>>& vertex_data, std::vector<std::vector<int>>& index_data, ContourCallback& partial_contour_callback);
 
     // histogram only (not full data message) : get if stored, else can calculate
     bool GetRegionMinMax(int region_id, int channel, int stokes, float& min_val, float& max_val);

--- a/Frame.h
+++ b/Frame.h
@@ -50,9 +50,9 @@ struct ContourSettings {
 
     // Equality operator for checking if contour settings have changed
     bool operator==(const ContourSettings& rhs) const {
-        if (this->smoothing_mode != rhs.smoothing_mode || this->decimation != rhs.decimation ||
-            this->compression_level != rhs.compression_level || this->reference_file_id != rhs.reference_file_id ||
-            this->chunk_size != rhs.chunk_size) {
+        if (this->smoothing_mode != rhs.smoothing_mode || this->smoothing_factor != rhs.smoothing_factor ||
+            this->decimation != rhs.decimation || this->compression_level != rhs.compression_level ||
+            this->reference_file_id != rhs.reference_file_id || this->chunk_size != rhs.chunk_size) {
             return false;
         }
         if (this->levels.size() != rhs.levels.size()) {

--- a/Session.cc
+++ b/Session.cc
@@ -1054,6 +1054,7 @@ bool Session::SendContourData(int file_id) {
             contour_set->set_raw_coordinates(compression_buffer.data(), compressed_size);
             contour_set->set_raw_start_indices(indices.data(), indices.size() * sizeof(int32_t));
             contour_set->set_decimation_factor(pixel_rounding);
+            contour_set->set_uncompressed_coordinates_size(src_size);
             SendFileEvent(partial_response.file_id(), CARTA::EventType::CONTOUR_IMAGE_DATA, 0, partial_response);
         };
 

--- a/Session.cc
+++ b/Session.cc
@@ -1018,64 +1018,46 @@ bool Session::SendContourData(int file_id) {
             return false;
         }
 
+        int64_t total_vertices = 0;
         std::vector<std::vector<float>> vertex_data(num_levels);
         std::vector<std::vector<int32_t>> index_data(num_levels);
 
-        if (frame->ContourImage(vertex_data, index_data)) {
-            CARTA::ContourImageData response;
-            response.set_file_id(file_id);
+        auto callback = [&](double level, double progress, const std::vector<float>& vertices, const std::vector<int>& indices) {
+            CARTA::ContourImageData partial_response;
+            partial_response.set_file_id(file_id);
             // Currently only supports identical reference file IDs
-            response.set_reference_file_id(settings.reference_file_id);
-            response.set_channel(frame->CurrentChannel());
-            response.set_stokes(frame->CurrentStokes());
+            partial_response.set_reference_file_id(settings.reference_file_id);
+            partial_response.set_channel(frame->CurrentChannel());
+            partial_response.set_stokes(frame->CurrentStokes());
+            partial_response.set_progress(progress);
 
             std::vector<char> compression_buffer;
             const float pixel_rounding = std::max(1, std::min(32, settings.decimation));
             const int compression_level = std::max(1, std::min(20, settings.compression_level));
 
-            auto t_start = std::chrono::high_resolution_clock::now();
-            double total_src_size = 0;
-            double total_compressed_size = 0;
+            // Fill contour set
+            auto contour_set = partial_response.add_contour_sets();
+            contour_set->set_level(level);
 
-            // TODO: handle image bounds correctly
-            for (auto i = 0; i < num_levels; i++) {
-                auto& vertices = vertex_data[i];
-                auto& indices = index_data[i];
+            const int N = vertices.size();
+            total_vertices += N;
 
-                // Skip empty contour sets
-                if (vertices.empty() || indices.empty()) {
-                    continue;
-                }
+            std::vector<int32_t> vertices_shuffled;
+            RoundAndEncodeVertices(vertices, vertices_shuffled, pixel_rounding);
 
-                // Fill contour set
-                auto contour_set = response.add_contour_sets();
-                contour_set->set_level(settings.levels[i]);
+            // Compress using Zstd library
+            const size_t src_size = N * sizeof(int32_t);
+            compression_buffer.resize(ZSTD_compressBound(src_size));
+            size_t compressed_size =
+                ZSTD_compress(compression_buffer.data(), compression_buffer.size(), vertices_shuffled.data(), src_size, compression_level);
 
-                const int N = vertices.size();
+            contour_set->set_raw_coordinates(compression_buffer.data(), compressed_size);
+            contour_set->set_raw_start_indices(indices.data(), indices.size() * sizeof(int32_t));
+            contour_set->set_decimation_factor(pixel_rounding);
+            SendFileEvent(partial_response.file_id(), CARTA::EventType::CONTOUR_IMAGE_DATA, 0, partial_response);
+        };
 
-                std::vector<int32_t> vertices_shuffled;
-                RoundAndEncodeVertices(vertices, vertices_shuffled, pixel_rounding);
-
-                // Compress using Zstd library
-                const size_t src_size = N * sizeof(int32_t);
-                compression_buffer.resize(ZSTD_compressBound(src_size));
-                size_t compressed_size = ZSTD_compress(
-                    compression_buffer.data(), compression_buffer.size(), vertices_shuffled.data(), src_size, compression_level);
-
-                contour_set->set_raw_coordinates(compression_buffer.data(), compressed_size);
-                contour_set->set_raw_start_indices(indices.data(), indices.size() * sizeof(int32_t));
-                contour_set->set_decimation_factor(pixel_rounding);
-                total_src_size += src_size;
-                total_compressed_size += compressed_size;
-            }
-            if (_verbose_logging) {
-                auto t_end = std::chrono::high_resolution_clock::now();
-                auto dt = std::chrono::duration_cast<std::chrono::microseconds>(t_end - t_start).count();
-                double ratio = ((double)total_compressed_size) / total_src_size;
-                fmt::print("Encoded and compressed {:.2f} kB to {:.2f} kB ({:.2f}%) in {} ms using compression level {}\n",
-                    total_src_size * 1.0e-3, total_compressed_size * 1.0e-3, ratio * 100, dt * 1.0e-3, compression_level);
-            }
-            SendFileEvent(response.file_id(), CARTA::EventType::CONTOUR_IMAGE_DATA, 0, response);
+        if (frame->ContourImage(vertex_data, index_data, callback)) {
             return true;
         } else {
             SendLogEvent("Error processing contours", {"contours"}, CARTA::ErrorSeverity::WARNING);

--- a/Session.cc
+++ b/Session.cc
@@ -1047,8 +1047,8 @@ bool Session::SendContourData(int file_id) {
                 // Compress using Zstd library
                 const size_t src_size = N * sizeof(int32_t);
                 compression_buffer.resize(ZSTD_compressBound(src_size));
-                size_t compressed_size =
-                    ZSTD_compress(compression_buffer.data(), compression_buffer.size(), vertices_shuffled.data(), src_size, compression_level);
+                size_t compressed_size = ZSTD_compress(
+                    compression_buffer.data(), compression_buffer.size(), vertices_shuffled.data(), src_size, compression_level);
 
                 contour_set->set_raw_coordinates(compression_buffer.data(), compressed_size);
                 contour_set->set_raw_start_indices(indices.data(), indices.size() * sizeof(int32_t));

--- a/Smoothing.cc
+++ b/Smoothing.cc
@@ -109,11 +109,11 @@ bool RunKernel(const vector<float>& kernel, const float* src_data, float* dest_d
 
 bool GaussianSmooth(const float* src_data, float* dest_data, int64_t src_width, int64_t src_height, int64_t dest_width, int64_t dest_height,
     int smoothing_factor, bool verbose_logging) {
-    float sigma = round(smoothing_factor / 2.0f);
-    int mask_size = smoothing_factor * 2 + 1;
-    const int apron_height = smoothing_factor;
-    int64_t calculated_dest_width = src_width - 2 * smoothing_factor;
-    int64_t calculated_dest_height = src_height - 2 * smoothing_factor;
+    float sigma = (smoothing_factor - 1) / 2.0f;
+    int mask_size = (smoothing_factor - 1) * 2 + 1;
+    const int apron_height = smoothing_factor - 1;
+    int64_t calculated_dest_width = src_width - 2 * (smoothing_factor - 1);
+    int64_t calculated_dest_height = src_height - 2 * (smoothing_factor - 1);
 
     if (dest_width * dest_height < calculated_dest_width * calculated_dest_height) {
         fmt::print(std::cerr, "Incorrectly sized destination array. Should be at least{}x{} (got {}x{})\n", calculated_dest_width,


### PR DESCRIPTION
Note: This is a companion PR of [carta-frontend/#573](https://github.com/CARTAvis/carta-frontend/pull/573). It should not be merged until both PRs are approved.

This PR adds the following:
- Adds support for uncompressed contours when the contour compression level is 0. Contours are sent as floating point values, rather than being decimated, encoded and compressed
- Streams contours in chunks (the number of vertices per chunk is sent from the frontend). This provides better pipelining of contour calculation, compression and data delivery, and lets the user see progress as the contours are being delivered. 
- minor adjustments to Gaussian smoothing parameters to match DS9 behaviour

(note, this bumps the ICD version to 10. I will update the google doc after these two PRs have been approved, but before they have been merged)