### PR TITLE
Fix DS9 region import

### DIFF
--- a/Region/Ds9ImportExport.cc
+++ b/Region/Ds9ImportExport.cc
@@ -718,9 +718,7 @@ RegionStyle Ds9ImportExport::ImportStyleParameters(std::unordered_map<std::strin
 
     // name
     if (properties.count("text")) {
-        std::string text(properties["text"]);
-        // Remove { }
-        style.name = text.substr(1, text.size() - 2);
+        style.name = properties["text"];
     }
 
     // color

--- a/Region/RegionImportExport.cc
+++ b/Region/RegionImportExport.cc
@@ -79,6 +79,12 @@ std::vector<std::string> RegionImportExport::ReadRegionFile(const std::string& f
         while (!region_file.eof()) {
             std::string single_line;
             getline(region_file, single_line);
+
+            if (single_line.back() == '\r') {
+                // Remove carriage return from DOS file
+                single_line.pop_back();
+            }
+
             file_lines.push_back(single_line);
         }
         region_file.close();

--- a/Util.cc
+++ b/Util.cc
@@ -105,6 +105,9 @@ void SplitString(std::string& input, char delim, std::vector<std::string>& parts
     std::string item;
     while (std::getline(ss, item, delim)) {
         if (!item.empty()) {
+            if (item.back() == '\r') {
+                item.pop_back();
+            }
             parts.push_back(item);
         }
     }


### PR DESCRIPTION
Fix issues in #637: region name parsing and support region file in dos format.  The region parameters parser is used by both DS9 and CRTF importers, when the imageanalysis casa::RegionTextList cannot be used for CRTF.