### PR TITLE
Angus/UUID token

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,8 +108,7 @@ set(LINK_LIBS
         ${PROTOBUF_LIBRARY}
         fmt
         uSockets
-        ssl
-        crypto
+        uuid
         z
         zfp
         zstd

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,7 +165,8 @@ set(SOURCE_FILES
         src/Timer/Timer.cc
         src/OnMessageTask.cc
         src/FileSettings.cc
-        src/Util.cc)
+        src/Util.cc
+        src/SimpleFrontendServer/SimpleFrontendServer.cc)
 
 add_definitions(-DHAVE_HDF5)
 add_executable(carta_backend ${SOURCE_FILES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,7 @@ set(SOURCE_FILES
 add_definitions(-DHAVE_HDF5)
 add_executable(carta_backend ${SOURCE_FILES})
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    list(REMOVE_ITEM LINK_LIBS uuid)
     target_link_libraries(carta_backend uv ${LINK_LIBS})
 endif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For more detailed example commands for installing the dependencies and performin
 
 ## Running the backend process
 
-Command-line arguments are in the format `arg=value` or `-arg value`. Run `carta_backend --help` for a list of option. By default, the backend will attempt to host frontend files from `../share/carta/frontend` (relative to the executable path). This can be changed with the `frontend_folder` argument. Hosting of the frontend can be disabled with the `no_http` argument.
+Command-line arguments are in the format `arg=value` or `-arg value`. Run `carta_backend --help` for a list of option. By default, the backend will attempt to host frontend files from `../share/carta/frontend` (relative to the executable path). This can be changed with the `frontend_folder` argument. Hosting of the frontend can be disabled with the `no_http` argument. Token-based authentication can be disabled for debugging or development purposes with the `debug_no_auth` argument.
 
 [![Build Status](http://acdc0.asiaa.sinica.edu.tw:47565/job/carta-backend/badge/icon)](http://acdc0.asiaa.sinica.edu.tw:47565/job/carta-backend) 
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# CARTA Image Viewer (Server)
-Server for simple web-based interface for viewing radio astronomy images in CASA, FITS, MIRIAD, and HDF5 formats (using the IDIA custom schema for HDF5). Unlike the conventional approach of rendering an image on the server and sending a rendered image to the client, the server sends a compressed subset of the data, and the client renders the image efficiently on the GPU using WebGL and GLSL shaders. While the data is compressed using the lossy ZFP algorithm, the compression artefacts are generally much less noticable than those cropping up from full-colour JPEG compression. While data sizes depend on compression quality used, sizes are [comparable](https://docs.google.com/spreadsheets/d/1lp1687TL0bYmbM3jGyjuPd9dYZnrAYGnLIQXWVpnmS0/edit?usp=sharing) with sizes of compressed JPEG images with a 95% quality setting, depending on the colour map used to generate the JPEG image. PNG compression is generally a factor of 2 larger than the ZFP compressed data.
+# CARTA Image Viewer (Backend)
+Backend process for simple web-based interface for viewing radio astronomy images in CASA, FITS, MIRIAD, and HDF5 formats (using the IDIA custom schema for HDF5). Unlike the conventional approach of rendering an image on the backend and sending a rendered image to the frontend client, the backend sends a compressed subset of the data, and the frontend renders the image efficiently on the GPU using WebGL and GLSL shaders. While the data is compressed using the lossy ZFP algorithm, the compression artefacts are generally much less noticeable than those cropping up from full-colour JPEG compression. While data sizes depend on compression quality used, sizes are [comparable](https://docs.google.com/spreadsheets/d/1lp1687TL0bYmbM3jGyjuPd9dYZnrAYGnLIQXWVpnmS0/edit?usp=sharing) with sizes of compressed JPEG images with a 95% quality setting, depending on the colour map used to generate the JPEG image. PNG compression is generally a factor of 2 larger than the ZFP compressed data.
 
 ## Building from source
 
 ### Submodules
 
-The protocol buffer definitions for communication between the server and client, and for communication between the scripting interface and the server. [µWebSockets](https://github.com/uNetworking/uWebSockets), which builds on [µSockets](https://github.com/uNetworking/uSockets), is used to communicate with the frontend. In order to get the right version of µWebSockets and its dependency µSockets, together with the other two submodules, a git initialized command must be applied as follows:
+The protocol buffer definitions for communication between the backend and frontend, and for communication between the scripting interface and the backend. [µWebSockets](https://github.com/uNetworking/uWebSockets), which builds on [µSockets](https://github.com/uNetworking/uSockets), is used to communicate with the frontend. In order to get the right version of µWebSockets and its dependency µSockets, together with the other two submodules, a git initialisation command must be applied as follows:
 ```
 git submodule update --init --recursive
 ```
@@ -14,7 +14,7 @@ If you use `git pull` to update an existing checkout of this repository, make su
 
 ### External dependencies
 
-The server build depends on the following libraries: 
+The backend build depends on the following libraries: 
 * [casacore and casa imageanalysis](https://github.com/CARTAvis/carta-casacore); follow the build instructions.
 * [zfp](https://github.com/LLNL/zfp) for data compression. The same library is used on the client, after being compiled to WebAssembly. Build and install from git repo. For best performance, build with AVX extensions.
 * [Zstd](https://github.com/facebook/zstd) for data compression. Debian package `libzstd-dev`.
@@ -22,7 +22,7 @@ The server build depends on the following libraries:
 * [protobuf](https://developers.google.com/protocol-buffers) for client-side communication using specific message formats. Debian package `libprotobuf-dev` (> 3.0 required. Can use [PPA](https://launchpad.net/~maarten-fonville/+archive/ubuntu/protobuf) for earlier versions of Ubuntu). The Debian package `protobuf-compiler` may also be required.
 * [HDF5](https://support.hdfgroup.org/HDF5/) C++ library for HDF5 support. Debian packages `libhdf5-dev` and `libhdf5-cpp-100`. By default, the serial version of the HDF5 library is targeted.
 * [tbb](https://www.threadingbuildingblocks.org/download) Threading Building Blocks for task parallelization. Debian package `libtbb-dev`.
-* [libcurl](https://curl.haxx.se/libcurl/) curl library for fetching data. Debian package `libcurl4-openssl-dev`.
+* [libcurl](https://curl.haxx.se/libcurl/) curl library for fetching data. Debian package `libcurl4-openssl-dev`.* [libuuid](https://linux.die.net/man/3/libuuid) for generating auth tokens (if not using external authentication). Debian package `uuid-dev`.
 * [gRPC](https://grpc.io/) for the scripting interface. Debian packages: `libprotobuf-dev protobuf-compiler libgrpc++-dev libgrpc-dev protobuf-compiler-grpc googletest`. On Ubuntu 16.04 or 18.04, use [a PPA](https://launchpad.net/~webispy/+archive/ubuntu/grpc).
 * [pugixml](https://pugixml.org/) for parsing catalog data. Debian package: `libpugixml-dev`. On Ubuntu 16.04, build from source. On newer versions you can also build from source to save memory: use the `PUGIXML_COMPACT` and `PUGIXML_NO_XPATH` flags.
 
@@ -38,21 +38,9 @@ make
 
 For more detailed example commands for installing the dependencies and performing the build on specific Linux distributions, please refer to the provided [Dockerfiles](https://github.com/CARTAvis/carta-backend/tree/dev/Dockerfiles).
 
-## Running the server
+## Running the backend process
 
-Command-line arguments are in the format arg=value.  Available arguments include:
-```
---help          List version and arguments
-debug           Debug level, default 0
-verbose         Verbose logging, default False
-perflog         Performance logging, default False
-port            Set server port, default 3002
-grpc_port       Set gRPC port for scripting
-threads         Set thread pool count, default 4
-base            Set folder for data files, default current directory
-root            Set top-level folder for data files, default /
-exit_after      Number of seconds to stay alive if no clients connect
-```
+Command-line arguments are in the format `arg=value` or `-arg value`. Run `carta_backend --help` for a list of option. By default, the backend will attempt to host frontend files from `../share/carta/frontend` (relative to the executable path). This can be changed with the `frontend_folder` argument. Hosting of the frontend can be disabled with the `no_http` argument.
 
 [![Build Status](http://acdc0.asiaa.sinica.edu.tw:47565/job/carta-backend/badge/icon)](http://acdc0.asiaa.sinica.edu.tw:47565/job/carta-backend) 
 

--- a/src/InterfaceConstants.h
+++ b/src/InterfaceConstants.h
@@ -10,7 +10,7 @@
 #define CARTA_BACKEND__INTERFACECONSTANTS_H_
 
 // version
-#define VERSION_ID "1.4"
+#define VERSION_ID "2.0.0-dev.3"
 
 // thread counts
 #define TBB_THREAD_COUNT 2

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -533,7 +533,7 @@ int main(int argc, const char* argv[]) {
         int omp_thread_count = OMP_THREAD_COUNT;
         string http_root_folder;
         bool no_http = false;
-        bool no_token = false;
+        bool debug_no_auth = false;
         bool no_browser = false;
 
         { // get values then let Input go out of scope
@@ -542,7 +542,7 @@ int main(int argc, const char* argv[]) {
             inp.create("verbose", "False", "display verbose logging", "Bool");
             inp.create("perflog", "False", "display performance logging", "Bool");
             inp.create("no_http", "False", "disable CARTA frontend HTTP server", "Bool");
-            inp.create("no_token", "False", "disable token validation on connection", "Bool");
+            inp.create("debug_no_auth", "False", "accept all incoming WebSocket connections (insecure, reserved for development and debugging", "Bool");
             inp.create("no_browser", "False", "prevent the frontend from automatically opening in the default browser on startup", "Bool");
             inp.create("port", to_string(port), "set server port", "Int");
             inp.create("grpc_port", to_string(grpc_port), "set grpc server port", "Int");
@@ -559,7 +559,7 @@ int main(int argc, const char* argv[]) {
             verbose = inp.getBool("verbose");
             perflog = inp.getBool("perflog");
             no_http = inp.getBool("no_http");
-            no_token = inp.getBool("no_token");
+            debug_no_auth = inp.getBool("debug_no_auth");
             no_browser = inp.getBool("no_browser");
             port = inp.getInt("port");
             grpc_port = inp.getInt("grpc_port");
@@ -582,7 +582,7 @@ int main(int argc, const char* argv[]) {
             return 1;
         }
 
-        if (!no_token) {
+        if (!debug_no_auth) {
             auto env_entry = getenv("CARTA_AUTH_TOKEN");
             if (env_entry) {
                 auth_token = env_entry;
@@ -644,7 +644,7 @@ int main(int argc, const char* argv[]) {
         }
 
         string ws_pattern;
-        if (no_token) {
+        if (debug_no_auth) {
             ws_pattern = "/*";
         } else {
             ws_pattern = "/token/:token";

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -637,7 +637,17 @@ int main(int argc, const char* argv[]) {
                     }
                 });
 
-                string frontend_url = fmt::format("http://{}:{}", host.empty() ? "localhost" : host, port);
+                string default_host_string = host;
+                if (host.empty()) {
+                    auto server_ip_entry = getenv("SERVER_IP");
+                    if (server_ip_entry) {
+                        default_host_string = server_ip_entry;
+                    } else {
+                        default_host_string = "localhost";
+                    }
+                }
+
+                string frontend_url = fmt::format("http://{}:{}", default_host_string, port);
                 if (!auth_token.empty()) {
                     frontend_url += fmt::format("?token={}", auth_token);
                 }

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -630,7 +630,7 @@ int main(int argc, const char* argv[]) {
                 }
                 if (!no_browser) {
 #if defined(__APPLE__)
-                    string open_command = "open"
+                    string open_command = "open";
 #else
                     string open_command = "xdg-open";
 #endif

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -690,14 +690,14 @@ int main(int argc, const char* argv[]) {
                                          .close = OnDisconnect})
             .listen(port, LIBUS_LISTEN_EXCLUSIVE_PORT,
                 [=](auto* token) {
-                    if (token) {
-                        fmt::print(
-                            "Listening on port {} with root folder {}, base folder {}, {} threads in worker thread pool and {} OMP "
-                            "threads\n",
-                            port, root_folder, base_folder, thread_count, omp_thread_count);
-                    } else {
-                        fmt::print("Error listening on port {}\n", port);
-                    }
+            if (token) {
+                fmt::print(
+                    "Listening on port {} with root folder {}, base folder {}, {} threads in worker thread pool and {} OMP "
+                    "threads\n",
+                    port, root_folder, base_folder, thread_count, omp_thread_count);
+            } else {
+                fmt::print("Error listening on port {}\n", port);
+            }
                 })
             .run();
     } catch (exception& e) {

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -542,7 +542,7 @@ int main(int argc, const char* argv[]) {
             inp.create("verbose", "False", "display verbose logging", "Bool");
             inp.create("perflog", "False", "display performance logging", "Bool");
             inp.create("no_http", "False", "disable CARTA frontend HTTP server", "Bool");
-            inp.create("debug_no_auth", "False", "accept all incoming WebSocket connections (insecure, reserved for development and debugging", "Bool");
+            inp.create("debug_no_auth", "False", "accept all incoming WebSocket connections (insecure, use with caution!)", "Bool");
             inp.create("no_browser", "False", "prevent the frontend from automatically opening in the default browser on startup", "Bool");
             inp.create("port", to_string(port), "set server port", "Int");
             inp.create("grpc_port", to_string(grpc_port), "set grpc server port", "Int");
@@ -634,12 +634,16 @@ int main(int argc, const char* argv[]) {
 #else
                     string open_command = "xdg-open";
 #endif
-                        auto open_result = system(fmt::format("{} {}", open_command, frontend_url).c_str());
+                    auto open_result = system(fmt::format("{} {}", open_command, frontend_url).c_str());
                     if (open_result) {
                         fmt::print("Failed to open the default browser automatically.\n");
                     }
                 }
                 fmt::print("CARTA is accessible at {}\n", frontend_url);
+            } else {
+                fmt::print(
+                    "Failed to host the CARTA frontend. Please install the frontend files in the default location "
+                    "(/usr/local/share/carta/frontend) or specify a custom location using the http_root_folder argument\n");
             }
         }
 

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -552,7 +552,7 @@ int main(int argc, const char* argv[]) {
             inp.create("omp_threads", to_string(omp_thread_count), "set OMP thread pool count", "Int");
             inp.create("base", base_folder, "set folder for data files", "String");
             inp.create("root", root_folder, "set top-level folder for data files", "String");
-            inp.create("frontend_folder", frontend_folder, "set folder to serve frontend file from", "String");
+            inp.create("frontend_folder", frontend_folder, "set folder to serve frontend files from", "String");
             inp.create("exit_after", "", "number of seconds to stay alive after last sessions exists", "Int");
 
             inp.create("init_exit_after", "", "number of seconds to stay alive at start if no clents connect", "Int");

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -629,11 +629,12 @@ int main(int argc, const char* argv[]) {
                     frontend_url += fmt::format("?socketUrl=ws://localhost:{}/token/{}", port, auth_token);
                 }
                 if (!no_browser) {
-                    auto open_result = system(fmt::format("xdg-open {}", frontend_url).c_str());
-                    if (open_result) {
-                        // Try the "open" command instead
-                        open_result = system(fmt::format("open {}", frontend_url).c_str());
-                    }
+#if defined(__APPLE__)
+                    string open_command = "open"
+#else
+                    string open_command = "xdg-open";
+#endif
+                        auto open_result = system(fmt::format("{} {}", open_command, frontend_url).c_str());
                     if (open_result) {
                         fmt::print("Failed to open the default browser automatically.\n");
                     }

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -546,7 +546,7 @@ int main(int argc, const char* argv[]) {
             inp.create("debug_no_auth", "False", "accept all incoming WebSocket connections (insecure, use with caution!)", "Bool");
             inp.create("no_browser", "False", "prevent the frontend from automatically opening in the default browser on startup", "Bool");
             inp.create("host", "", "only listen on the specified interface");
-            inp.create("port", to_string(port), "set server port", "Int");
+            inp.create("port", to_string(port), "set port on which to host frontend files and accept WebSocket connections", "Int");
             inp.create("grpc_port", to_string(grpc_port), "set grpc server port", "Int");
             inp.create("threads", to_string(thread_count), "set thread pool count", "Int");
             inp.create("omp_threads", to_string(omp_thread_count), "set OMP thread pool count", "Int");

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -682,22 +682,15 @@ int main(int argc, const char* argv[]) {
                                         .message = OnMessage,
                                         .close = OnDisconnect})
             .listen(host.empty() ? "0.0.0.0" : host, port, LIBUS_LISTEN_EXCLUSIVE_PORT,
-        uWS::App()
-            .ws<PerSocketData>("/*", (uWS::App::WebSocketBehavior){.compression = uWS::SHARED_COMPRESSOR,
-                                         .upgrade = OnUpgrade,
-                                         .open = OnConnect,
-                                         .message = OnMessage,
-                                         .close = OnDisconnect})
-            .listen(port, LIBUS_LISTEN_EXCLUSIVE_PORT,
                 [=](auto* token) {
-            if (token) {
-                fmt::print(
-                    "Listening on port {} with root folder {}, base folder {}, {} threads in worker thread pool and {} OMP "
-                    "threads\n",
-                    port, root_folder, base_folder, thread_count, omp_thread_count);
-            } else {
-                fmt::print("Error listening on port {}\n", port);
-            }
+                    if (token) {
+                        fmt::print(
+                            "Listening on port {} with root folder {}, base folder {}, {} threads in worker thread pool and {} OMP "
+                            "threads\n",
+                            port, root_folder, base_folder, thread_count, omp_thread_count);
+                    } else {
+                        fmt::print("Error listening on port {}\n", port);
+                    }
                 })
             .run();
     } catch (exception& e) {

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -545,7 +545,7 @@ int main(int argc, const char* argv[]) {
             inp.create("no_http", "False", "disable CARTA frontend HTTP server", "Bool");
             inp.create("debug_no_auth", "False", "accept all incoming WebSocket connections (insecure, use with caution!)", "Bool");
             inp.create("no_browser", "False", "prevent the frontend from automatically opening in the default browser on startup", "Bool");
-            inp.create("host", "", "only listen on the specified interface");
+            inp.create("host", host, "only listen on the specified interface (IP address or hostname)", "String");
             inp.create("port", to_string(port), "set port on which to host frontend files and accept WebSocket connections", "Int");
             inp.create("grpc_port", to_string(grpc_port), "set grpc server port", "Int");
             inp.create("threads", to_string(thread_count), "set thread pool count", "Int");

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -643,11 +643,18 @@ int main(int argc, const char* argv[]) {
             }
         }
 
-        app.ws<PerSocketData>("/token/:token", (uWS::App::WebSocketBehavior){.compression = uWS::SHARED_COMPRESSOR,
-                                                   .upgrade = OnUpgrade,
-                                                   .open = OnConnect,
-                                                   .message = OnMessage,
-                                                   .close = OnDisconnect})
+        string ws_pattern;
+        if (no_token) {
+            ws_pattern = "/*";
+        } else {
+            ws_pattern = "/token/:token";
+        }
+
+        app.ws<PerSocketData>(ws_pattern, (uWS::App::WebSocketBehavior){.compression = uWS::SHARED_COMPRESSOR,
+                                              .upgrade = OnUpgrade,
+                                              .open = OnConnect,
+                                              .message = OnMessage,
+                                              .close = OnDisconnect})
             .listen(port,
                 [=](auto* token) {
                     if (token) {

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -626,7 +626,7 @@ int main(int argc, const char* argv[]) {
 
                 string frontend_url = fmt::format("http://localhost:{}", port);
                 if (!auth_token.empty()) {
-                    frontend_url += fmt::format("?socketUrl=ws://localhost:{}/token/{}", port, auth_token);
+                    frontend_url += fmt::format("?token={}", auth_token);
                 }
                 if (!no_browser) {
 #if defined(__APPLE__)

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -82,12 +82,12 @@ void OnUpgrade(uWS::HttpResponse<false>* http_response, uWS::HttpRequest* http_r
         if (!req_token.empty()) {
             string token_header_value(req_token);
             if (token_header_value != auth_token) {
-                fmt::print("Header auth failed!\n");
+                fmt::print("Incorrect auth token supplied! Closing WebSocket connection\n");
                 http_response->close();
                 return;
             }
         } else {
-            fmt::print("Incorrect auth token supplied! Closing WebSocket connection\n");
+            fmt::print("No auth token supplied! Closing WebSocket connection\n");
             http_response->close();
             return;
         }

--- a/src/SimpleFrontendServer/MimeTypes.h
+++ b/src/SimpleFrontendServer/MimeTypes.h
@@ -1,0 +1,19 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+#ifndef CARTA_BACKEND_SRC_SIMPLEFRONTENDSERVER_MIMETYPES_H_
+#define CARTA_BACKEND_SRC_SIMPLEFRONTENDSERVER_MIMETYPES_H_
+
+#include <string>
+#include <unordered_map>
+
+namespace carta {
+const static std::unordered_map<std::string, std::string> MimeTypes = {{".css", "text/css"}, {".htm", "text/html"}, {".html", "text/html"},
+    {".jpg", "image/jpeg"}, {".jpeg", "image/jpeg"}, {".js", "text/javascript"}, {".json", "application/json"}, {".png", "image/png"},
+    {".svg", "image/svg+xml"}, {".woff", "font/woff"}, {".woff2", "font/woff2"}, {".wasm", "application/wasm"}};
+}
+
+#endif // CARTA_BACKEND_SRC_SIMPLEFRONTENDSERVER_MIMETYPES_H_

--- a/src/SimpleFrontendServer/SimpleFrontendServer.cc
+++ b/src/SimpleFrontendServer/SimpleFrontendServer.cc
@@ -17,13 +17,17 @@ using namespace std;
 SimpleFrontendServer::SimpleFrontendServer(string root_folder) {
     // If no folder is provided, check if /usr/local/share/carta/frontend exists.
     // If this does not exist, try /usr/share/carta/frontend.
-
     if (root_folder.empty()) {
         _http_root_folder = "/usr/local/share/carta/frontend";
-        _frontend_found = true;
+        if (!IsValidFrontendFolder(_http_root_folder)) {
+            _http_root_folder = "/usr/local/carta/frontend";
+            _frontend_found = IsValidFrontendFolder(_http_root_folder);
+        } else {
+            _frontend_found = true;
+        }
     } else {
         _http_root_folder = root_folder;
-        _frontend_found = true;
+        _frontend_found = IsValidFrontendFolder(root_folder);
     }
 
     if (_frontend_found) {
@@ -61,4 +65,20 @@ void SimpleFrontendServer::HandleRequest(uWS::HttpResponse<false>* res, uWS::Htt
         res->writeStatus(HTTP_404);
     }
     res->end();
+}
+
+bool SimpleFrontendServer::IsValidFrontendFolder(std::string folder) {
+    filesystem::path path(folder);
+    // Check that the folder exists
+    if (!filesystem::exists(path) || !filesystem::is_directory(path)) {
+        return false;
+    }
+    // Check that index.html exists
+    path/= "index.html";
+    if (!filesystem::exists(path) || !filesystem::is_regular_file(path)) {
+        return false;
+    }
+    // Check that index.html can be read
+    ifstream index_file(path);
+    return index_file.good();
 }

--- a/src/SimpleFrontendServer/SimpleFrontendServer.cc
+++ b/src/SimpleFrontendServer/SimpleFrontendServer.cc
@@ -12,8 +12,11 @@
 
 #include <fmt/format.h>
 
+#include "MimeTypes.h"
+
 using namespace std;
 
+namespace carta {
 SimpleFrontendServer::SimpleFrontendServer(string root_folder) {
     // If no folder is provided, check if /usr/local/share/carta/frontend exists.
     // If this does not exist, try /usr/share/carta/frontend.
@@ -56,6 +59,14 @@ void SimpleFrontendServer::HandleRequest(uWS::HttpResponse<false>* res, uWS::Htt
         vector<char> buffer(size);
         if (size && file.read(buffer.data(), size)) {
             res->writeStatus(HTTP_200);
+
+            auto extension = path.extension();
+            auto it = MimeTypes.find(extension);
+            if (it != MimeTypes.end()) {
+                auto val = it->second;
+                res->writeHeader("Content-Type", it->second);
+            }
+
             string_view sv(buffer.data(), buffer.size());
             res->write(sv);
         } else {
@@ -74,7 +85,7 @@ bool SimpleFrontendServer::IsValidFrontendFolder(std::string folder) {
         return false;
     }
     // Check that index.html exists
-    path/= "index.html";
+    path /= "index.html";
     if (!filesystem::exists(path) || !filesystem::is_regular_file(path)) {
         return false;
     }
@@ -82,3 +93,5 @@ bool SimpleFrontendServer::IsValidFrontendFolder(std::string folder) {
     ifstream index_file(path);
     return index_file.good();
 }
+
+} // namespace carta

--- a/src/SimpleFrontendServer/SimpleFrontendServer.cc
+++ b/src/SimpleFrontendServer/SimpleFrontendServer.cc
@@ -1,0 +1,64 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+#include "SimpleFrontendServer.h"
+
+#include <filesystem>
+#include <fstream>
+#include <vector>
+
+#include <fmt/format.h>
+
+using namespace std;
+
+SimpleFrontendServer::SimpleFrontendServer(string root_folder) {
+    // If no folder is provided, check if /usr/local/share/carta/frontend exists.
+    // If this does not exist, try /usr/share/carta/frontend.
+
+    if (root_folder.empty()) {
+        _http_root_folder = "/usr/local/share/carta/frontend";
+        _frontend_found = true;
+    } else {
+        _http_root_folder = root_folder;
+        _frontend_found = true;
+    }
+
+    if (_frontend_found) {
+        fmt::print("Serving CARTA frontend from {}\n", _http_root_folder);
+    } else {
+        fmt::print("Could not find CARTA frontend files.\n");
+    }
+}
+
+void SimpleFrontendServer::HandleRequest(uWS::HttpResponse<false>* res, uWS::HttpRequest* req) {
+    string_view url = req->getUrl();
+    string path_string = _http_root_folder;
+    if (url.empty() || url == "/") {
+        path_string.append("/index.html");
+    } else {
+        path_string.append(url);
+    }
+
+    filesystem::path path(path_string);
+    if (filesystem::exists(path) && filesystem::is_regular_file(path)) {
+        // Check file size
+        ifstream file(path, ios::binary | ios::ate);
+        streamsize size = file.tellg();
+        file.seekg(0, ios::beg);
+
+        vector<char> buffer(size);
+        if (size && file.read(buffer.data(), size)) {
+            res->writeStatus(HTTP_200);
+            string_view sv(buffer.data(), buffer.size());
+            res->write(sv);
+        } else {
+            res->writeStatus(HTTP_500);
+        }
+    } else {
+        res->writeStatus(HTTP_404);
+    }
+    res->end();
+}

--- a/src/SimpleFrontendServer/SimpleFrontendServer.h
+++ b/src/SimpleFrontendServer/SimpleFrontendServer.h
@@ -11,11 +11,10 @@
 
 #include <App.h>
 
+namespace carta {
 #define HTTP_200 "200 OK"
 #define HTTP_404 "404 Not Found"
 #define HTTP_500 "500 Internal Server Error"
-
-// TODO: Mime types!
 
 class SimpleFrontendServer {
 public:
@@ -31,4 +30,5 @@ private:
     bool _frontend_found;
 };
 
+} // namespace carta
 #endif // CARTA_BACKEND_SRC_HTTPSERVER_SIMPLEFRONTENDSERVER_H_

--- a/src/SimpleFrontendServer/SimpleFrontendServer.h
+++ b/src/SimpleFrontendServer/SimpleFrontendServer.h
@@ -1,0 +1,31 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+#ifndef CARTA_BACKEND_SRC_HTTPSERVER_SIMPLEFRONTENDSERVER_H_
+#define CARTA_BACKEND_SRC_HTTPSERVER_SIMPLEFRONTENDSERVER_H_
+
+#include <string>
+
+#include <App.h>
+
+#define HTTP_200 "200 OK"
+#define HTTP_404 "404 Not Found"
+#define HTTP_500 "500 Internal Server Error"
+
+class SimpleFrontendServer {
+public:
+    SimpleFrontendServer(std::string root_folder = "");
+    bool CanServeFrontend() {
+        return _frontend_found;
+    }
+    void HandleRequest(uWS::HttpResponse<false>* res, uWS::HttpRequest* req);
+
+private:
+    std::string _http_root_folder;
+    bool _frontend_found;
+};
+
+#endif // CARTA_BACKEND_SRC_HTTPSERVER_SIMPLEFRONTENDSERVER_H_

--- a/src/SimpleFrontendServer/SimpleFrontendServer.h
+++ b/src/SimpleFrontendServer/SimpleFrontendServer.h
@@ -11,6 +11,14 @@
 
 #include <App.h>
 
+#ifdef _BOOST_FILESYSTEM_
+#include <boost/filesystem.hpp>
+namespace fs = boost::filesystem;
+#else
+#include <filesystem>
+namespace fs = std::filesystem;
+#endif
+
 namespace carta {
 #define HTTP_200 "200 OK"
 #define HTTP_404 "404 Not Found"
@@ -18,15 +26,15 @@ namespace carta {
 
 class SimpleFrontendServer {
 public:
-    SimpleFrontendServer(std::string root_folder = "");
+    SimpleFrontendServer(fs::path root_folder);
     bool CanServeFrontend() {
         return _frontend_found;
     }
     void HandleRequest(uWS::HttpResponse<false>* res, uWS::HttpRequest* req);
 
 private:
-    static bool IsValidFrontendFolder(std::string folder);
-    std::string _http_root_folder;
+    static bool IsValidFrontendFolder(fs::path folder);
+    fs::path _http_root_folder;
     bool _frontend_found;
 };
 

--- a/src/SimpleFrontendServer/SimpleFrontendServer.h
+++ b/src/SimpleFrontendServer/SimpleFrontendServer.h
@@ -15,6 +15,8 @@
 #define HTTP_404 "404 Not Found"
 #define HTTP_500 "500 Internal Server Error"
 
+// TODO: Mime types!
+
 class SimpleFrontendServer {
 public:
     SimpleFrontendServer(std::string root_folder = "");
@@ -24,6 +26,7 @@ public:
     void HandleRequest(uWS::HttpResponse<false>* res, uWS::HttpRequest* req);
 
 private:
+    static bool IsValidFrontendFolder(std::string folder);
     std::string _http_root_folder;
     bool _frontend_found;
 };

--- a/src/Util.cc
+++ b/src/Util.cc
@@ -104,12 +104,12 @@ uint32_t GetMagicNumber(const string& filename) {
     return magic_number;
 }
 
-void SplitString(std::string& input, char delim, std::vector<std::string>& parts) {
+void SplitString(string& input, char delim, vector<string>& parts) {
     // util to split input string into parts by delimiter
     parts.clear();
-    std::stringstream ss(input);
-    std::string item;
-    while (std::getline(ss, item, delim)) {
+    stringstream ss(input);
+    string item;
+    while (getline(ss, item, delim)) {
         if (!item.empty()) {
             if (item.back() == '\r') {
                 item.pop_back();
@@ -119,7 +119,7 @@ void SplitString(std::string& input, char delim, std::vector<std::string>& parts
     }
 }
 
-casacore::String GetResolvedFilename(const std::string& root_dir, const std::string& directory, const std::string& file) {
+casacore::String GetResolvedFilename(const string& root_dir, const string& directory, const string& file) {
     // Given directory (relative to root folder) and file, return resolved path and filename
     // (absolute pathname with symlinks resolved)
     casacore::String resolved_filename;
@@ -137,7 +137,7 @@ casacore::String GetResolvedFilename(const std::string& root_dir, const std::str
     return resolved_filename;
 }
 
-CARTA::FileType GetCartaFileType(const std::string& filename) {
+CARTA::FileType GetCartaFileType(const string& filename) {
     // get casacore image type then convert to carta file type
     switch (CasacoreImageType(filename)) {
         case casacore::ImageOpener::AIPSPP:
@@ -172,8 +172,8 @@ void FillHistogramFromResults(CARTA::Histogram* histogram, carta::BasicStats<flo
     histogram->set_std_dev(stats.stdDev);
 }
 
-void FillSpectralProfileDataMessage(CARTA::SpectralProfileData& profile_message, std::string& coordinate,
-    std::vector<CARTA::StatsType>& required_stats, std::map<CARTA::StatsType, std::vector<double>>& spectral_data) {
+void FillSpectralProfileDataMessage(CARTA::SpectralProfileData& profile_message, string& coordinate,
+    vector<CARTA::StatsType>& required_stats, map<CARTA::StatsType, vector<double>>& spectral_data) {
     for (auto stats_type : required_stats) {
         // one SpectralProfile per stats type
         auto new_profile = profile_message.add_profiles();
@@ -181,7 +181,7 @@ void FillSpectralProfileDataMessage(CARTA::SpectralProfileData& profile_message,
         new_profile->set_stats_type(stats_type);
 
         if (spectral_data.find(stats_type) == spectral_data.end()) { // stat not provided
-            double nan_value = std::numeric_limits<double>::quiet_NaN();
+            double nan_value = numeric_limits<double>::quiet_NaN();
             new_profile->set_raw_values_fp64(&nan_value, sizeof(double));
         } else {
             new_profile->set_raw_values_fp64(spectral_data[stats_type].data(), spectral_data[stats_type].size() * sizeof(double));
@@ -189,8 +189,8 @@ void FillSpectralProfileDataMessage(CARTA::SpectralProfileData& profile_message,
     }
 }
 
-void FillStatisticsValuesFromMap(CARTA::RegionStatsData& stats_data, std::vector<CARTA::StatsType>& required_stats,
-    std::map<CARTA::StatsType, double>& stats_value_map) {
+void FillStatisticsValuesFromMap(
+    CARTA::RegionStatsData& stats_data, vector<CARTA::StatsType>& required_stats, map<CARTA::StatsType, double>& stats_value_map) {
     // inserts values from map into message StatisticsValue field; needed by Frame and RegionDataHandler
     for (auto type : required_stats) {
         double value(0.0); // default
@@ -199,7 +199,7 @@ void FillStatisticsValuesFromMap(CARTA::RegionStatsData& stats_data, std::vector
             value = stats_value_map[carta_stats_type];
         } else { // stat not provided
             if (carta_stats_type != CARTA::StatsType::NumPixels) {
-                value = std::numeric_limits<double>::quiet_NaN();
+                value = numeric_limits<double>::quiet_NaN();
             }
         }
 
@@ -210,7 +210,7 @@ void FillStatisticsValuesFromMap(CARTA::RegionStatsData& stats_data, std::vector
     }
 }
 
-void ConvertCoordinateToAxes(const std::string& coordinate, int& axis_index, int& stokes_index) {
+void ConvertCoordinateToAxes(const string& coordinate, int& axis_index, int& stokes_index) {
     // converts profile string into axis, stokes index into image shape
     // axis
     char axis_char(coordinate.back());
@@ -239,8 +239,8 @@ void ConvertCoordinateToAxes(const std::string& coordinate, int& axis_index, int
     }
 }
 
-std::string IPAsText(std::string_view binary) {
-    std::string result;
+string IPAsText(string_view binary) {
+    string result;
     if (!binary.length()) {
         return result;
     }
@@ -253,4 +253,12 @@ std::string IPAsText(std::string_view binary) {
     }
 
     return result;
+}
+string GetAuthTokenFromCookie(const string& header) {
+    regex header_regex("carta-auth-token=(.+?)(?:;|$)");
+    smatch sm;
+    if (regex_search(header, sm, header_regex) && sm.size() == 2) {
+        return sm[1];
+    }
+    return string();
 }

--- a/src/Util.h
+++ b/src/Util.h
@@ -79,6 +79,8 @@ void FillStatisticsValuesFromMap(
 
 std::string IPAsText(std::string_view binary);
 
+std::string GetAuthTokenFromCookie(const std::string& header);
+
 // ************ structs *************
 //
 // Usage of the ChannelRange:


### PR DESCRIPTION
closes #670 and closes #676.

Companion PR of https://github.com/CARTAvis/carta-frontend/pull/1294

This PR adds a basic HTTP server (using uWebSockets) on the same port as the websocket connection. This allows us to simplify deployment quite a bit, as we can now serve the frontend through the backend, and only need a single port for both the HTTP. This also means that we don't need a "remote" mode with the bundled app image, but can rather encourage users who need remote access to simply install the carta components. Users who run CARTA locally may also prefer this approach to the bundled version, as it closely mirrors the approach taken by jupyter-notebook.

By default, the backend attempts to host frontend files found in the path
`<location of carta_backend executable>../share/carta/frontend`.

This covers three main use cases:
- CARTA installed via a package manager under `/usr/`
- CARTA manaually installed (or via a script) under `/usr/local`
- CARTA running from a folder extracted from a tarbal (e.g. `~/Downloads/carta2.0/`)

There are a number of new command-line arguments introduced:
- `no_http` for disabling the HTTP server altogether
- `no_browser` for preventing automatically opening the frontend URL in the user's browser
- `debug_no_auth` for disabling any checking of auth tokens. This should only be done for debug purposes, as it will accept all incoming WebSocket connections
- `host` to allow incoming connections on a specific inferface only
- `frontend_folder` for specifying a custom frontend folder location

In addition to the HTTP server, this PR also adds simple UUID token generation for auth of incoming WebSocket connections. When running the backend, a random UUID token will be generated. This token will be passed to the frontend via the `token` URL query parameter. The full URL is displayed in the console, and opened in the user's default browser using `xdg-open` or `open` (for linux and MacOS respectively).