### PR TITLE
Set explicit cmake build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ include_directories(src)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_INCLUDE_DIRECTORIES_BEFORE ON)
 
+set(CMAKE_BUILD_TYPE "RelWithDebInfo")
+
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/third-party/install)
 
 include(uWebSockets)

--- a/third-party/install/uWebSockets.cmake
+++ b/third-party/install/uWebSockets.cmake
@@ -1,6 +1,6 @@
 macro(install_uWebSockets)
 
-    set(CMAKE_C_FLAGS "-DLIBUS_NO_SSL")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DLIBUS_NO_SSL")
 
     include_directories(${CMAKE_SOURCE_DIR}/third-party/uWebSockets/uSockets/src)
     include_directories(${CMAKE_SOURCE_DIR}/third-party/uWebSockets/src)

--- a/third-party/install/uWebSockets.cmake
+++ b/third-party/install/uWebSockets.cmake
@@ -1,6 +1,6 @@
 macro(install_uWebSockets)
 
-    set(CMAKE_C_FLAGS "-O3 -DLIBUS_NO_SSL")
+    set(CMAKE_C_FLAGS "-DLIBUS_NO_SSL")
 
     include_directories(${CMAKE_SOURCE_DIR}/third-party/uWebSockets/uSockets/src)
     include_directories(${CMAKE_SOURCE_DIR}/third-party/uWebSockets/src)


### PR DESCRIPTION
Currently the build type is set to `Release` as a side effect of the spdlog cmake configuration. I propose that we explicitly set it to `RelWithDebInfo`.