### PR TITLE
#689 Fix region histogram

### DIFF
--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -1276,7 +1276,19 @@ bool Frame::GetRegionData(const casacore::LattRegionHolder& region, std::vector<
         casacore::Slicer slicer(start, count); // entire subimage
         std::unique_lock<std::mutex> ulock(_image_mutex);
         sub_image.doGetSlice(tmp, slicer);
+
+        // Get mask that defines region in subimage bounding box
+        casacore::Array<bool> tmpmask;
+        sub_image.doGetMaskSlice(tmpmask, slicer);
         ulock.unlock();
+
+        // Apply mask to data
+        std::vector<bool> datamask = tmpmask.tovector();
+        for (size_t i = 0; i < data.size(); ++i) {
+            if (!datamask[i]) {
+                data[i] = NAN;
+            }
+        }
 
         if (_perflog) {
             auto t_end_get_subimage_data = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
Closes #689 .

Discovered when the region histogram was not updating for a rotated ellipse, but this was an issue for all regions.  The histogram was computed from the data for the entire subimage, not for the masked data indicating the pixels included in the region.  Now the histogram is updated, and the mean and stdDev stats sent in the region histogram message match the values for the region in the Statistics widget.