### PR TITLE
Increase maximum permitted websocket payload length to prevent socket closure on receipt of scripting response with data

### DIFF
--- a/src/Main.cc
+++ b/src/Main.cc
@@ -150,6 +150,9 @@ void OnConnect(uWS::WebSocket<false, true>* ws) {
 // Called on disconnect. Cleans up sessions. In future, we may want to delay this (in case of unintentional disconnects)
 void OnDisconnect(uWS::WebSocket<false, true>* ws, int code, std::string_view message) {
     // Skip server-forced disconnects
+
+    spdlog::debug("WebSocket closed with code {} and message '{}'.", code, message);
+
     if (code == 4003) {
         return;
     }
@@ -713,6 +716,7 @@ int main(int argc, char* argv[]) {
             }
 
             app.ws<PerSocketData>("/*", (uWS::App::WebSocketBehavior){.compression = uWS::DEDICATED_COMPRESSOR_256KB,
+                                            .maxPayloadLength = 16 * 1024 * 1024,
                                             .upgrade = OnUpgrade,
                                             .open = OnConnect,
                                             .message = OnMessage,

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -716,7 +716,7 @@ int main(int argc, char* argv[]) {
             }
 
             app.ws<PerSocketData>("/*", (uWS::App::WebSocketBehavior){.compression = uWS::DEDICATED_COMPRESSOR_256KB,
-                                            .maxPayloadLength = 16 * 1024 * 1024,
+                                            .maxPayloadLength = 256 * 1024 * 1024,
                                             .upgrade = OnUpgrade,
                                             .open = OnConnect,
                                             .message = OnMessage,


### PR DESCRIPTION
Fixes #741. The maximum payload length is set to 16K by default. I have set the maximum to 16M, but is this an appropriate upper limit? What image data size can we reasonably expect (given that a user might have a large viewport on a high-resolution screen)?

I have also permanently added a debugging message to log the reason that a websocket was closed.