### PR TITLE
Reduce the progress update cadence of cube histogram calculations

### DIFF
--- a/InterfaceConstants.h
+++ b/InterfaceConstants.h
@@ -37,6 +37,7 @@
 #define HISTOGRAM_START 0.0
 #define HISTOGRAM_COMPLETE 1.0
 #define HISTOGRAM_CANCEL -1.0
+#define UPDATE_HISTOGRAM_PROGRESS_PER_SECONDS 1.0
 
 // spectral profile calculation
 #define INIT_DELTA_CHANNEL 10

--- a/Session.cc
+++ b/Session.cc
@@ -1125,7 +1125,7 @@ bool Session::CalculateCubeHistogram(int file_id, CARTA::RegionHistogramData& cu
                 // check for progress update
                 auto t_end = std::chrono::high_resolution_clock::now();
                 auto dt = std::chrono::duration_cast<std::chrono::microseconds>(t_end - t_start).count();
-                if ((dt / 1e3) > 2.0) {
+                if ((dt / 1e6) > 1.0) {
                     // send progress
                     float this_chan(chan);
                     float progress = this_chan / total_channels;
@@ -1171,7 +1171,7 @@ bool Session::CalculateCubeHistogram(int file_id, CARTA::RegionHistogramData& cu
 
                     auto t_end = std::chrono::high_resolution_clock::now();
                     auto dt = std::chrono::duration_cast<std::chrono::microseconds>(t_end - t_start).count();
-                    if ((dt / 1e3) > 2.0) {
+                    if ((dt / 1e6) > 1.0) {
                         // Send progress update
                         float this_chan(chan);
                         progress = 0.5 + (this_chan / total_channels);

--- a/Session.cc
+++ b/Session.cc
@@ -1125,7 +1125,7 @@ bool Session::CalculateCubeHistogram(int file_id, CARTA::RegionHistogramData& cu
                 // check for progress update
                 auto t_end = std::chrono::high_resolution_clock::now();
                 auto dt = std::chrono::duration_cast<std::chrono::microseconds>(t_end - t_start).count();
-                if ((dt / 1e6) > 1.0) {
+                if ((dt / 1e6) > UPDATE_HISTOGRAM_PROGRESS_PER_SECONDS) {
                     // send progress
                     float this_chan(chan);
                     float progress = this_chan / total_channels;
@@ -1171,7 +1171,7 @@ bool Session::CalculateCubeHistogram(int file_id, CARTA::RegionHistogramData& cu
 
                     auto t_end = std::chrono::high_resolution_clock::now();
                     auto dt = std::chrono::duration_cast<std::chrono::microseconds>(t_end - t_start).count();
-                    if ((dt / 1e6) > 1.0) {
+                    if ((dt / 1e6) > UPDATE_HISTOGRAM_PROGRESS_PER_SECONDS) {
                         // Send progress update
                         float this_chan(chan);
                         progress = 0.5 + (this_chan / total_channels);


### PR DESCRIPTION
For issue #640, we now change the update of cube histogram progress by every 1 second.