### PR TITLE
adjust uWS compressor enum to fix firefox / ICD bug

### DIFF
--- a/src/Main.cc
+++ b/src/Main.cc
@@ -676,7 +676,7 @@ int main(int argc, const char* argv[]) {
             }
         }
 
-        app.ws<PerSocketData>("/*", (uWS::App::WebSocketBehavior){.compression = uWS::DEDICATED_COMPRESSOR,
+        app.ws<PerSocketData>("/*", (uWS::App::WebSocketBehavior){.compression = uWS::DEDICATED_COMPRESSOR_256KB,
                                         .upgrade = OnUpgrade,
                                         .open = OnConnect,
                                         .message = OnMessage,


### PR DESCRIPTION
this seems to fix the issue with Firefox clients. 

The uWebSocket release notes for v18.19.0 mention 
> Fixes a bug where using a non-256KB DEDICATED_COMPRESSOR while getting server_no_context_takeover from client would result in an invalid negotiation (leading to corrupt data sent/received).

which _might_ be the same issue.