### PR TITLE
Missing data in large image

### DIFF
--- a/Frame.cc
+++ b/Frame.cc
@@ -744,7 +744,7 @@ bool Frame::SetImageCache() {
     bool write_lock(true);
     tbb::queuing_rw_mutex::scoped_lock cache_lock(_cache_mutex, write_lock);
     try {
-        _image_cache.resize(_image_shape(0) * _image_shape(1), 0.0);
+        _image_cache.resize(_image_shape(0) * _image_shape(1));
     } catch (std::bad_alloc& alloc_error) {
         Log(_session_id, "Could not allocate memory for image data.");
         return false;

--- a/Frame.cc
+++ b/Frame.cc
@@ -74,7 +74,10 @@ Frame::Frame(uint32_t session_id, carta::FileLoader* loader, const std::string& 
     // set current channel, stokes, imageCache
     _channel_index = default_channel;
     _stokes_index = DEFAULT_STOKES;
-    SetImageCache();
+    if (!SetImageCache()) {
+        _valid = false;
+        return;
+    }
 
     try {
         // Resize stats vectors and load data from image, if the format supports it.
@@ -736,15 +739,25 @@ bool Frame::SetImageChannels(int new_channel, int new_stokes, std::string& messa
     return updated;
 }
 
-void Frame::SetImageCache() {
+bool Frame::SetImageCache() {
     // get image data for channel, stokes
     bool write_lock(true);
     tbb::queuing_rw_mutex::scoped_lock cache_lock(_cache_mutex, write_lock);
-    _image_cache.resize(_image_shape(0) * _image_shape(1));
+    try {
+        _image_cache.resize(_image_shape(0) * _image_shape(1), 0.0);
+    } catch (std::bad_alloc& alloc_error) {
+        Log(_session_id, "Could not allocate memory for image data.");
+        return false;
+    }
+
     casacore::Slicer section = GetChannelMatrixSlicer(_channel_index, _stokes_index);
     casacore::Array<float> tmp(section.length(), _image_cache.data(), casacore::StorageInitPolicy::SHARE);
     std::lock_guard<std::mutex> guard(_image_mutex);
-    _loader->GetSlice(tmp, section);
+    if (!_loader->GetSlice(tmp, section)) {
+        Log(_session_id, "Loading image cache failed.");
+        return false;
+    }
+    return true;
 }
 
 void Frame::GetChannelMatrix(std::vector<float>& chan_matrix, size_t channel, size_t stokes) {

--- a/Frame.h
+++ b/Frame.h
@@ -198,7 +198,7 @@ private:
 
     // Image data
     // save image region data for current channel, stokes
-    void SetImageCache();
+    bool SetImageCache();
     // downsampled data from image cache
     bool GetRasterData(std::vector<float>& image_data, CARTA::ImageBounds& bounds, int mip, bool mean_filter = true);
     bool GetRasterTileData(std::vector<float>& tile_data, const Tile& tile, int& width, int& height);

--- a/ImageData/FileLoader.cc
+++ b/ImageData/FileLoader.cc
@@ -1,5 +1,7 @@
 #include "FileLoader.h"
 
+#include <casacore/lattices/Lattices/MaskedLatticeIterator.h>
+
 #include "../Util.h"
 #include "CasaLoader.h"
 #include "FitsLoader.h"
@@ -194,22 +196,38 @@ bool FileLoader::GetSlice(casacore::Array<float>& data, const casacore::Slicer& 
         return false;
     }
 
-    // Get data slice
-    data = image->getSlice(slicer, removeDegenerateAxes);
-    if (image->isMasked()) {
-        // Apply mask: set unmasked values to NaN
-        casacore::Array<bool> mask = image->getMaskSlice(slicer, removeDegenerateAxes);
-        bool delete_data_ptr;
-        float* pData = data.getStorage(delete_data_ptr);
-        bool delete_mask_ptr;
-        const bool* pMask = mask.getStorage(delete_mask_ptr);
-        for (size_t i = 0; i < data.nelements(); ++i) {
-            if (!pMask[i]) {
-                pData[i] = std::numeric_limits<float>::quiet_NaN();
+    // Get data slice with mask applied
+    data.resize(slicer.length());
+    casacore::SubImage<float> subimage(*image, slicer);               // apply slicer to image to get appropriate cursor
+    casacore::RO_MaskedLatticeIterator<float> lattice_iter(subimage); // read-only
+    int i(0);
+    for (lattice_iter.reset(); !lattice_iter.atEnd(); ++lattice_iter) {
+        casacore::IPosition cursor_shape(lattice_iter.cursorShape());
+        casacore::IPosition cursor_position(lattice_iter.position());
+        casacore::Slicer cursor_slicer(cursor_position, cursor_shape); // where to put the data
+        casacore::Array<float> cursor_data = lattice_iter.cursor();
+
+        if (image->isMasked()) {
+            casacore::Array<float> masked_data(cursor_data); // reference the same storage
+            const casacore::Array<bool> cursor_mask = lattice_iter.getMask();
+            // Apply cursor mask to cursor data: set masked values to NaN.
+            // booleans are used to delete copy of data if necessary
+            bool del_mask_ptr;
+            const bool* pCursorMask = cursor_mask.getStorage(del_mask_ptr);
+            bool del_data_ptr;
+            float* pMaskedData = masked_data.getStorage(del_data_ptr);
+            for (size_t i = 0; i < cursor_data.nelements(); ++i) {
+                if (!pCursorMask[i]) {
+                    pMaskedData[i] = std::numeric_limits<float>::quiet_NaN();
+                }
             }
+
+            // free storage for cursor arrays
+            cursor_mask.freeStorage(pCursorMask, del_mask_ptr);
+            masked_data.putStorage(pMaskedData, del_data_ptr);
         }
-        mask.freeStorage(pMask, delete_mask_ptr);
-        data.putStorage(pData, delete_data_ptr);
+
+        data(cursor_slicer) = cursor_data;
     }
     return true;
 }

--- a/ImageData/FileLoader.cc
+++ b/ImageData/FileLoader.cc
@@ -200,7 +200,6 @@ bool FileLoader::GetSlice(casacore::Array<float>& data, const casacore::Slicer& 
     data.resize(slicer.length());
     casacore::SubImage<float> subimage(*image, slicer);               // apply slicer to image to get appropriate cursor
     casacore::RO_MaskedLatticeIterator<float> lattice_iter(subimage); // read-only
-    int i(0);
     for (lattice_iter.reset(); !lattice_iter.atEnd(); ++lattice_iter) {
         casacore::IPosition cursor_shape(lattice_iter.cursorShape());
         casacore::IPosition cursor_position(lattice_iter.position());


### PR DESCRIPTION
For very large image frames, the backend was improperly handling the entire data and mask arrays (probable memory error with very large arrays).  FileLoader::GetSlice was refactored to use a masked lattice iterator to apply the mask to data in chunks.  Also added code to catch bad_alloc when resizing the image cache vector.