### PR TITLE
careful handling of NaN values while contouring

### DIFF
--- a/Contouring.cc
+++ b/Contouring.cc
@@ -147,10 +147,8 @@ void TraceLevel(const float* image, int64_t width, int64_t height, double scale,
     for (j = 0, i = 0; i < width - 1; i++) {
         float pt_a = image[(j)*width + i];
         float pt_b = image[(j)*width + i + 1];
-        pt_a = isnan(pt_a) ? -std::numeric_limits<float>::max() : pt_a;
-        pt_b = isnan(pt_b) ? -std::numeric_limits<float>::max() : pt_b;
 
-        if (pt_a < level && level <= pt_b) {
+        if ((isnan(pt_a) || pt_a < level) && level <= pt_b) {
             indices.push_back(vertices.size());
             TraceSegment(image, visited, width, height, scale, offset, level, i, j, Edge::TopEdge, vertices);
             test_for_chunk_overflow();
@@ -162,10 +160,8 @@ void TraceLevel(const float* image, int64_t width, int64_t height, double scale,
     for (j = 0; j < height - 1; j++) {
         float pt_a = image[(j)*width + i];
         float pt_b = image[(j + 1) * width + i];
-        pt_a = isnan(pt_a) ? -std::numeric_limits<float>::max() : pt_a;
-        pt_b = isnan(pt_b) ? -std::numeric_limits<float>::max() : pt_b;
 
-        if (pt_a < level && level <= pt_b) {
+        if ((isnan(pt_a) || pt_a < level) && level <= pt_b) {
             indices.push_back(vertices.size());
             TraceSegment(image, visited, width, height, scale, offset, level, i - 1, j, Edge::RightEdge, vertices);
             test_for_chunk_overflow();
@@ -177,10 +173,8 @@ void TraceLevel(const float* image, int64_t width, int64_t height, double scale,
     for (i--; i >= 0; i--) {
         float pt_a = image[(j)*width + i + 1];
         float pt_b = image[(j)*width + i];
-        pt_a = isnan(pt_a) ? -std::numeric_limits<float>::max() : pt_a;
-        pt_b = isnan(pt_b) ? -std::numeric_limits<float>::max() : pt_b;
 
-        if (pt_a < level && level <= pt_b) {
+        if ((isnan(pt_a) || pt_a < level) && level <= pt_b) {
             indices.push_back(vertices.size());
             TraceSegment(image, visited, width, height, scale, offset, level, i, j - 1, Edge::BottomEdge, vertices);
             test_for_chunk_overflow();
@@ -192,10 +186,8 @@ void TraceLevel(const float* image, int64_t width, int64_t height, double scale,
     for (i = 0, j--; j >= 0; j--) {
         float pt_a = image[(j + 1) * width + i];
         float pt_b = image[(j)*width + i];
-        pt_a = isnan(pt_a) ? -std::numeric_limits<float>::max() : pt_a;
-        pt_b = isnan(pt_b) ? -std::numeric_limits<float>::max() : pt_b;
 
-        if (pt_a < level && level <= pt_b) {
+        if ((isnan(pt_a) || pt_a < level) && level <= pt_b) {
             indices.push_back(vertices.size());
             TraceSegment(image, visited, width, height, scale, offset, level, i, j, Edge::LeftEdge, vertices);
             test_for_chunk_overflow();
@@ -208,10 +200,8 @@ void TraceLevel(const float* image, int64_t width, int64_t height, double scale,
         for (i = 0; i < width - 1; i++) {
             float pt_a = image[(j)*width + i];
             float pt_b = image[(j)*width + i + 1];
-            pt_a = isnan(pt_a) ? -std::numeric_limits<float>::max() : pt_a;
-            pt_b = isnan(pt_b) ? -std::numeric_limits<float>::max() : pt_b;
 
-            if (!visited[j * width + i] && pt_a < level && level <= pt_b) {
+            if (!visited[j * width + i] && (isnan(pt_a) || pt_a < level) && level <= pt_b) {
                 indices.push_back(vertices.size());
                 TraceSegment(image, visited, width, height, scale, offset, level, i, j, TopEdge, vertices);
                 test_for_chunk_overflow();


### PR DESCRIPTION
Fixes #461 

Will  backport to `release/1.3` if its deemed to be a low-risk change by @pford or @confluence. @kswang1029 please double check that it's producing correct contours. 