### PR TITLE
Change the type of index in an OMP loop

### DIFF
--- a/Region/Histogram.cc
+++ b/Region/Histogram.cc
@@ -36,7 +36,7 @@ void Histogram::join(Histogram& h) { // NOLINT
     tbb::parallel_for(range, loop);
 }
 
-void Histogram::setup_bins(const size_t start, const size_t end) {
+void Histogram::setup_bins() {
     int64_t i, stride, buckets;
     int** bins_bin;
 

--- a/Region/Histogram.cc
+++ b/Region/Histogram.cc
@@ -71,8 +71,8 @@ void Histogram::setup_bins() {
         {
             for (omp_index = 0; omp_index <= (buckets - stride * 2); omp_index += stride * 2) {
 #pragma omp task
-                std::transform(
-                    (bins_bin[omp_index + stride]), &(bins_bin[omp_index + stride][_hist.size()]), (bins_bin[omp_index]), (bins_bin[omp_index]), std::plus<int>());
+                std::transform((bins_bin[omp_index + stride]), &(bins_bin[omp_index + stride][_hist.size()]), (bins_bin[omp_index]),
+                    (bins_bin[omp_index]), std::plus<int>());
             }
             stride *= 2;
         }

--- a/Region/Histogram.cc
+++ b/Region/Histogram.cc
@@ -37,14 +37,14 @@ void Histogram::join(Histogram& h) { // NOLINT
 }
 
 void Histogram::setup_bins(const size_t start, const size_t end) {
-    size_t i, stride, buckets;
+    int64_t i, stride, buckets;
     int** bins_bin;
 
     auto calc_lambda = [&](size_t start, size_t lstride) {
         int* lbins = new int[_hist.size()];
         size_t end = std::min((size_t)(start + lstride), _data.size());
         memset(lbins, 0, _hist.size() * sizeof(int));
-        for (size_t i = start; i < end; i++) {
+        for (auto i = start; i < end; i++) {
             auto v = _data[i];
             if (std::isfinite(v)) {
                 size_t bin_number = std::max<size_t>(std::min<size_t>((size_t)((v - _min_val) / _bin_width), (size_t)_hist.size() - 1), 0);

--- a/Region/Histogram.h
+++ b/Region/Histogram.h
@@ -22,7 +22,7 @@ public:
 
     void operator()(const tbb::blocked_range<size_t>& r);
     void join(Histogram& h); // NOLINT
-    void setup_bins(const size_t start, const size_t end);
+    void setup_bins();
 
     float GetBinWidth() const {
         return _bin_width;

--- a/Region/RegionStats.cc
+++ b/Region/RegionStats.cc
@@ -125,7 +125,7 @@ void RegionStats::CalcHistogram(int channel, int stokes, int num_bins, const Bas
         histogram_bins.resize(num_bins, 0);
     } else {
         Histogram hist(num_bins, stats.min_val, stats.max_val, data);
-        hist.setup_bins(0, data.size());
+        hist.setup_bins();
         histogram_bins = hist.GetHistogram();
         bin_width = hist.GetBinWidth();
         bin_center = stats.min_val + (bin_width / 2.0);


### PR DESCRIPTION
The main change is to assign the type `int64_t` for the index in an OMP loop. Using `size_t` would lead to a crash in the backend. The reason can be found in this link https://stackoverflow.com/questions/3988470/why-must-loop-variables-be-signed-in-a-parallel-for according to @kswang1029. 