### PR TITLE
Script for checking and adding copyright and licence headers, and first pass to add them

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
       - run:
           name: "checking the copyright and licence headers in the carta_backend code"
           command: |
-            python3 scripts/headers.py check
+            ./scripts/headers.py check
             echo "Finished"
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,12 @@ jobs:
           name: "checking the formatting of the carta_backend code"
           command: |
             ./scripts/checkformat.sh
-            echo "Finished !!!"
+            echo "Finished"
+      - run:
+          name: "checking the copyright and licence headers in the carta_backend code"
+          command: |
+            python3 scripts/headers.py check
+            echo "Finished"
 workflows:
   version: 2
   build:

--- a/AnimationObject.h
+++ b/AnimationObject.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #ifndef CARTA_BACKEND__ANIMATIONOBJECT_H_
 #define CARTA_BACKEND__ANIMATIONOBJECT_H_
 

--- a/Carta.h
+++ b/Carta.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #ifndef __CARTA_H__
 #define __CARTA_H__
 

--- a/DataStream/Compression.cc
+++ b/DataStream/Compression.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #include "Compression.h"
 
 #include <array>

--- a/DataStream/Compression.h
+++ b/DataStream/Compression.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #ifndef CARTA_BACKEND__COMPRESSION_H_
 #define CARTA_BACKEND__COMPRESSION_H_
 

--- a/DataStream/Contouring.cc
+++ b/DataStream/Contouring.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #include "Contouring.h"
 
 #include <chrono>

--- a/DataStream/Contouring.h
+++ b/DataStream/Contouring.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #ifndef CARTA_BACKEND__CONTOURING_H_
 #define CARTA_BACKEND__CONTOURING_H_
 

--- a/DataStream/Smoothing.cc
+++ b/DataStream/Smoothing.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #include "Smoothing.h"
 
 #include <chrono>

--- a/DataStream/Smoothing.h
+++ b/DataStream/Smoothing.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 //
 // Created by angus on 2019/09/23.
 //

--- a/DataStream/Tile.cc
+++ b/DataStream/Tile.cc
@@ -1,1 +1,7 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #include "Tile.h"

--- a/DataStream/Tile.h
+++ b/DataStream/Tile.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #ifndef CARTA_BACKEND__TILE_H_
 #define CARTA_BACKEND__TILE_H_
 

--- a/EventHeader.h
+++ b/EventHeader.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #ifndef CARTA_BACKEND__EVENTHEADER_H_
 #define CARTA_BACKEND__EVENTHEADER_H_
 

--- a/FileList/FileExtInfoLoader.cc
+++ b/FileList/FileExtInfoLoader.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 //# FileExtInfoLoader.cc: fill FileInfoExtended for all supported file types
 
 #include "FileExtInfoLoader.h"

--- a/FileList/FileExtInfoLoader.h
+++ b/FileList/FileExtInfoLoader.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 //# FileExtInfoLoader.h: load FileInfoExtended fields for all supported file types
 
 #ifndef CARTA_BACKEND__FILELIST_FILEEXTINFOLOADER_H_

--- a/FileList/FileInfoLoader.cc
+++ b/FileList/FileInfoLoader.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 //# FileInfoLoader.cc: fill FileInfo for all supported file types
 
 #include "FileInfoLoader.h"

--- a/FileList/FileInfoLoader.h
+++ b/FileList/FileInfoLoader.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 //# FileInfoLoader.h: load FileInfo fields for given file
 
 #ifndef CARTA_BACKEND__FILELIST_FILEINFOLOADER_H_

--- a/FileList/FileListHandler.cc
+++ b/FileList/FileListHandler.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #include "FileListHandler.h"
 
 #include <casacore/casa/OS/DirectoryIterator.h>

--- a/FileList/FileListHandler.h
+++ b/FileList/FileListHandler.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 // file list handler for all users' requests
 
 #ifndef CARTA_BACKEND__FILELISTHANDLER_H_

--- a/FileList/FitsHduList.cc
+++ b/FileList/FitsHduList.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 // FitsHduList.cc: Fill FileInfo HDU_list with hdu number and extension name
 
 #include "FitsHduList.h"

--- a/FileList/FitsHduList.h
+++ b/FileList/FitsHduList.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #ifndef CARTA_BACKEND_FILELIST_FITSHDULIST_H_
 #define CARTA_BACKEND_FILELIST_FITSHDULIST_H_
 

--- a/FileSettings.cc
+++ b/FileSettings.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #include "FileSettings.h"
 #include "Session.h"
 

--- a/FileSettings.h
+++ b/FileSettings.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 //# FileSettings.h: uses tbb::concurrent_unordered_map to keep latest per-file settings
 //# Used for cursor and view settings
 

--- a/Frame.cc
+++ b/Frame.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #include "Frame.h"
 
 #include <algorithm>

--- a/Frame.h
+++ b/Frame.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 //# Frame.h: represents an open image file.  Handles slicing data and region calculations
 //# (profiles, histograms, stats)
 

--- a/GrpcServer/CartaGrpcService.cc
+++ b/GrpcServer/CartaGrpcService.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 //# CartaGrpcService.cc: grpc server to receive messages from the python scripting client
 
 #include "CartaGrpcService.h"

--- a/GrpcServer/CartaGrpcService.h
+++ b/GrpcServer/CartaGrpcService.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 //# CartaGrpcService.h: service for a grpc client
 
 #ifndef CARTA_BACKEND_GRPCSERVER_CARTAGRPCSERVICE_H_

--- a/ImageData/CartaHdf5Image.cc
+++ b/ImageData/CartaHdf5Image.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 //# CartaHdf5Image.cc : specialized Image implementation for IDIA HDF5 schema
 
 #include "CartaHdf5Image.h"

--- a/ImageData/CartaHdf5Image.h
+++ b/ImageData/CartaHdf5Image.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 //# CartaHdf5Image.h : HDF5 Image class derived from casacore::ImageInterface
 
 #ifndef CARTA_BACKEND_IMAGEDATA_CARTAHDF5IMAGE_H_

--- a/ImageData/CartaMiriadImage.cc
+++ b/ImageData/CartaMiriadImage.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 //# CartaMiriadImage.cc : specialized Image implementation to manage headers and masks
 
 #include "CartaMiriadImage.h"

--- a/ImageData/CartaMiriadImage.h
+++ b/ImageData/CartaMiriadImage.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 //# CartaMiriadImage.h : MIRIAD Image class to support masks
 
 #ifndef CARTA_BACKEND_IMAGEDATA_CARTAMIRIADIMAGE_H_

--- a/ImageData/CasaLoader.h
+++ b/ImageData/CasaLoader.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #ifndef CARTA_BACKEND_IMAGEDATA_CASALOADER_H_
 #define CARTA_BACKEND_IMAGEDATA_CASALOADER_H_
 

--- a/ImageData/FileLoader.cc
+++ b/ImageData/FileLoader.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #include "FileLoader.h"
 
 #include <casacore/images/Images/SubImage.h>

--- a/ImageData/FileLoader.h
+++ b/ImageData/FileLoader.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #ifndef CARTA_BACKEND_IMAGEDATA_FILELOADER_H_
 #define CARTA_BACKEND_IMAGEDATA_FILELOADER_H_
 

--- a/ImageData/FitsLoader.h
+++ b/ImageData/FitsLoader.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #ifndef CARTA_BACKEND_IMAGEDATA_FITSLOADER_H_
 #define CARTA_BACKEND_IMAGEDATA_FITSLOADER_H_
 

--- a/ImageData/Hdf5Attributes.cc
+++ b/ImageData/Hdf5Attributes.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 //# Hdf5Attributes.cc: get HDF5 header attributes in casacore::Record
 #include "Hdf5Attributes.h"
 

--- a/ImageData/Hdf5Attributes.h
+++ b/ImageData/Hdf5Attributes.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 //# Hdf5Attributes.h: get HDF5 header attributes in casacore::Record
 #ifndef CARTA_BACKEND_IMAGEDATA_HDF5ATTRIBUTES_H_
 #define CARTA_BACKEND_IMAGEDATA_HDF5ATTRIBUTES_H_

--- a/ImageData/Hdf5Loader.cc
+++ b/ImageData/Hdf5Loader.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #include "Hdf5Loader.h"
 
 namespace carta {

--- a/ImageData/Hdf5Loader.h
+++ b/ImageData/Hdf5Loader.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #ifndef CARTA_BACKEND_IMAGEDATA_HDF5LOADER_H_
 #define CARTA_BACKEND_IMAGEDATA_HDF5LOADER_H_
 

--- a/ImageData/ImagePtrLoader.h
+++ b/ImageData/ImagePtrLoader.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #ifndef CARTA_BACKEND_IMAGEDATA_IMAGEPTRLOADER_H_
 #define CARTA_BACKEND_IMAGEDATA_IMAGEPTRLOADER_H_
 

--- a/ImageData/MiriadLoader.h
+++ b/ImageData/MiriadLoader.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #ifndef CARTA_BACKEND_IMAGEDATA_MIRIADLOADER_H_
 #define CARTA_BACKEND_IMAGEDATA_MIRIADLOADER_H_
 

--- a/ImageStats/BasicStatsCalculator.h
+++ b/ImageStats/BasicStatsCalculator.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #ifndef CARTA_BACKEND_IMAGESTATS_BASICSTATSCALCULATOR_H_
 #define CARTA_BACKEND_IMAGESTATS_BASICSTATSCALCULATOR_H_
 

--- a/ImageStats/Histogram.cc
+++ b/ImageStats/Histogram.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #include "Histogram.h"
 
 #include <algorithm>

--- a/ImageStats/Histogram.h
+++ b/ImageStats/Histogram.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #ifndef CARTA_BACKEND_IMAGESTATS_HISTOGRAM_H_
 #define CARTA_BACKEND_IMAGESTATS_HISTOGRAM_H_
 

--- a/ImageStats/StatsCalculator.cc
+++ b/ImageStats/StatsCalculator.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 //# StatsCalculator.cc: functions for calculating statistics and histograms
 
 #include "StatsCalculator.h"

--- a/ImageStats/StatsCalculator.h
+++ b/ImageStats/StatsCalculator.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 //# StatsCalculator.h: functions for calculating statistics and histograms
 
 #ifndef CARTA_BACKEND_IMAGESTATS_STATSCALCULATOR_H_

--- a/InterfaceConstants.h
+++ b/InterfaceConstants.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 //# InterfaceConstants.h: definitions used in the Interface Control Document
 //* Others added for implementation
 #ifndef CARTA_BACKEND__INTERFACECONSTANTS_H_

--- a/Main.cc
+++ b/Main.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #include <iostream>
 #include <thread>
 #include <tuple>

--- a/Moment/ImageMoments.h
+++ b/Moment/ImageMoments.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 //
 // Re-write from the file: "casa/code/imageanalysis/ImageAnalysis/ImageMoments.h"
 //

--- a/Moment/MomentGenerator.cc
+++ b/Moment/MomentGenerator.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #include "MomentGenerator.h"
 
 using namespace carta;

--- a/Moment/MomentGenerator.h
+++ b/Moment/MomentGenerator.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #ifndef CARTA_BACKEND_MOMENT_MOMENTGENERATOR_H_
 #define CARTA_BACKEND_MOMENT_MOMENTGENERATOR_H_
 

--- a/OnMessageTask.cc
+++ b/OnMessageTask.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #include "OnMessageTask.h"
 
 #include <algorithm>

--- a/OnMessageTask.h
+++ b/OnMessageTask.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 //# OnMessageTask.h: dequeues messages and calls appropriate Session handlers
 
 #ifndef CARTA_BACKEND__ONMESSAGETASK_H_

--- a/Region/CrtfImportExport.cc
+++ b/Region/CrtfImportExport.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 //# CrtfImportExport.cc: import and export regions in CRTF format
 
 #include "CrtfImportExport.h"

--- a/Region/CrtfImportExport.h
+++ b/Region/CrtfImportExport.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 //# CrtfImportExport.h: handle CRTF region file import and export
 
 #ifndef CARTA_BACKEND_REGION_CRTFIMPORTEXPORT_H_

--- a/Region/Ds9ImportExport.cc
+++ b/Region/Ds9ImportExport.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 //# Ds9ImportExport.cc: import and export regions in DS9 format
 
 #include "Ds9ImportExport.h"

--- a/Region/Ds9ImportExport.h
+++ b/Region/Ds9ImportExport.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 //# Ds9ImportExport.h: handle DS9 region file import and export
 
 #ifndef CARTA_BACKEND_REGION_DS9IMPORTEXPORT_H_

--- a/Region/Region.cc
+++ b/Region/Region.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 //# Region.cc: implementation of class for managing a region
 
 #include "Region.h"

--- a/Region/Region.h
+++ b/Region/Region.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 //# Region.h: class for managing 2D region parameters
 
 #ifndef CARTA_BACKEND_REGION_REGION_H_

--- a/Region/RegionHandler.cc
+++ b/Region/RegionHandler.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 // RegionDataHandler.cc: handle requirements and data streams for regions
 
 #include "RegionHandler.h"

--- a/Region/RegionHandler.h
+++ b/Region/RegionHandler.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 // RegionHandler.h: class for handling requirements and data streams for regions
 
 #ifndef CARTA_BACKEND_REGION_REGIONHANDLER_H_

--- a/Region/RegionImportExport.cc
+++ b/Region/RegionImportExport.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #include "RegionImportExport.h"
 
 #include <casacore/casa/Arrays/ArrayMath.h>

--- a/Region/RegionImportExport.h
+++ b/Region/RegionImportExport.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 //# RegionImportExport.h: handle region import/export in CRTF and DS9 formats
 
 #ifndef CARTA_BACKEND_REGION_REGIONIMPORTEXPORT_H_

--- a/RequirementsCache.h
+++ b/RequirementsCache.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #ifndef CARTA_BACKEND__REQUIREMENTSCACHE_H_
 #define CARTA_BACKEND__REQUIREMENTSCACHE_H_
 

--- a/Session.cc
+++ b/Session.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #include "Session.h"
 
 #include <signal.h>

--- a/Session.cc
+++ b/Session.cc
@@ -1,4 +1,4 @@
-/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+/* Thi file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
    Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
    Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
    SPDX-License-Identifier: GPL-3.0-or-later

--- a/Session.cc
+++ b/Session.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 /* Thi file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
    Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
    Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)

--- a/Session.cc
+++ b/Session.cc
@@ -4,12 +4,6 @@
    SPDX-License-Identifier: GPL-3.0-or-later
 */
 
-/* Thi file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
-   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
-   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
-   SPDX-License-Identifier: GPL-3.0-or-later
-*/
-
 #include "Session.h"
 
 #include <signal.h>

--- a/Session.h
+++ b/Session.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 //# Session.h: representation of a client connected to a server; processes requests from frontend
 
 #ifndef CARTA_BACKEND__SESSION_H_

--- a/SpectralLine/SpectralLineCrawler.cc
+++ b/SpectralLine/SpectralLineCrawler.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #include "SpectralLineCrawler.h"
 
 #include <curl/curl.h>

--- a/SpectralLine/SpectralLineCrawler.h
+++ b/SpectralLine/SpectralLineCrawler.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #ifndef CARTA_BACKEND_SPECTRAL_LINE_CRAWLER_H_
 #define CARTA_BACKEND_SPECTRAL_LINE_CRAWLER_H_
 

--- a/Table/Columns.cc
+++ b/Table/Columns.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #include "Columns.h"
 
 #include <fitsio.h>

--- a/Table/Columns.h
+++ b/Table/Columns.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #ifndef VOTABLE_TEST__COLUMNS_H_
 #define VOTABLE_TEST__COLUMNS_H_
 

--- a/Table/Table.cc
+++ b/Table/Table.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #include "Table.h"
 
 #include <fitsio.h>

--- a/Table/Table.h
+++ b/Table/Table.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #ifndef VOTABLE_TEST__TABLE_H_
 #define VOTABLE_TEST__TABLE_H_
 

--- a/Table/TableController.cc
+++ b/Table/TableController.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #include "TableController.h"
 
 #include <fmt/format.h>

--- a/Table/TableController.h
+++ b/Table/TableController.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #ifndef CARTA_BACKEND_TABLE_TABLECONTROLLER_H_
 #define CARTA_BACKEND_TABLE_TABLECONTROLLER_H_
 

--- a/Table/TableView.cc
+++ b/Table/TableView.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #include "TableView.h"
 
 #include <algorithm>

--- a/Table/TableView.h
+++ b/Table/TableView.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #ifndef VOTABLE_TEST__TABLEVIEW_H_
 #define VOTABLE_TEST__TABLEVIEW_H_
 

--- a/Timer/Timer.cc
+++ b/Timer/Timer.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #include "Timer.h"
 #include <iostream>
 

--- a/Timer/Timer.h
+++ b/Timer/Timer.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #ifndef CARTA_BACKEND_TIMER_TIMER_H_
 #define CARTA_BACKEND_TIMER_TIMER_H_
 

--- a/Util.cc
+++ b/Util.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #include "Util.h"
 
 using namespace std;

--- a/Util.h
+++ b/Util.h
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #ifndef CARTA_BACKEND__UTIL_H_
 #define CARTA_BACKEND__UTIL_H_
 

--- a/scripts/headers.py
+++ b/scripts/headers.py
@@ -5,16 +5,18 @@ import os
 import re
 import argparse
 
-HEADER = """// This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
-// Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
-// Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
-// SPDX-License-Identifier: GPL-3.0-or-later
+HEADER = """/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
 """
 
-FUZZY_HEADER_MATCH = """// This file is part of (.*)
-// Copyright (.*)
-(// (.*)
-)*// SPDX-License-Identifier: (.*)
+FUZZY_HEADER_MATCH = """/\* This file (.*)
+   Copyright (.*)
+(   (.*)
+)*   SPDX-License-Identifier: (.*)
+\*/
 """
 
 def cpp_files(directory):
@@ -50,6 +52,7 @@ if __name__ == "__main__":
                 out("Bad header found in", filename)
                 
                 if args.command == "fix":
+                    out("Fixing...")
                     data = re.sub(FUZZY_HEADER_MATCH, HEADER, data)
                     with open(filename, "w") as f:
                         f.write(data)
@@ -59,6 +62,7 @@ if __name__ == "__main__":
                 out("No header found in", filename)
                 
                 if args.command == "fix":
+                    out("Fixing...")
                     with open(filename, "w") as f:
                         f.write(HEADER)
                         f.write("\n")

--- a/scripts/headers.py
+++ b/scripts/headers.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+import re
+import argparse
+
+HEADER = """// This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+// Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+// Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+// SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
+FUZZY_HEADER_MATCH = """// This file is part of (.*)
+// Copyright (.*)
+(// (.*)
+)*// SPDX-License-Identifier: (.*)
+"""
+
+def cpp_files(directory):
+    for root, dirs, files in os.walk(directory):
+        dirs[:] = [d for d in dirs if d != "build"]
+        for basename in files:
+            if re.search("\.(cc|h)$", basename):
+                filename = os.path.join(root, basename)
+                yield filename
+                
+def noprint(*args):
+    pass
+
+if __name__ == "__main__":    
+    parser = argparse.ArgumentParser(description="Check or fix copyright and licence headers.")
+    parser.add_argument('command', help="Command (check or fix).", choices=("check", "fix"))
+    parser.add_argument('-d', '--directory', help="Location of the root directory (default is the current directory).", default=".")
+    parser.add_argument('-q', '--quiet', help="Suppress output", action='store_true')
+
+    args = parser.parse_args()
+    
+    out = noprint if args.quiet else print
+    return_status = 0
+    
+    for filename in cpp_files(args.directory):
+        with open(filename) as f:
+            data = f.read()
+            
+            if re.search(re.escape(HEADER), data):
+                pass
+            
+            elif re.search(FUZZY_HEADER_MATCH, data):
+                out("Bad header found in", filename)
+                
+                if args.command == "fix":
+                    data = re.sub(FUZZY_HEADER_MATCH, HEADER, data)
+                    with open(filename, "w") as f:
+                        f.write(data)
+                else:
+                    return_status = 1
+            else:
+                out("No header found in", filename)
+                
+                if args.command == "fix":
+                    with open(filename, "w") as f:
+                        f.write(HEADER)
+                        f.write("\n")
+                        f.write(data)
+                else:
+                    return_status = 1
+
+    
+    sys.exit(return_status)

--- a/test/TestFITS.cc
+++ b/test/TestFITS.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 

--- a/test/TestTileEncoding.cc
+++ b/test/TestTileEncoding.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #include <chrono>
 #include <random>
 

--- a/test/TestTimer.cc
+++ b/test/TestTimer.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #include <chrono>
 #include <thread>
 

--- a/test/TestVOTable.cc
+++ b/test/TestVOTable.cc
@@ -1,3 +1,9 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
This fixes #40. The script can check for files with missing or incorrect headers (`check` command), and can replace or add them (`fix` command). The idea would be to add this to the same build test as the format check. When we want to update the header (e.g. to add a year) we should be able to change the correct header in the script.