### PR TITLE
allow for zero-length message payloads

### DIFF
--- a/Main.cc
+++ b/Main.cc
@@ -148,7 +148,7 @@ void OnMessage(uWS::WebSocket<uWS::SERVER>* ws, char* raw_message, size_t length
     }
 
     if (op_code == uWS::OpCode::BINARY) {
-        if (length > sizeof(carta::EventHeader)) {
+        if (length >= sizeof(carta::EventHeader)) {
             carta::EventHeader head = *reinterpret_cast<carta::EventHeader*>(raw_message);
             char* event_buf = raw_message + sizeof(carta::EventHeader);
             int event_length = length - sizeof(carta::EventHeader);


### PR DESCRIPTION
fixes #544. This was actually caused by a zero-length protobuf message, because _all_ the fields of the `ResumeSession` message were the default. 