### PR TITLE
Fix clang-format settings and update directories to exclude in all scripts

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -21,3 +21,4 @@ AllowShortCaseLabelsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 AlignAfterOpenBracket: DontAlign
 AccessModifierOffset: -4
+IncludeBlocks: Preserve

--- a/ImageData/Hdf5Loader.cc
+++ b/ImageData/Hdf5Loader.cc
@@ -135,7 +135,9 @@ const Hdf5Loader::IPos Hdf5Loader::GetStatsDataShape(FileInfo::Data ds) {
         case casacore::TpDouble: {
             return GetStatsDataShapeTyped<casacore::Double>(ds);
         }
-        default: { throw casacore::HDF5Error("Dataset " + DataSetToString(ds) + " has an unsupported datatype."); }
+        default: {
+            throw casacore::HDF5Error("Dataset " + DataSetToString(ds) + " has an unsupported datatype.");
+        }
     }
 }
 
@@ -158,7 +160,9 @@ casacore::ArrayBase* Hdf5Loader::GetStatsData(FileInfo::Data ds) {
         case casacore::TpDouble: {
             return GetStatsDataTyped<casacore::Double, casacore::Float>(ds);
         }
-        default: { throw casacore::HDF5Error("Dataset " + DataSetToString(ds) + " has an unsupported datatype."); }
+        default: {
+            throw casacore::HDF5Error("Dataset " + DataSetToString(ds) + " has an unsupported datatype.");
+        }
     }
 }
 

--- a/ImageData/Hdf5Loader.cc
+++ b/ImageData/Hdf5Loader.cc
@@ -135,9 +135,8 @@ const Hdf5Loader::IPos Hdf5Loader::GetStatsDataShape(FileInfo::Data ds) {
         case casacore::TpDouble: {
             return GetStatsDataShapeTyped<casacore::Double>(ds);
         }
-        default: {
+        default:
             throw casacore::HDF5Error("Dataset " + DataSetToString(ds) + " has an unsupported datatype.");
-        }
     }
 }
 
@@ -160,9 +159,8 @@ casacore::ArrayBase* Hdf5Loader::GetStatsData(FileInfo::Data ds) {
         case casacore::TpDouble: {
             return GetStatsDataTyped<casacore::Double, casacore::Float>(ds);
         }
-        default: {
+        default:
             throw casacore::HDF5Error("Dataset " + DataSetToString(ds) + " has an unsupported datatype.");
-        }
     }
 }
 

--- a/scripts/checkformat.sh
+++ b/scripts/checkformat.sh
@@ -7,7 +7,7 @@
 # If changes are necessary the script will print a diff -- please run reformat.sh to fix the code.
 # The clang-format configuration is found in .clang-format
 
-PARAMS=(\( -regex '.*\.\(cc\|h\)' -not -path './*/carta-protobuf/*' -not -path './*/carta-scripting-grpc/*' \))
+PARAMS=(\( -regex '.*\.\(cc\|h\)' -not -path './build/*' -not -path './uWebSockets/*' \))
 
 find . "${PARAMS[@]}" -exec cat {} \; | diff -u <(find . "${PARAMS[@]}" -exec clang-format {} \;) -
 

--- a/scripts/checkstyle.sh
+++ b/scripts/checkstyle.sh
@@ -5,4 +5,4 @@
 # It should be run from the root directory of the repository.
 # The clang-tidy configuration is found in .clang-tidy
 
-find . -regex ".*\.\(cc\|h\)" -not -path "./*/carta-protobuf/*" -not -path "./*/carta-scripting-grpc/*" | xargs run-clang-tidy -p build
+find . -regex ".*\.\(cc\|h\)" -not -path "./build/*" -not -path './uWebSockets/*' | xargs run-clang-tidy -p build

--- a/scripts/headers.py
+++ b/scripts/headers.py
@@ -21,7 +21,7 @@ FUZZY_HEADER_MATCH = """/\* This file (.*)
 
 def cpp_files(directory):
     for root, dirs, files in os.walk(directory):
-        dirs[:] = [d for d in dirs if d != "build"]
+        dirs[:] = [d for d in dirs if d != "build" and d != "uWebSockets"]
         for basename in files:
             if re.search("\.(cc|h)$", basename):
                 filename = os.path.join(root, basename)

--- a/scripts/reformat.sh
+++ b/scripts/reformat.sh
@@ -7,4 +7,4 @@
 
 cformat=${1:-clang-format}
 
-find . -regex ".*\.\(cc\|h\)" -not -path "./*/carta-protobuf/*" -not -path "./*/carta-scripting-grpc/*" | xargs $cformat -i
+find . -regex ".*\.\(cc\|h\)" -not -path "./build/*" -not -path './uWebSockets/*' | xargs $cformat -i

--- a/scripts/reformat.sh
+++ b/scripts/reformat.sh
@@ -3,5 +3,8 @@
 # This is a utility script for reformatting all .h and .cc files recursively.
 # It should be run from the root directory of the repository.
 # The clang-format configuration is found in .clang-format
+# To use a specific clang-format version, pass the appropriate executable as a parameter.
 
-find . -regex ".*\.\(cc\|h\)" -not -path "./*/carta-protobuf/*" -not -path "./*/carta-scripting-grpc/*" | xargs clang-format -i
+cformat=${1:-clang-format}
+
+find . -regex ".*\.\(cc\|h\)" -not -path "./*/carta-protobuf/*" -not -path "./*/carta-scripting-grpc/*" | xargs $cformat -i


### PR DESCRIPTION
This fixes #677.

There were three separate issues: since `clang-format` 9, included headers were being reordered by default. I found @pford 's Slack comment about adding `IncludeBlocks: Preserve` to the config -- this fixes the reordering and is backwards-compatible, so there's no reason not to commit this change.

The other formatting issue was the handling of a particular set of `default` switch statement cases in one file. I believe that `clang-format` was handling this incorrectly before version 8 -- we have `AllowShortCaseLabelsOnASingleLine: false` in the config, but these particular labels were being contracted to a single line. This behaviour was triggered by the braces around the `default` blocks somehow. These braces are unnecessary, so I have removed them -- but the issue could recur in the future as long as anyone uses pre-8 `clang-format`, so I would suggest that we switch to 8 as the minimum version. It can be installed in Ubuntu 18.04.

A last, unrelated issue: because all our code is in the root directory of the repo, we have to explicitly exclude every submodule as well as the build directory from every script that we want to apply to our code files. We did not do this after the recent addition of the uWebSockets submodule, so files in this subdirectory were being affected. I have fixed these paths in all the scripts, but in the long term I think we should really consider moving our code to a subdirectory. I will create a separate issue for this.