### PR TITLE
use Histogram::Add when building the cube histogram

### DIFF
--- a/src/Session.cc
+++ b/src/Session.cc
@@ -1178,23 +1178,21 @@ bool Session::CalculateCubeHistogram(int file_id, CARTA::RegionHistogramData& cu
                 float progress = 0.50;
                 CARTA::RegionHistogramData half_progress;
                 CreateCubeHistogramMessage(half_progress, file_id, stokes, progress);
-                auto message_histogram = half_progress.add_histograms();
+                half_progress.add_histograms();
                 SendFileEvent(file_id, CARTA::EventType::REGION_HISTOGRAM_DATA, request_id, half_progress);
 
                 // get histogram bins for each channel and accumulate bin counts in cube_bins
-                std::vector<int> cube_bins;
                 carta::Histogram chan_histogram; // histogram for each channel using cube stats
+                carta::Histogram cube_histogram;
                 for (size_t chan = 0; chan < num_channels; ++chan) {
                     if (!_frames.at(file_id)->CalculateHistogram(CUBE_REGION_ID, chan, stokes, num_bins, cube_stats, chan_histogram)) {
                         return calculated; // channel histogram failed
                     }
 
-                    // add channel bins to cube bins
                     if (chan == 0) {
-                        cube_bins = {chan_histogram.GetHistogramBins().begin(), chan_histogram.GetHistogramBins().end()};
-                    } else { // add chan histogram bins to cube histogram bins
-                        std::transform(chan_histogram.GetHistogramBins().begin(), chan_histogram.GetHistogramBins().end(),
-                            cube_bins.begin(), cube_bins.begin(), std::plus<int>());
+                        cube_histogram = std::move(chan_histogram);
+                    } else {
+                        cube_histogram.Add(chan_histogram);
                     }
 
                     // check for cancel
@@ -1212,12 +1210,13 @@ bool Session::CalculateCubeHistogram(int file_id, CARTA::RegionHistogramData& cu
                         CreateCubeHistogramMessage(progress_msg, file_id, stokes, progress);
                         auto message_histogram = progress_msg.add_histograms();
                         message_histogram->set_channel(ALL_CHANNELS);
-                        message_histogram->set_num_bins(chan_histogram.GetNbins());
-                        message_histogram->set_bin_width(chan_histogram.GetBinWidth());
-                        message_histogram->set_first_bin_center(chan_histogram.GetBinCenter());
+                        message_histogram->set_num_bins(cube_histogram.GetNbins());
+                        message_histogram->set_bin_width(cube_histogram.GetBinWidth());
+                        message_histogram->set_first_bin_center(cube_histogram.GetBinCenter());
                         message_histogram->set_mean(cube_stats.mean);
                         message_histogram->set_std_dev(cube_stats.stdDev);
-                        *message_histogram->mutable_bins() = {cube_bins.begin(), cube_bins.end()};
+                        auto& bins = cube_histogram.GetHistogramBins();
+                        *message_histogram->mutable_bins() = {bins.begin(), bins.end()};
                         SendFileEvent(file_id, CARTA::EventType::REGION_HISTOGRAM_DATA, request_id, progress_msg);
                         t_start = t_end;
                     }
@@ -1233,17 +1232,16 @@ bool Session::CalculateCubeHistogram(int file_id, CARTA::RegionHistogramData& cu
                     cube_histogram_message.clear_histograms();
                     auto message_histogram = cube_histogram_message.add_histograms();
                     message_histogram->set_channel(ALL_CHANNELS);
-                    message_histogram->set_num_bins(chan_histogram.GetNbins());
-                    message_histogram->set_bin_width(chan_histogram.GetBinWidth());
-                    message_histogram->set_first_bin_center(chan_histogram.GetBinCenter());
+                    message_histogram->set_num_bins(cube_histogram.GetNbins());
+                    message_histogram->set_bin_width(cube_histogram.GetBinWidth());
+                    message_histogram->set_first_bin_center(cube_histogram.GetBinCenter());
                     message_histogram->set_mean(cube_stats.mean);
                     message_histogram->set_std_dev(cube_stats.stdDev);
-                    *message_histogram->mutable_bins() = {cube_bins.begin(), cube_bins.end()};
+                    auto& bins = cube_histogram.GetHistogramBins();
+                    *message_histogram->mutable_bins() = {bins.begin(), bins.end()};
 
                     // cache cube histogram
-                    carta::Histogram cube_results(chan_histogram);
-                    cube_results.SetHistogramBins(cube_bins);
-                    _frames.at(file_id)->CacheCubeHistogram(stokes, cube_results);
+                    _frames.at(file_id)->CacheCubeHistogram(stokes, cube_histogram);
 
                     auto t_end_cube_histogram = std::chrono::high_resolution_clock::now();
                     auto dt_cube_histogram =


### PR DESCRIPTION
Minor PR to make use of @jolopezl's `Histogram::Add` function when calculating a cube histogram. 
@kswang1029 can you check that this seems to behave correctly? I've done a simple comparison between HDF5 and FITS cube histograms, seems to be fine. Might be good to also check if #680 is still an issue.

