### PR TITLE
Use Hdf5Loader cursor spectral profile for point region

### DIFF
--- a/Frame.h
+++ b/Frame.h
@@ -141,8 +141,6 @@ public:
     // Apply Region/Slicer to image (Frame manages image mutex) and get shape, data, or stats
     casacore::LCRegion* GetImageRegion(int file_id, std::shared_ptr<carta::Region> region);
     casacore::IPosition GetRegionShape(const casacore::LattRegionHolder& region);
-    // Returns mask array
-    bool GetRegionMask(const casacore::LattRegionHolder& region, casacore::Array<casacore::Bool>& mask);
     // Returns data vector
     bool GetRegionData(const casacore::LattRegionHolder& region, std::vector<float>& data);
     bool GetSlicerData(const casacore::Slicer& slicer, std::vector<float>& data);
@@ -151,8 +149,9 @@ public:
         std::map<CARTA::StatsType, std::vector<double>>& stats_values);
     bool GetSlicerStats(const casacore::Slicer& slicer, std::vector<CARTA::StatsType>& required_stats, bool per_channel,
         std::map<CARTA::StatsType, std::vector<double>>& stats_values);
-    // Whether to use loader for spectral profiles
+    // Spectral profiles from loader
     bool UseLoaderSpectralData(const casacore::IPosition& region_shape);
+    bool GetLoaderPointSpectralData(std::vector<float>& profile, int stokes, CARTA::Point& point);
     bool GetLoaderSpectralData(int region_id, int stokes, const casacore::ArrayLattice<casacore::Bool>& mask,
         const casacore::IPosition& origin, std::map<CARTA::StatsType, std::vector<double>>& results, float& progress);
 

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -254,26 +254,27 @@ casacore::ArrayLattice<casacore::Bool> Region::GetImageRegionMask(int file_id) {
         std::unique_lock<std::mutex> ulock(_region_mutex);
         auto lcregion = _applied_regions.at(file_id)->cloneRegion();
         auto extended_region = static_cast<casacore::LCExtension*>(lcregion);
-
-        switch (_region_state.type) {
-            case CARTA::POINT: {
-                auto region = static_cast<const casacore::LCBox&>(extended_region->region());
-                mask = region.getMask();
-                break;
+        if (extended_region) {
+            switch (_region_state.type) {
+                case CARTA::POINT: {
+                    auto region = static_cast<const casacore::LCBox&>(extended_region->region());
+                    mask = region.getMask();
+                    break;
+                }
+                case CARTA::RECTANGLE:
+                case CARTA::POLYGON: {
+                    auto region = static_cast<const casacore::LCPolygon&>(extended_region->region());
+                    mask = region.getMask();
+                    break;
+                }
+                case CARTA::ELLIPSE: {
+                    auto region = static_cast<const casacore::LCEllipsoid&>(extended_region->region());
+                    mask = region.getMask();
+                    break;
+                }
+                default:
+                    break;
             }
-            case CARTA::RECTANGLE:
-            case CARTA::POLYGON: {
-                auto region = static_cast<const casacore::LCPolygon&>(extended_region->region());
-                mask = region.getMask();
-                break;
-            }
-            case CARTA::ELLIPSE: {
-                auto region = static_cast<const casacore::LCEllipsoid&>(extended_region->region());
-                mask = region.getMask();
-                break;
-            }
-            default:
-                break;
         }
         ulock.unlock();
     }


### PR DESCRIPTION
Closes #569.

Uses simpler GetCursorSpectralData to slice swizzled data for point region rather than the iterative/accumulative GetRegionSpectralData.