### PR TITLE
updating Dockerfiles and README with spdlog

### DIFF
--- a/Dockerfiles/Dockerfile-CentOS6
+++ b/Dockerfiles/Dockerfile-CentOS6
@@ -46,25 +46,6 @@ RUN \
   make -j 2 && make install && \
   cd /root && rm -rf CMake
 
-# Install newer fmt
-RUN \
-  source /etc/bashrc && \
-  cd /root && \
-  git clone https://github.com/fmtlib/fmt && \
-  mkdir -p fmt/build && cd fmt/build && \
-  cmake .. && make && make install && \
-  cd /root && rm -rf fmt
-
-# Install spdlog with external 'fmt' library support
-RUN \
-  source /etc/bashrc && \
-  cd /root && \
-  git clone https://github.com/gabime/spdlog && \
-  mkdir -p spdlog/build && cd spdlog/build && \
-  cmake .. -DSPDLOG_FMT_EXTERNAL=ON && \
-  make && make install && \
-  cd /root && rm -rf spdlog
-
 # Install a newer pugixml from source
 RUN \
   source /etc/bashrc && \

--- a/Dockerfiles/Dockerfile-CentOS6
+++ b/Dockerfiles/Dockerfile-CentOS6
@@ -55,6 +55,16 @@ RUN \
   cmake .. && make && make install && \
   cd /root && rm -rf fmt
 
+# Install spdlog with external 'fmt' library support
+RUN \
+  source /etc/bashrc && \
+  cd /root && \
+  git clone https://github.com/gabime/spdlog && \
+  mkdir -p spdlog/build && cd spdlog/build && \
+  cmake .. -DSPDLOG_FMT_EXTERNAL=ON && \
+  make && make install && \
+  cd /root && rm -rf spdlog
+
 # Install a newer pugixml from source
 RUN \
   source /etc/bashrc && \

--- a/Dockerfiles/Dockerfile-CentOS7
+++ b/Dockerfiles/Dockerfile-CentOS7
@@ -23,25 +23,6 @@ RUN \
   make -j 2 && make install && \
   cd /root && rm -rf CMake
 
-# Install newer fmt
-RUN \
-  source /etc/bashrc && \
-  cd /root && \
-  git clone https://github.com/fmtlib/fmt && \
-  mkdir -p fmt/build && cd fmt/build && \
-  cmake .. && make && make install && \
-  cd /root && rm -rf fmt
-
-# Install spdlog with external 'fmt' library support
-RUN \
-  source /etc/bashrc && \
-  cd /root && \
-  git clone https://github.com/gabime/spdlog && \
-  mkdir -p spdlog/build && cd spdlog/build && \
-  cmake .. -DSPDLOG_FMT_EXTERNAL=ON && \
-  make && make install && \
-  cd /root && rm -rf spdlog
-
 # CASA needs wcslib 4.7 but CentOS6 and CentOS7 provide 4.3, so install newer wcslib from source
 RUN \
   source /etc/bashrc && \

--- a/Dockerfiles/Dockerfile-CentOS7
+++ b/Dockerfiles/Dockerfile-CentOS7
@@ -32,6 +32,16 @@ RUN \
   cmake .. && make && make install && \
   cd /root && rm -rf fmt
 
+# Install spdlog with external 'fmt' library support
+RUN \
+  source /etc/bashrc && \
+  cd /root && \
+  git clone https://github.com/gabime/spdlog && \
+  mkdir -p spdlog/build && cd spdlog/build && \
+  cmake .. -DSPDLOG_FMT_EXTERNAL=ON && \
+  make && make install && \
+  cd /root && rm -rf spdlog
+
 # CASA needs wcslib 4.7 but CentOS6 and CentOS7 provide 4.3, so install newer wcslib from source
 RUN \
   source /etc/bashrc && \

--- a/Dockerfiles/Dockerfile-CentOS8
+++ b/Dockerfiles/Dockerfile-CentOS8
@@ -7,9 +7,9 @@ RUN \
   dnf -y install 'dnf-command(config-manager)' && \
   dnf -y config-manager --set-enabled powertools epel-testing elrepo-testing && \
   dnf -y update && \
-  dnf -y install autoconf automake bison blas-devel bzip2 cfitsio-devel curl-devel flex fmt-devel gcc \
+  dnf -y install autoconf automake bison blas-devel bzip2 cfitsio-devel curl-devel flex gcc \
          gcc-c++ git git-lfs gsl-devel hdf5-devel lapack-devel libtool libxml2-devel libzstd-devel make \
-         openssl-devel pugixml-devel spdlog-devel subversion tbb-devel wcslib-devel wcslib-devel wget zlib-devel \
+         openssl-devel pugixml-devel subversion tbb-devel wcslib-devel wcslib-devel wget zlib-devel \
          libuuid-devel
 
 # gRPC will need cmake >3.13 but CentOS8 only provides cmake 3.11.

--- a/Dockerfiles/Dockerfile-ubuntu-16.04
+++ b/Dockerfiles/Dockerfile-ubuntu-16.04
@@ -31,20 +31,6 @@ RUN \
   make -j 2 && make install && \
   cd /root && rm -rf CMake
 
-# Ubuntu 16.04 does not have libfmt-dev so build it from source
-RUN \
-  git clone https://github.com/fmtlib/fmt.git && cd fmt && cmake CMakeLists.txt && \
-  make && make install && cd .. && rm -rf fmt
-
-# Install newer spdlog with external 'fmt' library support
-RUN \
-  cd /root && \
-  git clone https://github.com/gabime/spdlog && \
-  mkdir -p spdlog/build && cd spdlog/build && \
-  cmake .. -DSPDLOG_FMT_EXTERNAL=ON && \
-  make && make install && \
-  cd /root && rm -rf spdlog
-
 # Install a newer pugixml from source
 RUN \
   cd /root && \

--- a/Dockerfiles/Dockerfile-ubuntu-16.04
+++ b/Dockerfiles/Dockerfile-ubuntu-16.04
@@ -36,6 +36,15 @@ RUN \
   git clone https://github.com/fmtlib/fmt.git && cd fmt && cmake CMakeLists.txt && \
   make && make install && cd .. && rm -rf fmt
 
+# Install newer spdlog with external 'fmt' library support
+RUN \
+  cd /root && \
+  git clone https://github.com/gabime/spdlog && \
+  mkdir -p spdlog/build && cd spdlog/build && \
+  cmake .. -DSPDLOG_FMT_EXTERNAL=ON && \
+  make && make install && \
+  cd /root && rm -rf spdlog
+
 # Install a newer pugixml from source
 RUN \
   cd /root && \

--- a/Dockerfiles/Dockerfile-ubuntu-18.04
+++ b/Dockerfiles/Dockerfile-ubuntu-18.04
@@ -37,24 +37,6 @@ RUN \
   apt-get update && \
   apt-get install -y libprotobuf-dev protobuf-compiler libgrpc++-dev libgrpc-dev protobuf-compiler-grpc googletest
 
-# Install fmt of at least version 5.3.0 because newer spdlog will need it for external 'fmt'
-RUN \
-  cd /root && \
-  git clone https://github.com/fmtlib/fmt && \
-  mkdir -p fmt/build && cd fmt/build && \
-  cmake .. && make && make install && \
-  cd /root && rm -rf fmt
-
-# libspdlog-dev version 11:0.16.3-1 with ubuntu 18.04 is too old.
-# Install newer spdlog with external 'fmt' library support 
-RUN \
-  cd /root && \
-  git clone https://github.com/gabime/spdlog && \
-  mkdir -p spdlog/build && cd spdlog/build && \
-  cmake .. -DSPDLOG_FMT_EXTERNAL=ON && \
-  make && make install && \
-  cd /root && rm -rf spdlog
-
 # Forward port so that the webapp can properly access it
 # from outside of the container
 EXPOSE 3002

--- a/Dockerfiles/Dockerfile-ubuntu-18.04
+++ b/Dockerfiles/Dockerfile-ubuntu-18.04
@@ -7,11 +7,11 @@ RUN \
   apt-get install -y apt-utils autoconf bison build-essential byobu curl default-jre emacs \
     fftw3-dev flex gdb g++-8 gcc-8 gfortran git git-lfs htop libblas-dev libcurl4-gnutls-dev \
     libpugixml-dev libcfitsio-dev libgtest-dev libhdf5-dev liblapack-dev libncurses-dev \
-    libreadline-dev libssl-dev libstarlink-ast-dev libtbb-dev libtool libfmt-dev \
+    libreadline-dev libssl-dev libstarlink-ast-dev libtbb-dev libtool \
     libxml2-dev libzstd-dev libgsl-dev man pkg-config python-pip python3-pip \
     software-properties-common unzip vim wcslib-dev wget cmake uuid-dev && \
   update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 80 --slave /usr/bin/g++ g++ /usr/bin/g++-8 --slave /usr/bin/gcov gcov /usr/bin/gcov-8
-    
+
 # Get carta dependencies
 # casacore data from Kernsuite PPA
 RUN \
@@ -36,6 +36,24 @@ RUN \
   add-apt-repository -y ppa:webispy/grpc && \
   apt-get update && \
   apt-get install -y libprotobuf-dev protobuf-compiler libgrpc++-dev libgrpc-dev protobuf-compiler-grpc googletest
+
+# Install fmt of at least version 5.3.0 because newer spdlog will need it for external 'fmt'
+RUN \
+  cd /root && \
+  git clone https://github.com/fmtlib/fmt && \
+  mkdir -p fmt/build && cd fmt/build && \
+  cmake .. && make && make install && \
+  cd /root && rm -rf fmt
+
+# libspdlog-dev version 11:0.16.3-1 with ubuntu 18.04 is too old.
+# Install newer spdlog with external 'fmt' library support 
+RUN \
+  cd /root && \
+  git clone https://github.com/gabime/spdlog && \
+  mkdir -p spdlog/build && cd spdlog/build && \
+  cmake .. -DSPDLOG_FMT_EXTERNAL=ON && \
+  make && make install && \
+  cd /root && rm -rf spdlog
 
 # Forward port so that the webapp can properly access it
 # from outside of the container

--- a/Dockerfiles/Dockerfile-ubuntu-20.04
+++ b/Dockerfiles/Dockerfile-ubuntu-20.04
@@ -8,9 +8,9 @@ RUN \
   apt-get install -y apt-utils autoconf bison build-essential cmake curl fftw3-dev flex gcc g++ \
     gdb gfortran git git-lfs googletest libblas-dev libcfitsio-dev libcurl4-gnutls-dev libfmt-dev \
     libgrpc-dev libgrpc++-dev libgsl-dev libgtest-dev libhdf5-dev liblapack-dev libncurses-dev \
-    libprotobuf-dev libpugixml-dev libreadline-dev libssl-dev libstarlink-ast-dev libtool libtbb-dev \
-    libxml2-dev libxslt1-dev libzstd-dev pkg-config protobuf-compiler-grpc software-properties-common \
-    unzip wcslib-dev wget uuid-dev
+    libprotobuf-dev libpugixml-dev libreadline-dev libspdlog-dev libssl-dev libstarlink-ast-dev \
+    libtool libtbb-dev libxml2-dev libxslt1-dev libzstd-dev pkg-config protobuf-compiler-grpc \
+    software-properties-common unzip wcslib-dev wget uuid-dev
 
 # Get carta dependencies
 # casacore data from Kernsuite PPA

--- a/Dockerfiles/Dockerfile-ubuntu-20.04
+++ b/Dockerfiles/Dockerfile-ubuntu-20.04
@@ -6,9 +6,9 @@ RUN \
   apt-get -y upgrade && \
   DEBIAN_FRONTEND=noninteractive \
   apt-get install -y apt-utils autoconf bison build-essential cmake curl fftw3-dev flex gcc g++ \
-    gdb gfortran git git-lfs googletest libblas-dev libcfitsio-dev libcurl4-gnutls-dev libfmt-dev \
+    gdb gfortran git git-lfs googletest libblas-dev libcfitsio-dev libcurl4-gnutls-dev \
     libgrpc-dev libgrpc++-dev libgsl-dev libgtest-dev libhdf5-dev liblapack-dev libncurses-dev \
-    libprotobuf-dev libpugixml-dev libreadline-dev libspdlog-dev libssl-dev libstarlink-ast-dev \
+    libprotobuf-dev libpugixml-dev libreadline-dev libssl-dev libstarlink-ast-dev \
     libtool libtbb-dev libxml2-dev libxslt1-dev libzstd-dev pkg-config protobuf-compiler-grpc \
     software-properties-common unzip wcslib-dev wget uuid-dev
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ The backend build depends on the following libraries:
 * [casacore and casa imageanalysis](https://github.com/CARTAvis/carta-casacore); follow the build instructions.
 * [zfp](https://github.com/LLNL/zfp) for data compression. The same library is used on the client, after being compiled to WebAssembly. Build and install from git repo. For best performance, build with AVX extensions.
 * [Zstd](https://github.com/facebook/zstd) for data compression. Debian package `libzstd-dev`.
-* [fmt](https://github.com/fmtlib/fmt) for python-style (and safe printf-style) string formatting and printing. Debian package `libfmt-dev`. On Ubuntu 16.04, build from source.
 * [protobuf](https://developers.google.com/protocol-buffers) for client-side communication using specific message formats. Debian package `libprotobuf-dev` (> 3.0 required. Can use [PPA](https://launchpad.net/~maarten-fonville/+archive/ubuntu/protobuf) for earlier versions of Ubuntu). The Debian package `protobuf-compiler` may also be required.
 * [HDF5](https://support.hdfgroup.org/HDF5/) C++ library for HDF5 support. Debian packages `libhdf5-dev` and `libhdf5-cpp-100`. By default, the serial version of the HDF5 library is targeted.
 * [tbb](https://www.threadingbuildingblocks.org/download) Threading Building Blocks for task parallelization. Debian package `libtbb-dev`.
@@ -26,7 +25,6 @@ The backend build depends on the following libraries:
 * [libuuid](https://linux.die.net/man/3/libuuid) for generating auth tokens (if not using external authentication). Debian package `uuid-dev`.
 * [gRPC](https://grpc.io/) for the scripting interface. Debian packages: `libprotobuf-dev protobuf-compiler libgrpc++-dev libgrpc-dev protobuf-compiler-grpc googletest`. On Ubuntu 16.04 or 18.04, use [a PPA](https://launchpad.net/~webispy/+archive/ubuntu/grpc).
 * [pugixml](https://pugixml.org/) for parsing catalog data. Debian package: `libpugixml-dev`. On Ubuntu 16.04, build from source. On newer versions you can also build from source to save memory: use the `PUGIXML_COMPACT` and `PUGIXML_NO_XPATH` flags.
-* [spdlog](https://github.com/gabime/spdlog) for logging. Debian package on Ubuntu 20.04 `libspdlog-dev`. On Ubuntu 18.04 it requires a version newer than that supplied by the package manager, so build from source. When building spdlog from source, it requires fmt 5.3.0. That is newer than the version of fmt supplied by the 18.04 package manager, so need to build fmt from source too. 
 
 ### Build
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The backend build depends on the following libraries:
 * [libuuid](https://linux.die.net/man/3/libuuid) for generating auth tokens (if not using external authentication). Debian package `uuid-dev`.
 * [gRPC](https://grpc.io/) for the scripting interface. Debian packages: `libprotobuf-dev protobuf-compiler libgrpc++-dev libgrpc-dev protobuf-compiler-grpc googletest`. On Ubuntu 16.04 or 18.04, use [a PPA](https://launchpad.net/~webispy/+archive/ubuntu/grpc).
 * [pugixml](https://pugixml.org/) for parsing catalog data. Debian package: `libpugixml-dev`. On Ubuntu 16.04, build from source. On newer versions you can also build from source to save memory: use the `PUGIXML_COMPACT` and `PUGIXML_NO_XPATH` flags.
+* [spdlog](https://github.com/gabime/spdlog) for logging. Debian package on Ubuntu 20.04 `libspdlog-dev`. On Ubuntu 18.04 it requires a version newer than that supplied by the package manager, so build from source. When building spdlog from source, it requires fmt 5.3.0. That is newer than the version of fmt supplied by the 18.04 package manager, so need to build fmt from source too. 
 
 ### Build
 


### PR DESCRIPTION
Here I updated the Dockerfiles and README with spdlog.

Unfortunately on ubuntu 18.04, we need a newer version of spdlog, otherwise some header file called `rotating_file_sink.h` is missing in the package manager's spdlog version 0.16.3.
Then to build spdlog from source, it requires fmt 5.3.0. 
I think Ubuntu's 18.04 package manager only supplies fmt version 4.0.0. So fmt is needed to be build from source too.