### PR TITLE
Confluence/downsampled region dims rounding fix

### DIFF
--- a/Frame.cc
+++ b/Frame.cc
@@ -903,8 +903,8 @@ bool Frame::FillRasterImageData(CARTA::RasterImageData& raster_image_data, std::
             int precision = lround(quality_setting);
             raster_image_data.set_compression_quality(precision);
 
-            auto row_length = (bounds_setting.x_max() - bounds_setting.x_min()) / mip_setting;
-            auto num_rows = (bounds_setting.y_max() - bounds_setting.y_min()) / mip_setting;
+            auto row_length = std::ceil((float)(bounds_setting.x_max() - bounds_setting.x_min()) / mip_setting);
+            auto num_rows = std::ceil((float)(bounds_setting.y_max() - bounds_setting.y_min()) / mip_setting);
             std::vector<std::vector<char>> compression_buffers(num_subsets_setting);
             std::vector<size_t> compressed_sizes(num_subsets_setting);
             std::vector<std::vector<int32_t>> nan_encodings(num_subsets_setting);
@@ -978,7 +978,6 @@ bool Frame::GetRasterData(std::vector<float>& image_data, CARTA::ImageBounds& bo
 
     if (mean_filter && mip > 1) {
         // Perform down-sampling by calculating the mean for each MIPxMIP block
-        // TODO TODO TODO: check if these bounds checks are correct
         auto range = tbb::blocked_range<size_t>(0, num_rows_region);
         auto loop = [&](const tbb::blocked_range<size_t>& r) {
             for (size_t j = r.begin(); j != r.end(); ++j) {

--- a/Frame.cc
+++ b/Frame.cc
@@ -948,7 +948,7 @@ bool Frame::GetRasterData(std::vector<float>& image_data, CARTA::ImageBounds& bo
     if (!_valid || _image_cache.empty()) {
         return false;
     }
-    
+
     const int x = bounds.x_min();
     const int y = bounds.y_min();
     const int req_height = bounds.y_max() - y;
@@ -971,7 +971,7 @@ bool Frame::GetRasterData(std::vector<float>& image_data, CARTA::ImageBounds& bo
     size_t row_length_region = std::ceil((float)req_width / mip);
     image_data.resize(num_rows_region * row_length_region);
     int num_image_columns = _image_shape(0);
-    
+
     // read lock imageCache
     bool write_lock(false);
     tbb::queuing_rw_mutex::scoped_lock lock(_cache_mutex, write_lock);


### PR DESCRIPTION
This is a fix for the off-by-one rounding error in the downsampled tile dimensions. It should be merged at the same time as [the corresponding front-end PR](https://github.com/CARTAvis/carta-frontend/pull/623). This needs more thorough testing.