### PR TITLE
fixes discarding SET_IMAGE_CHANNELS for different files

### DIFF
--- a/Main.cc
+++ b/Main.cc
@@ -164,13 +164,13 @@ void OnMessage(uWS::WebSocket<uWS::SERVER>* ws, char* raw_message, size_t length
                 case CARTA::EventType::SET_IMAGE_CHANNELS: {
                     CARTA::SetImageChannels message;
                     if (message.ParseFromArray(event_buf, event_length)) {
-                        session->ImageChannelLock();
-                        if (!session->ImageChannelTaskTestAndSet()) {
-                            tsk = new (tbb::task::allocate_root(session->Context())) SetImageChannelsTask(session);
+                        session->ImageChannelLock(message.file_id());
+                        if (!session->ImageChannelTaskTestAndSet(message.file_id())) {
+                            tsk = new (tbb::task::allocate_root(session->Context())) SetImageChannelsTask(session, message.file_id());
                         }
                         // has its own queue to keep channels in order during animation
                         session->AddToSetChannelQueue(message, head.request_id);
-                        session->ImageChannelUnlock();
+                        session->ImageChannelUnlock(message.file_id());
                     } else {
                         fmt::print("Bad SET_IMAGE_CHANNELS message!\n");
                     }

--- a/OnMessageTask.cc
+++ b/OnMessageTask.cc
@@ -69,10 +69,10 @@ tbb::task* SetImageChannelsTask::execute() {
     std::pair<CARTA::SetImageChannels, uint32_t> request_pair;
     bool tester;
 
-    _session->ImageChannelLock();
-    tester = _session->_set_channel_queue.try_pop(request_pair);
-    _session->ImageChannelTaskSetIdle();
-    _session->ImageChannelUnlock();
+    _session->ImageChannelLock(fileId);
+    tester = _session->_set_channel_queues[fileId].try_pop(request_pair);
+    _session->ImageChannelTaskSetIdle(fileId);
+    _session->ImageChannelUnlock(fileId);
 
     if (tester) {
         _session->ExecuteSetChannelEvt(request_pair);

--- a/OnMessageTask.h
+++ b/OnMessageTask.h
@@ -50,10 +50,11 @@ public:
 };
 
 class SetImageChannelsTask : public OnMessageTask {
+    int fileId;
     tbb::task* execute() override;
 
 public:
-    SetImageChannelsTask(Session* session) : OnMessageTask(session) {}
+    SetImageChannelsTask(Session* session, int fileId) : OnMessageTask(session), fileId(fileId) {}
     ~SetImageChannelsTask() = default;
 };
 

--- a/Session.cc
+++ b/Session.cc
@@ -1506,9 +1506,13 @@ void Session::DeleteFrame(int file_id) {
             frame.second.reset();             // delete Frame
         }
         _frames.clear();
+        _image_channel_mutexes.clear();
+        _image_channel_task_active.clear();
     } else if (_frames.count(file_id)) {
         _frames[file_id]->DisconnectCalled(); // call to stop Frame's jobs and wait for jobs finished
         _frames[file_id].reset();
         _frames.erase(file_id);
+        _image_channel_mutexes.erase(file_id);
+        _image_channel_task_active.erase(file_id);
     }
 }

--- a/Session.cc
+++ b/Session.cc
@@ -52,7 +52,6 @@ Session::Session(uWS::WebSocket<uWS::SERVER>* ws, uint32_t id, std::string root,
       _loader(nullptr),
       _outgoing_async(outgoing_async),
       _file_list_handler(file_list_handler),
-      _image_channel_task_active(false),
       _animation_id(0),
       _file_settings(this) {
     _histogram_progress = HISTOGRAM_COMPLETE;

--- a/Session.h
+++ b/Session.h
@@ -78,9 +78,9 @@ public:
     void AddToSetChannelQueue(CARTA::SetImageChannels message, uint32_t request_id) {
         std::pair<CARTA::SetImageChannels, uint32_t> rp;
         // Empty current queue first.
-        while (_set_channel_queue.try_pop(rp)) {
+        while (_set_channel_queues[message.file_id()].try_pop(rp)) {
         }
-        _set_channel_queue.push(std::make_pair(message, request_id));
+        _set_channel_queues[message.file_id()].push(std::make_pair(message, request_id));
     }
 
     // Task handling
@@ -115,22 +115,22 @@ public:
     void AddCursorSetting(CARTA::SetCursor message, uint32_t request_id) {
         _file_settings.AddCursorSetting(message, request_id);
     }
-    void ImageChannelLock() {
-        _image_channel_mutex.lock();
+    void ImageChannelLock(int fileId) {
+        _image_channel_mutexes[fileId].lock();
     }
-    void ImageChannelUnlock() {
-        _image_channel_mutex.unlock();
+    void ImageChannelUnlock(int fileId) {
+        _image_channel_mutexes[fileId].unlock();
     }
-    bool ImageChannelTaskTestAndSet() {
-        if (_image_channel_task_active) {
+    bool ImageChannelTaskTestAndSet(int fileId) {
+        if (_image_channel_task_active[fileId]) {
             return true;
         } else {
-            _image_channel_task_active = true;
+            _image_channel_task_active[fileId] = true;
             return false;
         }
     }
-    void ImageChannelTaskSetIdle() {
-        _image_channel_task_active = false;
+    void ImageChannelTaskSetIdle(int fileId) {
+        _image_channel_task_active[fileId] = false;
     }
     int IncreaseRefCount() {
         return ++_ref_count;
@@ -168,7 +168,7 @@ public:
     // TODO: should these be public? NO!!!!!!!!
     uint32_t _id;
     FileSettings _file_settings;
-    tbb::concurrent_queue<std::pair<CARTA::SetImageChannels, uint32_t>> _set_channel_queue;
+    std::unordered_map<int, tbb::concurrent_queue<std::pair<CARTA::SetImageChannels, uint32_t>>> _set_channel_queues;
 
 private:
     // File info
@@ -221,8 +221,8 @@ private:
     std::unique_ptr<AnimationObject> _animation_object;
 
     // Manage image channel
-    std::mutex _image_channel_mutex;
-    bool _image_channel_task_active;
+    std::unordered_map<int, std::mutex> _image_channel_mutexes;
+    std::unordered_map<int, bool> _image_channel_task_active;
 
     // Cube histogram progress: 0.0 to 1.0 (complete)
     float _histogram_progress;


### PR DESCRIPTION
This PR fixes an issue that crops up when doing spectral matching of images, which sends `SET_IMAGE_CHANNELS` messages for each image. Currently, all but the last one gets discarded on each update. 

This fixes the issue by adding a queue and mutex for each `fileId`