### PR TITLE
Add flux density support to selected files

### DIFF
--- a/ImageData/FileLoader.cc
+++ b/ImageData/FileLoader.cc
@@ -512,6 +512,8 @@ void FileLoader::LoadImageStats(bool load_percentiles) {
                 LoadStats2DPercent();
             }
 
+            bool has_flux = HasFlux();
+
             // If we loaded all the 2D stats successfully, assume all channel stats are valid
             for (size_t s = 0; s < _num_stokes; s++) {
                 for (size_t c = 0; c < _num_channels; c++) {
@@ -525,7 +527,7 @@ void FileLoader::LoadImageStats(bool load_percentiles) {
                         stats[CARTA::StatsType::Mean] = sum / num_pixels;
                         stats[CARTA::StatsType::Sigma] = sqrt((sum_sq - (sum * sum / num_pixels)) / (num_pixels - 1));
                         stats[CARTA::StatsType::RMS] = sqrt(sum_sq / num_pixels);
-                        if (HasFlux()) {
+                        if (has_flux) {
                             stats[CARTA::StatsType::FluxDensity] = CalculateFlux(sum);
                         }
 
@@ -551,6 +553,8 @@ void FileLoader::LoadImageStats(bool load_percentiles) {
                 LoadStats3DPercent();
             }
 
+            bool has_flux = HasFlux();
+
             // If we loaded all the 3D stats successfully, assume all cube stats are valid
             for (size_t s = 0; s < _num_stokes; s++) {
                 auto& stats = _cube_stats[s].basic_stats;
@@ -563,7 +567,7 @@ void FileLoader::LoadImageStats(bool load_percentiles) {
                     stats[CARTA::StatsType::Mean] = sum / num_pixels;
                     stats[CARTA::StatsType::Sigma] = sqrt((sum_sq - (sum * sum / num_pixels)) / (num_pixels - 1));
                     stats[CARTA::StatsType::RMS] = sqrt(sum_sq / num_pixels);
-                    if (HasFlux()) {
+                    if (has_flux) {
                         stats[CARTA::StatsType::FluxDensity] = CalculateFlux(sum);
                     }
 
@@ -608,15 +612,12 @@ bool FileLoader::HasFlux() {
     return (info.hasSingleBeam() && coord.hasDirectionCoordinate());
 }
 
+// Assumes that flux can be calculated
+// We call this inside loops after checking
 double FileLoader::CalculateFlux(double sum) {
     ImageRef image = GetImage();
-
     auto& info = image->imageInfo();
     auto& coord = image->coordinates();
-
-    if (!HasFlux()) {
-        return NAN;
-    }
 
     double beam_area = info.getBeamAreaInPixels(-1, -1, coord.directionCoordinate());
 

--- a/ImageData/FileLoader.cc
+++ b/ImageData/FileLoader.cc
@@ -525,6 +525,7 @@ void FileLoader::LoadImageStats(bool load_percentiles) {
                         stats[CARTA::StatsType::Mean] = sum / num_pixels;
                         stats[CARTA::StatsType::Sigma] = sqrt((sum_sq - (sum * sum / num_pixels)) / (num_pixels - 1));
                         stats[CARTA::StatsType::RMS] = sqrt(sum_sq / num_pixels);
+                        stats[CARTA::StatsType::FluxDensity] = CalculateFlux(s, c, sum);
 
                         _channel_stats[s][c].full = true;
                     }
@@ -560,6 +561,7 @@ void FileLoader::LoadImageStats(bool load_percentiles) {
                     stats[CARTA::StatsType::Mean] = sum / num_pixels;
                     stats[CARTA::StatsType::Sigma] = sqrt((sum_sq - (sum * sum / num_pixels)) / (num_pixels - 1));
                     stats[CARTA::StatsType::RMS] = sqrt(sum_sq / num_pixels);
+                    stats[CARTA::StatsType::FluxDensity] = CalculateFlux(s, -1, sum);
 
                     _cube_stats[s].full = true;
                 }
@@ -593,4 +595,9 @@ bool FileLoader::GetRegionSpectralData(int region_id, int config_stokes, int pro
 
 void FileLoader::SetFramePtr(Frame* frame) {
     // Must be implemented in subclasses
+}
+
+double FileLoader::CalculateFlux(int stokes, int channel, double sum) {
+    // TODO we can implement it here
+    return NAN;
 }

--- a/ImageData/FileLoader.cc
+++ b/ImageData/FileLoader.cc
@@ -598,6 +598,6 @@ void FileLoader::SetFramePtr(Frame* frame) {
 }
 
 double FileLoader::CalculateFlux(int stokes, int channel, double sum) {
-    // TODO we can implement it here
+    // Only used for HDF5 files, and implemented there
     return NAN;
 }

--- a/ImageData/FileLoader.cc
+++ b/ImageData/FileLoader.cc
@@ -525,7 +525,9 @@ void FileLoader::LoadImageStats(bool load_percentiles) {
                         stats[CARTA::StatsType::Mean] = sum / num_pixels;
                         stats[CARTA::StatsType::Sigma] = sqrt((sum_sq - (sum * sum / num_pixels)) / (num_pixels - 1));
                         stats[CARTA::StatsType::RMS] = sqrt(sum_sq / num_pixels);
-                        stats[CARTA::StatsType::FluxDensity] = CalculateFlux(sum);
+                        if (HasFlux()) {
+                            stats[CARTA::StatsType::FluxDensity] = CalculateFlux(sum);
+                        }
 
                         _channel_stats[s][c].full = true;
                     }
@@ -561,7 +563,9 @@ void FileLoader::LoadImageStats(bool load_percentiles) {
                     stats[CARTA::StatsType::Mean] = sum / num_pixels;
                     stats[CARTA::StatsType::Sigma] = sqrt((sum_sq - (sum * sum / num_pixels)) / (num_pixels - 1));
                     stats[CARTA::StatsType::RMS] = sqrt(sum_sq / num_pixels);
-                    stats[CARTA::StatsType::FluxDensity] = CalculateFlux(sum);
+                    if (HasFlux()) {
+                        stats[CARTA::StatsType::FluxDensity] = CalculateFlux(sum);
+                    }
 
                     _cube_stats[s].full = true;
                 }
@@ -597,14 +601,20 @@ void FileLoader::SetFramePtr(Frame* frame) {
     // Must be implemented in subclasses
 }
 
-// TODO this doesn't currently return an accurate value because of precision lost in the header conversion
+bool FileLoader::HasFlux() {
+    ImageRef image = GetImage();
+    auto& info = image->imageInfo();
+    auto& coord = image->coordinates();
+    return (info.hasSingleBeam() && coord.hasDirectionCoordinate());
+}
+
 double FileLoader::CalculateFlux(double sum) {
     ImageRef image = GetImage();
     
     auto& info = image->imageInfo();
     auto& coord = image->coordinates();
     
-    if (!info.hasSingleBeam() || !coord.hasDirectionCoordinate()) {
+    if (!HasFlux()) {
         return NAN;
     }
 

--- a/ImageData/FileLoader.cc
+++ b/ImageData/FileLoader.cc
@@ -610,15 +610,15 @@ bool FileLoader::HasFlux() {
 
 double FileLoader::CalculateFlux(double sum) {
     ImageRef image = GetImage();
-    
+
     auto& info = image->imageInfo();
     auto& coord = image->coordinates();
-    
+
     if (!HasFlux()) {
         return NAN;
     }
 
     double beam_area = info.getBeamAreaInPixels(-1, -1, coord.directionCoordinate());
-    
-    return sum/beam_area;
+
+    return sum / beam_area;
 }

--- a/ImageData/FileLoader.h
+++ b/ImageData/FileLoader.h
@@ -185,12 +185,11 @@ protected:
     virtual void LoadStats3DHist();
     virtual void LoadStats3DPercent();
     
+    virtual double CalculateFlux(int stokes, int channel, double sum);
 
 private:
     // Find spectral and stokes coordinates
     void FindCoordinates(int& spectral_axis, int& stokes_axis);
-    // TODO what parameters do we actually need?
-    double CalculateFlux(int stokes, int channel, double sum);
 };
 
 } // namespace carta

--- a/ImageData/FileLoader.h
+++ b/ImageData/FileLoader.h
@@ -54,7 +54,7 @@ struct RegionSpectralStats {
         std::vector<CARTA::StatsType> supported_stats = {
             CARTA::StatsType::NumPixels, CARTA::StatsType::NanCount, CARTA::StatsType::Sum,
             CARTA::StatsType::Mean, CARTA::StatsType::RMS, CARTA::StatsType::Sigma, CARTA::StatsType::SumSq,
-            CARTA::StatsType::Min, CARTA::StatsType::Max, CARTA::StatsType::Flux
+            CARTA::StatsType::Min, CARTA::StatsType::Max, CARTA::StatsType::FluxDensity
         };
 
         for (auto& s : supported_stats) {

--- a/ImageData/FileLoader.h
+++ b/ImageData/FileLoader.h
@@ -189,8 +189,7 @@ protected:
     virtual void LoadStats3DPercent();
 
     // Basic flux density calculation
-    bool HasFlux();
-    double CalculateFlux(double sum);
+    double CalculateBeamArea();
 
 private:
     // Find spectral and stokes coordinates

--- a/ImageData/FileLoader.h
+++ b/ImageData/FileLoader.h
@@ -51,9 +51,11 @@ struct RegionSpectralStats {
     RegionSpectralStats() {}
 
     RegionSpectralStats(casacore::IPosition origin, casacore::IPosition shape, int num_channels) : origin(origin), shape(shape) {
-        std::vector<CARTA::StatsType> supported_stats = {CARTA::StatsType::NumPixels, CARTA::StatsType::NanCount, CARTA::StatsType::Sum,
-            CARTA::StatsType::Mean, CARTA::StatsType::RMS, CARTA::StatsType::Sigma, CARTA::StatsType::SumSq, CARTA::StatsType::Min,
-            CARTA::StatsType::Max};
+        std::vector<CARTA::StatsType> supported_stats = {
+            CARTA::StatsType::NumPixels, CARTA::StatsType::NanCount, CARTA::StatsType::Sum,
+            CARTA::StatsType::Mean, CARTA::StatsType::RMS, CARTA::StatsType::Sigma, CARTA::StatsType::SumSq,
+            CARTA::StatsType::Min, CARTA::StatsType::Max, CARTA::StatsType::Flux
+        };
 
         for (auto& s : supported_stats) {
             stats.emplace(std::piecewise_construct, std::make_tuple(s), std::make_tuple(num_channels));
@@ -182,10 +184,13 @@ protected:
     virtual void LoadStats3DBasic(FileInfo::Data ds);
     virtual void LoadStats3DHist();
     virtual void LoadStats3DPercent();
+    
 
 private:
     // Find spectral and stokes coordinates
     void FindCoordinates(int& spectral_axis, int& stokes_axis);
+    // TODO what parameters do we actually need?
+    double CalculateFlux(int stokes, int channel, double sum);
 };
 
 } // namespace carta

--- a/ImageData/FileLoader.h
+++ b/ImageData/FileLoader.h
@@ -50,12 +50,16 @@ struct RegionSpectralStats {
 
     RegionSpectralStats() {}
 
-    RegionSpectralStats(casacore::IPosition origin, casacore::IPosition shape, int num_channels) : origin(origin), shape(shape) {
+    RegionSpectralStats(casacore::IPosition origin, casacore::IPosition shape, int num_channels, bool has_flux=false) : origin(origin), shape(shape) {
         std::vector<CARTA::StatsType> supported_stats = {
             CARTA::StatsType::NumPixels, CARTA::StatsType::NanCount, CARTA::StatsType::Sum,
             CARTA::StatsType::Mean, CARTA::StatsType::RMS, CARTA::StatsType::Sigma, CARTA::StatsType::SumSq,
-            CARTA::StatsType::Min, CARTA::StatsType::Max, CARTA::StatsType::FluxDensity
+            CARTA::StatsType::Min, CARTA::StatsType::Max
         };
+        
+        if (has_flux) {
+            supported_stats.push_back(CARTA::StatsType::FluxDensity);
+        }
 
         for (auto& s : supported_stats) {
             stats.emplace(std::piecewise_construct, std::make_tuple(s), std::make_tuple(num_channels));
@@ -186,6 +190,7 @@ protected:
     virtual void LoadStats3DPercent();
 
     // Basic flux density calculation
+    bool HasFlux();
     double CalculateFlux(double sum);
 
 private:

--- a/ImageData/FileLoader.h
+++ b/ImageData/FileLoader.h
@@ -184,8 +184,9 @@ protected:
     virtual void LoadStats3DBasic(FileInfo::Data ds);
     virtual void LoadStats3DHist();
     virtual void LoadStats3DPercent();
-    
-    virtual double CalculateFlux(int stokes, int channel, double sum);
+
+    // Basic flux density calculation
+    double CalculateFlux(double sum);
 
 private:
     // Find spectral and stokes coordinates

--- a/ImageData/FileLoader.h
+++ b/ImageData/FileLoader.h
@@ -50,13 +50,12 @@ struct RegionSpectralStats {
 
     RegionSpectralStats() {}
 
-    RegionSpectralStats(casacore::IPosition origin, casacore::IPosition shape, int num_channels, bool has_flux=false) : origin(origin), shape(shape) {
-        std::vector<CARTA::StatsType> supported_stats = {
-            CARTA::StatsType::NumPixels, CARTA::StatsType::NanCount, CARTA::StatsType::Sum,
-            CARTA::StatsType::Mean, CARTA::StatsType::RMS, CARTA::StatsType::Sigma, CARTA::StatsType::SumSq,
-            CARTA::StatsType::Min, CARTA::StatsType::Max
-        };
-        
+    RegionSpectralStats(casacore::IPosition origin, casacore::IPosition shape, int num_channels, bool has_flux = false)
+        : origin(origin), shape(shape) {
+        std::vector<CARTA::StatsType> supported_stats = {CARTA::StatsType::NumPixels, CARTA::StatsType::NanCount, CARTA::StatsType::Sum,
+            CARTA::StatsType::Mean, CARTA::StatsType::RMS, CARTA::StatsType::Sigma, CARTA::StatsType::SumSq, CARTA::StatsType::Min,
+            CARTA::StatsType::Max};
+
         if (has_flux) {
             supported_stats.push_back(CARTA::StatsType::FluxDensity);
         }

--- a/ImageData/Hdf5Attributes.cc
+++ b/ImageData/Hdf5Attributes.cc
@@ -66,7 +66,9 @@ std::string Hdf5Attributes::ReadScalar(hid_t attr_id, hid_t data_type_id, const 
             casacore::Double value;
             casacore::HDF5DataType data_type((casacore::Double*)0);
             H5Aread(attr_id, data_type.getHidMem(), &value);
-            std::string key_value = fmt::format("{:<8}= {}", name, std::to_string(value));
+            std::ostringstream ostream;
+            ostream << value;
+            std::string key_value = fmt::format("{:<8}= {}", name, ostream.str());
             return fmt::format("{:<80}", key_value);
         } break;
         case H5T_STRING: {

--- a/ImageData/Hdf5Loader.cc
+++ b/ImageData/Hdf5Loader.cc
@@ -397,8 +397,21 @@ void Hdf5Loader::SetFramePtr(Frame* frame) {
 }
 
 double Hdf5Loader::CalculateFlux(int stokes, int channel, double sum) {
-    // TODO: get the relevant header values from the image
-    std::cerr << "+++ UNITS: " << _image->units().getName() << std::endl;
+    // We don't currently use stokes or channel because we don't support multiple beams
+    auto& info = _image->imageInfo();
+    auto& coord = _image->coordinates();
+    
+    if (!info.hasSingleBeam() || !coord.hasDirectionCoordinate()) {
+        return NAN;
+    }
+    
+    auto beam_area = info.getBeamAreaInPixels(-1, -1, coord.directionCoordinate());
+    
+    std::cerr << "SUM/BEAM: " << sum/beam_area << "; JUST SUM: " << sum << std::endl;
+    
+//     std::string units = _image->units().getName();
+//     
+//     std::cerr << "+++ UNITS: " << units << std::endl;
     return NAN;
 }
 

--- a/ImageData/Hdf5Loader.cc
+++ b/ImageData/Hdf5Loader.cc
@@ -396,4 +396,10 @@ void Hdf5Loader::SetFramePtr(Frame* frame) {
     _frame = frame;
 }
 
+double Hdf5Loader::CalculateFlux(int stokes, int channel, double sum) {
+    // TODO: get the relevant header values from the image
+    std::cerr << "+++ UNITS: " << image->units() << std::endl;
+    return NAN;
+}
+
 } // namespace carta

--- a/ImageData/Hdf5Loader.cc
+++ b/ImageData/Hdf5Loader.cc
@@ -252,7 +252,7 @@ bool Hdf5Loader::GetRegionSpectralData(int region_id, int config_stokes, int pro
         auto& max = stats[CARTA::StatsType::Max];
         std::vector<double> dummy;
         auto& flux = (HasFlux()) ? stats[CARTA::StatsType::FluxDensity] : dummy;
-        
+
         std::vector<float> slice_data;
 
         // get the start of X

--- a/ImageData/Hdf5Loader.cc
+++ b/ImageData/Hdf5Loader.cc
@@ -398,7 +398,7 @@ void Hdf5Loader::SetFramePtr(Frame* frame) {
 
 double Hdf5Loader::CalculateFlux(int stokes, int channel, double sum) {
     // TODO: get the relevant header values from the image
-    std::cerr << "+++ UNITS: " << image->units() << std::endl;
+    std::cerr << "+++ UNITS: " << _image->units().getName() << std::endl;
     return NAN;
 }
 

--- a/ImageData/Hdf5Loader.cc
+++ b/ImageData/Hdf5Loader.cc
@@ -250,6 +250,7 @@ bool Hdf5Loader::GetRegionSpectralData(int region_id, int config_stokes, int pro
         auto& sum_sq = stats[CARTA::StatsType::SumSq];
         auto& min = stats[CARTA::StatsType::Min];
         auto& max = stats[CARTA::StatsType::Max];
+        auto& flux = stats[CARTA::StatsType::FluxDensity];
 
         std::vector<float> slice_data;
 
@@ -287,7 +288,7 @@ bool Hdf5Loader::GetRegionSpectralData(int region_id, int config_stokes, int pro
         auto t_start = std::chrono::high_resolution_clock::now();
         auto t_latest = t_start;
 
-        // Lambda to calculate mean, sigma and RMS
+        // Lambda to calculate additional stats
         auto calculate_stats = [&]() {
             double sum_z, sum_sq_z;
             uint64_t num_pixels_z;
@@ -301,6 +302,7 @@ bool Hdf5Loader::GetRegionSpectralData(int region_id, int config_stokes, int pro
                     mean[z] = sum_z / num_pixels_z;
                     rms[z] = sqrt(sum_sq_z / num_pixels_z);
                     sigma[z] = sqrt((sum_sq_z - (sum_z * sum_z / num_pixels_z)) / (num_pixels_z - 1));
+                    flux[z] = CalculateFlux(profile_stokes, z, sum_z);
                 } else {
                     // if there are no valid values, set all stats to NaN except the value and NaN counts
                     for (auto& kv : stats) {

--- a/ImageData/Hdf5Loader.cc
+++ b/ImageData/Hdf5Loader.cc
@@ -219,7 +219,8 @@ bool Hdf5Loader::GetRegionSpectralData(int region_id, int config_stokes, int pro
     bool recalculate(false);
     auto region_stats_id = FileInfo::RegionStatsId(region_id, profile_stokes);
 
-    bool has_flux = HasFlux();
+    double beam_area = CalculateBeamArea();
+    bool has_flux = !std::isnan(beam_area);
 
     if (_region_stats.find(region_stats_id) == _region_stats.end()) { // region stats never calculated
         _region_stats.emplace(std::piecewise_construct, std::forward_as_tuple(region_id, profile_stokes),
@@ -306,7 +307,7 @@ bool Hdf5Loader::GetRegionSpectralData(int region_id, int config_stokes, int pro
                     rms[z] = sqrt(sum_sq_z / num_pixels_z);
                     sigma[z] = sqrt((sum_sq_z - (sum_z * sum_z / num_pixels_z)) / (num_pixels_z - 1));
                     if (has_flux) {
-                        flux[z] = CalculateFlux(sum_z);
+                        flux[z] = sum_z / beam_area;
                     }
                 } else {
                     // if there are no valid values, set all stats to NaN except the value and NaN counts

--- a/ImageData/Hdf5Loader.cc
+++ b/ImageData/Hdf5Loader.cc
@@ -396,6 +396,7 @@ void Hdf5Loader::SetFramePtr(Frame* frame) {
     _frame = frame;
 }
 
+// TODO this doesn't currently return an accurate value because of precision lost in the header conversion
 double Hdf5Loader::CalculateFlux(int stokes, int channel, double sum) {
     // We don't currently use stokes or channel because we don't support multiple beams
     auto& info = _image->imageInfo();
@@ -404,15 +405,10 @@ double Hdf5Loader::CalculateFlux(int stokes, int channel, double sum) {
     if (!info.hasSingleBeam() || !coord.hasDirectionCoordinate()) {
         return NAN;
     }
+
+    double beam_area = info.getBeamAreaInPixels(-1, -1, coord.directionCoordinate());
     
-    auto beam_area = info.getBeamAreaInPixels(-1, -1, coord.directionCoordinate());
-    
-    std::cerr << "SUM/BEAM: " << sum/beam_area << "; JUST SUM: " << sum << std::endl;
-    
-//     std::string units = _image->units().getName();
-//     
-//     std::cerr << "+++ UNITS: " << units << std::endl;
-    return NAN;
+    return sum/beam_area;
 }
 
 } // namespace carta

--- a/ImageData/Hdf5Loader.cc
+++ b/ImageData/Hdf5Loader.cc
@@ -302,7 +302,7 @@ bool Hdf5Loader::GetRegionSpectralData(int region_id, int config_stokes, int pro
                     mean[z] = sum_z / num_pixels_z;
                     rms[z] = sqrt(sum_sq_z / num_pixels_z);
                     sigma[z] = sqrt((sum_sq_z - (sum_z * sum_z / num_pixels_z)) / (num_pixels_z - 1));
-                    flux[z] = CalculateFlux(profile_stokes, z, sum_z);
+                    flux[z] = CalculateFlux(sum_z);
                 } else {
                     // if there are no valid values, set all stats to NaN except the value and NaN counts
                     for (auto& kv : stats) {
@@ -394,21 +394,6 @@ bool Hdf5Loader::GetRegionSpectralData(int region_id, int config_stokes, int pro
 
 void Hdf5Loader::SetFramePtr(Frame* frame) {
     _frame = frame;
-}
-
-// TODO this doesn't currently return an accurate value because of precision lost in the header conversion
-double Hdf5Loader::CalculateFlux(int stokes, int channel, double sum) {
-    // We don't currently use stokes or channel because we don't support multiple beams
-    auto& info = _image->imageInfo();
-    auto& coord = _image->coordinates();
-    
-    if (!info.hasSingleBeam() || !coord.hasDirectionCoordinate()) {
-        return NAN;
-    }
-
-    double beam_area = info.getBeamAreaInPixels(-1, -1, coord.directionCoordinate());
-    
-    return sum/beam_area;
 }
 
 } // namespace carta

--- a/ImageData/Hdf5Loader.h
+++ b/ImageData/Hdf5Loader.h
@@ -4,6 +4,7 @@
 #include <unordered_map>
 
 #include <casacore/lattices/Lattices/HDF5Lattice.h>
+#include <casacore/coordinates/Coordinates/DirectionCoordinate.h>
 
 #include "../Frame.h"
 #include "../Util.h"

--- a/ImageData/Hdf5Loader.h
+++ b/ImageData/Hdf5Loader.h
@@ -3,7 +3,6 @@
 
 #include <unordered_map>
 
-#include <casacore/coordinates/Coordinates/DirectionCoordinate.h>
 #include <casacore/lattices/Lattices/HDF5Lattice.h>
 
 #include "../Frame.h"

--- a/ImageData/Hdf5Loader.h
+++ b/ImageData/Hdf5Loader.h
@@ -49,9 +49,7 @@ private:
     const IPos GetStatsDataShape(FileInfo::Data ds) override;
     casacore::ArrayBase* GetStatsData(FileInfo::Data ds) override;
 
-    casacore::Lattice<float>* LoadSwizzledData();
-    
-    double CalculateFlux(int stokes, int channel, double sum) override;
+    casacore::Lattice<float>* LoadSwizzledData();    
 };
 
 } // namespace carta

--- a/ImageData/Hdf5Loader.h
+++ b/ImageData/Hdf5Loader.h
@@ -3,8 +3,8 @@
 
 #include <unordered_map>
 
-#include <casacore/lattices/Lattices/HDF5Lattice.h>
 #include <casacore/coordinates/Coordinates/DirectionCoordinate.h>
+#include <casacore/lattices/Lattices/HDF5Lattice.h>
 
 #include "../Frame.h"
 #include "../Util.h"
@@ -49,7 +49,7 @@ private:
     const IPos GetStatsDataShape(FileInfo::Data ds) override;
     casacore::ArrayBase* GetStatsData(FileInfo::Data ds) override;
 
-    casacore::Lattice<float>* LoadSwizzledData();    
+    casacore::Lattice<float>* LoadSwizzledData();
 };
 
 } // namespace carta

--- a/ImageData/Hdf5Loader.h
+++ b/ImageData/Hdf5Loader.h
@@ -49,6 +49,8 @@ private:
     casacore::ArrayBase* GetStatsData(FileInfo::Data ds) override;
 
     casacore::Lattice<float>* LoadSwizzledData();
+    
+    double CalculateFlux(int stokes, int channel, double sum) override;
 };
 
 } // namespace carta

--- a/Region/Region.h
+++ b/Region/Region.h
@@ -244,8 +244,8 @@ private:
     std::mutex _stats_cache_mutex;
 
     // Define all stats types to calculate
-    std::vector<int> _all_stats = {CARTA::StatsType::Sum, CARTA::StatsType::Mean, CARTA::StatsType::RMS, CARTA::StatsType::Sigma,
-        CARTA::StatsType::SumSq, CARTA::StatsType::Min, CARTA::StatsType::Max};
+    std::vector<int> _all_stats = {CARTA::StatsType::Sum, CARTA::StatsType::FluxDensity, CARTA::StatsType::Mean, CARTA::StatsType::RMS,
+        CARTA::StatsType::Sigma, CARTA::StatsType::SumSq, CARTA::StatsType::Min, CARTA::StatsType::Max};
 };
 
 } // namespace carta


### PR DESCRIPTION
This fixes #424.

I have merged Pam's branch `424_spectral_flux` into this branch, and added an implementation of the flux density calculation to the HDF5 stats calculation. I have tested a few files to check that we match the level of support that we currently have for FITS files, but I'm not sure if this simple calculation covers all the cases that we want to cover.

Flux density should now work everywhere in supported files, including the stats widget.

This PR also includes a change to the HDF5 attribute parsing code -- we now use scientific notation when we convert double values back into strings. Using fixed notation was causing a loss in precision which was very noticeable in the flux density calculation.

When testing HDF5 files, please check out the latest converter (dev or master branch) -- there's a bug in the older versions which drops the last entry from every header, which leads to weird behaviour if it's something important like `BUNIT`.