### PR TITLE
Add an install target so that the executable is copied correctly.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,9 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     target_link_libraries(carta_backend ${LINK_LIBS})
 endif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
+install(TARGETS carta_backend
+    RUNTIME DESTINATION bin)
+
 # Tests
 option(test "Build tests." OFF)
 if (test)


### PR DESCRIPTION
This is needed for the executable to be installed correctly by Debian's packaging tools.