### PR TITLE
attempt to fix spectral profile crash with HDF5 files

### DIFF
--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -607,9 +607,10 @@ casacore::ArrayLattice<casacore::Bool> Region::GetImageRegionMask(int file_id) {
 
     if (lcregion) {
         std::lock_guard<std::mutex> guard(_region_mutex);
-        auto fixed_region = static_cast<casacore::LCRegionFixed*>(lcregion);
-        if (fixed_region) {
-            mask = fixed_region->getMask();
+        auto extended_region = static_cast<casacore::LCExtension*>(lcregion);
+        if (extended_region) {
+            auto& fixed_region = static_cast<const casacore::LCRegionFixed&>(extended_region->region());
+            mask = fixed_region.getMask();
         }
     }
 

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -607,10 +607,16 @@ casacore::ArrayLattice<casacore::Bool> Region::GetImageRegionMask(int file_id) {
 
     if (lcregion) {
         std::lock_guard<std::mutex> guard(_region_mutex);
-        auto extended_region = static_cast<casacore::LCExtension*>(lcregion);
+        // Region can either be an extension region or a fixed region, depending on whether image is matched or not
+        auto extended_region = dynamic_cast<casacore::LCExtension*>(lcregion);
         if (extended_region) {
             auto& fixed_region = static_cast<const casacore::LCRegionFixed&>(extended_region->region());
             mask = fixed_region.getMask();
+        } else {
+            auto fixed_region = dynamic_cast<casacore::LCRegionFixed*>(lcregion);
+            if (fixed_region) {
+                mask = fixed_region->getMask();
+            }
         }
     }
 


### PR DESCRIPTION
@confluence suggested this fix to prevent a hard crash when requesting a spectral profile from a region of an HDF5 file