### PR TITLE
Angus/catalog optimisation

### DIFF
--- a/Catalog/VOTableCarrier.cc
+++ b/Catalog/VOTableCarrier.cc
@@ -115,6 +115,22 @@ void VOTableCarrier::FillTdValues(int column_index, std::string value) {
     }
 }
 
+void VOTableCarrier::FillEmptyTd(int column_index) {
+    if (_fields[column_index].datatype == "char") {
+        _string_vectors[column_index].push_back("");
+    } else if (_fields[column_index].datatype == "boolean") {
+        _bool_vectors[column_index].push_back(false);
+    } else if ((_fields[column_index].datatype == "short") || (_fields[column_index].datatype == "int")) {
+        _int_vectors[column_index].push_back(std::numeric_limits<int>::quiet_NaN());
+    } else if (_fields[column_index].datatype == "long") {
+        _ll_vectors[column_index].push_back(std::numeric_limits<long long>::quiet_NaN());
+    } else if (_fields[column_index].datatype == "float") {
+        _float_vectors[column_index].push_back(std::numeric_limits<double>::quiet_NaN());
+    } else if (_fields[column_index].datatype == "double") {
+        _double_vectors[column_index].push_back(std::numeric_limits<double>::quiet_NaN());
+    }
+}
+
 void VOTableCarrier::UpdateNumOfTableRows() {
     if (_fields.empty()) {
         std::cerr << "There is no table column!" << std::endl;
@@ -502,7 +518,7 @@ void VOTableCarrier::GetFilteredData(
         // Calculate the progress
         ++accumulated_data_size;
         ++sending_data_size;
-        float progress = (float)accumulated_data_size / (float)subset_data_size;
+        float progress = (float) accumulated_data_size / (float) subset_data_size;
 
         ++row_index; // Proceed to the next row
 
@@ -660,37 +676,28 @@ bool VOTableCarrier::StringFilter(CARTA::FilterConfig filter, std::string value)
     return false;
 }
 
-template <typename T>
+template<typename T>
 bool VOTableCarrier::NumericFilter(CARTA::FilterConfig filter, T value) {
     bool result(true);
     CARTA::ComparisonOperator cmp_op = filter.comparison_operator();
     switch (cmp_op) {
-        case CARTA::ComparisonOperator::EqualTo:
-            result = (value == filter.min());
+        case CARTA::ComparisonOperator::EqualTo:result = (value == filter.min());
             break;
-        case CARTA::ComparisonOperator::NotEqualTo:
-            result = (value != filter.min());
+        case CARTA::ComparisonOperator::NotEqualTo:result = (value != filter.min());
             break;
-        case CARTA::ComparisonOperator::LessThan:
-            result = (value < filter.min());
+        case CARTA::ComparisonOperator::LessThan:result = (value < filter.min());
             break;
-        case CARTA::ComparisonOperator::GreaterThan:
-            result = (value > filter.min());
+        case CARTA::ComparisonOperator::GreaterThan:result = (value > filter.min());
             break;
-        case CARTA::ComparisonOperator::LessThanOrEqualTo:
-            result = (value <= filter.min());
+        case CARTA::ComparisonOperator::LessThanOrEqualTo:result = (value <= filter.min());
             break;
-        case CARTA::ComparisonOperator::GreaterThanOrEqualTo:
-            result = (value >= filter.min());
+        case CARTA::ComparisonOperator::GreaterThanOrEqualTo:result = (value >= filter.min());
             break;
-        case CARTA::ComparisonOperator::BetweenAnd:
-            result = (filter.min() <= value && value <= filter.max());
+        case CARTA::ComparisonOperator::BetweenAnd:result = (filter.min() <= value && value <= filter.max());
             break;
-        case CARTA::ComparisonOperator::FromTo:
-            result = (filter.min() < value && value < filter.max());
+        case CARTA::ComparisonOperator::FromTo:result = (filter.min() < value && value < filter.max());
             break;
-        default:
-            std::cerr << "Unknown comparison operator!" << std::endl;
+        default:std::cerr << "Unknown comparison operator!" << std::endl;
             break;
     }
     return result;
@@ -723,7 +730,7 @@ void VOTableCarrier::SortColumn(std::string column_name, CARTA::SortingType sort
     }
 }
 
-template <typename T>
+template<typename T>
 void VOTableCarrier::SortRowIndexes(const std::vector<T>& v, CARTA::SortingType sorting_type) {
     ResetRowIndexes();
     // Sort the column data and get the result as an index array

--- a/Catalog/VOTableCarrier.cc
+++ b/Catalog/VOTableCarrier.cc
@@ -518,7 +518,7 @@ void VOTableCarrier::GetFilteredData(
         // Calculate the progress
         ++accumulated_data_size;
         ++sending_data_size;
-        float progress = (float) accumulated_data_size / (float) subset_data_size;
+        float progress = (float)accumulated_data_size / (float)subset_data_size;
 
         ++row_index; // Proceed to the next row
 
@@ -676,28 +676,37 @@ bool VOTableCarrier::StringFilter(CARTA::FilterConfig filter, std::string value)
     return false;
 }
 
-template<typename T>
+template <typename T>
 bool VOTableCarrier::NumericFilter(CARTA::FilterConfig filter, T value) {
     bool result(true);
     CARTA::ComparisonOperator cmp_op = filter.comparison_operator();
     switch (cmp_op) {
-        case CARTA::ComparisonOperator::EqualTo:result = (value == filter.min());
+        case CARTA::ComparisonOperator::EqualTo:
+            result = (value == filter.min());
             break;
-        case CARTA::ComparisonOperator::NotEqualTo:result = (value != filter.min());
+        case CARTA::ComparisonOperator::NotEqualTo:
+            result = (value != filter.min());
             break;
-        case CARTA::ComparisonOperator::LessThan:result = (value < filter.min());
+        case CARTA::ComparisonOperator::LessThan:
+            result = (value < filter.min());
             break;
-        case CARTA::ComparisonOperator::GreaterThan:result = (value > filter.min());
+        case CARTA::ComparisonOperator::GreaterThan:
+            result = (value > filter.min());
             break;
-        case CARTA::ComparisonOperator::LessThanOrEqualTo:result = (value <= filter.min());
+        case CARTA::ComparisonOperator::LessThanOrEqualTo:
+            result = (value <= filter.min());
             break;
-        case CARTA::ComparisonOperator::GreaterThanOrEqualTo:result = (value >= filter.min());
+        case CARTA::ComparisonOperator::GreaterThanOrEqualTo:
+            result = (value >= filter.min());
             break;
-        case CARTA::ComparisonOperator::BetweenAnd:result = (filter.min() <= value && value <= filter.max());
+        case CARTA::ComparisonOperator::BetweenAnd:
+            result = (filter.min() <= value && value <= filter.max());
             break;
-        case CARTA::ComparisonOperator::FromTo:result = (filter.min() < value && value < filter.max());
+        case CARTA::ComparisonOperator::FromTo:
+            result = (filter.min() < value && value < filter.max());
             break;
-        default:std::cerr << "Unknown comparison operator!" << std::endl;
+        default:
+            std::cerr << "Unknown comparison operator!" << std::endl;
             break;
     }
     return result;
@@ -730,7 +739,7 @@ void VOTableCarrier::SortColumn(std::string column_name, CARTA::SortingType sort
     }
 }
 
-template<typename T>
+template <typename T>
 void VOTableCarrier::SortRowIndexes(const std::vector<T>& v, CARTA::SortingType sorting_type) {
     ResetRowIndexes();
     // Sort the column data and get the result as an index array

--- a/Catalog/VOTableCarrier.h
+++ b/Catalog/VOTableCarrier.h
@@ -72,6 +72,7 @@ public:
     void FillFieldAttributes(int count, std::string name, std::string value);
     void FillFieldDescriptions(int count, std::string value);
     void FillTdValues(int column_index, std::string value);
+    void FillEmptyTd(int column_index);
     void UpdateNumOfTableRows();
     std::string GetFileDescription();
     void GetHeaders(CARTA::CatalogFileInfoResponse& file_info_response);

--- a/Catalog/VOTableParser.cc
+++ b/Catalog/VOTableParser.cc
@@ -104,7 +104,6 @@ void VOTableParser::Parse() {
 
     switch (node_type) {
         case XML_READER_TYPE_ELEMENT:
-            Print("<" + name + ">", value);
             _pre_element_name = _element_name;
             _element_name = GetElementName(name);
             if (_only_read_to_header && _element_name == ElementName::DATA) {
@@ -118,7 +117,6 @@ void VOTableParser::Parse() {
             }
             break;
         case XML_READER_TYPE_END_ELEMENT:
-            Print("</" + name + ">", value);
             if (_element_name == ElementName::TD && !_td_filled && _carrier) {
                 // Fill the TR element values as "" if there is an empty column, i.e. <TD></TD>.
                 _carrier->FillTdValues(_td_counts, "");
@@ -126,11 +124,9 @@ void VOTableParser::Parse() {
             }
             break;
         case XML_READER_TYPE_ATTRIBUTE:
-            Print("    " + name, value);
             FillElementAttributes(_element_name, name, value);
             break;
         case XML_READER_TYPE_TEXT:
-            Print("    " + name, value);
             FillElementValues(_element_name, value);
             break;
 
@@ -162,18 +158,6 @@ void VOTableParser::Parse() {
 
         default:
             std::cerr << "Fail to parse the XML text!" << std::endl;
-    }
-}
-
-void VOTableParser::Print(std::string name, std::string value) {
-    if (_verbose) {
-        if (name.empty() && !value.empty()) {
-            std::cout << value << std::endl;
-        } else if (!name.empty() && value.empty()) {
-            std::cout << name << std::endl;
-        } else {
-            std::cout << name << " : " << value << std::endl;
-        }
     }
 }
 

--- a/Catalog/VOTableParser.cc
+++ b/Catalog/VOTableParser.cc
@@ -119,7 +119,7 @@ void VOTableParser::Parse() {
         case XML_READER_TYPE_END_ELEMENT:
             if (_element_name == ElementName::TD && !_td_filled && _carrier) {
                 // Fill the TR element values as "" if there is an empty column, i.e. <TD></TD>.
-                _carrier->FillTdValues(_td_counts, "");
+                _carrier->FillEmptyTd(_td_counts);
                 _td_filled = true; // Decrease the TD counter in order to mark such TR element has been filled
             }
             break;

--- a/Catalog/VOTableParser.cc
+++ b/Catalog/VOTableParser.cc
@@ -2,6 +2,19 @@
 
 using namespace catalog;
 
+const std::unordered_map<std::string, VOTableParser::ElementName> VOTableParser::elementEnumMap = {
+    {"VOTABLE", VOTableParser::ElementName::VOTABLE}, {"RESOURCE", VOTableParser::ElementName::RESOURCE},
+    {"DESCRIPTION", VOTableParser::ElementName::DESCRIPTION}, {"DEFINITIONS", VOTableParser::ElementName::DEFINITIONS},
+    {"INFO", VOTableParser::ElementName::INFO}, {"PARAM", VOTableParser::ElementName::PARAM}, {"TABLE", VOTableParser::ElementName::TABLE},
+    {"FIELD", VOTableParser::ElementName::FIELD}, {"GROUP", VOTableParser::ElementName::GROUP},
+    {"FIELDref", VOTableParser::ElementName::FIELDref}, {"PARAMref", VOTableParser::ElementName::PARAMref},
+    {"VALUES", VOTableParser::ElementName::VALUES}, {"MIN", VOTableParser::ElementName::MIN}, {"MAX", VOTableParser::ElementName::MAX},
+    {"OPTION", VOTableParser::ElementName::OPTION}, {"LINK", VOTableParser::ElementName::LINK}, {"DATA", VOTableParser::ElementName::DATA},
+    {"TABLEDATA", VOTableParser::ElementName::TABLEDATA}, {"TD", VOTableParser::ElementName::TD}, {"TR", VOTableParser::ElementName::TR},
+    {"FITS", VOTableParser::ElementName::FITS}, {"BINARY", VOTableParser::ElementName::BINARY},
+    {"BINARY2", VOTableParser::ElementName::BINARY2}, {"STREAM", VOTableParser::ElementName::STREAM},
+    {"COOSYS", VOTableParser::ElementName::COOSYS}};
+
 VOTableParser::VOTableParser(std::string filename, VOTableCarrier* carrier, bool only_read_to_header, bool verbose)
     : _carrier(carrier), _only_read_to_header(only_read_to_header), _verbose(verbose) {
     if (!IsVOTable(filename)) {
@@ -165,61 +178,11 @@ void VOTableParser::Print(std::string name, std::string value) {
 }
 
 VOTableParser::ElementName VOTableParser::GetElementName(std::string name) {
-    VOTableParser::ElementName result;
-    if (strcmp(name.c_str(), "VOTABLE") == 0) {
-        result = ElementName::VOTABLE;
-    } else if (strcmp(name.c_str(), "RESOURCE") == 0) {
-        result = ElementName::RESOURCE;
-    } else if (strcmp(name.c_str(), "DESCRIPTION") == 0) {
-        result = ElementName::DESCRIPTION;
-    } else if (strcmp(name.c_str(), "DEFINITIONS") == 0) {
-        result = ElementName::DEFINITIONS;
-    } else if (strcmp(name.c_str(), "INFO") == 0) {
-        result = ElementName::INFO;
-    } else if (strcmp(name.c_str(), "PARAM") == 0) {
-        result = ElementName::PARAM;
-    } else if (strcmp(name.c_str(), "TABLE") == 0) {
-        result = ElementName::TABLE;
-    } else if (strcmp(name.c_str(), "FIELD") == 0) {
-        result = ElementName::FIELD;
-    } else if (strcmp(name.c_str(), "GROUP") == 0) {
-        result = ElementName::GROUP;
-    } else if (strcmp(name.c_str(), "FIELDref") == 0) {
-        result = ElementName::FIELDref;
-    } else if (strcmp(name.c_str(), "PARAMref") == 0) {
-        result = ElementName::PARAMref;
-    } else if (strcmp(name.c_str(), "VALUES") == 0) {
-        result = ElementName::VALUES;
-    } else if (strcmp(name.c_str(), "MIN") == 0) {
-        result = ElementName::MIN;
-    } else if (strcmp(name.c_str(), "MAX") == 0) {
-        result = ElementName::MAX;
-    } else if (strcmp(name.c_str(), "OPTION") == 0) {
-        result = ElementName::OPTION;
-    } else if (strcmp(name.c_str(), "LINK") == 0) {
-        result = ElementName::LINK;
-    } else if (strcmp(name.c_str(), "DATA") == 0) {
-        result = ElementName::DATA;
-    } else if (strcmp(name.c_str(), "TABLEDATA") == 0) {
-        result = ElementName::TABLEDATA;
-    } else if (strcmp(name.c_str(), "TD") == 0) {
-        result = ElementName::TD;
-    } else if (strcmp(name.c_str(), "TR") == 0) {
-        result = ElementName::TR;
-    } else if (strcmp(name.c_str(), "FITS") == 0) {
-        result = ElementName::FITS;
-    } else if (strcmp(name.c_str(), "BINARY") == 0) {
-        result = ElementName::BINARY;
-    } else if (strcmp(name.c_str(), "BINARY2") == 0) {
-        result = ElementName::BINARY2;
-    } else if (strcmp(name.c_str(), "STREAM") == 0) {
-        result = ElementName::STREAM;
-    } else if (strcmp(name.c_str(), "COOSYS") == 0) {
-        result = ElementName::COOSYS;
-    } else {
-        result = ElementName::NONE;
+    auto itr = elementEnumMap.find(name);
+    if (itr == elementEnumMap.end()) {
+        return ElementName::NONE;
     }
-    return result;
+    return itr->second;
 }
 
 void VOTableParser::IncreaseElementCounts(ElementName element_name) {

--- a/Catalog/VOTableParser.h
+++ b/Catalog/VOTableParser.h
@@ -42,6 +42,8 @@ class VOTableParser {
         NONE = 25
     };
 
+    static const std::unordered_map<std::string, VOTableParser::ElementName> elementEnumMap;
+
 public:
     VOTableParser(std::string filename, VOTableCarrier* carrier, bool only_read_to_header = false, bool verbose = false);
     ~VOTableParser();


### PR DESCRIPTION
Improves catalog loading speed:

- Removes debug printing function, which was still causing millions of strings to be built
- Replaced chain of `if/elseif` in `VOTableParser::GetElementName` with an `unordered_map`
- (Most important change) Added function for adding default values (e.g. empty strings or `NaN`), rather than parsing empty strings and throwing an exception millions of times

With my initial tests with `m42_2deg_simbad.xml`, this results in a roughly 3x speedup in catalog loading. 