### PR TITLE
Set region states in the main thread

### DIFF
--- a/InterfaceConstants.h
+++ b/InterfaceConstants.h
@@ -6,6 +6,10 @@
 // version
 #define VERSION_ID "1.3"
 
+// thread counts
+#define TBB_THREAD_COUNT 2
+#define OMP_THREAD_COUNT 4
+
 // file ids
 #define ALL_FILES -1
 

--- a/Main.cc
+++ b/Main.cc
@@ -388,7 +388,7 @@ int main(int argc, const char* argv[]) {
 
         // define and get input arguments
         int port(3002);
-        int thread_count = 2;
+        int thread_count = 4;
         int omp_thread_count = 4;
         { // get values then let Input go out of scope
             casacore::Input inp;

--- a/Main.cc
+++ b/Main.cc
@@ -332,6 +332,15 @@ void OnMessage(uWS::WebSocket<uWS::SERVER>* ws, char* raw_message, size_t length
                     tsk = new (tbb::task::allocate_root(session->Context())) OnSetContourParametersTask(session, message);
                     break;
                 }
+                case CARTA::EventType::SET_REGION: {
+                    CARTA::SetRegion message;
+                    if (message.ParseFromArray(event_buf, event_length)) {
+                        session->OnSetRegion(message, head.request_id);
+                    } else {
+                        fmt::print("Bad SET_REGION message!\n");
+                    }
+                    break;
+                }
                 default: {
                     // Copy memory into new buffer to be used and disposed by MultiMessageTask::execute
                     char* message_buffer = new char[event_length];
@@ -388,7 +397,7 @@ int main(int argc, const char* argv[]) {
 
         // define and get input arguments
         int port(3002);
-        int thread_count = 4;
+        int thread_count = 2;
         int omp_thread_count = 4;
         { // get values then let Input go out of scope
             casacore::Input inp;

--- a/Main.cc
+++ b/Main.cc
@@ -415,8 +415,8 @@ int main(int argc, const char* argv[]) {
 
         // define and get input arguments
         int port(3002);
-        int thread_count = 2;
-        int omp_thread_count = 4;
+        int thread_count = TBB_THREAD_COUNT;
+        int omp_thread_count = OMP_THREAD_COUNT;
         { // get values then let Input go out of scope
             casacore::Input inp;
             string json_fname;

--- a/Main.cc
+++ b/Main.cc
@@ -341,6 +341,15 @@ void OnMessage(uWS::WebSocket<uWS::SERVER>* ws, char* raw_message, size_t length
                     }
                     break;
                 }
+                case CARTA::EventType::REMOVE_REGION: {
+                    CARTA::RemoveRegion message;
+                    if (message.ParseFromArray(event_buf, event_length)) {
+                        session->OnRemoveRegion(message);
+                    } else {
+                        fmt::print("Bad REMOVE_REGION message!\n");
+                    }
+                    break;
+                }
                 case CARTA::EventType::SET_SPECTRAL_REQUIREMENTS: {
                     CARTA::SetSpectralRequirements message;
                     if (message.ParseFromArray(event_buf, event_length)) {

--- a/Main.cc
+++ b/Main.cc
@@ -341,6 +341,15 @@ void OnMessage(uWS::WebSocket<uWS::SERVER>* ws, char* raw_message, size_t length
                     }
                     break;
                 }
+                case CARTA::EventType::SET_SPECTRAL_REQUIREMENTS: {
+                    CARTA::SetSpectralRequirements message;
+                    if (message.ParseFromArray(event_buf, event_length)) {
+                        session->OnSetSpectralRequirements(message);
+                    } else {
+                        fmt::print("Bad SET_SPECTRAL_REQUIREMENTS message!\n");
+                    }
+                    break;
+                }
                 default: {
                     // Copy memory into new buffer to be used and disposed by MultiMessageTask::execute
                     char* message_buffer = new char[event_length];

--- a/OnMessageTask.cc
+++ b/OnMessageTask.cc
@@ -29,15 +29,6 @@ tbb::task* MultiMessageTask::execute() {
             }
             break;
         }
-        case CARTA::EventType::REMOVE_REGION: {
-            CARTA::RemoveRegion message;
-            if (message.ParseFromArray(_event_buffer, _event_length)) {
-                _session->OnRemoveRegion(message);
-            } else {
-                fmt::print("Bad REMOVE_REGION message!\n");
-            }
-            break;
-        }
         default: {
             fmt::print("Bad event type in MultiMessageType:execute : ({})", _header.type);
             break;

--- a/OnMessageTask.cc
+++ b/OnMessageTask.cc
@@ -38,15 +38,6 @@ tbb::task* MultiMessageTask::execute() {
             }
             break;
         }
-        case CARTA::EventType::SET_REGION: {
-            CARTA::SetRegion message;
-            if (message.ParseFromArray(_event_buffer, _event_length)) {
-                _session->OnSetRegion(message, _header.request_id);
-            } else {
-                fmt::print("Bad SET_REGION message!\n");
-            }
-            break;
-        }
         case CARTA::EventType::REMOVE_REGION: {
             CARTA::RemoveRegion message;
             if (message.ParseFromArray(_event_buffer, _event_length)) {
@@ -119,5 +110,10 @@ tbb::task* OnAddRequiredTilesTask::execute() {
 
 tbb::task* OnSetContourParametersTask::execute() {
     _session->OnSetContourParameters(_message);
+    return nullptr;
+}
+
+tbb::task* RegionDataStreamsTask::execute() {
+    _session->RegionDataStreams(_file_id, _region_id);
     return nullptr;
 }

--- a/OnMessageTask.cc
+++ b/OnMessageTask.cc
@@ -20,15 +20,6 @@ tbb::task* MultiMessageTask::execute() {
             }
             break;
         }
-        case CARTA::EventType::SET_SPECTRAL_REQUIREMENTS: {
-            CARTA::SetSpectralRequirements message;
-            if (message.ParseFromArray(_event_buffer, _event_length)) {
-                _session->OnSetSpectralRequirements(message);
-            } else {
-                fmt::print("Bad SET_SPECTRAL_REQUIREMENTS message!\n");
-            }
-            break;
-        }
         case CARTA::EventType::SET_STATS_REQUIREMENTS: {
             CARTA::SetStatsRequirements message;
             if (message.ParseFromArray(_event_buffer, _event_length)) {
@@ -115,5 +106,10 @@ tbb::task* OnSetContourParametersTask::execute() {
 
 tbb::task* RegionDataStreamsTask::execute() {
     _session->RegionDataStreams(_file_id, _region_id);
+    return nullptr;
+}
+
+tbb::task* SpectralProfileTask::execute() {
+    _session->SendSpectralProfileData(_file_id, _region_id);
     return nullptr;
 }

--- a/OnMessageTask.h
+++ b/OnMessageTask.h
@@ -128,4 +128,16 @@ public:
     ~RegionDataStreamsTask() = default;
 };
 
+class SpectralProfileTask : public OnMessageTask {
+    tbb::task* execute() override;
+    int _file_id, _region_id;
+
+public:
+    SpectralProfileTask(Session* session, int file_id, int region_id) : OnMessageTask(session) {
+        _file_id = file_id;
+        _region_id = region_id;
+    }
+    ~SpectralProfileTask() = default;
+};
+
 #endif // CARTA_BACKEND__ONMESSAGETASK_H_

--- a/OnMessageTask.h
+++ b/OnMessageTask.h
@@ -116,4 +116,16 @@ public:
     ~OnSetContourParametersTask() = default;
 };
 
+class RegionDataStreamsTask : public OnMessageTask {
+    tbb::task* execute() override;
+    int _file_id, _region_id;
+
+public:
+    RegionDataStreamsTask(Session* session, int file_id, int region_id) : OnMessageTask(session) {
+        _file_id = file_id;
+        _region_id = region_id;
+    }
+    ~RegionDataStreamsTask() = default;
+};
+
 #endif // CARTA_BACKEND__ONMESSAGETASK_H_

--- a/Session.cc
+++ b/Session.cc
@@ -1250,9 +1250,7 @@ void Session::UpdateRegionData(int file_id, bool send_image_histogram, bool chan
             } else if (region_id != IMAGE_REGION_ID) {
                 SendRegionHistogramData(file_id, region_id, channel_changed);
             }
-            _frames.at(file_id)->IncreaseZProfileCount(region_id);
             SendSpectralProfileData(file_id, region_id, channel_changed, stokes_changed);
-            _frames.at(file_id)->DecreaseZProfileCount(region_id);
         }
     }
 }

--- a/Session.cc
+++ b/Session.cc
@@ -545,12 +545,8 @@ bool Session::OnSetRegion(const CARTA::SetRegion& message, uint32_t request_id, 
     }
     // update data streams if requirements set
     if (success && _frames.at(file_id)->RegionChanged(region_id)) {
-        _frames.at(file_id)->IncreaseZProfileCount(region_id);
-        SendRegionStatsData(file_id, region_id);
-        SendSpatialProfileData(file_id, region_id);
-        SendRegionHistogramData(file_id, region_id);
-        SendSpectralProfileData(file_id, region_id);
-        _frames.at(file_id)->DecreaseZProfileCount(region_id);
+        OnMessageTask* tsk = new (tbb::task::allocate_root(this->Context())) RegionDataStreamsTask(this, file_id, region_id);
+        tbb::task::enqueue(*tsk);
     }
     return success;
 }
@@ -1253,6 +1249,15 @@ void Session::UpdateRegionData(int file_id, bool send_image_histogram, bool chan
             SendSpectralProfileData(file_id, region_id, channel_changed, stokes_changed);
         }
     }
+}
+
+void Session::RegionDataStreams(int file_id, int region_id) {
+    _frames.at(file_id)->IncreaseZProfileCount(region_id);
+    SendRegionStatsData(file_id, region_id);
+    SendSpatialProfileData(file_id, region_id);
+    SendRegionHistogramData(file_id, region_id);
+    SendSpectralProfileData(file_id, region_id);
+    _frames.at(file_id)->DecreaseZProfileCount(region_id);
 }
 
 // *********************************************************************************

--- a/Session.cc
+++ b/Session.cc
@@ -704,7 +704,8 @@ void Session::OnSetSpectralRequirements(const CARTA::SetSpectralRequirements& me
                     region_id, std::vector<CARTA::SetSpectralRequirements_SpectralConfig>(
                                    message.spectral_profiles().begin(), message.spectral_profiles().end()))) {
                 // RESPONSE
-                SendSpectralProfileData(file_id, region_id);
+                OnMessageTask* tsk = new (tbb::task::allocate_root(this->Context())) SpectralProfileTask(this, file_id, region_id);
+                tbb::task::enqueue(*tsk);
             } else {
                 string error = fmt::format("Spectral requirements for region id {} failed to validate ", region_id);
                 SendLogEvent(error, {"spectral"}, CARTA::ErrorSeverity::ERROR);

--- a/Session.h
+++ b/Session.h
@@ -168,6 +168,7 @@ public:
 
     // Region data streams
     void RegionDataStreams(int file_id, int region_id);
+    bool SendSpectralProfileData(int file_id, int region_id, bool channel_changed = false, bool stokes_changed = false);
 
     // TODO: should these be public? NO!!!!!!!!
     uint32_t _id;
@@ -193,7 +194,6 @@ private:
     // Only set channel_changed and stokes_changed if they are the only trigger for new data
     // (i.e. result of SET_IMAGE_CHANNELS) to prevent sending unneeded data streams.
     bool SendSpatialProfileData(int file_id, int region_id, bool stokes_changed = false);
-    bool SendSpectralProfileData(int file_id, int region_id, bool channel_changed = false, bool stokes_changed = false);
     bool SendRegionHistogramData(int file_id, int region_id, bool channel_changed = false);
     bool SendRegionStatsData(int file_id, int region_id); // update stats in all cases
     bool SendContourData(int file_id);

--- a/Session.h
+++ b/Session.h
@@ -165,6 +165,10 @@ public:
     inline uint32_t GetId() {
         return _id;
     }
+
+    // Region data streams
+    void RegionDataStreams(int file_id, int region_id);
+
     // TODO: should these be public? NO!!!!!!!!
     uint32_t _id;
     FileSettings _file_settings;


### PR DESCRIPTION
It is to solve the stuck problem for region spectral profile calculations. By moving the setting of region states and its statistical requirements in the main thread. The region data streams or spectral profile calculations are done in TBB concurrent threads.