### PR TITLE
Fix extrema stat for whole-image regions of HDF5 files

### DIFF
--- a/ImageData/FileLoader.cc
+++ b/ImageData/FileLoader.cc
@@ -505,7 +505,7 @@ void FileLoader::LoadImageStats(bool load_percentiles) {
     // Remove this check when we drop support for the old schema.
     // We assume that checking for only one of these datasets is sufficient.
     bool full(HasData(FileInfo::Data::STATS_2D_SUM));
-    double sum, sum_sq;
+    double sum, sum_sq, min, max;
     uint64_t num_pixels;
 
     if (HasData(FileInfo::Data::STATS)) {
@@ -535,11 +535,14 @@ void FileLoader::LoadImageStats(bool load_percentiles) {
                         num_pixels = _channel_size - stats[CARTA::StatsType::NanCount];
                         sum = stats[CARTA::StatsType::Sum];
                         sum_sq = stats[CARTA::StatsType::SumSq];
+                        min = stats[CARTA::StatsType::Min];
+                        max = stats[CARTA::StatsType::Max];
 
                         stats[CARTA::StatsType::NumPixels] = num_pixels;
                         stats[CARTA::StatsType::Mean] = sum / num_pixels;
                         stats[CARTA::StatsType::Sigma] = sqrt((sum_sq - (sum * sum / num_pixels)) / (num_pixels - 1));
                         stats[CARTA::StatsType::RMS] = sqrt(sum_sq / num_pixels);
+                        stats[CARTA::StatsType::Extrema] = (abs(min) > abs(max) ? min : max);
                         if (has_flux) {
                             stats[CARTA::StatsType::FluxDensity] = sum / beam_area;
                         }
@@ -576,11 +579,14 @@ void FileLoader::LoadImageStats(bool load_percentiles) {
                     num_pixels = (_channel_size * _num_channels) - stats[CARTA::StatsType::NanCount];
                     sum = stats[CARTA::StatsType::Sum];
                     sum_sq = stats[CARTA::StatsType::SumSq];
+                    min = stats[CARTA::StatsType::Min];
+                    max = stats[CARTA::StatsType::Max];
 
                     stats[CARTA::StatsType::NumPixels] = num_pixels;
                     stats[CARTA::StatsType::Mean] = sum / num_pixels;
                     stats[CARTA::StatsType::Sigma] = sqrt((sum_sq - (sum * sum / num_pixels)) / (num_pixels - 1));
                     stats[CARTA::StatsType::RMS] = sqrt(sum_sq / num_pixels);
+                    stats[CARTA::StatsType::Extrema] = (abs(min) > abs(max) ? min : max);
                     if (has_flux) {
                         stats[CARTA::StatsType::FluxDensity] = sum / beam_area;
                     }

--- a/ImageData/Hdf5Loader.cc
+++ b/ImageData/Hdf5Loader.cc
@@ -274,7 +274,6 @@ bool Hdf5Loader::GetRegionSpectralData(int region_id, int stokes, const casacore
         if ((x_start == 0) || (num_pixels[z] == 0)) {
             min[z] = std::numeric_limits<float>::max();
             max[z] = std::numeric_limits<float>::lowest();
-            extrema[z] = NAN;
             num_pixels[z] = 0;
             nan_count[z] = 0;
             sum[z] = 0;

--- a/ImageData/Hdf5Loader.cc
+++ b/ImageData/Hdf5Loader.cc
@@ -268,9 +268,9 @@ bool Hdf5Loader::GetRegionSpectralData(int region_id, int stokes, const casacore
 
     // get the start of X
     size_t x_start = _region_stats[region_stats_id].latest_x;
-    
+
     std::vector<float> slice_data;
-    
+
     std::function<void(size_t)> accumulate;
 
     auto lazy_accumulate = [&](size_t y) {
@@ -290,7 +290,7 @@ bool Hdf5Loader::GetRegionSpectralData(int region_id, int stokes, const casacore
             }
         }
     };
-    
+
     auto first_accumulate = [&](size_t y) {
         for (size_t z = 0; z < num_z; z++) {
             double v = slice_data[y * num_z + z];
@@ -340,9 +340,9 @@ bool Hdf5Loader::GetRegionSpectralData(int region_id, int stokes, const casacore
             }
         }
     };
-    
+
     accumulate = first_accumulate;
-    
+
     // Set initial values of stats, or those set to NAN in previous iterations
     for (size_t z = 0; z < num_z; z++) {
         if ((x_start == 0) || (num_pixels[z] == 0)) {
@@ -372,7 +372,7 @@ bool Hdf5Loader::GetRegionSpectralData(int region_id, int stokes, const casacore
                 continue;
             }
 
-            // This will use a lazy min/max evaluation for every pixel after the first. 
+            // This will use a lazy min/max evaluation for every pixel after the first.
             accumulate(y);
         }
     }


### PR DESCRIPTION
The stats widget uses the whole-image stats for HDF5 files.