### PR TITLE
Rwjs/update ani params

### DIFF
--- a/AnimationObject.h
+++ b/AnimationObject.h
@@ -9,8 +9,8 @@
 #include <carta-protobuf/set_image_channels.pb.h>
 
 namespace CARTA {
-const int AnimationFlowWindowConstant = 5;
-const int AnimationFlowWindowScaler = 2;
+const int AnimationWaitsPerSecond = 3;
+const int InitialWindowScale = 1;
 } // namespace CARTA
 
 class AnimationObject {
@@ -25,6 +25,8 @@ class AnimationObject {
     CARTA::AnimationFrame _next_frame;
     CARTA::AnimationFrame _last_flow_frame;
     int _frame_rate;
+    int _waits_per_second;
+    int _window_scale;
     std::chrono::microseconds _frame_interval;
     std::chrono::time_point<std::chrono::high_resolution_clock> _t_start;
     std::chrono::time_point<std::chrono::high_resolution_clock> _t_last;
@@ -69,9 +71,11 @@ public:
         _file_open = true;
         _waiting_flow_event = false;
         _last_flow_frame = start_frame;
+        _waits_per_second = CARTA::InitialAnimationWaitsPerSecond;
+        _window_scale = CARTA::InitialWindowScale;
     }
     int CurrentFlowWindowSize() {
-        return (CARTA::AnimationFlowWindowConstant * CARTA::AnimationFlowWindowScaler * _frame_rate);
+        return (_frame_rate / _waits_per_second) * _window_scale;
     }
     void CancelExecution() {
         _tbb_context.cancel_group_execution();

--- a/AnimationObject.h
+++ b/AnimationObject.h
@@ -9,7 +9,7 @@
 #include <carta-protobuf/set_image_channels.pb.h>
 
 namespace CARTA {
-const int AnimationWaitsPerSecond = 3;
+const int InitialAnimationWaitsPerSecond = 3;
 const int InitialWindowScale = 1;
 } // namespace CARTA
 

--- a/Session.cc
+++ b/Session.cc
@@ -398,7 +398,6 @@ void Session::OnAddRequiredTiles(const CARTA::AddRequiredTiles& message, bool sk
         start_message.set_stokes(stokes);
         start_message.set_animation_id(animation_id);
         start_message.set_end_sync(false);
-        start_message.set_animation_id(animation_id);
         SendFileEvent(file_id, CARTA::EventType::RASTER_TILE_SYNC, 0, start_message);
 
         int n = message.tiles_size();
@@ -444,7 +443,6 @@ void Session::OnAddRequiredTiles(const CARTA::AddRequiredTiles& message, bool sk
         final_message.set_stokes(stokes);
         final_message.set_animation_id(animation_id);
         final_message.set_end_sync(true);
-        final_message.set_animation_id(animation_id);
         SendFileEvent(file_id, CARTA::EventType::RASTER_TILE_SYNC, 0, final_message);
     }
 }


### PR DESCRIPTION
One line fix to the animation flow window calculation.
Update of perimeter names to make them more understandable.
Remove two lines of repeated code from Session.cc