### PR TITLE
Moving json-c into LINK_LIBS for AuthServer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,8 @@ if (AuthServer)
     set(LINK_LIBS
             jsoncpp
             mongoc-1.0
-            bson-1.0)
+            bson-1.0
+            json-c)
     set(SOURCE_FILES
             DBConnect.cc)
 endif (AuthServer)
@@ -61,7 +62,6 @@ set(LINK_LIBS
         zfp
         zstd
         tbb
-        json-c
         casa_casa
         casa_coordinates
         casa_tables


### PR DESCRIPTION
json-c is only required for the server version of CARTA, so it shouldn't be required as a normal dependency. We just need to move it up inside the AuthServer block's LINK_LIBS section.