### PR TITLE
Remove cached file info from the session object

### DIFF
--- a/FileList/FileExtInfoLoader.cc
+++ b/FileList/FileExtInfoLoader.cc
@@ -22,9 +22,9 @@ using namespace carta;
 FileExtInfoLoader::FileExtInfoLoader(carta::FileLoader* loader) : _loader(loader) {}
 
 bool FileExtInfoLoader::FillFileExtInfo(
-    CARTA::FileInfoExtended* extended_info, const std::string& filename, const std::string& hdu, std::string& message) {
+    CARTA::FileInfoExtended& extended_info, const std::string& filename, const std::string& hdu, std::string& message) {
     // set name from filename
-    auto entry = extended_info->add_computed_entries();
+    auto entry = extended_info.add_computed_entries();
     entry->set_name("Name");
     entry->set_value(filename);
     entry->set_entry_type(CARTA::EntryType::STRING);
@@ -37,7 +37,7 @@ bool FileExtInfoLoader::FillFileExtInfo(
     return file_ok;
 }
 
-bool FileExtInfoLoader::FillFileInfoFromImage(CARTA::FileInfoExtended* extended_info, const std::string& hdu, std::string& message) {
+bool FileExtInfoLoader::FillFileInfoFromImage(CARTA::FileInfoExtended& extended_info, const std::string& hdu, std::string& message) {
     // add header_entries in FITS format (issue #13) using ImageInterface from FileLoader
     bool file_ok(false);
     if (_loader) {
@@ -154,7 +154,7 @@ bool FileExtInfoLoader::FillFileInfoFromImage(CARTA::FileInfoExtended* extended_
                                 if (!comment.empty()) {
                                     bool_string.append(" / " + comment);
                                 }
-                                auto header_entry = extended_info->add_header_entries();
+                                auto header_entry = extended_info.add_header_entries();
                                 header_entry->set_name(name);
                                 *header_entry->mutable_value() = bool_string;
                                 header_entry->set_entry_type(CARTA::EntryType::INT);
@@ -168,7 +168,7 @@ bool FileExtInfoLoader::FillFileInfoFromImage(CARTA::FileInfoExtended* extended_
                                 if (!comment.empty()) {
                                     string_value.append(" / " + comment);
                                 }
-                                auto header_entry = extended_info->add_header_entries();
+                                auto header_entry = extended_info.add_header_entries();
                                 header_entry->set_name(name);
                                 *header_entry->mutable_value() = string_value;
                                 header_entry->set_entry_type(CARTA::EntryType::INT);
@@ -192,7 +192,7 @@ bool FileExtInfoLoader::FillFileInfoFromImage(CARTA::FileInfoExtended* extended_
                                 if (!comment.empty()) {
                                     string_value.append(" / " + comment);
                                 }
-                                auto header_entry = extended_info->add_header_entries();
+                                auto header_entry = extended_info.add_header_entries();
                                 header_entry->set_name(name);
                                 *header_entry->mutable_value() = string_value;
                                 header_entry->set_entry_type(CARTA::EntryType::FLOAT);
@@ -219,7 +219,7 @@ bool FileExtInfoLoader::FillFileInfoFromImage(CARTA::FileInfoExtended* extended_
                                         fkw_string.append(" / " + comment);
                                     }
 
-                                    auto header_entry = extended_info->add_header_entries();
+                                    auto header_entry = extended_info.add_header_entries();
                                     header_entry->set_name(name);
                                     *header_entry->mutable_value() = fkw_string;
                                     header_entry->set_entry_type(CARTA::EntryType::STRING);
@@ -268,21 +268,21 @@ bool FileExtInfoLoader::FillFileInfoFromImage(CARTA::FileInfoExtended* extended_
 // ***** Computed entries *****
 
 void FileExtInfoLoader::AddShapeEntries(
-    CARTA::FileInfoExtended* extended_info, const casacore::IPosition& shape, int chan_axis, int stokes_axis) {
+    CARTA::FileInfoExtended& extended_info, const casacore::IPosition& shape, int chan_axis, int stokes_axis) {
     // Set fields/header entries for shape: dimensions, width, height, depth, stokes
     int num_dims(shape.size());
-    extended_info->set_dimensions(num_dims);
-    extended_info->set_width(shape(0));
-    extended_info->set_height(shape(1));
+    extended_info.set_dimensions(num_dims);
+    extended_info.set_width(shape(0));
+    extended_info.set_height(shape(1));
     if (num_dims == 2) { // 2D
-        extended_info->set_depth(1);
-        extended_info->set_stokes(1);
+        extended_info.set_depth(1);
+        extended_info.set_stokes(1);
     } else if (num_dims == 3) { // 3D
-        extended_info->set_depth(shape(2));
-        extended_info->set_stokes(1);
+        extended_info.set_depth(shape(2));
+        extended_info.set_stokes(1);
     } else { // 4D
-        extended_info->set_depth(shape(chan_axis));
-        extended_info->set_stokes(shape(stokes_axis));
+        extended_info.set_depth(shape(chan_axis));
+        extended_info.set_stokes(shape(stokes_axis));
     }
 
     // shape computed_entry
@@ -298,7 +298,7 @@ void FileExtInfoLoader::AddShapeEntries(
             shape_string = fmt::format("[{}, {}, {}, {}]", shape(0), shape(1), shape(2), shape(3));
             break;
     }
-    auto shape_entry = extended_info->add_computed_entries();
+    auto shape_entry = extended_info.add_computed_entries();
     shape_entry->set_name("Shape");
     shape_entry->set_value(shape_string);
     shape_entry->set_entry_type(CARTA::EntryType::STRING);
@@ -306,7 +306,7 @@ void FileExtInfoLoader::AddShapeEntries(
     if (chan_axis >= 0) {
         // header entry for number of channels
         unsigned int nchan = shape(chan_axis);
-        auto entry = extended_info->add_computed_entries();
+        auto entry = extended_info.add_computed_entries();
         entry->set_name("Number of channels");
         entry->set_value(casacore::String::toString(nchan));
         entry->set_entry_type(CARTA::EntryType::INT);
@@ -315,7 +315,7 @@ void FileExtInfoLoader::AddShapeEntries(
     if (stokes_axis >= 0) {
         // header entry for number of stokes
         unsigned int nstokes = shape(stokes_axis);
-        auto entry = extended_info->add_computed_entries();
+        auto entry = extended_info.add_computed_entries();
         entry->set_name("Number of stokes");
         entry->set_value(casacore::String::toString(nstokes));
         entry->set_entry_type(CARTA::EntryType::INT);
@@ -324,7 +324,7 @@ void FileExtInfoLoader::AddShapeEntries(
 }
 
 void FileExtInfoLoader::AddComputedEntries(
-    CARTA::FileInfoExtended* extended_info, casacore::ImageInterface<float>* image, casacore::String& radesys) {
+    CARTA::FileInfoExtended& extended_info, casacore::ImageInterface<float>* image, casacore::String& radesys) {
     // add computed_entries to extended info (ensures the proper order in file browser)
     casacore::CoordinateSystem coord_system(image->coordinates());
     casacore::Vector<casacore::String> axis_names = coord_system.worldAxisNames();
@@ -334,7 +334,7 @@ void FileExtInfoLoader::AddComputedEntries(
     casacore::Vector<casacore::Double> increment = coord_system.increment();
 
     if (!axis_names.empty()) {
-        auto entry = extended_info->add_computed_entries();
+        auto entry = extended_info.add_computed_entries();
         entry->set_name("Coordinate type");
         std::string coord_type = fmt::format("{}, {}", axis_names(0), axis_names(1));
         entry->set_value(coord_type);
@@ -348,7 +348,7 @@ void FileExtInfoLoader::AddComputedEntries(
             projection = "SIN / NCP";
         }
         if (!projection.empty()) {
-            auto entry = extended_info->add_computed_entries();
+            auto entry = extended_info.add_computed_entries();
             entry->set_name("Projection");
             entry->set_value(projection);
             entry->set_entry_type(CARTA::EntryType::STRING);
@@ -356,7 +356,7 @@ void FileExtInfoLoader::AddComputedEntries(
     }
 
     if (!reference_pixels.empty()) {
-        auto entry = extended_info->add_computed_entries();
+        auto entry = extended_info.add_computed_entries();
         entry->set_name("Image reference pixels");
         std::string ref_pix = fmt::format("[{}, {}]", reference_pixels(0) + 1.0, reference_pixels(1) + 1.0);
         entry->set_value(ref_pix);
@@ -364,7 +364,7 @@ void FileExtInfoLoader::AddComputedEntries(
     }
 
     if (!axis_names.empty() && !reference_values.empty() && !axis_units.empty()) {
-        auto entry = extended_info->add_computed_entries();
+        auto entry = extended_info.add_computed_entries();
         entry->set_name("Image reference coords");
         std::string format_coord1 = MakeAngleString(axis_names(0), reference_values(0), axis_units(0));
         std::string format_coord2 = MakeAngleString(axis_names(1), reference_values(1), axis_units(1));
@@ -374,7 +374,7 @@ void FileExtInfoLoader::AddComputedEntries(
     }
 
     if (!reference_values.empty() && !axis_units.empty()) {
-        auto entry = extended_info->add_computed_entries();
+        auto entry = extended_info.add_computed_entries();
         entry->set_name("Image ref coords (deg)");
         casacore::Quantity coord0(reference_values(0), axis_units(0));
         casacore::Quantity coord1(reference_values(1), axis_units(1));
@@ -397,7 +397,7 @@ void FileExtInfoLoader::AddComputedEntries(
             direction_frame = radesys + ", " + direction_frame;
         }
 
-        auto entry = extended_info->add_computed_entries();
+        auto entry = extended_info.add_computed_entries();
         entry->set_name("Celestial frame");
         entry->set_value(direction_frame);
         entry->set_entry_type(CARTA::EntryType::STRING);
@@ -405,12 +405,12 @@ void FileExtInfoLoader::AddComputedEntries(
 
     if (coord_system.hasSpectralAxis()) {
         casacore::String spectral_frame = casacore::MFrequency::showType(coord_system.spectralCoordinate().frequencySystem(true));
-        auto entry = extended_info->add_computed_entries();
+        auto entry = extended_info.add_computed_entries();
         entry->set_name("Spectral frame");
         entry->set_value(spectral_frame);
         entry->set_entry_type(CARTA::EntryType::STRING);
         casacore::String vel_doppler = casacore::MDoppler::showType(coord_system.spectralCoordinate().velocityDoppler());
-        entry = extended_info->add_computed_entries();
+        entry = extended_info.add_computed_entries();
         entry->set_name("Velocity definition");
         entry->set_value(vel_doppler);
         entry->set_entry_type(CARTA::EntryType::STRING);
@@ -418,14 +418,14 @@ void FileExtInfoLoader::AddComputedEntries(
 
     casacore::String brightness_unit(image->units().getName());
     if (!brightness_unit.empty()) {
-        auto entry = extended_info->add_computed_entries();
+        auto entry = extended_info.add_computed_entries();
         entry->set_name("Pixel unit");
         entry->set_value(brightness_unit);
         entry->set_entry_type(CARTA::EntryType::STRING);
     }
 
     if (!increment.empty() && !axis_units.empty()) {
-        auto entry = extended_info->add_computed_entries();
+        auto entry = extended_info.add_computed_entries();
         entry->set_name("Pixel increment");
         casacore::Quantity inc0(increment(0), axis_units(0));
         casacore::Quantity inc1(increment(1), axis_units(1));
@@ -436,7 +436,7 @@ void FileExtInfoLoader::AddComputedEntries(
 
     casacore::ImageInfo image_info(image->imageInfo());
     if (image_info.hasBeam()) {
-        auto entry = extended_info->add_computed_entries();
+        auto entry = extended_info.add_computed_entries();
         entry->set_entry_type(CARTA::EntryType::STRING);
         casacore::GaussianBeam gaussian_beam;
         if (image_info.hasSingleBeam()) {

--- a/FileList/FileExtInfoLoader.h
+++ b/FileList/FileExtInfoLoader.h
@@ -16,14 +16,14 @@ class FileExtInfoLoader {
 public:
     FileExtInfoLoader(carta::FileLoader* loader);
 
-    bool FillFileExtInfo(CARTA::FileInfoExtended* extended_info, const std::string& filename, const std::string& hdu, std::string& message);
+    bool FillFileExtInfo(CARTA::FileInfoExtended& extended_info, const std::string& filename, const std::string& hdu, std::string& message);
 
 private:
     // FileInfoExtended
-    bool FillFileInfoFromImage(CARTA::FileInfoExtended* ext_info, const std::string& hdu, std::string& message);
-    void AddMiscInfoHeaders(CARTA::FileInfoExtended* extended_info, const casacore::TableRecord& misc_info);
-    void AddShapeEntries(CARTA::FileInfoExtended* extended_info, const casacore::IPosition& shape, int chan_axis, int stokes_axis);
-    void AddComputedEntries(CARTA::FileInfoExtended* extended_info, casacore::ImageInterface<float>* image, casacore::String& radesys);
+    bool FillFileInfoFromImage(CARTA::FileInfoExtended& extended_info, const std::string& hdu, std::string& message);
+    void AddMiscInfoHeaders(CARTA::FileInfoExtended& extended_info, const casacore::TableRecord& misc_info);
+    void AddShapeEntries(CARTA::FileInfoExtended& extended_info, const casacore::IPosition& shape, int chan_axis, int stokes_axis);
+    void AddComputedEntries(CARTA::FileInfoExtended& extended_info, casacore::ImageInterface<float>* image, casacore::String& radesys);
     std::string MakeAngleString(const std::string& type, double val, const std::string& unit); // convert MVAngle to string
 
     carta::FileLoader* _loader;

--- a/FileList/FileInfoLoader.cc
+++ b/FileList/FileInfoLoader.cc
@@ -14,14 +14,14 @@ FileInfoLoader::FileInfoLoader(const std::string& filename) : _filename(filename
     _type = GetCartaFileType(filename);
 }
 
-bool FileInfoLoader::FillFileInfo(CARTA::FileInfo* file_info) {
+bool FileInfoLoader::FillFileInfo(CARTA::FileInfo& file_info) {
     // Fill FileInfo submessage with type, size, hdus
     casacore::File cc_file(_filename);
     if (!cc_file.exists()) {
         return false;
     }
     std::string filename_only = cc_file.path().baseName();
-    file_info->set_name(filename_only);
+    file_info.set_name(filename_only);
 
     // fill FileInfo submessage
     int64_t file_size(cc_file.size());
@@ -34,8 +34,8 @@ bool FileInfoLoader::FillFileInfo(CARTA::FileInfo* file_info) {
         file_size = linked_file.size();
     }
 
-    file_info->set_size(file_size);
-    file_info->set_type(_type);
+    file_info.set_size(file_size);
+    file_info.set_type(_type);
     // add hdu for FITS, HDF5
     if (_type == CARTA::FileType::FITS) {
         casacore::String abs_file_name(cc_file.path().absoluteName());
@@ -44,25 +44,25 @@ bool FileInfoLoader::FillFileInfo(CARTA::FileInfo* file_info) {
         casacore::String abs_file_name(cc_file.path().absoluteName());
         return GetHdf5HduList(file_info, abs_file_name);
     } else {
-        file_info->add_hdu_list("");
+        file_info.add_hdu_list("");
         return true;
     }
 }
 
-bool FileInfoLoader::GetFitsHduList(CARTA::FileInfo* file_info, const std::string& filename) {
+bool FileInfoLoader::GetFitsHduList(CARTA::FileInfo& file_info, const std::string& filename) {
     FitsHduList fits_hdu_list = FitsHduList(filename);
     return fits_hdu_list.GetHduList(file_info);
 }
 
-bool FileInfoLoader::GetHdf5HduList(CARTA::FileInfo* file_info, const std::string& filename) {
+bool FileInfoLoader::GetHdf5HduList(CARTA::FileInfo& file_info, const std::string& filename) {
     // fill FileInfo hdu list for Hdf5
     casacore::HDF5File hdf_file(filename);
     std::vector<casacore::String> hdus(casacore::HDF5Group::linkNames(hdf_file));
     if (hdus.empty()) {
-        file_info->add_hdu_list("");
+        file_info.add_hdu_list("");
     } else {
         for (auto group_name : hdus) {
-            file_info->add_hdu_list(group_name);
+            file_info.add_hdu_list(group_name);
         }
     }
     return true;

--- a/FileList/FileInfoLoader.h
+++ b/FileList/FileInfoLoader.h
@@ -11,13 +11,13 @@ class FileInfoLoader {
 public:
     FileInfoLoader(const std::string& filename);
 
-    bool FillFileInfo(CARTA::FileInfo* file_info);
-    bool FillFileExtInfo(CARTA::FileInfoExtended* ext_info, std::string& hdu, std::string& message);
+    bool FillFileInfo(CARTA::FileInfo& file_info);
+    bool FillFileExtInfo(CARTA::FileInfoExtended& extended_info, std::string& hdu, std::string& message);
 
 private:
     // FileInfo
-    bool GetFitsHduList(CARTA::FileInfo* file_info, const std::string& abs_filename);
-    bool GetHdf5HduList(CARTA::FileInfo* file_info, const std::string& abs_filename);
+    bool GetFitsHduList(CARTA::FileInfo& file_info, const std::string& abs_filename);
+    bool GetHdf5HduList(CARTA::FileInfo& file_info, const std::string& abs_filename);
 
     std::string _filename;
     CARTA::FileType _type;

--- a/FileList/FileListHandler.cc
+++ b/FileList/FileListHandler.cc
@@ -125,7 +125,7 @@ void FileListHandler::GetFileList(CARTA::FileListResponse& file_list, string fol
                             if (cc_file.isRegular(true) && cc_file.isReadable()) {
                                 CARTA::FileType file_type(GetRegionType(full_path));
                                 if (file_type != CARTA::FileType::UNKNOWN) {
-                                    auto file_info = file_list.add_files();
+                                    auto file_info = *file_list.add_files();
                                     FillRegionFileInfo(file_info, full_path, file_type);
                                     is_region = true;
                                 }
@@ -160,8 +160,8 @@ void FileListHandler::GetFileList(CARTA::FileListResponse& file_list, string fol
                         }
 
                         if (add_image) { // add image to file list
-                            auto file_info = file_list.add_files();
-                            file_info->set_name(name);
+                            auto file_info = *file_list.add_files();
+                            file_info.set_name(name);
                             FillFileInfo(file_info, full_path);
                         }
                     }
@@ -263,7 +263,7 @@ std::string FileListHandler::GetCasacoreTypeString(casacore::ImageOpener::ImageT
     return type_str;
 }
 
-bool FileListHandler::FillFileInfo(CARTA::FileInfo* file_info, const string& filename) {
+bool FileListHandler::FillFileInfo(CARTA::FileInfo& file_info, const string& filename) {
     // fill FileInfo submessage
     FileInfoLoader info_loader = FileInfoLoader(filename);
     return info_loader.FillFileInfo(file_info);
@@ -330,7 +330,7 @@ CARTA::FileType FileListHandler::GetRegionType(const std::string& filename) {
     return file_type;
 }
 
-bool FileListHandler::FillRegionFileInfo(CARTA::FileInfo* file_info, const string& filename, CARTA::FileType type) {
+bool FileListHandler::FillRegionFileInfo(CARTA::FileInfo& file_info, const string& filename, CARTA::FileType type) {
     // For region list and info response: name, type, size
     casacore::File cc_file(filename);
     if (!cc_file.exists()) {
@@ -339,13 +339,13 @@ bool FileListHandler::FillRegionFileInfo(CARTA::FileInfo* file_info, const strin
 
     // name
     std::string filename_only = cc_file.path().baseName();
-    file_info->set_name(filename_only);
+    file_info.set_name(filename_only);
 
     // FileType
     if (type == CARTA::FileType::UNKNOWN) { // not passed in
         type = GetRegionType(filename);
     }
-    file_info->set_type(type);
+    file_info.set_type(type);
 
     // size
     int64_t file_size(cc_file.size());
@@ -354,8 +354,8 @@ bool FileListHandler::FillRegionFileInfo(CARTA::FileInfo* file_info, const strin
         casacore::File linked_file(resolved_filename);
         file_size = linked_file.size();
     }
-    file_info->set_size(file_size);
-    file_info->add_hdu_list("");
+    file_info.set_size(file_size);
+    file_info.add_hdu_list("");
     return true;
 }
 
@@ -381,10 +381,10 @@ void FileListHandler::OnRegionFileInfoRequest(
         response.add_contents(contents);
     } else {
         casacore::String full_name(cc_file.path().resolvedName());
-        auto file_info = response.mutable_file_info();
+        auto file_info = *response.mutable_file_info();
         FillRegionFileInfo(file_info, full_name);
         std::vector<std::string> file_contents;
-        if (file_info->type() == CARTA::FileType::UNKNOWN) {
+        if (file_info.type() == CARTA::FileType::UNKNOWN) {
             message = "File " + filename + " is not a region file.";
             response.add_contents(contents);
         } else {

--- a/FileList/FileListHandler.cc
+++ b/FileList/FileListHandler.cc
@@ -125,7 +125,7 @@ void FileListHandler::GetFileList(CARTA::FileListResponse& file_list, string fol
                             if (cc_file.isRegular(true) && cc_file.isReadable()) {
                                 CARTA::FileType file_type(GetRegionType(full_path));
                                 if (file_type != CARTA::FileType::UNKNOWN) {
-                                    auto file_info = *file_list.add_files();
+                                    auto& file_info = *file_list.add_files();
                                     FillRegionFileInfo(file_info, full_path, file_type);
                                     is_region = true;
                                 }
@@ -160,7 +160,7 @@ void FileListHandler::GetFileList(CARTA::FileListResponse& file_list, string fol
                         }
 
                         if (add_image) { // add image to file list
-                            auto file_info = *file_list.add_files();
+                            auto& file_info = *file_list.add_files();
                             file_info.set_name(name);
                             FillFileInfo(file_info, full_path);
                         }
@@ -381,7 +381,7 @@ void FileListHandler::OnRegionFileInfoRequest(
         response.add_contents(contents);
     } else {
         casacore::String full_name(cc_file.path().resolvedName());
-        auto file_info = *response.mutable_file_info();
+        auto& file_info = *response.mutable_file_info();
         FillRegionFileInfo(file_info, full_name);
         std::vector<std::string> file_contents;
         if (file_info.type() == CARTA::FileType::UNKNOWN) {

--- a/FileList/FileListHandler.h
+++ b/FileList/FileListHandler.h
@@ -39,8 +39,8 @@ private:
     // ICD: File/Region list response
     void GetFileList(CARTA::FileListResponse& file_list, std::string folder, ResultMsg& result_msg, bool region_list = false);
 
-    bool FillFileInfo(CARTA::FileInfo* file_info, const std::string& filename);
-    bool FillRegionFileInfo(CARTA::FileInfo* file_info, const string& filename, CARTA::FileType type = CARTA::FileType::UNKNOWN);
+    bool FillFileInfo(CARTA::FileInfo& file_info, const std::string& filename);
+    bool FillRegionFileInfo(CARTA::FileInfo& file_info, const string& filename, CARTA::FileType type = CARTA::FileType::UNKNOWN);
     void GetRegionFileContents(std::string& full_name, std::vector<std::string>& file_contents);
 
     void GetRelativePath(std::string& folder);

--- a/FileList/FitsHduList.cc
+++ b/FileList/FitsHduList.cc
@@ -6,7 +6,7 @@ FitsHduList::FitsHduList(const std::string& filename) {
     _filename = filename;
 }
 
-bool FitsHduList::GetHduList(CARTA::FileInfo* file_info) {
+bool FitsHduList::GetHduList(CARTA::FileInfo& file_info) {
     bool hdu_ok(false);
     casacore::FitsInput fits_input(_filename.c_str(), casacore::FITS::Disk, 10, FitsInfoErrHandler);
     if (fits_input.err() == casacore::FitsIO::OK) { // check for cfitsio error
@@ -27,7 +27,7 @@ bool FitsHduList::GetHduList(CARTA::FileInfo* file_info) {
                             if (!ext_name.empty()) {
                                 hdu_name += " ExtName: " + ext_name;
                             }
-                            file_info->add_hdu_list(hdu_name);
+                            file_info.add_hdu_list(hdu_name);
                         }
                         fits_input.skip_all(hdu_type); // skip data to next hdu
                     } else {

--- a/FileList/FitsHduList.h
+++ b/FileList/FitsHduList.h
@@ -14,7 +14,7 @@ inline void FitsInfoErrHandler(const char* err_message, casacore::FITSError::Err
 class FitsHduList {
 public:
     FitsHduList(const std::string& filename);
-    bool GetHduList(CARTA::FileInfo* file_info);
+    bool GetHduList(CARTA::FileInfo& file_info);
 
 private:
     bool IsImageHdu(casacore::FITS::HDUType hdu_type);

--- a/Session.cc
+++ b/Session.cc
@@ -239,8 +239,8 @@ void Session::OnFileListRequest(const CARTA::FileListRequest& request, uint32_t 
 
 void Session::OnFileInfoRequest(const CARTA::FileInfoRequest& request, uint32_t request_id) {
     CARTA::FileInfoResponse response;
-    auto file_info = *response.mutable_file_info();
-    auto file_info_extended = *response.mutable_file_info_extended();
+    auto& file_info = *response.mutable_file_info();
+    auto& file_info_extended = *response.mutable_file_info_extended();
     string message;
 
     casacore::String hdu_name(request.hdu());

--- a/Session.cc
+++ b/Session.cc
@@ -282,14 +282,14 @@ bool Session::OnOpenFile(const CARTA::OpenFile& message, uint32_t request_id, bo
     CARTA::OpenFileAck ack;
     ack.set_file_id(file_id);
     string err_message;
-    
+
     CARTA::FileInfo file_info;
     CARTA::FileInfoExtended file_info_extended;
 
     bool info_loaded = FillExtendedFileInfo(file_info_extended, file_info, directory, filename, hdu, err_message);
 
     bool success(false);
-    
+
     if (info_loaded) {
         // Set hdu if empty
         if (hdu.empty()) { // use first

--- a/Session.h
+++ b/Session.h
@@ -183,8 +183,7 @@ public:
 
 private:
     // File info
-    void ResetFileInfo(bool create = false); // delete existing file info ptrs, optionally create new ones
-    bool FillExtendedFileInfo(CARTA::FileInfoExtended* extended_info, CARTA::FileInfo* file_info, const std::string& folder,
+    bool FillExtendedFileInfo(CARTA::FileInfoExtended& extended_info, CARTA::FileInfo& file_info, const std::string& folder,
         const std::string& filename, std::string hdu, std::string& message);
 
     // Delete Frame(s)
@@ -218,9 +217,7 @@ private:
     // File browser
     FileListHandler* _file_list_handler;
 
-    // File info for browser, open file
-    std::unique_ptr<CARTA::FileInfo> _file_info;
-    std::unique_ptr<CARTA::FileInfoExtended> _file_info_extended;
+    // File loader
     std::unique_ptr<carta::FileLoader> _loader;
 
     // Frame


### PR DESCRIPTION
The file info which is cached on the session object is not invalidated correctly if the file browser is bypassed (which happens when a scripting command is used to open or append a file) and the file name hasn't changed. This leads to unexpected scripting behaviour when an attempt is made to load the same file multiple times, even if it was closed in the interim, or even to load a file with a different path but the same filename, including non-existent files.

The latter issue could be solved if we also cached and checked the directory, but this would not solve the underlying issue with loading the exact same file again. We could possibly invalidate the cached data after loading each file, but the simplest solution is to remove the caching, which doesn't save a lot of bandwidth. Apart from the scripting issue, caching could cause a problem if the user overwrites a file with a different file while the file info is open in the browser. Please comment if you think that it's worth keeping the caching and fixing it.

This PR removes the caching and (for consistency) converts some pointers to file info message objects passed by value into the underlying objects passed by reference.