### PR TITLE
ajm/jenkinsfile updates

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -605,6 +605,67 @@ pipeline {
                 }
             }
         }
+        stage('ICD tests: spatial profiler') {
+            parallel {
+                stage('CentOS7') {
+                    agent {
+                        label "centos7-1"
+                    }
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
+                        {
+                        sh "export PATH=/usr/local/bin:$PATH"
+                        dir ('build') {
+                            unstash "centos7-1_carta_backend_icd"
+                            sh "./run.sh # run carta_backend in the background"
+                            dir ('carta-backend-ICD-test') {
+                                sh "cp ../../../run-jenkins-spatial-profiler.sh . && ./run-jenkins-spatial-profiler.sh # run the tests"
+                            }
+                        }
+                        echo "Finished !!"
+                        }
+                    }
+                }
+                stage('Ubuntu') {
+                    agent {
+                        label "ubuntu-1"
+                    }
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
+                        {
+                        sh "export PATH=/usr/local/bin:$PATH"
+                        dir ('build') {
+                            unstash "ubuntu-1_carta_backend_icd"
+                            sh "./run.sh # run carta_backend in the background"
+                            dir ('carta-backend-ICD-test') {
+                                sh "cp ../../../run-jenkins-spatial-profiler.sh . && ./run-jenkins-spatial-profiler.sh # run the tests"
+                            }
+                        }
+                        echo "Finished !!"
+                        }
+                    }
+                }
+                stage('MacOS') {
+                    agent {
+                        label "macos-1"
+                    }
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
+                        {
+                        sh "export PATH=/usr/local/bin:$PATH"
+                        dir ('build') {
+                            unstash "macos-1_carta_backend_icd"
+                            sh "./run.sh # run carta_backend in the background"
+                            dir ('carta-backend-ICD-test') {
+                                sh "cp ../../../run-jenkins-spatial-profiler.sh . && ./run-jenkins-spatial-profiler.sh # run the tests"
+                            }
+                        }
+                        echo "Finished !!"
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,7 +84,7 @@ pipeline {
                 }
             }
         }
-        stage('Preparing ICD tests') {
+        stage('Prepare ICD tests') {
             parallel {
                 stage('CentOS7') {
                     agent {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -666,6 +666,67 @@ pipeline {
                 }
             }
         }
+        stage('ICD tests: raster tiles') {
+            parallel {
+                stage('CentOS7') {
+                    agent {
+                        label "centos7-1"
+                    }
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
+                        {
+                        sh "export PATH=/usr/local/bin:$PATH"
+                        dir ('build') {
+                            unstash "centos7-1_carta_backend_icd"
+                            sh "./run.sh # run carta_backend in the background"
+                            dir ('carta-backend-ICD-test') {
+                                sh "cp ../../../run-jenkins-raster-tiles.sh . && ./run-jenkins-raster-tiles.sh # run the tests"
+                            }
+                        }
+                        echo "Finished !!"
+                        }
+                    }
+                }
+                stage('Ubuntu') {
+                    agent {
+                        label "ubuntu-1"
+                    }
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
+                        {
+                        sh "export PATH=/usr/local/bin:$PATH"
+                        dir ('build') {
+                            unstash "ubuntu-1_carta_backend_icd"
+                            sh "./run.sh # run carta_backend in the background"
+                            dir ('carta-backend-ICD-test') {
+                                sh "cp ../../../run-jenkins-raster-tiles.sh . && ./run-jenkins-raster-tiles.sh # run the tests"
+                            }
+                        }
+                        echo "Finished !!"
+                        }
+                    }
+                }
+                stage('MacOS') {
+                    agent {
+                        label "macos-1"
+                    }
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
+                        {
+                        sh "export PATH=/usr/local/bin:$PATH"
+                        dir ('build') {
+                            unstash "macos-1_carta_backend_icd"
+                            sh "./run.sh # run carta_backend in the background"
+                            dir ('carta-backend-ICD-test') {
+                                sh "cp ../../../run-jenkins-raster-tiles.sh . && ./run-jenkins-raster-tiles.sh # run the tests"
+                            }
+                        }
+                        echo "Finished !!"
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -663,6 +663,67 @@ pipeline {
                 }
             }
         }
+        stage('ICD tests: spectral line query') {
+            parallel {
+                stage('CentOS7') {
+                    agent {
+                        label "centos7-1"
+                    }
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
+                        {
+                        sh "export PATH=/usr/local/bin:$PATH"
+                        dir ('build') {
+                            unstash "centos7-1_carta_backend_icd"
+                            sh "./run.sh # run carta_backend in the background"
+                            dir ('carta-backend-ICD-test') {
+                                sh "cp ../../../run-jenkins-line-query.sh . && ./run-jenkins-line-query.sh # run the tests"
+                            }
+                        }
+                        echo "Finished !!"
+                        }
+                    }
+                }
+                stage('Ubuntu') {
+                    agent {
+                        label "ubuntu-1"
+                    }
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
+                        {
+                        sh "export PATH=/usr/local/bin:$PATH"
+                        dir ('build') {
+                            unstash "ubuntu-1_carta_backend_icd"
+                            sh "./run.sh # run carta_backend in the background"
+                            dir ('carta-backend-ICD-test') {
+                                sh "cp ../../../run-jenkins-line-query.sh . && ./run-jenkins-line-query.sh # run the tests"
+                            }
+                        }
+                        echo "Finished !!"
+                        }
+                    }
+                }
+                stage('MacOS') {
+                    agent {
+                        label "macos-1"
+                    }
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
+                        {
+                        sh "export PATH=/usr/local/bin:$PATH"
+                        dir ('build') {
+                            unstash "macos-1_carta_backend_icd"
+                            sh "./run.sh # run carta_backend in the background"
+                            dir ('carta-backend-ICD-test') {
+                                sh "cp ../../../run-jenkins-line-query.sh . && ./run-jenkins-line-query.sh # run the tests"
+                            }
+                        }
+                        echo "Finished !!"
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ void setBuildStatus(String message, String state) {
 pipeline {
     agent none
     stages {
-        stage('build backend') {
+        stage('Build') {
             parallel {
                 stage('CentOS7 build') {
                     agent {
@@ -65,7 +65,6 @@ pipeline {
                             sh "./build_proto.sh"
                         }
                         sh "cp ../../../ws-config.json src/test/config.json"
-
                         stash includes: "carta_backend", name: "macos-1_carta_backend_icd"
                         }
                     }
@@ -98,7 +97,6 @@ pipeline {
                             sh "./build_proto.sh"
                         }
                         sh "cp ../../../ws-config.json src/test/config.json"
-
                         stash includes: "carta_backend", name: "ubuntu-1_carta_backend_icd"
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,16 @@ pipeline {
                         sh "cp ../../cmake-command.sh ."
                         sh "./cmake-command.sh"
                         sh "make"
-                        stash includes: "carta_backend", name: "centos7-1_carta_backend"
+                        echo "Preparing for upcoming ICD tests"
+                        sh "rm -rf carta-backend-ICD-test"
+                        sh "git clone https://github.com/CARTAvis/carta-backend-ICD-test.git && cp ../../run.sh ."
+                        dir ('carta-backend-ICD-test') {
+                            sh "git submodule init && git submodule update && npm install"
+                            dir ('protobuf') {
+                            sh "./build_proto.sh"
+                        }
+                        sh "cp ../../../ws-config.json src/test/config.json"
+                        stash includes: "carta_backend", name: "centos7-1_carta_backend_icd"
                         }
                     }
                     post {
@@ -47,7 +56,17 @@ pipeline {
                         sh "cp ../../cmake-command.sh ."
                         sh "./cmake-command.sh"
                         sh "make"
-                        stash includes: "carta_backend", name: "macos-1_carta_backend"
+                        echo "Preparing for upcoming ICD tests"
+                        sh "rm -rf carta-backend-ICD-test"
+                        sh "git clone https://github.com/CARTAvis/carta-backend-ICD-test.git && cp ../../run.sh ."
+                        dir ('carta-backend-ICD-test') {
+                            sh "git submodule init && git submodule update && npm install"
+                            dir ('protobuf') {
+                            sh "./build_proto.sh"
+                        }
+                        sh "cp ../../../ws-config.json src/test/config.json"
+
+                        stash includes: "carta_backend", name: "macos-1_carta_backend_icd"
                         }
                     }
                     post {
@@ -70,7 +89,17 @@ pipeline {
                         sh "cp ../../cmake-command.sh ."
                         sh "./cmake-command.sh"
                         sh "make"
-                        stash includes: "carta_backend", name: "ubuntu-1_carta_backend"
+                        echo "Preparing for upcoming ICD tests"
+                        sh "rm -rf carta-backend-ICD-test"
+                        sh "git clone https://github.com/CARTAvis/carta-backend-ICD-test.git && cp ../../run.sh ."
+                        dir ('carta-backend-ICD-test') {
+                            sh "git submodule init && git submodule update && npm install"
+                            dir ('protobuf') {
+                            sh "./build_proto.sh"
+                        }
+                        sh "cp ../../../ws-config.json src/test/config.json"
+
+                        stash includes: "carta_backend", name: "ubuntu-1_carta_backend_icd"
                         }
                     }
                     post {
@@ -79,100 +108,6 @@ pipeline {
                         }
                         failure {
                             setBuildStatus("MacOS build failed", "FAILURE");
-                        }
-                    }
-                }
-            }
-        }
-        stage('Prepare ICD tests') {
-            parallel {
-                stage('CentOS7') {
-                    agent {
-                        label "centos7-1"
-                    }
-                    steps {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "centos7-1_carta_backend"
-                            sh "rm -rf carta-backend-ICD-test"
-                            sh "git clone https://github.com/CARTAvis/carta-backend-ICD-test.git && cp ../../run.sh ."
-                            dir ('carta-backend-ICD-test') {
-                                sh "git submodule init && git submodule update && npm install"
-                                dir ('protobuf') {
-                                     sh "./build_proto.sh"
-                                }
-                                sh "cp ../../../ws-config.json src/test/config.json"
-                            }
-                        stash includes: "carta_backend", name: "centos7-1_carta_backend_icd"
-                        }
-                        echo "Finished !!"
-                    }
-                    post {
-                        success {
-                            setBuildStatus("CentOS7 ICD prepared", "SUCCESS");
-                        }
-                        failure {
-                            setBuildStatus("CentOS7 ICD prepare failed", "FAILURE");
-                        }     
-                    }
-                 }
-                 stage('Ubuntu ICD') {
-                     agent {
-                         label "ubuntu-1"
-                     }
-                     steps {
-                         sh "export PATH=/usr/local/bin:$PATH"
-                         dir ('build') {
-                             unstash "ubuntu-1_carta_backend"
-                             sh "rm -rf carta-backend-ICD-test"
-                             sh "git clone https://github.com/CARTAvis/carta-backend-ICD-test.git && cp ../../run.sh ."
-                             dir ('carta-backend-ICD-test') {
-                                 sh "git submodule init && git submodule update && npm install"
-                                 dir ('protobuf') {
-                                     sh "./build_proto.sh"
-                                 }
-                                 sh "cp ../../../ws-config.json src/test/config.json"
-                             }
-                         stash includes: "carta_backend", name: "ubuntu-1_carta_backend_icd"
-                         }
-                         echo "Finished !!"
-                     }
-                     post {
-                         success {
-                             setBuildStatus("Ubuntu ICD prepared", "SUCCESS");
-                         }
-                         failure {
-                             setBuildStatus("Ubuntu ICD prepare failed", "FAILURE");
-                         }     
-                     }
-                  }
-                 stage('MacOS ICD') {
-                     agent {
-                         label "macos-1"
-                     }
-                     steps {
-                         sh "export PATH=/usr/local/bin:$PATH"
-                         dir ('build') {
-                             unstash "macos-1_carta_backend"
-                             sh "rm -rf carta-backend-ICD-test"
-                             sh "git clone https://github.com/CARTAvis/carta-backend-ICD-test.git && cp ../../run.sh ."
-                             dir ('carta-backend-ICD-test') {
-                                 sh "git submodule init && git submodule update && npm install"
-                                 dir ('protobuf') {
-                                     sh "./build_proto.sh"
-                                 }
-                                 sh "cp ../../../ws-config.json src/test/config.json"
-                             }
-                         stash includes: "carta_backend", name: "macos-1_carta_backend_icd"
-                         }
-                         echo "Finished !!"
-                     }
-                     post {
-                         success {
-                             setBuildStatus("MacOS ICD prepared", "SUCCESS");
-                         }
-                         failure {
-                             setBuildStatus("MacOS ICD prepare failed", "FAILURE");
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -300,7 +300,7 @@ pipeline {
                 }
             }
         }
-        stage('ICD animator') {
+        stage('ICD tests: animator') {
             parallel {
                 stage('CentOS7') {
                     agent {
@@ -361,7 +361,7 @@ pipeline {
                }     
             }
         }
-        stage('ICD contour') {
+        stage('ICD tests: contour') {
             parallel {
                 stage('CentOS7') {
                     agent {
@@ -422,7 +422,7 @@ pipeline {
                 }
             }
         }
-        stage('ICD region statistics') {
+        stage('ICD tests: region statistics') {
             parallel {
                 stage('CentOS7') {
                     agent {
@@ -483,7 +483,7 @@ pipeline {
                 }
             }
         }
-        stage('ICD region manipulation') {
+        stage('ICD tests: region manipulation') {
             parallel {
                 stage('CentOS7') {
                     agent {
@@ -544,7 +544,7 @@ pipeline {
                 }
             }
         }
-        stage('ICD cube histogram') {
+        stage('ICD tests: cube histogram') {
             parallel {
                 stage('CentOS7') {
                     agent {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -799,7 +799,7 @@ pipeline {
                             unstash "centos7-1_carta_backend_icd"
                             sh "./run.sh # run carta_backend in the background"
                             dir ('carta-backend-ICD-test') {
-                                sh "cp ../../../run-resume.sh . && ./run-jenkins-resume.sh # run the tests"
+                                sh "cp ../../../run-jenkins-resume.sh . && ./run-jenkins-resume.sh # run the tests"
                             }
                         }
                         echo "Finished !!"
@@ -818,7 +818,7 @@ pipeline {
                             unstash "ubuntu-1_carta_backend_icd"
                             sh "./run.sh # run carta_backend in the background"
                             dir ('carta-backend-ICD-test') {
-                                sh "cp ../../../run-resume.sh . && ./run-jenkins-resume.sh # run the tests"
+                                sh "cp ../../../run-jenkins-resume.sh . && ./run-jenkins-resume.sh # run the tests"
                             }
                         }
                         echo "Finished !!"
@@ -837,7 +837,7 @@ pipeline {
                             unstash "macos-1_carta_backend_icd"
                             sh "./run.sh # run carta_backend in the background"
                             dir ('carta-backend-ICD-test') {
-                                sh "cp ../../../run-resume.sh . && ./run-jenkins-resume.sh # run the tests"
+                                sh "cp ../../../run-jenkins-resume.sh . && ./run-jenkins-resume.sh # run the tests"
                             }
                         }
                         echo "Finished !!"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -724,6 +724,128 @@ pipeline {
                 }
             }
         }
+        stage('ICD tests: moments') {
+            parallel {
+                stage('CentOS7') {
+                    agent {
+                        label "centos7-1"
+                    }
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
+                        {
+                        sh "export PATH=/usr/local/bin:$PATH"
+                        dir ('build') {
+                            unstash "centos7-1_carta_backend_icd"
+                            sh "./run.sh # run carta_backend in the background"
+                            dir ('carta-backend-ICD-test') {
+                                sh "cp ../../../run-jenkins-moments.sh . && ./run-jenkins-moments.sh # run the tests"
+                            }
+                        }
+                        echo "Finished !!"
+                        }
+                    }
+                }
+                stage('Ubuntu') {
+                    agent {
+                        label "ubuntu-1"
+                    }
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
+                        {
+                        sh "export PATH=/usr/local/bin:$PATH"
+                        dir ('build') {
+                            unstash "ubuntu-1_carta_backend_icd"
+                            sh "./run.sh # run carta_backend in the background"
+                            dir ('carta-backend-ICD-test') {
+                                sh "cp ../../../run-jenkins-moments.sh . && ./run-jenkins-moments.sh # run the tests"
+                            }
+                        }
+                        echo "Finished !!"
+                        }
+                    }
+                }
+                stage('MacOS') {
+                    agent {
+                        label "macos-1"
+                    }
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
+                        {
+                        sh "export PATH=/usr/local/bin:$PATH"
+                        dir ('build') {
+                            unstash "macos-1_carta_backend_icd"
+                            sh "./run.sh # run carta_backend in the background"
+                            dir ('carta-backend-ICD-test') {
+                                sh "cp ../../../run-jenkins-moments.sh . && ./run-jenkins-moments.sh # run the tests"
+                            }
+                        }
+                        echo "Finished !!"
+                        }
+                    }
+                }
+            }
+        }
+        stage('ICD tests: resume') {
+            parallel {
+                stage('CentOS7') {
+                    agent {
+                        label "centos7-1"
+                    }
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
+                        {
+                        sh "export PATH=/usr/local/bin:$PATH"
+                        dir ('build') {
+                            unstash "centos7-1_carta_backend_icd"
+                            sh "./run.sh # run carta_backend in the background"
+                            dir ('carta-backend-ICD-test') {
+                                sh "cp ../../../run-resume.sh . && ./run-jenkins-resume.sh # run the tests"
+                            }
+                        }
+                        echo "Finished !!"
+                        }
+                    }
+                }
+                stage('Ubuntu') {
+                    agent {
+                        label "ubuntu-1"
+                    }
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
+                        {
+                        sh "export PATH=/usr/local/bin:$PATH"
+                        dir ('build') {
+                            unstash "ubuntu-1_carta_backend_icd"
+                            sh "./run.sh # run carta_backend in the background"
+                            dir ('carta-backend-ICD-test') {
+                                sh "cp ../../../run-resume.sh . && ./run-jenkins-resume.sh # run the tests"
+                            }
+                        }
+                        echo "Finished !!"
+                        }
+                    }
+                }
+                stage('MacOS') {
+                    agent {
+                        label "macos-1"
+                    }
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
+                        {
+                        sh "export PATH=/usr/local/bin:$PATH"
+                        dir ('build') {
+                            unstash "macos-1_carta_backend_icd"
+                            sh "./run.sh # run carta_backend in the background"
+                            dir ('carta-backend-ICD-test') {
+                                sh "cp ../../../run-resume.sh . && ./run-jenkins-resume.sh # run the tests"
+                            }
+                        }
+                        echo "Finished !!"
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,19 +21,20 @@ pipeline {
                         sh "export PATH=/usr/local/bin:$PATH"
                         sh "git submodule init && git submodule update"
                         dir ('build') {
-                        sh "cp ../../cmake-command.sh ."
-                        sh "./cmake-command.sh"
-                        sh "make"
-                        echo "Preparing for upcoming ICD tests"
-                        sh "rm -rf carta-backend-ICD-test"
-                        sh "git clone https://github.com/CARTAvis/carta-backend-ICD-test.git && cp ../../run.sh ."
-                        dir ('carta-backend-ICD-test') {
-                            sh "git submodule init && git submodule update && npm install"
-                            dir ('protobuf') {
-                            sh "./build_proto.sh"
-                        }
-                        sh "cp ../../../ws-config.json src/test/config.json"
-                        stash includes: "carta_backend", name: "centos7-1_carta_backend_icd"
+                           sh "cp ../../cmake-command.sh ."
+                           sh "./cmake-command.sh"
+                           sh "make"
+                           echo "Preparing for upcoming ICD tests"
+                           sh "rm -rf carta-backend-ICD-test"
+                           sh "git clone https://github.com/CARTAvis/carta-backend-ICD-test.git && cp ../../run.sh ."
+                           dir ('carta-backend-ICD-test') {
+                              sh "git submodule init && git submodule update && npm install"
+                              dir ('protobuf') {
+                                 sh "./build_proto.sh"
+                              }
+                              sh "cp ../../../ws-config.json src/test/config.json"
+                           }
+                           stash includes: "carta_backend", name: "centos7-1_carta_backend_icd"
                         }
                     }
                     post {
@@ -53,19 +54,20 @@ pipeline {
                         sh "export PATH=/usr/local/bin:$PATH"
                         sh "git submodule init && git submodule update"
                         dir ('build') {
-                        sh "cp ../../cmake-command.sh ."
-                        sh "./cmake-command.sh"
-                        sh "make"
-                        echo "Preparing for upcoming ICD tests"
-                        sh "rm -rf carta-backend-ICD-test"
-                        sh "git clone https://github.com/CARTAvis/carta-backend-ICD-test.git && cp ../../run.sh ."
-                        dir ('carta-backend-ICD-test') {
-                            sh "git submodule init && git submodule update && npm install"
-                            dir ('protobuf') {
-                            sh "./build_proto.sh"
-                        }
-                        sh "cp ../../../ws-config.json src/test/config.json"
-                        stash includes: "carta_backend", name: "macos-1_carta_backend_icd"
+                           sh "cp ../../cmake-command.sh ."
+                           sh "./cmake-command.sh"
+                           sh "make"
+                           echo "Preparing for upcoming ICD tests"
+                           sh "rm -rf carta-backend-ICD-test"
+                           sh "git clone https://github.com/CARTAvis/carta-backend-ICD-test.git && cp ../../run.sh ."
+                           dir ('carta-backend-ICD-test') {
+                              sh "git submodule init && git submodule update && npm install"
+                              dir ('protobuf') {
+                                 sh "./build_proto.sh"
+                              }
+                              sh "cp ../../../ws-config.json src/test/config.json"
+                           }
+                           stash includes: "carta_backend", name: "macos-1_carta_backend_icd"
                         }
                     }
                     post {
@@ -85,19 +87,20 @@ pipeline {
                         sh "export PATH=/usr/local/bin:$PATH"
                         sh "git submodule init && git submodule update"
                         dir ('build') {
-                        sh "cp ../../cmake-command.sh ."
-                        sh "./cmake-command.sh"
-                        sh "make"
-                        echo "Preparing for upcoming ICD tests"
-                        sh "rm -rf carta-backend-ICD-test"
-                        sh "git clone https://github.com/CARTAvis/carta-backend-ICD-test.git && cp ../../run.sh ."
-                        dir ('carta-backend-ICD-test') {
-                            sh "git submodule init && git submodule update && npm install"
-                            dir ('protobuf') {
-                            sh "./build_proto.sh"
-                        }
-                        sh "cp ../../../ws-config.json src/test/config.json"
-                        stash includes: "carta_backend", name: "ubuntu-1_carta_backend_icd"
+                           sh "cp ../../cmake-command.sh ."
+                           sh "./cmake-command.sh"
+                           sh "make"
+                           echo "Preparing for upcoming ICD tests"
+                           sh "rm -rf carta-backend-ICD-test"
+                           sh "git clone https://github.com/CARTAvis/carta-backend-ICD-test.git && cp ../../run.sh ."
+                           dir ('carta-backend-ICD-test') {
+                              sh "git submodule init && git submodule update && npm install"
+                              dir ('protobuf') {
+                                 sh "./build_proto.sh"
+                              }
+                              sh "cp ../../../ws-config.json src/test/config.json"
+                         }
+                         stash includes: "carta_backend", name: "ubuntu-1_carta_backend_icd"
                         }
                     }
                     post {


### PR DESCRIPTION
This new Jenkinsfile should get the Jenkins ICD tests working again. It has switched from wss:// to ws://

Each set of tests are divided into separate "stages" that run in parallel over each system. 
If the backend build process fails, everything stops.
If one of the ICD test stages fails, it will continues onto the next stage.
Hopefully this will help make it easier to identify what potential problems are.

Some tests still be a bit fragile but we are working on making them more robust.

Each stage simply runs tests from a shell script file:
e.g. `run-jenkins-sessions.sh` contains

> CI=true npm test src/test/ACCESS_CARTA_DEFAULT.test.ts
> CI=true npm test src/test/ACCESS_CARTA_KNOWN_SESSION.test.ts
> CI=true npm test src/test/ACCESS_CARTA_NO_CLIENT_FEATURE.test.ts
> CI=true npm test src/test/ACCESS_CARTA_SAME_ID_TWICE.test.ts
> CI=true npm test src/test/ACCESS_CARTA_DEFAULT_CONCURRENT.test.ts
> CI=true npm test src/test/ACCESS_WEBSOCKET.test.ts

This way we can add new tests to an exisitng "stage" without needing a new pull request.

However, adding new stages (e.g. ICD tests: save images) or a new system (e.g. CentOS8) would require new pull request.

At the moment, the "moment" test is only a placeholder calling an empty script. We will add those tests in when they are complete.