### PR TITLE
Fix for HDF5 cursor shape used for moment generation

### DIFF
--- a/Moment/ImageMoments.tcc
+++ b/Moment/ImageMoments.tcc
@@ -548,7 +548,10 @@ void ImageMoments<T>::LineMultiApply(casacore::PtrBlock<casacore::MaskedLattice<
     const casacore::IPosition chunk_slice_end_at_chunk_iter_begin = chunk_slice_end; // As an increment of a chunk for the lattice iterator
 
     // Get a chunk shape and used it to set the data iterator
+    auto nice_shape = lattice_in.niceCursorShape();
     casacore::IPosition chunk_shape_init = ChunkShape(collapse_axis, lattice_in);
+    chunk_shape_init[0] = nice_shape[0];
+    chunk_shape_init[1] = nice_shape[1];
     casacore::LatticeStepper my_stepper(in_shape, chunk_shape_init, LatticeStepper::RESIZE);
     casacore::RO_MaskedLatticeIterator<T> lat_iter(lattice_in, my_stepper);
 

--- a/Moment/ImageMoments.tcc
+++ b/Moment/ImageMoments.tcc
@@ -548,10 +548,19 @@ void ImageMoments<T>::LineMultiApply(casacore::PtrBlock<casacore::MaskedLattice<
     const casacore::IPosition chunk_slice_end_at_chunk_iter_begin = chunk_slice_end; // As an increment of a chunk for the lattice iterator
 
     // Get a chunk shape and used it to set the data iterator
-    auto nice_shape = lattice_in.niceCursorShape();
+    
     casacore::IPosition chunk_shape_init = ChunkShape(collapse_axis, lattice_in);
-    chunk_shape_init[0] = nice_shape[0];
-    chunk_shape_init[1] = nice_shape[1];
+    
+    casacore::IPosition hdf5_chunk_shape(in_ndim, 1);
+    hdf5_chunk_shape[0] = 512;
+    hdf5_chunk_shape[1] = 512;
+    
+    auto nice_shape = lattice_in.niceCursorShape();
+    if (nice_shape == hdf5_chunk_shape) {
+        chunk_shape_init[0] = nice_shape[0];
+        chunk_shape_init[1] = nice_shape[1];
+    }
+        
     casacore::LatticeStepper my_stepper(in_shape, chunk_shape_init, LatticeStepper::RESIZE);
     casacore::RO_MaskedLatticeIterator<T> lat_iter(lattice_in, my_stepper);
 


### PR DESCRIPTION
This is an interim solution to reduce the slowness of generating moments from HDF5 files. Ultimately this will probably need to be replaced by a more complicated fix which uses the HDF5 rotated dataset for moments.

This overrides the first two dimensions of the generated chunk shape with the HDF5 chunk dimensions if the nice cursor shape generated for the lattice matches the HDF5 chunk dimensions. (There appears not to be a more robust way to determine whether the underlying lattice is an HDF5 lattice because it's a private member of the parent lattice class.)