### PR TITLE
Add try/catch around statistics for flux density calc

### DIFF
--- a/Region/RegionStats.cc
+++ b/Region/RegionStats.cc
@@ -234,12 +234,16 @@ bool RegionStats::CalcStatsValues(std::map<CARTA::StatsType, std::vector<double>
     casacore::ImageStatistics<float> image_stats = casacore::ImageStatistics<float>(image,
         /*showProgress*/ false, /*forceDisk*/ false, /*clone*/ false);
 
+    size_t results_size(1);
     if (per_channel) { // get stats per xy plane
         casacore::Vector<int> display_axes(2);
         display_axes(0) = 0;
         display_axes(1) = 1;
-        if (!image_stats.setAxes(display_axes))
+        if (!image_stats.setAxes(display_axes)) {
             return false;
+        }
+        casacore::IPosition xy_axes(display_axes);
+        results_size = image.shape().removeAxes(xy_axes).product();
     }
 
     casacore::Array<casacore::Double> num_points;
@@ -305,21 +309,31 @@ bool RegionStats::CalcStatsValues(std::map<CARTA::StatsType, std::vector<double>
             default:
                 break;
         }
+
         if (lattice_stats_type < casacore::LatticeStatsBase::NSTATS) { // get lattice statistic
             casacore::Array<casacore::Double> result;                  // must be double
-            if (image_stats.getStatistic(result, lattice_stats_type)) {
-                if (anyEQ(result, 0.0)) { // actually 0, or NaN?
-                    // NaN if number of points is zero
-                    if (num_points.empty())
-                        image_stats.getStatistic(num_points, casacore::LatticeStatsBase::NPTS);
-                    for (size_t j = 0; j < result.size(); ++j) {
-                        casacore::IPosition index(1, j);
-                        if ((result(index) == 0.0) && (num_points(index) == 0.0)) {
-                            result(index) = std::numeric_limits<double>::quiet_NaN();
+            try {
+                if (image_stats.getStatistic(result, lattice_stats_type)) {
+                    if (anyEQ(result, 0.0)) { // actually 0, or NaN?
+                        if (num_points.empty()) {
+                            image_stats.getStatistic(num_points, casacore::LatticeStatsBase::NPTS);
+                        }
+
+                        // NaN if number of points is zero
+                        for (size_t j = 0; j < result.size(); ++j) {
+                            casacore::IPosition index(1, j);
+                            if ((result(index) == 0.0) && (num_points(index) == 0.0)) {
+                                result(index) = std::numeric_limits<double>::quiet_NaN();
+                            }
                         }
                     }
+                    result.tovector(dbl_result);
                 }
-                result.tovector(dbl_result);
+            } catch (const casacore::AipsError& err) {
+                // catch exceptions for calculated stats, e.g. flux density
+                for (size_t j = 0; j < results_size; ++j) {
+                    dbl_result.push_back(std::numeric_limits<double>::quiet_NaN());
+                }
             }
         }
 


### PR DESCRIPTION
Return NaN if ImageStatistics throws an exception.  For release 1.3 patch issue #486 .