### PR TITLE
Fix IsSubdirectory when top folder is root

### DIFF
--- a/src/Util.cc
+++ b/src/Util.cc
@@ -83,7 +83,9 @@ bool CheckFolderPaths(string& top_level_string, string& starting_string) {
 bool IsSubdirectory(string folder, string top_folder) {
     folder = casacore::Path(folder).absoluteName();
     top_folder = casacore::Path(top_folder).absoluteName();
-
+    if (top_folder.empty()) {
+        return true;
+    }
     if (folder == top_folder) {
         return true;
     }

--- a/test/TestUtil.cc
+++ b/test/TestUtil.cc
@@ -58,3 +58,9 @@ TEST(UtilTest, ParentNotSubdirectory) {
     EXPECT_FALSE(IsSubdirectory((pwd / "..").string(), pwd.string()));
     EXPECT_FALSE(IsSubdirectory("../", "./"));
 }
+
+TEST(UtilTest, TopIsRoot) {
+    auto pwd = fs::current_path();
+    EXPECT_TRUE(IsSubdirectory(pwd.string(), "/"));
+    EXPECT_TRUE(IsSubdirectory("./", "/"));
+}


### PR DESCRIPTION
`casacore::Path("/").absoluteName()` is `""`, which breaks `IsSubdirectory` when the top level folder is root and the starting folder is anything.

Am I missing some weird case where something can *not* be a subdirectory of `/`?