### PR TITLE
Fix hardcoded user directory variable in the help text; make default frontend folder configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,10 @@ if (CartaUserFolderPrefix)
     add_compile_definitions(CARTA_USER_FOLDER_PREFIX="${CartaUserFolderPrefix}")
 endif (CartaUserFolderPrefix)
 
+if (CartaDefaultFrontendFolder)
+    add_compile_definitions(CARTA_DEFAULT_FRONTEND_FOLDER="${CartaDefaultFrontendFolder}")
+endif (CartaDefaultFrontendFolder)
+
 install(TARGETS carta_backend
     RUNTIME DESTINATION bin)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,6 +183,10 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     target_link_libraries(carta_backend ${LINK_LIBS})
 endif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
+if (CartaUserFolderPrefix)
+    add_compile_definitions(CARTA_USER_FOLDER_PREFIX="${CartaUserFolderPrefix}")
+endif (CartaUserFolderPrefix)
+
 install(TARGETS carta_backend
     RUNTIME DESTINATION bin)
 

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -86,6 +86,11 @@
 #define CARTA_USER_FOLDER_PREFIX ".carta"
 #endif
 
+// Frontend folder
+#ifndef CARTA_DEFAULT_FRONTEND_FOLDER
+#define CARTA_DEFAULT_FRONTEND_FOLDER "../share/carta/frontend"
+#endif
+
 // Schema URLs
 #define CARTA_PREFERENCES_SCHEMA_URL "https://cartavis.github.io/schemas/preference_schema_1.json"
 #define CARTA_LAYOUT_SCHEMA_URL "https://cartavis.github.io/schemas/layout_schema_2.json"

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -611,7 +611,7 @@ int main(int argc, char* argv[]) {
                 frontend_path = settings.frontend_folder;
             } else if (have_executable_path) {
                 fs::path executable_parent = fs::path(executable_path).parent_path();
-                frontend_path = executable_parent / "../share/carta/frontend";
+                frontend_path = executable_parent / CARTA_DEFAULT_FRONTEND_FOLDER;
             } else {
                 spdlog::warn(
                     "Failed to determine the default location of the CARTA frontend. Please specify a custom location using the "

--- a/src/SessionManager/ProgramSettings.cc
+++ b/src/SessionManager/ProgramSettings.cc
@@ -95,19 +95,19 @@ default browser.
 The gRPC service is disabled unless a gRPC port is set. By default the number of 
 OpenMP threads is automatically set to the detected number of logical cores.
 
-Logs are written both to the terminal and to a log file, '.carta/log/carta.log' 
+Logs are written both to the terminal and to a log file, '{}/log/carta.log' 
 in the user's home directory. Possible log levels are:{}
 
 Performance and protocol message logging is disabled by default, but can be 
 enabled with flags. The verbosity takes precedence: the additional log messages 
 will only be visible if the level is set to 5 (debug). Performance logs are 
-written to a separate log file, '.carta/log/performance.log'.
+written to a separate log file, '{}/log/performance.log'.
 
 Options are provided to shut the backend down automatically if it is idle (if no 
 clients are connected), and to kill frontend sessions that are idle (no longer 
 sending messages to the backend).
 )",
-        DEFAULT_SOCKET_PORT, log_levels);
+        DEFAULT_SOCKET_PORT, CARTA_USER_FOLDER_PREFIX, log_levels, CARTA_USER_FOLDER_PREFIX);
 
     if (result.count("version")) {
         cout << VERSION_ID << endl;

--- a/src/SessionManager/ProgramSettings.cc
+++ b/src/SessionManager/ProgramSettings.cc
@@ -85,7 +85,7 @@ folder, and uses the root of the filesystem (/) as the top-level data folder. If
 a custom top-level folder is set, the backend will be restricted from accessing 
 files outside this directory.
 
-Frontend files are served from '../share/carta/frontend' (relative to the 
+Frontend files are served from '{}' (relative to the 
 location of the backend executable). By default the backend listens for HTTP and 
 WebSocket connections on all available interfaces, and automatically selects the 
 first available port starting from {}.  On startup the backend prints out a URL 
@@ -107,7 +107,7 @@ Options are provided to shut the backend down automatically if it is idle (if no
 clients are connected), and to kill frontend sessions that are idle (no longer 
 sending messages to the backend).
 )",
-        DEFAULT_SOCKET_PORT, CARTA_USER_FOLDER_PREFIX, log_levels, CARTA_USER_FOLDER_PREFIX);
+        CARTA_DEFAULT_FRONTEND_FOLDER, DEFAULT_SOCKET_PORT, CARTA_USER_FOLDER_PREFIX, log_levels, CARTA_USER_FOLDER_PREFIX);
 
     if (result.count("version")) {
         cout << VERSION_ID << endl;


### PR DESCRIPTION
Making the default frontend folder configurable simplifies making the release and development packages installable side by side. It's also useful for working with multiple local source builds without having to organise the directories in a particular way or to specify custom folders at runtime every time.