### PR TITLE
Modify check for boolean attribute

### DIFF
--- a/src/ImageData/Hdf5Attributes.cc
+++ b/src/ImageData/Hdf5Attributes.cc
@@ -72,10 +72,7 @@ std::string Hdf5Attributes::ReadScalar(hid_t attr_id, hid_t data_type_id, const 
             casacore::Double value;
             casacore::HDF5DataType data_type((casacore::Double*)0);
             H5Aread(attr_id, data_type.getHidMem(), &value);
-            std::ostringstream ostream;
-            ostream.precision(13);
-            ostream << value;
-            std::string key_value = fmt::format("{:<8}= {}", name, ostream.str());
+            std::string key_value = fmt::format("{:<8}= {:#.13G}", name, value);
             return fmt::format("{:<80}", key_value);
         } break;
         case H5T_STRING: {

--- a/src/ImageData/Hdf5Attributes.cc
+++ b/src/ImageData/Hdf5Attributes.cc
@@ -53,7 +53,7 @@ std::string Hdf5Attributes::ReadScalar(hid_t attr_id, hid_t data_type_id, const 
     int sz = H5Tget_size(data_type_id);
     switch (H5Tget_class(data_type_id)) {
         case H5T_INTEGER: {
-            if ((sz == 4) && (H5Tget_sign(data_type_id) == H5T_SGN_2)) {
+            if ((sz == 1) && (H5Tget_sign(data_type_id) == H5T_SGN_NONE)) {
                 casacore::Bool value;
                 casacore::HDF5DataType data_type((casacore::Bool*)0);
                 H5Aread(attr_id, data_type.getHidMem(), &value);


### PR DESCRIPTION
Possibly fixes #747, which is caused by incorrect detection of boolean attributes in HDF5 files.

In addition to the symptoms described in the issue (a header entry in the file browser with no name and a value of 1), viewing affected files in the browser causes a casacore error to be logged to the console, for example:

    Keyword Error:  name = EXTEND of type  LONG  and value 1                                                                                                                     
            Keyword value has wrong data type.                                                                                   

Any boolean attribute is affected, including `SIMPLE` -- I'm assuming that the reason the `SIMPLE` attribute is always displayed correctly is that it is handled differently in casacore.

In `Hdf5Attributes.cc`, we currently check whether an integer attribute is a boolean by looking for a signed 4-byte integer. However, when I test this (on 64-bit Linux), these values are actually stored as unsigned 1-byte integers (displayed in `h5dump` as `H5T_STD_U8LE`).

@pford, can you recall how this check was originally tested -- on what operating system(s), and with what files?

~This is not documented online very well, but it appears that the underlying type is not consistent across all architectures, and this may affect both the converter (which maps booleans to the HDF5 integer type using the C++ API's `NATIVE_HBOOL`, which should be the same as `hbool_t`) and the backend (which tries to map them back). I have found reports that on some architectures `hbool_t` is a 4-byte _unsigned_ integer -- but possibly only on Windows, which we don't officially support.~

~The change in this PR checks specifically for an unsigned 1-byte integer, but if necessary I can make the check more permissive, and attempt to cover both options. Could we test this in as many different environments as possible? We may also need to test whether files produced by the converter in different environments are the same.~

Edit: it turns out that this is not that mysterious: at least one old version of the converter wrote booleans as signed 4-byte integers. Pam had an old test file; this caused the discrepancy. So there shouldn't be any complications to merging this.

We are planning to preserve the original FITS header in the HDF5 file; once that is implemented in the converter, we will be able to bypass this entire parsing round trip.