### PR TITLE
Change how we initialize the lattice of an HDF5 image to avoid a segfault if it fails.

### DIFF
--- a/ImageData/CartaHdf5Image.cc
+++ b/ImageData/CartaHdf5Image.cc
@@ -21,8 +21,8 @@ CartaHdf5Image::CartaHdf5Image(
     : casacore::ImageInterface<float>(casacore::RegionHandlerHDF5(GetHdf5File, this)),
       _valid(false),
       _pixel_mask(nullptr),
-      _mask_spec(mask_spec) {
-    _lattice = casacore::HDF5Lattice<float>(casacore::CountedPtr<casacore::HDF5File>(new casacore::HDF5File(filename)), array_name, hdu);
+      _mask_spec(mask_spec),
+      _lattice(casacore::CountedPtr<casacore::HDF5File>(new casacore::HDF5File(filename)), array_name, hdu) {
     _shape = _lattice.shape();
     _pixel_mask = new casacore::ArrayLattice<bool>();
     _valid = SetUpImage();


### PR DESCRIPTION
This fixes #452 .