### PR TITLE
fixed behaviour with relative paths

### DIFF
--- a/src/Util.cc
+++ b/src/Util.cc
@@ -80,7 +80,10 @@ bool CheckFolderPaths(string& top_level_string, string& starting_string) {
     return true;
 }
 
-bool IsSubdirectory(const string& folder, const string& top_folder) {
+bool IsSubdirectory(string folder, string top_folder) {
+    folder = casacore::Path(folder).absoluteName();
+    top_folder = casacore::Path(top_folder).absoluteName();
+
     if (folder == top_folder) {
         return true;
     }

--- a/src/Util.h
+++ b/src/Util.h
@@ -21,7 +21,7 @@
 
 // ************ Utilities *************
 bool FindExecutablePath(std::string& path);
-bool IsSubdirectory(const std::string& folder, const std::string& top_folder);
+bool IsSubdirectory(std::string folder, std::string top_folder);
 bool CheckFolderPaths(std::string& top_level_string, std::string& starting_string);
 uint32_t GetMagicNumber(const std::string& filename);
 

--- a/test/TestProgramSettings.cc
+++ b/test/TestProgramSettings.cc
@@ -70,7 +70,7 @@ TEST_F(ProgramSettingsTest, DefaultConstructor) {
     EXPECT_EQ(settings.verbosity, 4);
     EXPECT_EQ(settings.wait_time, -1);
     EXPECT_EQ(settings.init_wait_time, -1);
-    EXPECT_EQ(settings.idle_session_timeout, -1);
+    EXPECT_EQ(settings.idle_session_wait_time, -1);
 }
 
 TEST_F(ProgramSettingsTest, EmptyArugments) {
@@ -84,7 +84,7 @@ TEST_F(ProgramSettingsTest, EmptyArugments) {
 TEST_F(ProgramSettingsTest, ExpectedValuesLong) {
     auto settings = SettingsFromString(
         "carta_backend --verbosity 6 --no_log --no_http --no_browser --host helloworld --port 1234 --grpc_port 5678 --omp_threads 10"
-        " --top_level_folder /tmp --frontend_folder /var --exit_after 10 --init_exit_after 11 --debug_no_auth");
+        " --top_level_folder /tmp --frontend_folder /var --exit_timeout 10 --initial_timeout 11 --debug_no_auth");
     EXPECT_EQ(settings.verbosity, 6);
     EXPECT_EQ(settings.no_log, true);
     EXPECT_EQ(settings.no_http, true);


### PR DESCRIPTION
Minor PR to fix the infinite loop that occurs when you pass `IsDirectory` a set of relative paths. Also fixes a minor issue with the program settings test after some commandline argument changes.

After this PR is merged, all the unit tests should pass, which means we can _finally_ start adding them to CI