### PR TITLE
Angus/disable performance tests default

### DIFF
--- a/src/SessionManager/ProgramSettings.cc
+++ b/src/SessionManager/ProgramSettings.cc
@@ -89,6 +89,7 @@ ProgramSettings::ProgramSettings(int argc, char** argv) {
     applyOptionalArgument(top_level_folder, "top_level_folder", result);
 
     applyOptionalArgument(frontend_folder, "frontend_folder", result);
+    applyOptionalArgument(host, "host", result);
     applyOptionalArgument(port, "port", result);
     applyOptionalArgument(grpc_port, "grpc_port", result);
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 3.5)
 project(carta_backend_test)
 
+# Performance tests should not be run by default, since they need to be run in isolation
+option(performance_tests "Build performance tests." OFF)
+if (performance_tests)
+    add_definitions(-DCOMPILE_PERFORMANCE_TESTS)
+endif ()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_INCLUDE_DIRECTORIES_BEFORE ON)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
@@ -42,3 +48,4 @@ add_test(NAME ${BINARY} COMMAND ${BINARY})
 target_link_libraries(${BINARY}
         ${TEST_COMMON_LIBS}
         ${LINK_LIBS})
+

--- a/test/TestBlockSmooth.cc
+++ b/test/TestBlockSmooth.cc
@@ -9,11 +9,14 @@
 
 #include <casa/Arrays/ArrayMath.h>
 #include <casa/Arrays/Matrix.h>
-#include <fmt/format.h>
 #include <gtest/gtest.h>
 
-#include "../src/DataStream/Smoothing.h"
-#include "../src/Timer/Timer.h"
+#include "DataStream/Smoothing.h"
+
+#ifdef COMPILE_PERFORMANCE_TESTS
+#include <fmt/format.h>
+#include "Timer/Timer.h"
+#endif
 
 #define MAX_ABS_ERROR 1.0e-3f
 #define MAX_SUM_ERROR 1.0e-1f
@@ -183,7 +186,7 @@ TEST_F(BlockSmoothingTest, TestSSEAccuracy) {
     }
 }
 
-#ifdef NDEBUG
+#ifdef COMPILE_PERFORMANCE_TESTS
 TEST_F(BlockSmoothingTest, TestSSEPerformance) {
     Timer t;
     for (auto i = 0; i < NUM_ITERS; i++) {
@@ -227,7 +230,7 @@ TEST_F(BlockSmoothingTest, TestAVXAccuracy) {
     }
 }
 
-#ifdef NDEBUG
+#ifdef COMPILE_PERFORMANCE_TESTS
 TEST_F(BlockSmoothingTest, TestAVXPerformance) {
     Timer t;
     for (auto i = 0; i < NUM_ITERS; i++) {

--- a/test/TestHistogram.cc
+++ b/test/TestHistogram.cc
@@ -7,12 +7,15 @@
 #include <random>
 #include <vector>
 
-#include <fmt/format.h>
 #include <gtest/gtest.h>
 
 #include "ImageStats/Histogram.h"
 #include "Threading.h"
+
+#ifdef COMPILE_PERFORMANCE_TESTS
+#include <fmt/format.h>
 #include "Timer/Timer.h"
+#endif
 
 using namespace std;
 
@@ -81,7 +84,7 @@ TEST_F(HistogramTest, TestMultithreading) {
         EXPECT_TRUE(CompareResults(results_st, results_mt));
     }
 }
-#ifdef NDEBUG
+#ifdef COMPILE_PERFORMANCE_TESTS
 
 TEST_F(HistogramTest, TestMultithreadingPerformance) {
     std::vector<float> data(1024 * 1024);

--- a/test/TestTileEncoding.cc
+++ b/test/TestTileEncoding.cc
@@ -51,7 +51,7 @@ TEST(TileEncodingTest, RoundTrip) {
     }
 }
 
-#ifdef NDEBUG
+#ifdef COMPILE_PERFORMANCE_TESTS
 
 TEST(TileEncoding, PerformanceTestEncoding) {
     int32_t layer = 12;


### PR DESCRIPTION
This PR just moves the "performance" unit tests (checking SIMD block smoothing speedup among other things) behind a CMake `performance_tests` option, because these tests should only be run in isolation in order to get reliable results.

Also fixes an issue that @confluence picked up: the `host` command-line argument was being ignored.