### PR TITLE
Pam/685 region style

### DIFF
--- a/src/InterfaceConstants.h
+++ b/src/InterfaceConstants.h
@@ -68,9 +68,9 @@
 #define OUTPUT_ID_MULTIPLIER 1000
 
 // CARTA default region style
-#define STYLE_COLOR "#2EE6D6"
-#define STYLE_DASH_LENGTH 2
-#define STYLE_LINE_WIDTH 2
+#define REGION_COLOR "#2EE6D6"
+#define REGION_DASH_LENGTH 2
+#define REGION_LINE_WIDTH 2
 
 // Shared region polygon approximation
 #define DEFAULT_VERTEX_COUNT 1000

--- a/src/InterfaceConstants.h
+++ b/src/InterfaceConstants.h
@@ -67,8 +67,10 @@
 #define MOMENT_COMPLETE 1.0
 #define OUTPUT_ID_MULTIPLIER 1000
 
-// region style
-#define DASH_LENGTH 2
+// CARTA default region style
+#define STYLE_COLOR "#2EE6D6"
+#define STYLE_DASH_LENGTH 2
+#define STYLE_LINE_WIDTH 2
 
 // Shared region polygon approximation
 #define DEFAULT_VERTEX_COUNT 1000

--- a/src/Region/CrtfImportExport.cc
+++ b/src/Region/CrtfImportExport.cc
@@ -783,7 +783,7 @@ RegionStyle CrtfImportExport::ImportStyleParameters(std::unordered_map<std::stri
     }
 
     // color
-    std::string import_color;
+    std::string import_color("green"); // CRTF default
     if (properties.count("color")) {
         import_color = FormatColor(properties["color"]);
     } else if (_global_properties.count(casa::AnnotationBase::COLOR)) {
@@ -800,6 +800,8 @@ RegionStyle CrtfImportExport::ImportStyleParameters(std::unordered_map<std::stri
         style.line_width = std::stoi(properties["linewidth"]);
     } else if (_global_properties.count(casa::AnnotationBase::LINEWIDTH)) {
         style.line_width = std::stoi(_global_properties[casa::AnnotationBase::LINEWIDTH]);
+    } else {
+        style.line_width = 1; // CRTF default
     }
 
     // linestyle

--- a/src/Region/CrtfImportExport.cc
+++ b/src/Region/CrtfImportExport.cc
@@ -789,7 +789,7 @@ RegionStyle CrtfImportExport::ImportStyleParameters(std::unordered_map<std::stri
     } else if (_global_properties.count(casa::AnnotationBase::COLOR)) {
         import_color = FormatColor(_global_properties[casa::AnnotationBase::COLOR]);
     }
-    if (!import_color.empty() && std::strtoul(import_color.c_str(), nullptr, 16)) {
+    if (std::strtoul(import_color.c_str(), nullptr, 16)) {
         // add prefix if hex
         import_color = "#" + import_color;
     }

--- a/src/Region/CrtfImportExport.cc
+++ b/src/Region/CrtfImportExport.cc
@@ -552,7 +552,7 @@ RegionStyle CrtfImportExport::ImportStyleParameters(casacore::CountedPtr<const c
     if (annotation_region->getLineStyle() == casa::AnnotationBase::SOLID) {
         style.dash_list = {0, 0};
     } else {
-        style.dash_list = {STYLE_DASH_LENGTH, STYLE_DASH_LENGTH};
+        style.dash_list = {REGION_DASH_LENGTH, REGION_DASH_LENGTH};
     }
     return style;
 }
@@ -659,6 +659,7 @@ RegionState CrtfImportExport::ImportAnnSymbol(std::vector<std::string>& paramete
 RegionState CrtfImportExport::ImportAnnBox(std::vector<std::string>& parameters) {
     // Import Annotation box to RegionState; params must be in pixel coords for linear coord sys
     RegionState region_state;
+
     if (parameters.size() >= 5) {
         // [box blcx blcy trcx trcy], [centerbox cx cy width height], or [rotbox cx cy width height angle]
         std::string region(parameters[0]);
@@ -673,7 +674,7 @@ RegionState CrtfImportExport::ImportAnnBox(std::vector<std::string>& parameters)
 
         // Create RegionState and add to vector
         CARTA::RegionType type(CARTA::RegionType::RECTANGLE);
-        RegionState region_state(_file_id, type, control_points, rotation);
+        region_state = RegionState(_file_id, type, control_points, rotation);
     } else {
         _import_errors.append("box syntax invalid.\n");
     }
@@ -811,7 +812,7 @@ RegionStyle CrtfImportExport::ImportStyleParameters(std::unordered_map<std::stri
     if (linestyle == "-") { // solid line
         style.dash_list = {0, 0};
     } else {
-        style.dash_list = {STYLE_DASH_LENGTH, STYLE_DASH_LENGTH};
+        style.dash_list = {REGION_DASH_LENGTH, REGION_DASH_LENGTH};
     }
 
     return style;
@@ -979,6 +980,7 @@ bool CrtfImportExport::GetCenterBoxPoints(const std::string& region, casacore::Q
         point.set_y(WorldToPixelLength(height, 1));
         control_points.push_back(point);
     }
+
     return true;
 }
 

--- a/src/Region/CrtfImportExport.cc
+++ b/src/Region/CrtfImportExport.cc
@@ -552,7 +552,7 @@ RegionStyle CrtfImportExport::ImportStyleParameters(casacore::CountedPtr<const c
     if (annotation_region->getLineStyle() == casa::AnnotationBase::SOLID) {
         style.dash_list = {0, 0};
     } else {
-        style.dash_list = {DASH_LENGTH, DASH_LENGTH};
+        style.dash_list = {STYLE_DASH_LENGTH, STYLE_DASH_LENGTH};
     }
     return style;
 }
@@ -811,7 +811,7 @@ RegionStyle CrtfImportExport::ImportStyleParameters(std::unordered_map<std::stri
     if (linestyle == "-") { // solid line
         style.dash_list = {0, 0};
     } else {
-        style.dash_list = {DASH_LENGTH, DASH_LENGTH};
+        style.dash_list = {STYLE_DASH_LENGTH, STYLE_DASH_LENGTH};
     }
 
     return style;

--- a/src/Region/Ds9ImportExport.cc
+++ b/src/Region/Ds9ImportExport.cc
@@ -733,7 +733,7 @@ RegionStyle Ds9ImportExport::ImportStyleParameters(std::unordered_map<std::strin
     } else if (_global_properties.count("color")) {
         style.color = FormatColor(_global_properties["color"]);
     } else {
-        style.color = STYLE_COLOR;
+        style.color = REGION_COLOR;
     }
 
     // width
@@ -742,7 +742,7 @@ RegionStyle Ds9ImportExport::ImportStyleParameters(std::unordered_map<std::strin
     } else if (_global_properties.count("width")) {
         style.line_width = std::stoi(_global_properties["width"]);
     } else {
-        style.line_width = STYLE_LINE_WIDTH;
+        style.line_width = REGION_LINE_WIDTH;
     }
 
     // dash

--- a/src/Region/Ds9ImportExport.cc
+++ b/src/Region/Ds9ImportExport.cc
@@ -732,6 +732,8 @@ RegionStyle Ds9ImportExport::ImportStyleParameters(std::unordered_map<std::strin
         style.color = FormatColor(properties["color"]);
     } else if (_global_properties.count("color")) {
         style.color = FormatColor(_global_properties["color"]);
+    } else {
+        style.color = STYLE_COLOR;
     }
 
     // width
@@ -739,6 +741,8 @@ RegionStyle Ds9ImportExport::ImportStyleParameters(std::unordered_map<std::strin
         style.line_width = std::stoi(properties["width"]);
     } else if (_global_properties.count("width")) {
         style.line_width = std::stoi(_global_properties["width"]);
+    } else {
+        style.line_width = STYLE_LINE_WIDTH;
     }
 
     // dash


### PR DESCRIPTION
Closes #685.

Use default style parameters for region import if not defined in region file: carta defaults for DS9 import, CRTF defaults for CRTF import.