### PR TITLE
Calculate fail in large image

### DIFF
--- a/Region/BasicStatsCalculator.h
+++ b/Region/BasicStatsCalculator.h
@@ -13,7 +13,7 @@ namespace carta {
 
 template <typename T>
 struct BasicStats {
-    size_t num_pixels;
+    uint64_t num_pixels;
     double sum;
     double mean;
     double stdDev;
@@ -22,7 +22,7 @@ struct BasicStats {
     double rms;
     double sumSq;
 
-    BasicStats<T>(size_t num_pixels, double sum, double mean, double stdDev, T min_val, T max_val, double rms, double sumSq);
+    BasicStats<T>(uint64_t num_pixels, double sum, double mean, double stdDev, T min_val, T max_val, double rms, double sumSq);
     BasicStats<T>();
     void join(BasicStats<T>& other);
 };
@@ -31,16 +31,16 @@ template <typename T>
 class BasicStatsCalculator {
     T _min_val, _max_val;
     double _sum, _sum_squares;
-    size_t _num_pixels;
+    uint64_t _num_pixels;
     const std::vector<T>& _data;
 
 public:
     BasicStatsCalculator(const std::vector<T>& data);
     BasicStatsCalculator(BasicStatsCalculator& mm, tbb::split);
 
-    void operator()(const tbb::blocked_range<size_t>& r);
+    void operator()(const tbb::blocked_range<uint64_t>& r);
     void join(BasicStatsCalculator& other); // NOLINT
-    void reduce(const int start, const int end);
+    void reduce(const uint64_t start, const uint64_t end);
 
     BasicStats<T> GetStats() const;
 };

--- a/Region/BasicStatsCalculator.h
+++ b/Region/BasicStatsCalculator.h
@@ -13,7 +13,7 @@ namespace carta {
 
 template <typename T>
 struct BasicStats {
-    uint64_t num_pixels;
+    size_t num_pixels;
     double sum;
     double mean;
     double stdDev;
@@ -22,7 +22,7 @@ struct BasicStats {
     double rms;
     double sumSq;
 
-    BasicStats<T>(uint64_t num_pixels, double sum, double mean, double stdDev, T min_val, T max_val, double rms, double sumSq);
+    BasicStats<T>(size_t num_pixels, double sum, double mean, double stdDev, T min_val, T max_val, double rms, double sumSq);
     BasicStats<T>();
     void join(BasicStats<T>& other);
 };
@@ -31,16 +31,16 @@ template <typename T>
 class BasicStatsCalculator {
     T _min_val, _max_val;
     double _sum, _sum_squares;
-    uint64_t _num_pixels;
+    size_t _num_pixels;
     const std::vector<T>& _data;
 
 public:
     BasicStatsCalculator(const std::vector<T>& data);
     BasicStatsCalculator(BasicStatsCalculator& mm, tbb::split);
 
-    void operator()(const tbb::blocked_range<uint64_t>& r);
+    void operator()(const tbb::blocked_range<size_t>& r);
     void join(BasicStatsCalculator& other); // NOLINT
-    void reduce(const uint64_t start, const uint64_t end);
+    void reduce(const size_t start, const size_t end);
 
     BasicStats<T> GetStats() const;
 };

--- a/Region/BasicStatsCalculator.tcc
+++ b/Region/BasicStatsCalculator.tcc
@@ -20,7 +20,7 @@ void BasicStats<T>::join(BasicStats<T>& other) {
 }
 
 template <typename T>
-BasicStats<T>::BasicStats(uint64_t num_pixels, double sum, double mean, double stdDev, T min_val, T max_val, double rms, double sumSq)
+BasicStats<T>::BasicStats(size_t num_pixels, double sum, double mean, double stdDev, T min_val, T max_val, double rms, double sumSq)
     : num_pixels(num_pixels), sum(sum), mean(mean), stdDev(stdDev), min_val(min_val), max_val(max_val), rms(rms), sumSq(sumSq) {}
 template <typename T>
 BasicStats<T>::BasicStats()
@@ -52,10 +52,10 @@ BasicStatsCalculator<T>::BasicStatsCalculator(BasicStatsCalculator<T>& mm, tbb::
       _data(mm._data) {}
 
 template <typename T>
-void BasicStatsCalculator<T>::operator()(const tbb::blocked_range<uint64_t>& r) {
+void BasicStatsCalculator<T>::operator()(const tbb::blocked_range<size_t>& r) {
     T t_min = _min_val;
     T t_max = _max_val;
-    for (uint64_t i = r.begin(); i != r.end(); ++i) {
+    for (size_t i = r.begin(); i != r.end(); ++i) {
         T val = _data[i];
         if (std::isfinite(val)) {
             if (val < t_min) {
@@ -74,8 +74,8 @@ void BasicStatsCalculator<T>::operator()(const tbb::blocked_range<uint64_t>& r) 
 }
 
 template <typename T>
-void BasicStatsCalculator<T>::reduce(const uint64_t start, const uint64_t end) {
-    uint64_t i;
+void BasicStatsCalculator<T>::reduce(const size_t start, const size_t end) {
+    size_t i;
 #pragma omp parallel for private(i) shared(_data) reduction(min: _min_val) reduction(max:_max_val) reduction(+:_num_pixels) reduction(+:_sum) reduction(+:_sum_squares)
     for (i = start; i < end; i++) {
         T val = _data[i];

--- a/Region/BasicStatsCalculator.tcc
+++ b/Region/BasicStatsCalculator.tcc
@@ -5,7 +5,7 @@
 
 namespace carta {
 
-template<typename T>
+template <typename T>
 void BasicStats<T>::join(BasicStats<T>& other) {
     if (other.num_pixels) {
         sum += other.sum;
@@ -14,33 +14,48 @@ void BasicStats<T>::join(BasicStats<T>& other) {
         min_val = std::min(min_val, other.min_val);
         max_val = std::max(max_val, other.max_val);
         mean = sum / num_pixels;
-        stdDev = num_pixels > 1 ? sqrt((sumSq - (sum * sum / num_pixels)) / (num_pixels - 1)): NAN;
+        stdDev = num_pixels > 1 ? sqrt((sumSq - (sum * sum / num_pixels)) / (num_pixels - 1)) : NAN;
         rms = sqrt(sumSq / num_pixels);
     }
 }
 
-template<typename T>
-BasicStats<T>::BasicStats(size_t num_pixels, double sum, double mean, double stdDev, T min_val, T max_val, double rms, double sumSq)
-    : num_pixels(num_pixels), sum(sum), mean(mean), stdDev(stdDev), min_val(min_val), max_val(max_val), rms(rms), sumSq(sumSq){
-}
-template<typename T>
+template <typename T>
+BasicStats<T>::BasicStats(uint64_t num_pixels, double sum, double mean, double stdDev, T min_val, T max_val, double rms, double sumSq)
+    : num_pixels(num_pixels), sum(sum), mean(mean), stdDev(stdDev), min_val(min_val), max_val(max_val), rms(rms), sumSq(sumSq) {}
+template <typename T>
 BasicStats<T>::BasicStats()
-    : num_pixels(0), sum(0), mean(0), stdDev(0), min_val(std::numeric_limits<T>::max()), max_val(std::numeric_limits<T>::lowest()), rms(0), sumSq(0) {
-}
+    : num_pixels(0),
+      sum(0),
+      mean(0),
+      stdDev(0),
+      min_val(std::numeric_limits<T>::max()),
+      max_val(std::numeric_limits<T>::lowest()),
+      rms(0),
+      sumSq(0) {}
 
-template<typename T>
+template <typename T>
 BasicStatsCalculator<T>::BasicStatsCalculator(const std::vector<T>& data)
-    : _min_val(std::numeric_limits<T>::max()), _max_val(std::numeric_limits<T>::lowest()), _sum(0), _sum_squares(0), _num_pixels(0), _data(data) {}
+    : _min_val(std::numeric_limits<T>::max()),
+      _max_val(std::numeric_limits<T>::lowest()),
+      _sum(0),
+      _sum_squares(0),
+      _num_pixels(0),
+      _data(data) {}
 
-template<typename T>
+template <typename T>
 BasicStatsCalculator<T>::BasicStatsCalculator(BasicStatsCalculator<T>& mm, tbb::split)
-    : _min_val(std::numeric_limits<T>::max()), _max_val(std::numeric_limits<T>::lowest()), _sum(0), _sum_squares(0), _num_pixels(0), _data(mm._data) {}
+    : _min_val(std::numeric_limits<T>::max()),
+      _max_val(std::numeric_limits<T>::lowest()),
+      _sum(0),
+      _sum_squares(0),
+      _num_pixels(0),
+      _data(mm._data) {}
 
-template<typename T>
-void BasicStatsCalculator<T>::operator()(const tbb::blocked_range<size_t>& r) {
+template <typename T>
+void BasicStatsCalculator<T>::operator()(const tbb::blocked_range<uint64_t>& r) {
     T t_min = _min_val;
     T t_max = _max_val;
-    for (size_t i = r.begin(); i != r.end(); ++i) {
+    for (uint64_t i = r.begin(); i != r.end(); ++i) {
         T val = _data[i];
         if (std::isfinite(val)) {
             if (val < t_min) {
@@ -58,11 +73,11 @@ void BasicStatsCalculator<T>::operator()(const tbb::blocked_range<size_t>& r) {
     _max_val = t_max;
 }
 
-template<typename T>
-void BasicStatsCalculator<T>::reduce(const int start, const int end) {
-    int i;
+template <typename T>
+void BasicStatsCalculator<T>::reduce(const uint64_t start, const uint64_t end) {
+    uint64_t i;
 #pragma omp parallel for private(i) shared(_data) reduction(min: _min_val) reduction(max:_max_val) reduction(+:_num_pixels) reduction(+:_sum) reduction(+:_sum_squares)
-    for (i = start; i < end ; i++) {
+    for (i = start; i < end; i++) {
         T val = _data[i];
         if (std::isfinite(val)) {
             if (val < _min_val) {
@@ -78,8 +93,7 @@ void BasicStatsCalculator<T>::reduce(const int start, const int end) {
     }
 }
 
-
-template<typename T>
+template <typename T>
 void BasicStatsCalculator<T>::join(BasicStatsCalculator<T>& other) { // NOLINT
     _min_val = std::min(_min_val, other._min_val);
     _max_val = std::max(_max_val, other._max_val);
@@ -88,7 +102,7 @@ void BasicStatsCalculator<T>::join(BasicStatsCalculator<T>& other) { // NOLINT
     _sum_squares += other._sum_squares;
 }
 
-template<typename T>
+template <typename T>
 BasicStats<T> BasicStatsCalculator<T>::GetStats() const {
     double mean;
     double stdDev;
@@ -96,7 +110,7 @@ BasicStats<T> BasicStatsCalculator<T>::GetStats() const {
 
     if (_num_pixels > 0) {
         mean = _sum / _num_pixels;
-        stdDev = _num_pixels > 1 ? sqrt((_sum_squares - (_sum * _sum / _num_pixels)) / (_num_pixels - 1)): NAN;
+        stdDev = _num_pixels > 1 ? sqrt((_sum_squares - (_sum * _sum / _num_pixels)) / (_num_pixels - 1)) : NAN;
         rms = sqrt(_sum_squares / _num_pixels);
     } else {
         mean = NAN;
@@ -104,18 +118,9 @@ BasicStats<T> BasicStatsCalculator<T>::GetStats() const {
         rms = NAN;
     }
 
-    return BasicStats<T>{
-        _num_pixels,
-        _sum,
-        mean,
-        stdDev,
-        _min_val,
-        _max_val,
-        rms,
-        _sum_squares
-    };
+    return BasicStats<T>{_num_pixels, _sum, mean, stdDev, _min_val, _max_val, rms, _sum_squares};
 }
 
 } // namespace carta
 
-#endif //CARTA_BACKEND_REGION_BASICSTATSCALCULATOR_TCC_
+#endif // CARTA_BACKEND_REGION_BASICSTATSCALCULATOR_TCC_

--- a/Region/Histogram.cc
+++ b/Region/Histogram.cc
@@ -13,47 +13,41 @@ Histogram::Histogram(int num_bins, float min_value, float max_value, const std::
 
 Histogram::Histogram(Histogram& h, tbb::split) : _bin_width(h._bin_width), _min_val(h._min_val), _hist(h._hist.size(), 0), _data(h._data) {}
 
-void Histogram::operator()(const tbb::blocked_range<uint64_t>& r) {
-    std::vector<uint64_t> tmp(_hist);
+void Histogram::operator()(const tbb::blocked_range<size_t>& r) {
+    std::vector<size_t> tmp(_hist);
     for (auto i = r.begin(); i != r.end(); ++i) {
         auto v = _data[i];
         if (std::isnan(v) || std::isinf(v))
             continue;
-        // int bin = std::max(std::min((int)((v - _min_val) / _bin_width), (int)_hist.size() - 1), 0);
-        uint64_t _1 = (v - _min_val) / _bin_width;
-        uint64_t _2 = _hist.size() - 1;
-        uint64_t _3 = _1 < _2 ? _1 : _2;
-        uint64_t bin = _3 >= 0 ? _3 : 0;
+        size_t bin = std::max<size_t>(std::min<size_t>((size_t)((v - _min_val) / _bin_width), (size_t)_hist.size() - 1), 0);
+
         ++tmp[bin];
     }
     _hist = tmp;
 }
 
 void Histogram::join(Histogram& h) { // NOLINT
-    auto range = tbb::blocked_range<uint64_t>(0, _hist.size());
-    auto loop = [this, &h](const tbb::blocked_range<uint64_t>& r) {
+    auto range = tbb::blocked_range<size_t>(0, _hist.size());
+    auto loop = [this, &h](const tbb::blocked_range<size_t>& r) {
         size_t beg = r.begin();
         size_t end = r.end();
-        std::transform(&h._hist[beg], &h._hist[end], &_hist[beg], &_hist[beg], std::plus<uint64_t>());
+        std::transform(&h._hist[beg], &h._hist[end], &_hist[beg], &_hist[beg], std::plus<size_t>());
     };
     tbb::parallel_for(range, loop);
 }
 
-void Histogram::setup_bins(const uint64_t start, const uint64_t end) {
-    uint64_t i, stride, buckets;
-    uint64_t** bins_bin;
+void Histogram::setup_bins(const size_t start, const size_t end) {
+    size_t i, stride, buckets;
+    size_t** bins_bin;
 
-    auto calc_lambda = [&](uint64_t start, uint64_t lstride) {
-        uint64_t* lbins = new uint64_t[_hist.size()];
-        uint64_t end = std::min((size_t)(start + lstride), _data.size());
+    auto calc_lambda = [&](size_t start, size_t lstride) {
+        size_t* lbins = new size_t[_hist.size()];
+        size_t end = std::min((size_t)(start + lstride), _data.size());
         memset(lbins, 0, _hist.size() * sizeof(int));
-        for (uint64_t i = start; i < end; i++) {
+        for (size_t i = start; i < end; i++) {
             auto v = _data[i];
             if (std::isfinite(v)) {
-                uint64_t _1 = (v - _min_val) / _bin_width;
-                uint64_t _2 = _hist.size() - 1;
-                uint64_t _3 = _1 < _2 ? _1 : _2;
-                uint64_t binN = _3 >= 0 ? _3 : 0;
+                size_t binN = std::max<size_t>(std::min<size_t>((size_t)((v - _min_val) / _bin_width), (size_t)_hist.size() - 1), 0);
                 ++lbins[binN];
             }
         }
@@ -65,7 +59,7 @@ void Histogram::setup_bins(const uint64_t start, const uint64_t end) {
 #pragma omp single
     {
         stride = _data.size() / buckets + 1;
-        bins_bin = new uint64_t*[buckets + 1];
+        bins_bin = new size_t*[buckets + 1];
     }
 #pragma omp parallel for
     for (i = 0; i < buckets; i++) {

--- a/Region/Histogram.cc
+++ b/Region/Histogram.cc
@@ -43,7 +43,7 @@ void Histogram::setup_bins(const size_t start, const size_t end) {
     auto calc_lambda = [&](size_t start, size_t lstride) {
         size_t* lbins = new size_t[_hist.size()];
         size_t end = std::min((size_t)(start + lstride), _data.size());
-        memset(lbins, 0, _hist.size() * sizeof(int));
+        memset(lbins, 0, _hist.size() * sizeof(size_t));
         for (size_t i = start; i < end; i++) {
             auto v = _data[i];
             if (std::isfinite(v)) {

--- a/Region/Histogram.cc
+++ b/Region/Histogram.cc
@@ -13,40 +13,47 @@ Histogram::Histogram(int num_bins, float min_value, float max_value, const std::
 
 Histogram::Histogram(Histogram& h, tbb::split) : _bin_width(h._bin_width), _min_val(h._min_val), _hist(h._hist.size(), 0), _data(h._data) {}
 
-void Histogram::operator()(const tbb::blocked_range<size_t>& r) {
-    std::vector<int> tmp(_hist);
+void Histogram::operator()(const tbb::blocked_range<uint64_t>& r) {
+    std::vector<uint64_t> tmp(_hist);
     for (auto i = r.begin(); i != r.end(); ++i) {
         auto v = _data[i];
         if (std::isnan(v) || std::isinf(v))
             continue;
-        int bin = std::max(std::min((int)((v - _min_val) / _bin_width), (int)_hist.size() - 1), 0);
+        // int bin = std::max(std::min((int)((v - _min_val) / _bin_width), (int)_hist.size() - 1), 0);
+        uint64_t _1 = (v - _min_val) / _bin_width;
+        uint64_t _2 = _hist.size() - 1;
+        uint64_t _3 = _1 < _2 ? _1 : _2;
+        uint64_t bin = _3 >= 0 ? _3 : 0;
         ++tmp[bin];
     }
     _hist = tmp;
 }
 
 void Histogram::join(Histogram& h) { // NOLINT
-    auto range = tbb::blocked_range<size_t>(0, _hist.size());
-    auto loop = [this, &h](const tbb::blocked_range<size_t>& r) {
+    auto range = tbb::blocked_range<uint64_t>(0, _hist.size());
+    auto loop = [this, &h](const tbb::blocked_range<uint64_t>& r) {
         size_t beg = r.begin();
         size_t end = r.end();
-        std::transform(&h._hist[beg], &h._hist[end], &_hist[beg], &_hist[beg], std::plus<int>());
+        std::transform(&h._hist[beg], &h._hist[end], &_hist[beg], &_hist[beg], std::plus<uint64_t>());
     };
     tbb::parallel_for(range, loop);
 }
 
-void Histogram::setup_bins(const int start, const int end) {
-    int i, stride, buckets;
-    int** bins_bin;
+void Histogram::setup_bins(const uint64_t start, const uint64_t end) {
+    uint64_t i, stride, buckets;
+    uint64_t** bins_bin;
 
-    auto calc_lambda = [&](int start, int lstride) {
-        int* lbins = new int[_hist.size()];
-        int end = std::min((size_t)(start + lstride), _data.size());
+    auto calc_lambda = [&](uint64_t start, uint64_t lstride) {
+        uint64_t* lbins = new uint64_t[_hist.size()];
+        uint64_t end = std::min((size_t)(start + lstride), _data.size());
         memset(lbins, 0, _hist.size() * sizeof(int));
-        for (auto i = start; i < end; i++) {
+        for (uint64_t i = start; i < end; i++) {
             auto v = _data[i];
             if (std::isfinite(v)) {
-                int binN = std::max(std::min((int)((v - _min_val) / _bin_width), (int)_hist.size() - 1), 0);
+                uint64_t _1 = (v - _min_val) / _bin_width;
+                uint64_t _2 = _hist.size() - 1;
+                uint64_t _3 = _1 < _2 ? _1 : _2;
+                uint64_t binN = _3 >= 0 ? _3 : 0;
                 ++lbins[binN];
             }
         }
@@ -58,7 +65,7 @@ void Histogram::setup_bins(const int start, const int end) {
 #pragma omp single
     {
         stride = _data.size() / buckets + 1;
-        bins_bin = new int*[buckets + 1];
+        bins_bin = new uint64_t*[buckets + 1];
     }
 #pragma omp parallel for
     for (i = 0; i < buckets; i++) {

--- a/Region/Histogram.h
+++ b/Region/Histogram.h
@@ -13,22 +13,22 @@ namespace carta {
 class Histogram {
     float _bin_width;
     float _min_val;
-    std::vector<int> _hist;
+    std::vector<uint64_t> _hist;
     const std::vector<float>& _data;
 
 public:
     Histogram(int num_bins, float min_value, float max_value, const std::vector<float>& data);
     Histogram(Histogram& h, tbb::split);
 
-    void operator()(const tbb::blocked_range<size_t>& r);
+    void operator()(const tbb::blocked_range<uint64_t>& r);
     void join(Histogram& h); // NOLINT
-    void setup_bins(const int start, const int end);
+    void setup_bins(const uint64_t start, const uint64_t end);
 
     float GetBinWidth() const {
         return _bin_width;
     }
 
-    std::vector<int> GetHistogram() const {
+    std::vector<uint64_t> GetHistogram() const {
         return _hist;
     }
 };

--- a/Region/Histogram.h
+++ b/Region/Histogram.h
@@ -13,22 +13,22 @@ namespace carta {
 class Histogram {
     float _bin_width;
     float _min_val;
-    std::vector<uint64_t> _hist;
+    std::vector<size_t> _hist;
     const std::vector<float>& _data;
 
 public:
     Histogram(int num_bins, float min_value, float max_value, const std::vector<float>& data);
     Histogram(Histogram& h, tbb::split);
 
-    void operator()(const tbb::blocked_range<uint64_t>& r);
+    void operator()(const tbb::blocked_range<size_t>& r);
     void join(Histogram& h); // NOLINT
-    void setup_bins(const uint64_t start, const uint64_t end);
+    void setup_bins(const size_t start, const size_t end);
 
     float GetBinWidth() const {
         return _bin_width;
     }
 
-    std::vector<uint64_t> GetHistogram() const {
+    std::vector<size_t> GetHistogram() const {
         return _hist;
     }
 };

--- a/Region/Histogram.h
+++ b/Region/Histogram.h
@@ -13,7 +13,7 @@ namespace carta {
 class Histogram {
     float _bin_width;
     float _min_val;
-    std::vector<size_t> _hist;
+    std::vector<int> _hist;
     const std::vector<float>& _data;
 
 public:
@@ -28,7 +28,7 @@ public:
         return _bin_width;
     }
 
-    std::vector<size_t> GetHistogram() const {
+    std::vector<int> GetHistogram() const {
         return _hist;
     }
 };

--- a/Region/RegionStats.cc
+++ b/Region/RegionStats.cc
@@ -119,7 +119,7 @@ void RegionStats::CalcHistogram(int channel, int stokes, int num_bins, const Bas
     CARTA::Histogram& histogram_msg) {
     // Calculate and store histogram for given channel, stokes, nbins; return histogram
     float bin_width(0), bin_center(0);
-    std::vector<size_t> histogram_bins;
+    std::vector<int> histogram_bins;
     if ((stats.min_val == std::numeric_limits<float>::max()) || (stats.max_val == std::numeric_limits<float>::min()) || data.empty()) {
         // empty / NaN region
         histogram_bins.resize(num_bins, 0);

--- a/Region/RegionStats.cc
+++ b/Region/RegionStats.cc
@@ -119,7 +119,7 @@ void RegionStats::CalcHistogram(int channel, int stokes, int num_bins, const Bas
     CARTA::Histogram& histogram_msg) {
     // Calculate and store histogram for given channel, stokes, nbins; return histogram
     float bin_width(0), bin_center(0);
-    std::vector<int> histogram_bins;
+    std::vector<uint64_t> histogram_bins;
     if ((stats.min_val == std::numeric_limits<float>::max()) || (stats.max_val == std::numeric_limits<float>::min()) || data.empty()) {
         // empty / NaN region
         histogram_bins.resize(num_bins, 0);

--- a/Region/RegionStats.cc
+++ b/Region/RegionStats.cc
@@ -119,7 +119,7 @@ void RegionStats::CalcHistogram(int channel, int stokes, int num_bins, const Bas
     CARTA::Histogram& histogram_msg) {
     // Calculate and store histogram for given channel, stokes, nbins; return histogram
     float bin_width(0), bin_center(0);
-    std::vector<uint64_t> histogram_bins;
+    std::vector<size_t> histogram_bins;
     if ((stats.min_val == std::numeric_limits<float>::max()) || (stats.max_val == std::numeric_limits<float>::min()) || data.empty()) {
         // empty / NaN region
         histogram_bins.resize(num_bins, 0);


### PR DESCRIPTION
Fixed #466, use size_t instead of int to break the limitation of min/max and histogram calculator. (fixed)