### PR TITLE
1.3 backport of the non-schema HDF5 file crash fix

### DIFF
--- a/ImageData/CartaHdf5Image.cc
+++ b/ImageData/CartaHdf5Image.cc
@@ -21,8 +21,8 @@ CartaHdf5Image::CartaHdf5Image(
     : casacore::ImageInterface<float>(casacore::RegionHandlerHDF5(GetHdf5File, this)),
       _valid(false),
       _pixel_mask(nullptr),
-      _mask_spec(mask_spec) {
-    _lattice = casacore::HDF5Lattice<float>(casacore::CountedPtr<casacore::HDF5File>(new casacore::HDF5File(filename)), array_name, hdu);
+      _mask_spec(mask_spec),
+      _lattice(casacore::CountedPtr<casacore::HDF5File>(new casacore::HDF5File(filename)), array_name, hdu) {
     _shape = _lattice.shape();
     _pixel_mask = new casacore::ArrayLattice<bool>();
     _valid = SetUpImage();


### PR DESCRIPTION
This is a backport of the fix to #452 which was made in `dev`.