### PR TITLE
file modification time

### DIFF
--- a/EventHeader.h
+++ b/EventHeader.h
@@ -2,7 +2,7 @@
 #define CARTA_BACKEND__EVENTHEADER_H_
 
 namespace carta {
-const uint16_t ICD_VERSION = 14;
+const uint16_t ICD_VERSION = 15;
 struct EventHeader {
     uint16_t type;
     uint16_t icd_version;

--- a/FileList/FileInfoLoader.cc
+++ b/FileList/FileInfoLoader.cc
@@ -34,6 +34,7 @@ bool FileInfoLoader::FillFileInfo(CARTA::FileInfo& file_info) {
         file_size = linked_file.size();
     }
 
+    file_info.set_date(cc_file.modifyTime());
     file_info.set_size(file_size);
     file_info.set_type(_type);
     // add hdu for FITS, HDF5

--- a/FileList/FileListHandler.cc
+++ b/FileList/FileListHandler.cc
@@ -322,7 +322,7 @@ CARTA::FileType FileListHandler::GetRegionType(const std::string& filename) {
         if (first_line.find("#CRTF") == 0) {
             file_type = CARTA::FileType::CRTF;
         } else if (first_line.find("# Region file format: DS9") == 0) { // optional header, but what else to do?
-            file_type = CARTA::FileType::REG;
+            file_type = CARTA::FileType::DS9_REG;
         }
     } catch (std::ios_base::failure& f) {
         region_file.close();

--- a/FileList/FileListHandler.cc
+++ b/FileList/FileListHandler.cc
@@ -355,6 +355,7 @@ bool FileListHandler::FillRegionFileInfo(CARTA::FileInfo& file_info, const strin
         file_size = linked_file.size();
     }
     file_info.set_size(file_size);
+    file_info.set_date(cc_file.modifyTime());
     file_info.add_hdu_list("");
     return true;
 }

--- a/Region/RegionHandler.cc
+++ b/Region/RegionHandler.cc
@@ -104,7 +104,7 @@ void RegionHandler::ImportRegion(int file_id, std::shared_ptr<Frame> frame, CART
             importer = std::unique_ptr<RegionImportExport>(
                 new CrtfImportExport(csys, shape, frame->StokesAxis(), file_id, region_file, file_is_filename));
             break;
-        case CARTA::FileType::REG:
+        case CARTA::FileType::DS9_REG:
             importer = std::unique_ptr<RegionImportExport>(new Ds9ImportExport(csys, shape, file_id, region_file, file_is_filename));
             break;
         default:
@@ -197,7 +197,7 @@ void RegionHandler::ExportRegion(int file_id, std::shared_ptr<Frame> frame, CART
         case CARTA::FileType::CRTF:
             exporter = std::unique_ptr<RegionImportExport>(new CrtfImportExport(output_csys, output_shape, frame->StokesAxis()));
             break;
-        case CARTA::FileType::REG:
+        case CARTA::FileType::DS9_REG:
             exporter = std::unique_ptr<RegionImportExport>(new Ds9ImportExport(output_csys, output_shape, pixel_coord));
             break;
         default:

--- a/Session.cc
+++ b/Session.cc
@@ -412,7 +412,7 @@ void Session::OnAddRequiredTiles(const CARTA::AddRequiredTiles& message, bool sk
                 raster_tile_data.set_animation_id(animation_id);
                 auto tile = Tile::Decode(encoded_coordinate);
                 if (_frames.count(file_id) && _frames.at(file_id)->FillRasterTileData(
-                        raster_tile_data, tile, channel, stokes, compression_type, compression_quality)) {
+                                                  raster_tile_data, tile, channel, stokes, compression_type, compression_quality)) {
                     SendFileEvent(file_id, CARTA::EventType::RASTER_TILE_DATA, 0, raster_tile_data);
                 } else {
                     fmt::print("Problem getting tile layer={}, x={}, y={}\n", tile.layer, tile.x, tile.y);

--- a/Session.cc
+++ b/Session.cc
@@ -411,7 +411,7 @@ void Session::OnAddRequiredTiles(const CARTA::AddRequiredTiles& message, bool sk
                 raster_tile_data.set_file_id(file_id);
                 raster_tile_data.set_animation_id(animation_id);
                 auto tile = Tile::Decode(encoded_coordinate);
-                if (_frames.at(file_id)->FillRasterTileData(
+                if (_frames.count(file_id) && _frames.at(file_id)->FillRasterTileData(
                         raster_tile_data, tile, channel, stokes, compression_type, compression_quality)) {
                     SendFileEvent(file_id, CARTA::EventType::RASTER_TILE_DATA, 0, raster_tile_data);
                 } else {

--- a/Table/TableController.cc
+++ b/Table/TableController.cc
@@ -204,9 +204,9 @@ void TableController::OnFileListRequest(
             file_info->set_file_size(fs::file_size(entry));
 
             // Fill in file time
-            struct stat sb;
-            stat(entry.path().c_str(), &sb);
-            file_info->set_date(sb.st_mtim.tv_sec);
+            struct stat file_stats;
+            stat(entry.path().c_str(), &file_stats);
+            file_info->set_date(file_stats.st_mtim.tv_sec);
         }
     }
 

--- a/Table/TableController.cc
+++ b/Table/TableController.cc
@@ -1,6 +1,7 @@
 #include "TableController.h"
 
 #include <fmt/format.h>
+#include <sys/stat.h>
 
 #include "../Util.h"
 
@@ -201,6 +202,11 @@ void TableController::OnFileListRequest(
             file_info->set_name(entry.path().filename().string());
             file_info->set_type(file_type);
             file_info->set_file_size(fs::file_size(entry));
+
+            // Fill in file time
+            struct stat sb;
+            stat(entry.path().c_str(), &sb);
+            file_info->set_date(sb.st_mtim.tv_sec);
         }
     }
 


### PR DESCRIPTION
This PR adds the file modification time to all the file entries returned when a file list is requested (for catalogs, regions and images). 

For the catalog stuff, I've used `stat` instead of the C++17 `fs::last_write_time` because it was causing compatibility headaches.

~~I haven't bumped the ICD version, because this is backward compatible with the previous one, since it's just adding an extra field that can be blank anyway~~ edit: I've bumped the ICD version because I've changed the file type enum for easier alphabetical sorting 