### PR TITLE
adjusted debug_no_auth text

### DIFF
--- a/src/SessionManager/ProgramSettings.cc
+++ b/src/SessionManager/ProgramSettings.cc
@@ -57,7 +57,7 @@ ProgramSettings::ProgramSettings(int argc, char** argv) {
         ("files", "Files to load", cxxopts::value<vector<string>>(positional_arguments));
 
     options.add_options("deprecated and debug")
-        ("debug_no_auth", "Accept all incoming WebSocket connections (insecure, use with caution!)", cxxopts::value<bool>())
+        ("debug_no_auth", "Accept all incoming WebSocket connections on the specified port (not secure, use with caution!)", cxxopts::value<bool>())
         ("threads", "[Deprecated] No longer supported", cxxopts::value<int>(), "<thread count>")
         ("base", "[Deprecated] Set starting folder for data files", cxxopts::value<string>(), "<path>")
         ("root", "[Deprecated] Use 'top_level_folder' instead", cxxopts::value<string>(), "<path>");

--- a/src/SessionManager/ProgramSettings.cc
+++ b/src/SessionManager/ProgramSettings.cc
@@ -49,7 +49,7 @@ ProgramSettings::ProgramSettings(int argc, char** argv) {
         ("host", "Only listen on the specified interface (IP address or hostname). If this is unset, the backend listens on all available interfaces.", cxxopts::value<string>()->default_value(host), "<interface>")
         ("p,port", "Manually set the port on which to host frontend files and accept WebSocket connections. If this is unset, the backend will automatically find an unused port, starting from the default.", cxxopts::value<int>()->default_value(to_string(DEFAULT_SOCKET_PORT)), "<port>")
         ("g,grpc_port", "Set gRPC server port. If this is unset, the gRPC service is disabled.", cxxopts::value<int>(), "<port>")
-        ("t,omp_threads", "Manually set OpenMP thread pool count. By default this is automatically set to the number of cores detected by the backend.", cxxopts::value<int>(), "<threads>")
+        ("t,omp_threads", "Manually set OpenMP thread pool count. By default this is automatically set to the number of logical cores detected by the backend.", cxxopts::value<int>(), "<threads>")
         ("top_level_folder", "Set top-level folder for data files. Files outside of this directory will not be accessible.", cxxopts::value<string>()->default_value(top_level_folder), "<dir>")
         ("frontend_folder", "Set folder from which frontend files are served. By default a path relative to the location of the backend executable is used: '../share/carta/frontend'.", cxxopts::value<string>(), "<dir>")
         ("exit_after", "Number of seconds to stay alive after last session exits. By default the backend will not shut down automatically after all sessions exit.", cxxopts::value<int>(), "<sec>")

--- a/src/SessionManager/ProgramSettings.cc
+++ b/src/SessionManager/ProgramSettings.cc
@@ -52,7 +52,7 @@ ProgramSettings::ProgramSettings(int argc, char** argv) {
         ("t,omp_threads", "Manually set OpenMP thread pool count", cxxopts::value<int>(), "<thread count>")
         ("top_level_folder", "Set top-level folder for data files. Files outside of this directory will not be accessible", cxxopts::value<string>(), "<path>")
         ("frontend_folder", "Set folder to serve frontend files from", cxxopts::value<string>(), "<path>")
-        ("exit_after", "Number of seconds to stay alive after last sessions exists", cxxopts::value<int>(), "<duration>")
+        ("exit_after", "Number of seconds to stay alive after last sessions exits", cxxopts::value<int>(), "<duration>")
         ("init_exit_after", "Number of seconds to stay alive at start if no clients connect", cxxopts::value<int>(), "<duration>")
         ("files", "Files to load", cxxopts::value<vector<string>>(positional_arguments));
 

--- a/src/SessionManager/ProgramSettings.cc
+++ b/src/SessionManager/ProgramSettings.cc
@@ -35,7 +35,7 @@ void applyOptionalArgument(T& val, const string& argument_name, const cxxopts::P
 ProgramSettings::ProgramSettings(int argc, char** argv) {
     vector<string> positional_arguments;
 
-    cxxopts::Options options("CARTA", "CARTA Backend");
+    cxxopts::Options options("carta", "CARTA Backend");
     // clang-format off
     // clang-format doesn't like this chain of calls
     options.add_options()("h,help", "Print usage.")
@@ -44,23 +44,23 @@ ProgramSettings::ProgramSettings(int argc, char** argv) {
          "Display verbose logging from this level (0: off, 1: critical, 2: error, 3: warning, 4: info, 5: debug, 6: trace).",
          cxxopts::value<int>()->default_value(to_string(verbosity)), "<level>")
         ("no_log", "Do not log output to a log file. By default output is logged both to the terminal and to a log file, '~/.carta/log/carta.log'.", cxxopts::value<bool>())
-        ("no_http", "Disable CARTA frontend HTTP server. By default the backend serves the frontend files.", cxxopts::value<bool>())
+        ("no_http", "Disable frontend HTTP server. By default the backend serves the frontend files.", cxxopts::value<bool>())
         ("no_browser", "Don't open the frontend URL in a browser on startup. By default the backend prints the frontend URL in the terminal and also opens it in the default browser.", cxxopts::value<bool>())
         ("host", "Only listen on the specified interface (IP address or hostname). If this is unset, the backend listens on all available interfaces.", cxxopts::value<string>()->default_value(host), "<interface>")
-        ("p,port", "Manually set the port on which to host frontend files and accept WebSocket connections. If this is unset, the backend will automatically find an unused port, starting from the default.", cxxopts::value<int>()->default_value(to_string(DEFAULT_SOCKET_PORT)), "<port number>")
-        ("g,grpc_port", "Set gRPC server port. If this is unset, the gRPC service is disabled.", cxxopts::value<int>(), "<port number>")
-        ("t,omp_threads", "Manually set OpenMP thread pool count. By default this is automatically set to the number of cores detected by the backend.", cxxopts::value<int>(), "<thread count>")
-        ("top_level_folder", "Set top-level folder for data files. Files outside of this directory will not be accessible.", cxxopts::value<string>()->default_value(top_level_folder), "<path>")
-        ("frontend_folder", "Set folder from which frontend files are served. By default a path relative to the location of the backend executable is used: '../share/carta/frontend'.", cxxopts::value<string>(), "<path>")
-        ("exit_after", "Number of seconds to stay alive after last session exits. By default the backend will not shut down automatically after all sessions exit.", cxxopts::value<int>(), "<duration>")
-        ("init_exit_after", "Number of seconds to stay alive at start if no clients connect. By default the backend will not shut down automatically if no clients connect.", cxxopts::value<int>(), "<duration>")
+        ("p,port", "Manually set the port on which to host frontend files and accept WebSocket connections. If this is unset, the backend will automatically find an unused port, starting from the default.", cxxopts::value<int>()->default_value(to_string(DEFAULT_SOCKET_PORT)), "<port>")
+        ("g,grpc_port", "Set gRPC server port. If this is unset, the gRPC service is disabled.", cxxopts::value<int>(), "<port>")
+        ("t,omp_threads", "Manually set OpenMP thread pool count. By default this is automatically set to the number of cores detected by the backend.", cxxopts::value<int>(), "<threads>")
+        ("top_level_folder", "Set top-level folder for data files. Files outside of this directory will not be accessible.", cxxopts::value<string>()->default_value(top_level_folder), "<dir>")
+        ("frontend_folder", "Set folder from which frontend files are served. By default a path relative to the location of the backend executable is used: '../share/carta/frontend'.", cxxopts::value<string>(), "<dir>")
+        ("exit_after", "Number of seconds to stay alive after last session exits. By default the backend will not shut down automatically after all sessions exit.", cxxopts::value<int>(), "<sec>")
+        ("init_exit_after", "Number of seconds to stay alive at start if no clients connect. By default the backend will not shut down automatically if no clients connect.", cxxopts::value<int>(), "<sec>")
         ("files", "Files to load", cxxopts::value<vector<string>>(positional_arguments));
 
     options.add_options("Deprecated and debug")
         ("debug_no_auth", "Accept all incoming WebSocket connections on the specified port (not secure; use with caution!)", cxxopts::value<bool>())
-        ("threads", "[Deprecated] No longer supported.", cxxopts::value<int>(), "<thread count>")
-        ("base", "[Deprecated] Set starting folder for data files. Use the positional parameter instead.", cxxopts::value<string>(), "<path>")
-        ("root", "[Deprecated] Use 'top_level_folder' instead.", cxxopts::value<string>(), "<path>");
+        ("threads", "[Deprecated] No longer supported.", cxxopts::value<int>(), "<threads>")
+        ("base", "[Deprecated] Set starting folder for data files. Use the positional parameter instead.", cxxopts::value<string>(), "<dir>")
+        ("root", "[Deprecated] Use 'top_level_folder' instead.", cxxopts::value<string>(), "<dir>");
     // clang-format on
 
     options.positional_help("<file or folder to open>");

--- a/src/SessionManager/ProgramSettings.cc
+++ b/src/SessionManager/ProgramSettings.cc
@@ -35,7 +35,7 @@ void applyOptionalArgument(T& val, const string& argument_name, const cxxopts::P
 ProgramSettings::ProgramSettings(int argc, char** argv) {
     vector<string> positional_arguments;
 
-    cxxopts::Options options("carta", "CARTA Backend");
+    cxxopts::Options options("carta", "Cube Analysis and Rendering Tool for Astronomy");
     // clang-format off
     // clang-format doesn't like this chain of calls
     options.add_options()("h,help", "Print usage.")
@@ -63,7 +63,7 @@ ProgramSettings::ProgramSettings(int argc, char** argv) {
         ("root", "[Deprecated] Use 'top_level_folder' instead.", cxxopts::value<string>(), "<dir>");
     // clang-format on
 
-    options.positional_help("<file or folder to open>");
+    options.positional_help("<file or folder to open> (current directory is the default)");
     options.parse_positional("files");
     auto result = options.parse(argc, argv);
 

--- a/src/SessionManager/ProgramSettings.cc
+++ b/src/SessionManager/ProgramSettings.cc
@@ -38,32 +38,32 @@ ProgramSettings::ProgramSettings(int argc, char** argv) {
     cxxopts::Options options("CARTA", "CARTA Backend");
     // clang-format off
     // clang-format doesn't like this chain of calls
-    options.add_options()("h,help", "Print usage")
-        ("v,version", "Print version")
+    options.add_options()("h,help", "Print usage.")
+        ("v,version", "Print version.")
         ("verbosity",
-         "Display verbose logging from level (0: off, 1: critical, 2: error, 3: warning, 4: info, 5: debug, 6: trace)",
+         "Display verbose logging from this level (0: off, 1: critical, 2: error, 3: warning, 4: info, 5: debug, 6: trace).",
          cxxopts::value<int>()->default_value(to_string(verbosity)), "<level>")
-        ("no_log", "Do not output to a log file", cxxopts::value<bool>())
-        ("no_http", "Disable CARTA frontend HTTP server", cxxopts::value<bool>())
-        ("no_browser", "Prevent the frontend from automatically opening in the default browser on startup", cxxopts::value<bool>())
-        ("host", "Only listen on the specified interface (IP address or hostname)", cxxopts::value<string>()->default_value(host), "<interface>")
-        ("p,port", "Manually set port on which to host frontend files and accept WebSocket connections", cxxopts::value<int>(), "<port number>")
-        ("g,grpc_port", "Set grpc server port", cxxopts::value<int>(), "<port number>")
-        ("t,omp_threads", "Manually set OpenMP thread pool count", cxxopts::value<int>(), "<thread count>")
-        ("top_level_folder", "Set top-level folder for data files. Files outside of this directory will not be accessible", cxxopts::value<string>(), "<path>")
-        ("frontend_folder", "Set folder to serve frontend files from", cxxopts::value<string>(), "<path>")
-        ("exit_after", "Number of seconds to stay alive after last sessions exits", cxxopts::value<int>(), "<duration>")
-        ("init_exit_after", "Number of seconds to stay alive at start if no clients connect", cxxopts::value<int>(), "<duration>")
+        ("no_log", "Do not log output to a log file. By default output is logged both to the terminal and to a log file, '~/.carta/log/carta.log'.", cxxopts::value<bool>())
+        ("no_http", "Disable CARTA frontend HTTP server. By default the backend serves the frontend files.", cxxopts::value<bool>())
+        ("no_browser", "Don't open the frontend URL in a browser on startup. By default the backend prints the frontend URL in the terminal and also opens it in the default browser.", cxxopts::value<bool>())
+        ("host", "Only listen on the specified interface (IP address or hostname). If this is unset, the backend listens on all available interfaces.", cxxopts::value<string>()->default_value(host), "<interface>")
+        ("p,port", "Manually set the port on which to host frontend files and accept WebSocket connections. If this is unset, the backend will automatically find an unused port, starting from the default.", cxxopts::value<int>()->default_value(to_string(DEFAULT_SOCKET_PORT)), "<port number>")
+        ("g,grpc_port", "Set gRPC server port. If this is unset, the gRPC service is disabled.", cxxopts::value<int>(), "<port number>")
+        ("t,omp_threads", "Manually set OpenMP thread pool count. By default this is automatically set to the number of cores detected by the backend.", cxxopts::value<int>(), "<thread count>")
+        ("top_level_folder", "Set top-level folder for data files. Files outside of this directory will not be accessible.", cxxopts::value<string>()->default_value(top_level_folder), "<path>")
+        ("frontend_folder", "Set folder from which frontend files are served. By default a path relative to the location of the backend executable is used: '../share/carta/frontend'.", cxxopts::value<string>(), "<path>")
+        ("exit_after", "Number of seconds to stay alive after last session exits. By default the backend will not shut down automatically after all sessions exit.", cxxopts::value<int>(), "<duration>")
+        ("init_exit_after", "Number of seconds to stay alive at start if no clients connect. By default the backend will not shut down automatically if no clients connect.", cxxopts::value<int>(), "<duration>")
         ("files", "Files to load", cxxopts::value<vector<string>>(positional_arguments));
 
-    options.add_options("deprecated and debug")
-        ("debug_no_auth", "Accept all incoming WebSocket connections on the specified port (not secure, use with caution!)", cxxopts::value<bool>())
-        ("threads", "[Deprecated] No longer supported", cxxopts::value<int>(), "<thread count>")
-        ("base", "[Deprecated] Set starting folder for data files", cxxopts::value<string>(), "<path>")
-        ("root", "[Deprecated] Use 'top_level_folder' instead", cxxopts::value<string>(), "<path>");
+    options.add_options("Deprecated and debug")
+        ("debug_no_auth", "Accept all incoming WebSocket connections on the specified port (not secure; use with caution!)", cxxopts::value<bool>())
+        ("threads", "[Deprecated] No longer supported.", cxxopts::value<int>(), "<thread count>")
+        ("base", "[Deprecated] Set starting folder for data files. Use the positional parameter instead.", cxxopts::value<string>(), "<path>")
+        ("root", "[Deprecated] Use 'top_level_folder' instead.", cxxopts::value<string>(), "<path>");
     // clang-format on
 
-    options.positional_help("<file(s) or folder to open>");
+    options.positional_help("<file or folder to open>");
     options.parse_positional("files");
     auto result = options.parse(argc, argv);
 


### PR DESCRIPTION
Minor change to the command-line argument text, but I think we should use this PR to take a closer look at the help text in general. This will be user-facing from 2.0 on for a number of use cases (basically any time a user opens CARTA from the commandline), so we may want to incorparate some of @ajm-asiaa's text from the electron app's command-line options.