### PR TITLE
Check for coordinate axes failure in file info loader (dev)

### DIFF
--- a/FileList/FileExtInfoLoader.cc
+++ b/FileList/FileExtInfoLoader.cc
@@ -237,10 +237,11 @@ bool FileExtInfoLoader::FillFileInfoFromImage(CARTA::FileInfoExtended* extended_
                 }
 
                 int spectral_axis, stokes_axis;
-                _loader->FindCoordinateAxes(image_shape, spectral_axis, stokes_axis, message);
-                AddShapeEntries(extended_info, image_shape, spectral_axis, stokes_axis);
-                AddComputedEntries(extended_info, image, radesys);
-                file_ok = true;
+                if (_loader->FindCoordinateAxes(image_shape, spectral_axis, stokes_axis, message)) {
+                    AddShapeEntries(extended_info, image_shape, spectral_axis, stokes_axis);
+                    AddComputedEntries(extended_info, image, radesys);
+                    file_ok = true;
+                }
             } else { // image failed
                 message = "Image could not be opened.";
             }


### PR DESCRIPTION
Prevents seg fault in FileInfoExtended shape entries.