### PR TITLE
Send cursor spatial message to update value

### DIFF
--- a/Frame.cc
+++ b/Frame.cc
@@ -895,12 +895,8 @@ bool Frame::SetSpatialRequirements(int region_id, const std::vector<std::string>
 
 bool Frame::FillSpatialProfileData(int region_id, CARTA::SpatialProfileData& spatial_data) {
     // Fill spatial profile message for cursor only
+    // Send even if no requirements, to update value of data at cursor
     if (region_id != CURSOR_REGION_ID) {
-        return false;
-    }
-
-    // No spatial profile requirements
-    if (_cursor_spatial_configs.empty()) {
         return false;
     }
 
@@ -971,15 +967,14 @@ bool Frame::FillSpatialProfileData(int region_id, CARTA::SpatialProfileData& spa
         }
     }
 
-    bool have_spatial_profiles = (spatial_data.profiles_size() > 0);
-    if (_verbose && have_spatial_profiles) {
+    if (_verbose) {
         auto t_end_spatial_profile = std::chrono::high_resolution_clock::now();
         auto dt_spatial_profile =
             std::chrono::duration_cast<std::chrono::milliseconds>(t_end_spatial_profile - t_start_spatial_profile).count();
         fmt::print("Fill spatial profile in {} ms\n", dt_spatial_profile);
     }
 
-    return have_spatial_profiles;
+    return true;
 }
 
 // ****************************************************


### PR DESCRIPTION
Closes #553. 

After set cursor, backend will send spatial profile message regardless of requirements.  Tested with mix n match.