### PR TITLE
Fix to make it C++17 compatible the MacOS compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(carta_backend)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_INCLUDE_DIRECTORIES_BEFORE ON)
 
 # Enable OpenMP if package is found

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.8)
 project(carta_backend)
 
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
Attempt number two at this one line change to the CMakeLists.txt file to make it compatible with the MacOS compiler which needs `CMAKE_CXX_STANDARD 17` explicitly set when the code contains C++17 functions. 