### PR TITLE
Angus/deprecated threads arg

### DIFF
--- a/src/Constants.h
+++ b/src/Constants.h
@@ -14,6 +14,7 @@
 
 // thread counts
 #define OMP_THREAD_COUNT 4
+#define THREAD_COUNT 3
 
 // file ids
 #define ALL_FILES -1

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -574,8 +574,8 @@ int main(int argc, const char* argv[]) {
             port = inp.getInt("port");
             host = inp.getString("host");
             grpc_port = inp.getInt("grpc_port");
-            omp_thread_count = inp.getInt("threads");
-            thread_count = inp.getInt("omp_threads");
+            omp_thread_count = inp.getInt("omp_threads");
+            thread_count = inp.getInt("threads");
             base_folder = inp.getString("base");
             root_folder = inp.getString("root");
             frontend_folder = inp.getString("frontend_folder");

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -555,6 +555,7 @@ int main(int argc, const char* argv[]) {
             inp.create("host", host, "only listen on the specified interface (IP address or hostname)", "String");
             inp.create("port", to_string(port), "set port on which to host frontend files and accept WebSocket connections", "Int");
             inp.create("grpc_port", to_string(grpc_port), "set grpc server port", "Int");
+            inp.create("threads", "", "Deprecated. Please use omp_threads to set the number of threads used in compute tasks", "Int");
             inp.create("omp_threads", to_string(omp_thread_count), "set OMP thread pool count", "Int");
             inp.create("base", base_folder, "set folder for data files", "String");
             inp.create("root", root_folder, "set top-level folder for data files", "String");

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -684,7 +684,7 @@ int main(int argc, const char* argv[]) {
 
         if (port_ok) {
             fmt::print("Listening on port {} with root folder {}, base folder {}, and {} OMP threads\n", port, root_folder, base_folder,
-                       omp_thread_count);
+                omp_thread_count);
 
             if (http_server && http_server->CanServeFrontend()) {
                 string default_host_string = host;


### PR DESCRIPTION
As requested by @robsimmonds, I've re-introduced the old behaviour of the `threads` argument, because setting the scheduler's thread limit might be required in order to queue blocking messages, rather than trying to handle them all at once.

I've also deferred printing of the frontend URL until the port has been determined.