### PR TITLE
Angus/tiled animations

### DIFF
--- a/AnimationObject.h
+++ b/AnimationObject.h
@@ -23,7 +23,6 @@ class AnimationObject {
     CARTA::AnimationFrame _delta_frame;
     CARTA::AnimationFrame _current_frame;
     CARTA::AnimationFrame _next_frame;
-    CARTA::AnimationFrame _stop_frame;
     CARTA::AnimationFrame _last_flow_frame;
     int _frame_rate;
     std::chrono::microseconds _frame_interval;
@@ -70,7 +69,6 @@ public:
         _file_open = true;
         _waiting_flow_event = false;
         _last_flow_frame = start_frame;
-        _stop_frame = start_frame;
     }
     int CurrentFlowWindowSize() {
         return (CARTA::AnimationFlowWindowConstant * CARTA::AnimationFlowWindowScaler * _frame_rate);

--- a/EventHeader.h
+++ b/EventHeader.h
@@ -2,7 +2,7 @@
 #define CARTA_BACKEND__EVENTHEADER_H_
 
 namespace carta {
-const uint16_t ICD_VERSION = 11;
+const uint16_t ICD_VERSION = 12;
 struct EventHeader {
     uint16_t type;
     uint16_t icd_version;

--- a/FileSettings.cc
+++ b/FileSettings.cc
@@ -36,8 +36,6 @@ bool FileSettings::ExecuteOne(const std::string& event_name, const uint32_t file
 
 void FileSettings::ClearSettings(const uint32_t file_id) {
     bool write_lock(true);
-    tbb::queuing_rw_mutex::scoped_lock view_lock(_view_mutex, write_lock);
-    _latest_view.unsafe_erase(file_id);
     tbb::queuing_rw_mutex::scoped_lock cursor_lock(_cursor_mutex, write_lock);
     _latest_cursor.unsafe_erase(file_id);
 }

--- a/FileSettings.h
+++ b/FileSettings.h
@@ -11,7 +11,6 @@
 #include <tbb/queuing_rw_mutex.h>
 
 #include <carta-protobuf/set_cursor.pb.h>
-#include <carta-protobuf/set_image_view.pb.h>
 
 class Session;
 

--- a/FileSettings.h
+++ b/FileSettings.h
@@ -26,13 +26,7 @@ public:
 
 private:
     Session* _session;
-    tbb::queuing_rw_mutex _view_mutex, _cursor_mutex;
-
-    // pair is <message, requestId)
-    using view_info_t = std::pair<CARTA::SetImageView, uint32_t>;
-    using view_iter = tbb::concurrent_unordered_map<int, view_info_t>::iterator;
-    // map is <fileId, view info>
-    tbb::concurrent_unordered_map<int, view_info_t> _latest_view;
+    tbb::queuing_rw_mutex _cursor_mutex;
 
     // pair is <message, requestId)
     using cursor_info_t = std::pair<CARTA::SetCursor, uint32_t>;

--- a/Frame.cc
+++ b/Frame.cc
@@ -661,57 +661,6 @@ void Frame::ExportDs9Regions(std::vector<int>& region_ids, CARTA::CoordinateType
 
 // ********************************************************************
 // Image region parameters: view, channel/stokes, slicers
-
-bool Frame::SetImageView(
-    const CARTA::ImageBounds& image_bounds, int new_mip, CARTA::CompressionType compression, float quality, int num_subsets) {
-    // set image bounds and compression settings
-    if (!_valid) {
-        return false;
-    }
-    const int x_min = image_bounds.x_min();
-    const int x_max = image_bounds.x_max();
-    const int y_min = image_bounds.y_min();
-    const int y_max = image_bounds.y_max();
-    const int req_height = y_max - y_min;
-    const int req_width = x_max - x_min;
-
-    // out of bounds check
-    if ((req_height < 0) || (req_width < 0)) {
-        return false;
-    }
-    if ((_image_shape(1) < y_min + req_height) || (_image_shape(0) < x_min + req_width)) {
-        return false;
-    }
-    if (new_mip <= 0) {
-        return false;
-    }
-
-    // changed check
-    ViewSettings current_view_settings = GetViewSettings();
-    CARTA::ImageBounds current_view_bounds = current_view_settings.image_bounds;
-    if ((current_view_bounds.x_min() == x_min) && (current_view_bounds.x_max() == x_max) && (current_view_bounds.y_min() == y_min) &&
-        (current_view_bounds.y_max() == y_max) && (current_view_settings.mip == new_mip) &&
-        (current_view_settings.compression_type == compression) && (current_view_settings.quality == quality) &&
-        (current_view_settings.num_subsets == num_subsets)) {
-        return false;
-    }
-
-    SetViewSettings(image_bounds, new_mip, compression, quality, num_subsets);
-    return true;
-}
-
-void Frame::SetViewSettings(
-    const CARTA::ImageBounds& new_bounds, int new_mip, CARTA::CompressionType new_compression, float new_quality, int new_subsets) {
-    // save new view settings in atomic operation
-    ViewSettings settings;
-    settings.image_bounds = new_bounds;
-    settings.mip = new_mip;
-    settings.compression_type = new_compression;
-    settings.quality = new_quality;
-    settings.num_subsets = new_subsets;
-    _view_settings = settings;
-}
-
 bool Frame::SetImageChannels(int new_channel, int new_stokes, std::string& message) {
     bool updated(false);
 
@@ -894,81 +843,6 @@ bool Frame::SetRegionStatsRequirements(int region_id, const std::vector<int>& st
 
 // ****************************************************
 // Data for Image region
-
-bool Frame::FillRasterImageData(CARTA::RasterImageData& raster_image_data, std::string& message) {
-    // fill data message with compressed channel cache data
-    bool raster_data_ok(false);
-    // retrieve settings
-    ViewSettings view_settings = GetViewSettings();
-    // get downsampled raster data for message
-    std::vector<float> image_data;
-    CARTA::ImageBounds bounds_setting(view_settings.image_bounds);
-    int mip_setting(view_settings.mip);
-    if (GetRasterData(image_data, bounds_setting, mip_setting)) {
-        // set common message fields
-        raster_image_data.mutable_image_bounds()->set_x_min(bounds_setting.x_min());
-        raster_image_data.mutable_image_bounds()->set_x_max(bounds_setting.x_max());
-        raster_image_data.mutable_image_bounds()->set_y_min(bounds_setting.y_min());
-        raster_image_data.mutable_image_bounds()->set_y_max(bounds_setting.y_max());
-        raster_image_data.set_channel(_channel_index);
-        raster_image_data.set_stokes(_stokes_index);
-        raster_image_data.set_mip(mip_setting);
-        CARTA::CompressionType compression_setting = view_settings.compression_type;
-        raster_image_data.set_compression_type(compression_setting);
-
-        // add data
-        if (compression_setting == CARTA::CompressionType::NONE) {
-            raster_image_data.set_compression_quality(0);
-            raster_image_data.add_image_data(image_data.data(), image_data.size() * sizeof(float));
-            raster_data_ok = true;
-        } else if (compression_setting == CARTA::CompressionType::ZFP) {
-            // compression settings
-            float quality_setting(view_settings.quality);
-            int num_subsets_setting(view_settings.num_subsets);
-
-            int precision = lround(quality_setting);
-            raster_image_data.set_compression_quality(precision);
-
-            auto row_length = std::ceil((float)(bounds_setting.x_max() - bounds_setting.x_min()) / mip_setting);
-            auto num_rows = std::ceil((float)(bounds_setting.y_max() - bounds_setting.y_min()) / mip_setting);
-            std::vector<std::vector<char>> compression_buffers(num_subsets_setting);
-            std::vector<size_t> compressed_sizes(num_subsets_setting);
-            std::vector<std::vector<int32_t>> nan_encodings(num_subsets_setting);
-
-            auto num_subsets = std::min(num_subsets_setting, MAX_SUBSETS);
-            auto range = tbb::blocked_range<int>(0, num_subsets);
-            auto loop = [&](const tbb::blocked_range<int>& r) {
-                for (int i = r.begin(); i != r.end(); ++i) {
-                    int subset_row_start = i * (num_rows / num_subsets);
-                    int subset_row_end = (i + 1) * (num_rows / num_subsets);
-                    if (i == num_subsets - 1) {
-                        subset_row_end = num_rows;
-                    }
-                    int subset_element_start = subset_row_start * row_length;
-                    int subset_element_end = subset_row_end * row_length;
-                    nan_encodings[i] =
-                        GetNanEncodingsBlock(image_data, subset_element_start, row_length, subset_row_end - subset_row_start);
-                    Compress(image_data, subset_element_start, compression_buffers[i], compressed_sizes[i], row_length,
-                        subset_row_end - subset_row_start, precision);
-                }
-            };
-            tbb::parallel_for(range, loop);
-
-            // Complete message
-            for (auto i = 0; i < num_subsets_setting; i++) {
-                raster_image_data.add_image_data(compression_buffers[i].data(), compressed_sizes[i]);
-                raster_image_data.add_nan_encodings((char*)nan_encodings[i].data(), nan_encodings[i].size() * sizeof(int));
-            }
-            raster_data_ok = true;
-        } else {
-            message = "SZ compression not implemented";
-        }
-    } else {
-        message = "Raster image data failed to load";
-    }
-    return raster_data_ok;
-}
-
 bool Frame::GetRasterData(std::vector<float>& image_data, CARTA::ImageBounds& bounds, int mip, bool mean_filter) {
     // apply bounds and downsample image cache
     if (!_valid || _image_cache.empty()) {

--- a/Frame.h
+++ b/Frame.h
@@ -19,7 +19,6 @@
 #include <carta-protobuf/defs.pb.h>
 #include <carta-protobuf/export_region.pb.h>
 #include <carta-protobuf/import_region.pb.h>
-#include <carta-protobuf/raster_image.pb.h>
 #include <carta-protobuf/raster_tile.pb.h>
 #include <carta-protobuf/region_histogram.pb.h>
 #include <carta-protobuf/spatial_profile.pb.h>

--- a/Frame.h
+++ b/Frame.h
@@ -24,20 +24,13 @@
 #include <carta-protobuf/region_histogram.pb.h>
 #include <carta-protobuf/spatial_profile.pb.h>
 #include <carta-protobuf/spectral_profile.pb.h>
+#include <carta-protobuf/tiles.pb.h>
 
 #include "Contouring.h"
 #include "ImageData/FileLoader.h"
 #include "InterfaceConstants.h"
 #include "Region/Region.h"
 #include "Tile.h"
-
-struct ViewSettings {
-    CARTA::ImageBounds image_bounds;
-    int mip;
-    CARTA::CompressionType compression_type;
-    float quality;
-    int num_subsets;
-};
 
 struct ContourSettings {
     std::vector<double> levels;
@@ -104,8 +97,13 @@ public:
         CARTA::ExportRegionAck& export_ack);
 
     // image view, channels
-    bool SetImageView(
-        const CARTA::ImageBounds& image_bounds, int new_mip, CARTA::CompressionType compression, float quality, int num_subsets);
+    inline void SetAnimationViewSettings(const CARTA::AddRequiredTiles& required_animation_tiles) {
+        _required_animation_tiles = required_animation_tiles;
+    }
+    inline CARTA::AddRequiredTiles GetAnimationViewSettings() {
+        return _required_animation_tiles;
+    };
+
     bool SetImageChannels(int new_channel, int new_stokes, std::string& message);
 
     // set requirements
@@ -116,7 +114,6 @@ public:
 
     // fill data, profiles, stats messages
     // For some messages, prevent sending data when current channel/stokes changes
-    bool FillRasterImageData(CARTA::RasterImageData& raster_image_data, std::string& message);
     bool FillRasterTileData(CARTA::RasterTileData& raster_tile_data, const Tile& tile, int channel, int stokes,
         CARTA::CompressionType compression_type, float compression_quality);
     bool FillSpatialProfileData(int region_id, CARTA::SpatialProfileData& profile_data, bool stokes_changed = false);
@@ -182,13 +179,6 @@ private:
     void ExportDs9Regions(std::vector<int>& region_ids, CARTA::CoordinateType coord_type, const casacore::CoordinateSystem& coord_sys,
         std::string& ds9_filename, CARTA::ExportRegionAck& export_ack);
 
-    // Image view settings
-    void SetViewSettings(
-        const CARTA::ImageBounds& new_bounds, int new_mip, CARTA::CompressionType new_compression, float new_quality, int new_subsets);
-    inline ViewSettings GetViewSettings() {
-        return _view_settings;
-    };
-
     // validate channel, stokes index values
     bool CheckChannel(int channel);
     bool CheckStokes(int stokes);
@@ -251,7 +241,7 @@ private:
     size_t _num_stokes;
 
     // Image settings
-    ViewSettings _view_settings;
+    CARTA::AddRequiredTiles _required_animation_tiles;
 
     // Contour settings
     ContourSettings _contour_settings;

--- a/Main.cc
+++ b/Main.cc
@@ -174,15 +174,6 @@ void OnMessage(uWS::WebSocket<uWS::SERVER>* ws, char* raw_message, size_t length
                     }
                     break;
                 }
-                case CARTA::EventType::SET_IMAGE_VIEW: {
-                    CARTA::SetImageView message;
-                    if (message.ParseFromArray(event_buf, event_length)) {
-                        session->OnSetImageView(message);
-                    } else {
-                        fmt::print("Bad SET_IMAGE_VIEW message!\n");
-                    }
-                    break;
-                }
                 case CARTA::EventType::SET_CURSOR: {
                     CARTA::SetCursor message;
                     if (message.ParseFromArray(event_buf, event_length)) {

--- a/OnMessageTask.cc
+++ b/OnMessageTask.cc
@@ -113,7 +113,7 @@ tbb::task* AnimationTask::execute() {
 }
 
 tbb::task* OnAddRequiredTilesTask::execute() {
-    _session->OnAddRequiredTiles(_message);
+    _session->OnAddRequiredTiles(_message, _session->AnimationRunning());
     return nullptr;
 }
 

--- a/OnMessageTask.cc
+++ b/OnMessageTask.cc
@@ -81,11 +81,6 @@ tbb::task* SetImageChannelsTask::execute() {
     return nullptr;
 }
 
-tbb::task* SetImageViewTask::execute() {
-    _session->_file_settings.ExecuteOne("SET_IMAGE_VIEW", _file_id);
-    return nullptr;
-}
-
 tbb::task* SetCursorTask::execute() {
     _session->_file_settings.ExecuteOne("SET_CURSOR", _file_id);
     return nullptr;

--- a/OnMessageTask.h
+++ b/OnMessageTask.h
@@ -57,17 +57,6 @@ public:
     ~SetImageChannelsTask() = default;
 };
 
-class SetImageViewTask : public OnMessageTask {
-    int _file_id;
-    tbb::task* execute() override;
-
-public:
-    SetImageViewTask(Session* session, int file_id) : OnMessageTask(session) {
-        _file_id = file_id;
-    }
-    ~SetImageViewTask() = default;
-};
-
 class SetCursorTask : public OnMessageTask {
     int _file_id;
     tbb::task* execute() override;

--- a/Session.cc
+++ b/Session.cc
@@ -41,7 +41,7 @@ bool Session::_exit_when_all_sessions_closed = false;
 
 // Default constructor. Associates a websocket with a UUID and sets the root folder for all files
 Session::Session(uWS::WebSocket<uWS::SERVER>* ws, uint32_t id, std::string root, uS::Async* outgoing_async,
-                 FileListHandler* file_list_handler, bool verbose)
+    FileListHandler* file_list_handler, bool verbose)
     : _id(id),
       _socket(ws),
       _root_folder(root),
@@ -143,7 +143,7 @@ void Session::ConnectCalled() {
 // File browser
 
 bool Session::FillExtendedFileInfo(CARTA::FileInfoExtended* extended_info, CARTA::FileInfo* file_info, const string& folder,
-                                   const string& filename, string hdu, string& message) {
+    const string& filename, string hdu, string& message) {
     // fill CARTA::FileInfoResponse submessages CARTA::FileInfo and CARTA::FileInfoExtended
     bool ext_file_info_ok(true);
     try {
@@ -405,7 +405,8 @@ void Session::OnAddRequiredTiles(const CARTA::AddRequiredTiles& message, bool sk
                 raster_tile_data.set_file_id(file_id);
                 raster_tile_data.set_animation_id(animation_id);
                 auto tile = Tile::Decode(encoded_coordinate);
-                if (_frames.at(file_id)->FillRasterTileData(raster_tile_data, tile, channel, stokes, compression_type, compression_quality)) {
+                if (_frames.at(file_id)->FillRasterTileData(
+                        raster_tile_data, tile, channel, stokes, compression_type, compression_quality)) {
                     SendFileEvent(file_id, CARTA::EventType::RASTER_TILE_DATA, 0, raster_tile_data);
                 } else {
                     fmt::print("Problem getting tile layer={}, x={}, y={}\n", tile.layer, tile.x, tile.y);
@@ -639,7 +640,7 @@ void Session::OnSetSpatialRequirements(const CARTA::SetSpatialRequirements& mess
         try {
             auto region_id = message.region_id();
             if (_frames.at(file_id)->SetRegionSpatialRequirements(
-                region_id, std::vector<std::string>(message.spatial_profiles().begin(), message.spatial_profiles().end()))) {
+                    region_id, std::vector<std::string>(message.spatial_profiles().begin(), message.spatial_profiles().end()))) {
                 // RESPONSE
                 SendSpatialProfileData(file_id, region_id);
             } else {
@@ -662,8 +663,8 @@ void Session::OnSetHistogramRequirements(const CARTA::SetHistogramRequirements& 
         try {
             auto region_id = message.region_id();
             if (_frames.at(file_id)->SetRegionHistogramRequirements(
-                region_id, std::vector<CARTA::SetHistogramRequirements_HistogramConfig>(
-                    message.histograms().begin(), message.histograms().end()))) {
+                    region_id, std::vector<CARTA::SetHistogramRequirements_HistogramConfig>(
+                                   message.histograms().begin(), message.histograms().end()))) {
                 // RESPONSE
                 if (region_id == CUBE_REGION_ID) {
                     SendCubeHistogramData(message, request_id);
@@ -690,8 +691,8 @@ void Session::OnSetSpectralRequirements(const CARTA::SetSpectralRequirements& me
         try {
             auto region_id = message.region_id();
             if (_frames.at(file_id)->SetRegionSpectralRequirements(
-                region_id, std::vector<CARTA::SetSpectralRequirements_SpectralConfig>(
-                    message.spectral_profiles().begin(), message.spectral_profiles().end()))) {
+                    region_id, std::vector<CARTA::SetSpectralRequirements_SpectralConfig>(
+                                   message.spectral_profiles().begin(), message.spectral_profiles().end()))) {
                 // RESPONSE
                 SendSpectralProfileData(file_id, region_id);
             } else {
@@ -714,7 +715,7 @@ void Session::OnSetStatsRequirements(const CARTA::SetStatsRequirements& message)
         try {
             auto region_id = message.region_id();
             if (_frames.at(file_id)->SetRegionStatsRequirements(
-                region_id, std::vector<int>(message.stats().begin(), message.stats().end()))) {
+                    region_id, std::vector<int>(message.stats().begin(), message.stats().end()))) {
                 // RESPONSE
                 SendRegionStatsData(file_id, region_id);
             } else {
@@ -971,7 +972,7 @@ bool Session::SendCubeHistogramData(const CARTA::SetHistogramRequirements& messa
                             cube_bins = {chan_histogram.bins().begin(), chan_histogram.bins().end()};
                         } else { // add chan histogram bins to cube histogram bins
                             std::transform(chan_histogram.bins().begin(), chan_histogram.bins().end(), cube_bins.begin(), cube_bins.begin(),
-                                           std::plus<int>());
+                                std::plus<int>());
                         }
 
                         // check for cancel
@@ -1233,7 +1234,7 @@ void Session::SendEvent(CARTA::EventType event_type, uint32_t event_id, google::
     int message_length = message.ByteSize();
     size_t required_size = message_length + sizeof(carta::EventHeader);
     std::vector<char> msg(required_size, 0);
-    carta::EventHeader* head = (carta::EventHeader*) msg.data();
+    carta::EventHeader* head = (carta::EventHeader*)msg.data();
 
     head->type = event_type;
     head->icd_version = carta::ICD_VERSION;
@@ -1310,7 +1311,7 @@ void Session::ExecuteAnimationFrameInner(bool stopped) {
 
     if (stopped) {
         if (((_animation_object->_stop_frame.channel() == _animation_object->_current_frame.channel()) &&
-            (_animation_object->_stop_frame.stokes() == _animation_object->_current_frame.stokes()))) {
+                (_animation_object->_stop_frame.stokes() == _animation_object->_current_frame.stokes()))) {
             return;
         }
         curr_frame = _animation_object->_stop_frame;
@@ -1445,9 +1446,9 @@ void Session::StopAnimation(int file_id, const CARTA::AnimationFrame& frame) {
 
     if (_animation_object->_file_id != file_id) {
         std::fprintf(stderr,
-                     "%p Session::StopAnimation called with file id %d."
-                     "Expected file id %d",
-                     this, file_id, _animation_object->_file_id);
+            "%p Session::StopAnimation called with file id %d."
+            "Expected file id %d",
+            this, file_id, _animation_object->_file_id);
         return;
     }
 
@@ -1485,7 +1486,7 @@ void Session::HandleAnimationFlowControlEvt(CARTA::AnimationFlowControl& message
     if (_animation_object->_waiting_flow_event) {
         if (gap <= CurrentFlowWindowSize()) {
             _animation_object->_waiting_flow_event = false;
-            OnMessageTask* tsk = new(tbb::task::allocate_root(_animation_context)) AnimationTask(this);
+            OnMessageTask* tsk = new (tbb::task::allocate_root(_animation_context)) AnimationTask(this);
             tbb::task::enqueue(*tsk);
         }
     }

--- a/Session.cc
+++ b/Session.cc
@@ -1310,19 +1310,10 @@ void Session::BuildAnimationObject(CARTA::StartAnimation& msg, uint32_t request_
     }
 }
 
-void Session::ExecuteAnimationFrameInner(bool stopped) {
+void Session::ExecuteAnimationFrameInner() {
     CARTA::AnimationFrame curr_frame;
 
-    if (stopped) {
-        if (((_animation_object->_stop_frame.channel() == _animation_object->_current_frame.channel()) &&
-                (_animation_object->_stop_frame.stokes() == _animation_object->_current_frame.stokes()))) {
-            return;
-        }
-        curr_frame = _animation_object->_stop_frame;
-    } else {
-        curr_frame = _animation_object->_next_frame;
-    }
-
+    curr_frame = _animation_object->_next_frame;
     auto file_id(_animation_object->_file_id);
     if (_frames.count(file_id)) {
         const std::unique_ptr<Frame>& frame = _frames.at(file_id);
@@ -1379,7 +1370,6 @@ bool Session::ExecuteAnimationFrame() {
     }
 
     if (_animation_object->_stop_called) {
-        ExecuteAnimationFrameInner(true);
         return false;
     }
 
@@ -1391,12 +1381,11 @@ bool Session::ExecuteAnimationFrame() {
         std::this_thread::sleep_for(wait_duration_ms);
 
         if (_animation_object->_stop_called) {
-            ExecuteAnimationFrameInner(true);
             return false;
         }
 
         curr_frame = _animation_object->_next_frame;
-        ExecuteAnimationFrameInner(false);
+        ExecuteAnimationFrameInner();
 
         CARTA::AnimationFrame tmp_frame;
         CARTA::AnimationFrame delta_frame = _animation_object->_delta_frame;
@@ -1456,7 +1445,6 @@ void Session::StopAnimation(int file_id, const CARTA::AnimationFrame& frame) {
         return;
     }
 
-    _animation_object->_stop_frame = frame;
     _animation_object->_stop_called = true;
 }
 

--- a/Session.cc
+++ b/Session.cc
@@ -41,7 +41,7 @@ bool Session::_exit_when_all_sessions_closed = false;
 
 // Default constructor. Associates a websocket with a UUID and sets the root folder for all files
 Session::Session(uWS::WebSocket<uWS::SERVER>* ws, uint32_t id, std::string root, uS::Async* outgoing_async,
-    FileListHandler* file_list_handler, bool verbose)
+                 FileListHandler* file_list_handler, bool verbose)
     : _id(id),
       _socket(ws),
       _root_folder(root),
@@ -143,7 +143,7 @@ void Session::ConnectCalled() {
 // File browser
 
 bool Session::FillExtendedFileInfo(CARTA::FileInfoExtended* extended_info, CARTA::FileInfo* file_info, const string& folder,
-    const string& filename, string hdu, string& message) {
+                                   const string& filename, string hdu, string& message) {
     // fill CARTA::FileInfoResponse submessages CARTA::FileInfo and CARTA::FileInfoExtended
     bool ext_file_info_ok(true);
     try {
@@ -377,12 +377,21 @@ void Session::OnAddRequiredTiles(const CARTA::AddRequiredTiles& message, bool sk
     auto file_id = message.file_id();
     auto channel = _frames.at(file_id)->CurrentChannel();
     auto stokes = _frames.at(file_id)->CurrentStokes();
+    auto animation_id = AnimationRunning() ? 1 : 0;
     if (!message.tiles().empty() && _frames.count(file_id)) {
         if (skip_data) {
             // Update view settings and skip sending data
             _frames.at(file_id)->SetAnimationViewSettings(message);
             return;
         }
+
+        CARTA::RasterTileSync start_message;
+        start_message.set_file_id(file_id);
+        start_message.set_channel(channel);
+        start_message.set_stokes(stokes);
+        start_message.set_end_sync(false);
+        start_message.set_animation_id(animation_id);
+
         int n = message.tiles_size();
         CARTA::CompressionType compression_type = message.compression_type();
         float compression_quality = message.compression_quality();
@@ -393,9 +402,9 @@ void Session::OnAddRequiredTiles(const CARTA::AddRequiredTiles& message, bool sk
                 const auto& encoded_coordinate = message.tiles(i);
                 CARTA::RasterTileData raster_tile_data;
                 raster_tile_data.set_file_id(file_id);
+                raster_tile_data.set_animation_id(animation_id);
                 auto tile = Tile::Decode(encoded_coordinate);
-                if (_frames.at(file_id)->FillRasterTileData(
-                        raster_tile_data, tile, channel, stokes, compression_type, compression_quality)) {
+                if (_frames.at(file_id)->FillRasterTileData(raster_tile_data, tile, channel, stokes, compression_type, compression_quality)) {
                     SendFileEvent(file_id, CARTA::EventType::RASTER_TILE_DATA, 0, raster_tile_data);
                 } else {
                     fmt::print("Problem getting tile layer={}, x={}, y={}\n", tile.layer, tile.x, tile.y);
@@ -410,12 +419,12 @@ void Session::OnAddRequiredTiles(const CARTA::AddRequiredTiles& message, bool sk
         g.wait();
 
         // Send final message with no tiles to signify end of the tile stream, for synchronisation purposes
-        CARTA::RasterTileData final_message;
+        CARTA::RasterTileSync final_message;
         final_message.set_file_id(file_id);
         final_message.set_channel(channel);
         final_message.set_stokes(stokes);
-        final_message.set_compression_quality(compression_quality);
-        final_message.set_compression_type(compression_type);
+        final_message.set_end_sync(true);
+        final_message.set_animation_id(animation_id);
         SendFileEvent(file_id, CARTA::EventType::RASTER_TILE_DATA, 0, final_message);
     }
 }
@@ -629,7 +638,7 @@ void Session::OnSetSpatialRequirements(const CARTA::SetSpatialRequirements& mess
         try {
             auto region_id = message.region_id();
             if (_frames.at(file_id)->SetRegionSpatialRequirements(
-                    region_id, std::vector<std::string>(message.spatial_profiles().begin(), message.spatial_profiles().end()))) {
+                region_id, std::vector<std::string>(message.spatial_profiles().begin(), message.spatial_profiles().end()))) {
                 // RESPONSE
                 SendSpatialProfileData(file_id, region_id);
             } else {
@@ -652,8 +661,8 @@ void Session::OnSetHistogramRequirements(const CARTA::SetHistogramRequirements& 
         try {
             auto region_id = message.region_id();
             if (_frames.at(file_id)->SetRegionHistogramRequirements(
-                    region_id, std::vector<CARTA::SetHistogramRequirements_HistogramConfig>(
-                                   message.histograms().begin(), message.histograms().end()))) {
+                region_id, std::vector<CARTA::SetHistogramRequirements_HistogramConfig>(
+                    message.histograms().begin(), message.histograms().end()))) {
                 // RESPONSE
                 if (region_id == CUBE_REGION_ID) {
                     SendCubeHistogramData(message, request_id);
@@ -680,8 +689,8 @@ void Session::OnSetSpectralRequirements(const CARTA::SetSpectralRequirements& me
         try {
             auto region_id = message.region_id();
             if (_frames.at(file_id)->SetRegionSpectralRequirements(
-                    region_id, std::vector<CARTA::SetSpectralRequirements_SpectralConfig>(
-                                   message.spectral_profiles().begin(), message.spectral_profiles().end()))) {
+                region_id, std::vector<CARTA::SetSpectralRequirements_SpectralConfig>(
+                    message.spectral_profiles().begin(), message.spectral_profiles().end()))) {
                 // RESPONSE
                 SendSpectralProfileData(file_id, region_id);
             } else {
@@ -704,7 +713,7 @@ void Session::OnSetStatsRequirements(const CARTA::SetStatsRequirements& message)
         try {
             auto region_id = message.region_id();
             if (_frames.at(file_id)->SetRegionStatsRequirements(
-                    region_id, std::vector<int>(message.stats().begin(), message.stats().end()))) {
+                region_id, std::vector<int>(message.stats().begin(), message.stats().end()))) {
                 // RESPONSE
                 SendRegionStatsData(file_id, region_id);
             } else {
@@ -961,7 +970,7 @@ bool Session::SendCubeHistogramData(const CARTA::SetHistogramRequirements& messa
                             cube_bins = {chan_histogram.bins().begin(), chan_histogram.bins().end()};
                         } else { // add chan histogram bins to cube histogram bins
                             std::transform(chan_histogram.bins().begin(), chan_histogram.bins().end(), cube_bins.begin(), cube_bins.begin(),
-                                std::plus<int>());
+                                           std::plus<int>());
                         }
 
                         // check for cancel
@@ -1223,7 +1232,7 @@ void Session::SendEvent(CARTA::EventType event_type, uint32_t event_id, google::
     int message_length = message.ByteSize();
     size_t required_size = message_length + sizeof(carta::EventHeader);
     std::vector<char> msg(required_size, 0);
-    carta::EventHeader* head = (carta::EventHeader*)msg.data();
+    carta::EventHeader* head = (carta::EventHeader*) msg.data();
 
     head->type = event_type;
     head->icd_version = carta::ICD_VERSION;
@@ -1300,7 +1309,7 @@ void Session::ExecuteAnimationFrameInner(bool stopped) {
 
     if (stopped) {
         if (((_animation_object->_stop_frame.channel() == _animation_object->_current_frame.channel()) &&
-                (_animation_object->_stop_frame.stokes() == _animation_object->_current_frame.stokes()))) {
+            (_animation_object->_stop_frame.stokes() == _animation_object->_current_frame.stokes()))) {
             return;
         }
         curr_frame = _animation_object->_stop_frame;
@@ -1435,9 +1444,9 @@ void Session::StopAnimation(int file_id, const CARTA::AnimationFrame& frame) {
 
     if (_animation_object->_file_id != file_id) {
         std::fprintf(stderr,
-            "%p Session::StopAnimation called with file id %d."
-            "Expected file id %d",
-            this, file_id, _animation_object->_file_id);
+                     "%p Session::StopAnimation called with file id %d."
+                     "Expected file id %d",
+                     this, file_id, _animation_object->_file_id);
         return;
     }
 
@@ -1475,7 +1484,7 @@ void Session::HandleAnimationFlowControlEvt(CARTA::AnimationFlowControl& message
     if (_animation_object->_waiting_flow_event) {
         if (gap <= CurrentFlowWindowSize()) {
             _animation_object->_waiting_flow_event = false;
-            OnMessageTask* tsk = new (tbb::task::allocate_root(_animation_context)) AnimationTask(this);
+            OnMessageTask* tsk = new(tbb::task::allocate_root(_animation_context)) AnimationTask(this);
             tbb::task::enqueue(*tsk);
         }
     }

--- a/Session.cc
+++ b/Session.cc
@@ -391,6 +391,7 @@ void Session::OnAddRequiredTiles(const CARTA::AddRequiredTiles& message, bool sk
         start_message.set_stokes(stokes);
         start_message.set_end_sync(false);
         start_message.set_animation_id(animation_id);
+        SendFileEvent(file_id, CARTA::EventType::RASTER_TILE_SYNC, 0, start_message);
 
         int n = message.tiles_size();
         CARTA::CompressionType compression_type = message.compression_type();
@@ -425,7 +426,7 @@ void Session::OnAddRequiredTiles(const CARTA::AddRequiredTiles& message, bool sk
         final_message.set_stokes(stokes);
         final_message.set_end_sync(true);
         final_message.set_animation_id(animation_id);
-        SendFileEvent(file_id, CARTA::EventType::RASTER_TILE_DATA, 0, final_message);
+        SendFileEvent(file_id, CARTA::EventType::RASTER_TILE_SYNC, 0, final_message);
     }
 }
 

--- a/Session.cc
+++ b/Session.cc
@@ -390,6 +390,7 @@ void Session::OnAddRequiredTiles(const CARTA::AddRequiredTiles& message, bool sk
         start_message.set_file_id(file_id);
         start_message.set_channel(channel);
         start_message.set_stokes(stokes);
+        start_message.set_animation_id(animation_id);
         start_message.set_end_sync(false);
         start_message.set_animation_id(animation_id);
         SendFileEvent(file_id, CARTA::EventType::RASTER_TILE_SYNC, 0, start_message);
@@ -426,6 +427,7 @@ void Session::OnAddRequiredTiles(const CARTA::AddRequiredTiles& message, bool sk
         final_message.set_file_id(file_id);
         final_message.set_channel(channel);
         final_message.set_stokes(stokes);
+        final_message.set_animation_id(animation_id);
         final_message.set_end_sync(true);
         final_message.set_animation_id(animation_id);
         SendFileEvent(file_id, CARTA::EventType::RASTER_TILE_SYNC, 0, final_message);

--- a/Session.cc
+++ b/Session.cc
@@ -1034,35 +1034,6 @@ void Session::CreateCubeHistogramMessage(CARTA::RegionHistogramData& msg, int fi
     msg.set_progress(progress);
 }
 
-//bool Session::SendRasterImageData(int file_id, bool send_histogram) {
-//    // return true if data sent
-//    bool data_sent(false);
-//
-//    if (_frames.count(file_id)) {
-//        try {
-//            CARTA::RasterImageData raster_data;
-//            raster_data.set_file_id(file_id);
-//            std::string message;
-//            if (_frames.at(file_id)->FillRasterImageData(raster_data, message)) {
-//                if (send_histogram) {
-//                    CARTA::RegionHistogramData* histogram_data = GetRegionHistogramData(file_id, IMAGE_REGION_ID);
-//                    raster_data.set_allocated_channel_histogram_data(histogram_data);
-//                }
-//                SendFileEvent(file_id, CARTA::EventType::RASTER_IMAGE_DATA, 0, raster_data);
-//            } else {
-//                SendLogEvent(message, {"raster"}, CARTA::ErrorSeverity::ERROR);
-//            }
-//        } catch (std::out_of_range& range_error) {
-//            string error = fmt::format("File id {} closed", file_id);
-//            SendLogEvent(error, {"spatial"}, CARTA::ErrorSeverity::DEBUG);
-//        }
-//    } else {
-//        string error = fmt::format("File id {} not found", file_id);
-//        SendLogEvent(error, {"spatial"}, CARTA::ErrorSeverity::DEBUG);
-//    }
-//    return data_sent;
-//}
-
 bool Session::SendSpatialProfileData(int file_id, int region_id, bool stokes_changed) {
     // return true if data sent
     bool data_sent(false);
@@ -1311,8 +1282,8 @@ void Session::BuildAnimationObject(CARTA::StartAnimation& msg, uint32_t request_
 
     if (_frames.count(file_id)) {
         _frames.at(file_id)->SetAnimationViewSettings(msg.required_tiles());
-        _animation_object = std::unique_ptr<AnimationObject>(
-            new AnimationObject(file_id, start_frame, first_frame, last_frame, delta_frame, frame_rate, looping, reverse_at_end, always_wait));
+        _animation_object = std::unique_ptr<AnimationObject>(new AnimationObject(
+            file_id, start_frame, first_frame, last_frame, delta_frame, frame_rate, looping, reverse_at_end, always_wait));
 
         ack_message.set_success(true);
         ack_message.set_message("Starting animation");

--- a/Session.cc
+++ b/Session.cc
@@ -373,13 +373,13 @@ void Session::OnCloseFile(const CARTA::CloseFile& message) {
     DeleteFrame(message.file_id());
 }
 
-void Session::OnAddRequiredTiles(const CARTA::AddRequiredTiles& message) {
+void Session::OnAddRequiredTiles(const CARTA::AddRequiredTiles& message, bool skip_data) {
     auto file_id = message.file_id();
     auto channel = _frames.at(file_id)->CurrentChannel();
     auto stokes = _frames.at(file_id)->CurrentStokes();
     if (!message.tiles().empty() && _frames.count(file_id)) {
-        if (AnimationRunning()) {
-            // Update view settings and skip sending data if in an animation
+        if (skip_data) {
+            // Update view settings and skip sending data
             _frames.at(file_id)->SetAnimationViewSettings(message);
             return;
         }

--- a/Session.h
+++ b/Session.h
@@ -29,7 +29,6 @@
 #include <carta-protobuf/resume_session.pb.h>
 #include <carta-protobuf/set_cursor.pb.h>
 #include <carta-protobuf/set_image_channels.pb.h>
-#include <carta-protobuf/set_image_view.pb.h>
 #include <carta-protobuf/tiles.pb.h>
 #include <carta-protobuf/user_layout.pb.h>
 #include <carta-protobuf/user_preferences.pb.h>

--- a/Session.h
+++ b/Session.h
@@ -55,7 +55,7 @@ public:
     void OnFileInfoRequest(const CARTA::FileInfoRequest& request, uint32_t request_id);
     bool OnOpenFile(const CARTA::OpenFile& message, uint32_t request_id, bool silent = false);
     void OnCloseFile(const CARTA::CloseFile& message);
-    void OnAddRequiredTiles(const CARTA::AddRequiredTiles& message);
+    void OnAddRequiredTiles(const CARTA::AddRequiredTiles& message, bool skip_data = false);
     void OnSetImageChannels(const CARTA::SetImageChannels& message);
     void OnSetCursor(const CARTA::SetCursor& message, uint32_t request_id);
     bool OnSetRegion(const CARTA::SetRegion& message, uint32_t request_id, bool silent = false);

--- a/Session.h
+++ b/Session.h
@@ -104,7 +104,7 @@ public:
     }
     void BuildAnimationObject(CARTA::StartAnimation& msg, uint32_t request_id);
     bool ExecuteAnimationFrame();
-    void ExecuteAnimationFrameInner(bool stopped);
+    void ExecuteAnimationFrameInner();
     void StopAnimation(int file_id, const ::CARTA::AnimationFrame& frame);
     void HandleAnimationFlowControlEvt(CARTA::AnimationFlowControl& message);
     int CurrentFlowWindowSize() {

--- a/Session.h
+++ b/Session.h
@@ -187,7 +187,6 @@ private:
     void CreateCubeHistogramMessage(CARTA::RegionHistogramData& msg, int file_id, int stokes, float progress);
 
     // Send data streams
-    //bool SendRasterImageData(int file_id, bool send_histogram = false);
     // Only set channel_changed and stokes_changed if they are the only trigger for new data
     // (i.e. result of SET_IMAGE_CHANNELS) to prevent sending unneeded data streams.
     bool SendSpatialProfileData(int file_id, int region_id, bool stokes_changed = false);

--- a/Session.h
+++ b/Session.h
@@ -240,6 +240,7 @@ private:
     tbb::task_group_context _animation_context;
 
     int _ref_count;
+    int _animation_id;
     bool _connected;
     static int _num_sessions;
     static int _exit_after_num_seconds;

--- a/Session.h
+++ b/Session.h
@@ -55,7 +55,6 @@ public:
     void OnFileInfoRequest(const CARTA::FileInfoRequest& request, uint32_t request_id);
     bool OnOpenFile(const CARTA::OpenFile& message, uint32_t request_id, bool silent = false);
     void OnCloseFile(const CARTA::CloseFile& message);
-    void OnSetImageView(const CARTA::SetImageView& message);
     void OnAddRequiredTiles(const CARTA::AddRequiredTiles& message);
     void OnSetImageChannels(const CARTA::SetImageChannels& message);
     void OnSetCursor(const CARTA::SetCursor& message, uint32_t request_id);
@@ -188,7 +187,7 @@ private:
     void CreateCubeHistogramMessage(CARTA::RegionHistogramData& msg, int file_id, int stokes, float progress);
 
     // Send data streams
-    bool SendRasterImageData(int file_id, bool send_histogram = false);
+    //bool SendRasterImageData(int file_id, bool send_histogram = false);
     // Only set channel_changed and stokes_changed if they are the only trigger for new data
     // (i.e. result of SET_IMAGE_CHANNELS) to prevent sending unneeded data streams.
     bool SendSpatialProfileData(int file_id, int region_id, bool stokes_changed = false);


### PR DESCRIPTION
This PR switches to the tile-based rendering during animations. The old RASTER_IMAGE_DATA codepath has been removed.

This PR required an ICD change, and as such there is a companion PR for carta-frontend, and the two should be merged in at the same time (along with the protobuf branch): [carta-frontend/#745](https://github.com/CARTAvis/carta-frontend/pull/745)