### PR TITLE
#704 Use coordsys for 3D image before default axes

### DIFF
--- a/src/FileList/FileExtInfoLoader.cc
+++ b/src/FileList/FileExtInfoLoader.cc
@@ -321,8 +321,17 @@ void FileExtInfoLoader::AddShapeEntries(
         extended_info.set_depth(1);
         extended_info.set_stokes(1);
     } else if (num_dims == 3) { // 3D
-        extended_info.set_depth(shape(2));
-        extended_info.set_stokes(1);
+        if (chan_axis >= 0) {
+            extended_info.set_depth(shape(chan_axis));
+        } else {
+            extended_info.set_depth(1);
+        }
+
+        if (stokes_axis >= 0) {
+            extended_info.set_stokes(shape(stokes_axis));
+        } else {
+            extended_info.set_stokes(1);
+        }
     } else { // 4D
         extended_info.set_depth(shape(chan_axis));
         extended_info.set_stokes(shape(stokes_axis));

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -140,9 +140,26 @@ bool FileLoader::FindCoordinateAxes(IPos& shape, int& spectral_axis, int& stokes
 
     // 3D image
     if (_num_dims == 3) {
-        spectral_axis = (spectral_axis < 0 ? 2 : spectral_axis);
-        _num_channels = shape(spectral_axis);
-        _num_stokes = 1;
+        if ((spectral_axis >= 0) && (stokes_axis >= 0)) {
+            // both are known
+            _num_channels = shape(spectral_axis);
+            _num_stokes = shape(stokes_axis);
+        } else if ((spectral_axis >= 0) && (stokes_axis < 0)) {
+            // spectral is known
+            _num_channels = shape(spectral_axis);
+            _num_stokes = 1;
+        } else if ((spectral_axis < 0) && (stokes_axis >= 0)) {
+            // stokes is known
+            _num_stokes = shape(stokes_axis);
+            _num_channels = 1;
+        } else {
+            // neither is known, assume third is spectral
+            spectral_axis = 2;
+            _num_channels = shape(spectral_axis);
+            _num_stokes = 1;
+        }
+
+        // save axes
         _spectral_axis = spectral_axis;
         _stokes_axis = stokes_axis;
         return true;


### PR DESCRIPTION
Closes #704.

FileLoader assumed the third axis of a 3D image is spectral, now checks the coord sys and only guesses default axes if they are not defined.