### PR TITLE
fix carta/44 rectangle region export import bug 

### DIFF
--- a/src/Region/Region.cc
+++ b/src/Region/Region.cc
@@ -286,8 +286,8 @@ void Region::RectanglePointsToCorners(
         y(3) = y_max;
     } else {
         // Apply rotation matrix to get width and height vectors in rotated basis
-        float cos_x = cos(rotation * M_PI / 180.0f);
-        float sin_x = sin(rotation * M_PI / 180.0f);
+        float cos_x = cos((rotation + 90.0f) * M_PI / 180.0f);
+        float sin_x = sin((rotation + 90.0f) * M_PI / 180.0f);
         float width_vector_x = cos_x * width;
         float width_vector_y = sin_x * width;
         float height_vector_x = -sin_x * height;

--- a/src/Region/RegionImportExport.cc
+++ b/src/Region/RegionImportExport.cc
@@ -332,14 +332,19 @@ bool RegionImportExport::ConvertRecordToRectangle(
 
     double cx, cy, width, height;
     casacore::Double blc_x = x[0];
+    casacore::Double brc_x = x[1];
     casacore::Double trc_x = x[2];
+    casacore::Double tlc_x = x[3];
     casacore::Double blc_y = y[0];
+    casacore::Double brc_y = y[1];
     casacore::Double trc_y = y[2];
+    casacore::Double tlc_y = y[3];
+
     // Control points: center point, width/height
     cx = (blc_x + trc_x) / 2.0;
     cy = (blc_y + trc_y) / 2.0;
-    width = fabs(trc_x - blc_x);
-    height = fabs(trc_y - blc_y);
+    width = sqrt(pow((brc_x - blc_x), 2) + pow((brc_y - blc_y), 2));
+    height = sqrt(pow((tlc_x - blc_x), 2) + pow((tlc_y - blc_y), 2));
 
     if (pixel_coord) {
         // Convert pixel value to Quantity in control points

--- a/src/Region/RegionImportExport.cc
+++ b/src/Region/RegionImportExport.cc
@@ -359,6 +359,7 @@ bool RegionImportExport::ConvertRecordToRectangle(
         _coord_sys->toWorld(world_center, pixel_center);
 
         // Convert width/height to world coords
+        casacore::Vector<casacore::String> world_units = _coord_sys->worldAxisUnits();
         casacore::Quantity world_width = _coord_sys->toWorldLength(width, 0);
         casacore::Quantity world_height = _coord_sys->toWorldLength(height, 1);
 

--- a/src/Region/RegionImportExport.cc
+++ b/src/Region/RegionImportExport.cc
@@ -364,7 +364,7 @@ bool RegionImportExport::ConvertRecordToRectangle(
         casacore::Quantity world_height = _coord_sys->toWorldLength(height, 1);
 
         // Convert to Quantities and add to control_points
-        casacore::Vector<casacore::String> world_units = _coord_sys->worldAxisUnits();
+        //casacore::Vector<casacore::String> world_units = _coord_sys->worldAxisUnits();
         control_points.push_back(casacore::Quantity(world_center(0), world_units(0)));
         control_points.push_back(casacore::Quantity(world_center(1), world_units(1)));
         control_points.push_back(world_width);


### PR DESCRIPTION
The root cause is the calculation of rectangle width and height from the four corners. A rectangle is actually treated as a four-point polygon with rotation considered. So the width and height calculations was not correct, resulting the issue.