### PR TITLE
attempt to get remote address from x-forwarded-for header

### DIFF
--- a/Main.cc
+++ b/Main.cc
@@ -97,8 +97,14 @@ void OnConnect(uWS::WebSocket<uWS::SERVER>* ws, uWS::HttpRequest http_request) {
     session->IncreaseRefCount();
     outgoing->setData(session);
 
-    Log(session_number, "Client {} [{}] Connected. Num sessions: {}", session_number, ws->getAddress().address,
-        Session::NumberOfSessions());
+    string address;
+    auto ip_header = http_request.getHeader("x-forwarded-for");
+    if (ip_header) {
+        address = ip_header.toString();
+    } else {
+        address = ws->getAddress().address;
+    }
+    Log(session_number, "Client {} [{}] Connected. Num sessions: {}", session_number, address, Session::NumberOfSessions());
 }
 
 // Called on disconnect. Cleans up sessions. In future, we may want to delay this (in case of unintentional disconnects)

--- a/Main.cc
+++ b/Main.cc
@@ -119,7 +119,7 @@ void OnDisconnect(uWS::WebSocket<uWS::SERVER>* ws, int code, char* message, size
     if (session) {
         auto uuid = session->GetId();
         session->DisconnectCalled();
-        Log(uuid, "Client {} [{}] Disconnected. Remaining sessions: {}", uuid, ws->getAddress().address, Session::NumberOfSessions());
+        Log(uuid, "Client {} Disconnected. Remaining sessions: {}", uuid, Session::NumberOfSessions());
         if (carta_grpc_service) {
             carta_grpc_service->RemoveSession(session);
         }

--- a/Session.cc
+++ b/Session.cc
@@ -41,10 +41,11 @@ int Session::_exit_after_num_seconds = 5;
 bool Session::_exit_when_all_sessions_closed = false;
 
 // Default constructor. Associates a websocket with a UUID and sets the root folder for all files
-Session::Session(uWS::WebSocket<uWS::SERVER>* ws, uint32_t id, std::string root, std::string base, uS::Async* outgoing_async,
-    FileListHandler* file_list_handler, bool verbose)
+Session::Session(uWS::WebSocket<uWS::SERVER>* ws, uint32_t id, std::string address, std::string root, std::string base,
+    uS::Async* outgoing_async, FileListHandler* file_list_handler, bool verbose)
     : _socket(ws),
       _id(id),
+      _address(address),
       _root_folder(root),
       _base_folder(base),
       _table_controller(std::make_unique<carta::TableController>(_root_folder, _base_folder)),

--- a/Session.h
+++ b/Session.h
@@ -50,8 +50,8 @@
 
 class Session {
 public:
-    Session(uWS::WebSocket<uWS::SERVER>* ws, uint32_t id, std::string root, std::string base, uS::Async* outgoing_async,
-        FileListHandler* file_list_handler, bool verbose = false);
+    Session(uWS::WebSocket<uWS::SERVER>* ws, uint32_t id, std::string address, std::string root, std::string base,
+        uS::Async* outgoing_async, FileListHandler* file_list_handler, bool verbose = false);
     ~Session();
 
     // CARTA ICD
@@ -178,6 +178,10 @@ public:
         return _id;
     }
 
+    inline std::string GetAddress() {
+        return _address;
+    }
+
     // RegionDataStreams
     void RegionDataStreams(int file_id, int region_id);
     bool SendSpectralProfileData(int file_id, int region_id, bool stokes_changed = false);
@@ -216,6 +220,7 @@ private:
 
     uWS::WebSocket<uWS::SERVER>* _socket;
     uint32_t _id;
+    std::string _address;
     std::string _api_key;
     std::string _root_folder;
     std::string _base_folder;


### PR DESCRIPTION
very minor update to check the `x-forwarded-for` header for the remote address first, before assuming it is the same as the WebSocket connection address. This prevents us from always logging `127.0.0.1` as the remote address.