### PR TITLE
Set StdDev to zero in HDF5 region spectral profile if there is only one pixel

### DIFF
--- a/src/ImageData/Hdf5Loader.cc
+++ b/src/ImageData/Hdf5Loader.cc
@@ -299,7 +299,7 @@ bool Hdf5Loader::GetRegionSpectralData(int region_id, int stokes, const casacore
 
                 mean[z] = sum_z / num_pixels_z;
                 rms[z] = sqrt(sum_sq_z / num_pixels_z);
-                sigma[z] = sqrt((sum_sq_z - (sum_z * sum_z / num_pixels_z)) / (num_pixels_z - 1));
+                sigma[z] = num_pixels_z > 1 ? sqrt((sum_sq_z - (sum_z * sum_z / num_pixels_z)) / (num_pixels_z - 1)) : 0;
                 extrema[z] = (abs(min[z]) > abs(max[z]) ? min[z] : max[z]);
 
                 if (has_flux) {


### PR DESCRIPTION
Fixes #707.