### PR TITLE
Increases the uWebSockets max backpressure

### DIFF
--- a/src/Constants.h
+++ b/src/Constants.h
@@ -69,6 +69,9 @@
 // Shared region polygon approximation
 #define DEFAULT_VERTEX_COUNT 1000
 
+// uWebSockets setting
+#define MAX_BACKPRESSURE 256 * 1024 * 1024
+
 // socket port
 #define DEFAULT_SOCKET_PORT 3002
 #define MAX_SOCKET_PORT_TRIALS 100

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -159,10 +159,10 @@ void OnDrain(uWS::WebSocket<false, true>* ws) {
     uint32_t session_id = static_cast<PerSocketData*>(ws->getUserData())->session_id;
     Session* session = sessions[session_id];
     if (session) {
-        spdlog::warn("Client {} [{}] WebSocket backpressure drains, remaining buffer amount: {} (bytes)", session->GetId(),
+        spdlog::debug("Client {} [{}] WebSocket backpressure drains, remaining buffered amount: {} (bytes)", session->GetId(),
             session->GetAddress(), ws->getBufferedAmount());
     } else {
-        spdlog::warn("Unknown client WebSocket backpressure drains, remaining buffer amount: {} (bytes)", ws->getBufferedAmount());
+        spdlog::debug("Unknown client WebSocket backpressure drains, remaining buffered amount: {} (bytes)", ws->getBufferedAmount());
     }
 }
 
@@ -719,7 +719,7 @@ int main(int argc, char* argv[]) {
 
             app.ws<PerSocketData>("/*", (uWS::App::WebSocketBehavior){.compression = uWS::DEDICATED_COMPRESSOR_256KB,
                                             .maxPayloadLength = 256 * 1024 * 1024,
-                                            .maxBackpressure = 256 * 1024 * 1024,
+                                            .maxBackpressure = MAX_BACKPRESSURE,
                                             .upgrade = OnUpgrade,
                                             .open = OnConnect,
                                             .message = OnMessage,

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -159,10 +159,10 @@ void OnDrain(uWS::WebSocket<false, true>* ws) {
     uint32_t session_id = static_cast<PerSocketData*>(ws->getUserData())->session_id;
     Session* session = sessions[session_id];
     if (session) {
-        spdlog::debug("Client {} [{}] WebSocket backpressure drains, remaining buffered amount: {} (bytes)", session->GetId(),
+        spdlog::debug("Draining WebSocket backpressure: client {} [{}]. Remaining buffered amount: {} (bytes).", session->GetId(),
             session->GetAddress(), ws->getBufferedAmount());
     } else {
-        spdlog::debug("Unknown client WebSocket backpressure drains, remaining buffered amount: {} (bytes)", ws->getBufferedAmount());
+        spdlog::debug("Draining WebSocket backpressure: unknown client. Remaining buffered amount: {} (bytes).", ws->getBufferedAmount());
     }
 }
 

--- a/src/Session.cc
+++ b/src/Session.cc
@@ -1573,8 +1573,7 @@ void Session::SendEvent(CARTA::EventType event_type, uint32_t event_id, const go
             while (_out_msgs.try_pop(msg)) {
                 auto expected_buffered_amount = msg.first.size() + _socket->getBufferedAmount();
                 if (expected_buffered_amount > MAX_BACKPRESSURE) {
-                    spdlog::warn(
-                        "Client {} [{}] WebSocket buffered amount {} (bytes) exceeds the max backpressure! May losing some messages..",
+                    spdlog::warn("Exceeded maximum backpressure: client {} [{}]. Buffered amount: {} (bytes). May lose some messages.",
                         GetId(), GetAddress(), expected_buffered_amount);
                 }
                 std::string_view sv(msg.first.data(), msg.first.size());

--- a/src/Session.cc
+++ b/src/Session.cc
@@ -1573,8 +1573,9 @@ void Session::SendEvent(CARTA::EventType event_type, uint32_t event_id, const go
             while (_out_msgs.try_pop(msg)) {
                 auto expected_buffered_amount = msg.first.size() + _socket->getBufferedAmount();
                 if (expected_buffered_amount > MAX_BACKPRESSURE) {
-                    spdlog::warn("WebSocket buffered amount {} (bytes) exceeds the max backpressure! May losing some messages..",
-                        expected_buffered_amount);
+                    spdlog::warn(
+                        "Client {} [{}] WebSocket buffered amount {} (bytes) exceeds the max backpressure! May losing some messages..",
+                        GetId(), GetAddress(), expected_buffered_amount);
                 }
                 std::string_view sv(msg.first.data(), msg.first.size());
                 _socket->send(sv, uWS::OpCode::BINARY, msg.second);

--- a/src/Session.cc
+++ b/src/Session.cc
@@ -1571,6 +1571,11 @@ void Session::SendEvent(CARTA::EventType event_type, uint32_t event_id, const go
         std::pair<std::vector<char>, bool> msg;
         if (_connected) {
             while (_out_msgs.try_pop(msg)) {
+                auto expected_buffered_amount = msg.first.size() + _socket->getBufferedAmount();
+                if (expected_buffered_amount > MAX_BACKPRESSURE) {
+                    spdlog::warn("WebSocket buffered amount {} (bytes) exceeds the max backpressure! May losing some messages..",
+                        expected_buffered_amount);
+                }
                 std::string_view sv(msg.first.data(), msg.first.size());
                 _socket->send(sv, uWS::OpCode::BINARY, msg.second);
             }


### PR DESCRIPTION
Closes #758. Increases the uWebSockets max backpressure. According to the [doc](https://unetworking.github.io/uWebSockets.js/generated/interfaces/websocketbehavior.html), `maxBackpressure` is the maximum length of allowed backpressure per socket when PUBLISHING messages. Slow receivers with too high backpressure will be skipped until they catch up or timeout. Also, I add an `OnDrain` handler for when WebSocket backpressure drains. According to the document, we can check the buffered amount here and use this to guide/drive your backpressure throttling.