### PR TITLE
carta miriad image

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ set(SOURCE_FILES
         ImageData/FileLoader.cc
         ImageData/Hdf5Loader.cc
         ImageData/CartaHdf5Image.cc
+        ImageData/CartaMiriadImage.cc
         FileList/FileExtInfoLoader.cc
         FileList/FileInfoLoader.cc
         FileList/FileListHandler.cc

--- a/FileList/FileExtInfoLoader.cc
+++ b/FileList/FileExtInfoLoader.cc
@@ -14,6 +14,7 @@
 #include <casacore/measures/Measures/MFrequency.h>
 #include <casacore/mirlib/miriad.h>
 
+#include "../ImageData/CartaMiriadImage.h"
 #include "../ImageData/FileLoader.h"
 
 using namespace carta;
@@ -54,9 +55,15 @@ bool FileExtInfoLoader::FillFileInfoFromImage(CARTA::FileInfoExtended* extended_
                 bool prefer_velocity(false), optical_velocity(false);
                 bool prefer_wavelength(false), air_wavelength(false);
                 casacore::CoordinateSystem coord_sys(image->coordinates());
-                if (coord_sys.hasSpectralAxis()) {
-                    // retain spectral axis native type in headers
-                    switch (coord_sys.spectralCoordinate().nativeType()) {
+                if (coord_sys.hasSpectralAxis()) { // prefer spectral axis native type
+                    casacore::SpectralCoordinate::SpecType native_type;
+                    if (image->imageType() == "CartaMiriadImage") { // workaround to get correct native type
+                        CartaMiriadImage* miriad_image = static_cast<CartaMiriadImage*>(image);
+                        native_type = miriad_image->NativeType();
+                    } else {
+                        native_type = coord_sys.spectralCoordinate().nativeType();
+                    }
+                    switch (native_type) {
                         case casacore::SpectralCoordinate::FREQ: {
                             break;
                         }
@@ -67,7 +74,8 @@ bool FileExtInfoLoader::FillFileInfoFromImage(CARTA::FileInfoExtended* extended_
                         }
                         case casacore::SpectralCoordinate::VOPT: {
                             prefer_velocity = true;
-                            // If VELREF is not set in headers, spectral native type (mirlib) is VOPT even when CTYPE is VRAD
+
+                            // Check doppler type; oddly, native type can be VOPT but doppler is RADIO--?
                             casacore::MDoppler::Types vel_doppler(coord_sys.spectralCoordinate().velocityDoppler());
                             if ((vel_doppler == casacore::MDoppler::Z) || (vel_doppler == casacore::MDoppler::OPTICAL)) {
                                 optical_velocity = true;
@@ -329,12 +337,10 @@ void FileExtInfoLoader::AddComputedEntries(
     }
 
     if (coord_system.hasDirectionCoordinate()) {
-        std::string projection;
         casacore::DirectionCoordinate dir_coord(coord_system.directionCoordinate());
-        if (dir_coord.isNCP()) {
-            projection = "NCP";
-        } else {
-            projection = dir_coord.projection().name();
+        std::string projection(dir_coord.projection().name());
+        if ((projection == "SIN") && (dir_coord.isNCP())) {
+            projection = "SIN / NCP";
         }
         if (!projection.empty()) {
             auto entry = extended_info->add_computed_entries();

--- a/FileList/FileExtInfoLoader.cc
+++ b/FileList/FileExtInfoLoader.cc
@@ -329,7 +329,13 @@ void FileExtInfoLoader::AddComputedEntries(
     }
 
     if (coord_system.hasDirectionCoordinate()) {
-        std::string projection(coord_system.directionCoordinate().projection().name());
+        std::string projection;
+        casacore::DirectionCoordinate dir_coord(coord_system.directionCoordinate());
+        if (dir_coord.isNCP()) {
+            projection = "NCP";
+        } else {
+            projection = dir_coord.projection().name();
+        }
         if (!projection.empty()) {
             auto entry = extended_info->add_computed_entries();
             entry->set_name("Projection");

--- a/ImageData/CartaMiriadImage.cc
+++ b/ImageData/CartaMiriadImage.cc
@@ -21,10 +21,7 @@ CartaMiriadImage::CartaMiriadImage(const std::string& filename, casacore::MaskSp
 }
 
 CartaMiriadImage::CartaMiriadImage(const CartaMiriadImage& other)
-    : casacore::MIRIADImage(other),
-      _filename(other._filename),
-      _mask_spec(other._mask_spec),
-      _pixel_mask(nullptr) {
+    : casacore::MIRIADImage(other), _filename(other._filename), _mask_spec(other._mask_spec), _pixel_mask(nullptr) {
     SetUp();
     if (other._pixel_mask != nullptr) {
         _pixel_mask = other._pixel_mask->clone();

--- a/ImageData/CartaMiriadImage.h
+++ b/ImageData/CartaMiriadImage.h
@@ -1,0 +1,54 @@
+//# CartaMiriadImage.h : MIRIAD Image class to support masks
+
+#ifndef CARTA_BACKEND_IMAGEDATA_CARTAMIRIADIMAGE_H_
+#define CARTA_BACKEND_IMAGEDATA_CARTAMIRIADIMAGE_H_
+
+#include <casacore/images/Images/MIRIADImage.h>
+#include <casacore/images/Images/MaskSpecifier.h>
+
+namespace carta {
+
+class CartaMiriadImage : public casacore::MIRIADImage {
+public:
+    // Construct an image from a pre-existing file.
+    CartaMiriadImage(const std::string& filename, casacore::MaskSpecifier = casacore::MaskSpecifier());
+    // Copy constructor
+    CartaMiriadImage(const CartaMiriadImage& other);
+    ~CartaMiriadImage();
+
+    inline bool Valid() {
+        return _valid;
+    };
+
+    // implement casacore ImageInterface
+    casacore::String imageType() const override;
+    casacore::String name(bool stripPath = false) const override;
+    casacore::ImageInterface<float>* cloneII() const override;
+
+    // implement functions in other casacore Image classes
+    casacore::Bool isMasked() const override;
+    casacore::Bool hasPixelMask() const override;
+    const casacore::Lattice<bool>& pixelMask() const override;
+    casacore::Lattice<bool>& pixelMask() override;
+    casacore::Bool doGetMaskSlice(casacore::Array<bool>& buffer, const casacore::Slicer& section) override;
+
+private:
+    void SetUp();
+    void OpenImage();
+    void CloseImage();
+    void GetPlaneFlags(casacore::Array<bool>& buffer, const casacore::Slicer& section, int z = -1, int w = -1);
+
+    casacore::String _filename;
+    casacore::MaskSpecifier _mask_spec;
+    bool _valid;
+    bool _is_open;
+    int _file_handle;
+
+    bool _has_mask;
+    casacore::String _mask_name; // full path to mask file
+    casacore::Lattice<casacore::Bool>* _pixel_mask;
+};
+
+} // namespace carta
+
+#endif // CARTA_BACKEND_IMAGEDATA_CARTAMIRIADIMAGE_H_

--- a/ImageData/CartaMiriadImage.h
+++ b/ImageData/CartaMiriadImage.h
@@ -3,6 +3,7 @@
 #ifndef CARTA_BACKEND_IMAGEDATA_CARTAMIRIADIMAGE_H_
 #define CARTA_BACKEND_IMAGEDATA_CARTAMIRIADIMAGE_H_
 
+#include <casacore/coordinates/Coordinates/SpectralCoordinate.h>
 #include <casacore/images/Images/MIRIADImage.h>
 #include <casacore/images/Images/MaskSpecifier.h>
 
@@ -20,6 +21,10 @@ public:
         return _valid;
     };
 
+    inline casacore::SpectralCoordinate::SpecType NativeType() {
+        return _native_type;
+    }
+
     // implement casacore ImageInterface
     casacore::String imageType() const override;
     casacore::String name(bool stripPath = false) const override;
@@ -36,6 +41,10 @@ private:
     void SetUp();
     void OpenImage();
     void CloseImage();
+    void SetMask();
+    void SetNativeType();
+
+    // for doGetMaskSlice, read flag rows from mask file using mirlib
     void GetPlaneFlags(casacore::Array<bool>& buffer, const casacore::Slicer& section, int z = -1, int w = -1);
 
     casacore::String _filename;
@@ -43,6 +52,7 @@ private:
     bool _valid;
     bool _is_open;
     int _file_handle;
+    casacore::SpectralCoordinate::SpecType _native_type;
 
     bool _has_mask;
     casacore::String _mask_name; // full path to mask file

--- a/ImageData/FileLoader.cc
+++ b/ImageData/FileLoader.cc
@@ -196,8 +196,11 @@ bool FileLoader::GetSlice(casacore::Array<float>& data, const casacore::Slicer& 
         return false;
     }
 
+    if (data.shape() != slicer.length()) {
+        data.resize(slicer.length());
+    }
+
     // Get data slice with mask applied
-    data.resize(slicer.length());
     casacore::SubImage<float> subimage(*image, slicer);               // apply slicer to image to get appropriate cursor
     casacore::RO_MaskedLatticeIterator<float> lattice_iter(subimage); // read-only
     for (lattice_iter.reset(); !lattice_iter.atEnd(); ++lattice_iter) {
@@ -225,7 +228,6 @@ bool FileLoader::GetSlice(casacore::Array<float>& data, const casacore::Slicer& 
             cursor_mask.freeStorage(pCursorMask, del_mask_ptr);
             masked_data.putStorage(pMaskedData, del_data_ptr);
         }
-
         data(cursor_slicer) = cursor_data;
     }
     return true;

--- a/ImageData/MiriadLoader.h
+++ b/ImageData/MiriadLoader.h
@@ -1,8 +1,7 @@
 #ifndef CARTA_BACKEND_IMAGEDATA_MIRIADLOADER_H_
 #define CARTA_BACKEND_IMAGEDATA_MIRIADLOADER_H_
 
-#include <casacore/images/Images/MIRIADImage.h>
-
+#include "CartaMiriadImage.h"
 #include "FileLoader.h"
 
 namespace carta {
@@ -53,7 +52,7 @@ bool MiriadLoader::CanOpenFile(std::string& error) {
 
 void MiriadLoader::OpenFile(const std::string& /*hdu*/) {
     if (!_image) {
-        _image.reset(new casacore::MIRIADImage(_filename));
+        _image.reset(new CartaMiriadImage(_filename));
         _num_dims = _image->shape().size();
     }
 }


### PR DESCRIPTION
This image class derived from casacore::MIRIADImage addresses its missing implementation of masks and native spectral type.

The file info checks for native NCP projection conversion to SIN (in all image types).  When the direction coordinate projection in the image coordinate system is SIN, the backend checks whether the projection is equivalent to NCP (projection parameter 1 is 1/tan(dec)) and displays the projection as "SIN / NCP".  This is the best approximation unless we read the actual headers for all image types (e.g. FITS), which we are trying to avoid with the unified file info for all image types.