### PR TITLE
This is a backport of the HDF5 float attribute precision fix.

### DIFF
--- a/ImageData/Hdf5Attributes.cc
+++ b/ImageData/Hdf5Attributes.cc
@@ -67,6 +67,7 @@ std::string Hdf5Attributes::ReadScalar(hid_t attr_id, hid_t data_type_id, const 
             casacore::HDF5DataType data_type((casacore::Double*)0);
             H5Aread(attr_id, data_type.getHidMem(), &value);
             std::ostringstream ostream;
+            ostream.precision(13);
             ostream << value;
             std::string key_value = fmt::format("{:<8}= {}", name, ostream.str());
             return fmt::format("{:<80}", key_value);


### PR DESCRIPTION
This fixes #494 in the release branch.