### PR TITLE
block instead of sleeping when testing timer

### DIFF
--- a/test/TestTimer.cc
+++ b/test/TestTimer.cc
@@ -15,15 +15,24 @@ using namespace std;
 
 class TimerTest : public ::testing::Test {
 public:
-    // Test for 2 ms accuracy
-    static constexpr double timer_eps = 2;
-    static constexpr int delay_millis = 25;
+    // Test for 0.1 ms accuracy
+    static constexpr double timer_eps = 0.1;
+    static constexpr double delay_millis = 2.5;
+
+    void block_for_millis(double millis) {
+        double dt = 0;
+        auto t_start = chrono::high_resolution_clock::now();
+        while (dt < millis) {
+            auto now = chrono::high_resolution_clock::now();
+            dt = chrono::duration_cast<chrono::microseconds>(now - t_start).count() / 1000.0;
+        }
+    }
 };
 
 TEST_F(TimerTest, RecordTime) {
     Timer t;
     t.Start("RecordTime");
-    std::this_thread::sleep_for(std::chrono::milliseconds(delay_millis));
+    block_for_millis(delay_millis);
     t.End("RecordTime");
     auto dt = t.GetMeasurement("RecordTime").count();
     EXPECT_GT(dt, 0);
@@ -32,7 +41,7 @@ TEST_F(TimerTest, RecordTime) {
 TEST_F(TimerTest, IgnoresWrongOrder) {
     Timer t;
     t.End("IgnoresWrongOrder");
-    std::this_thread::sleep_for(std::chrono::milliseconds(delay_millis));
+    block_for_millis(delay_millis);
     t.End("IgnoresWrongOrder");
     auto dt = t.GetMeasurement("IgnoresWrongOrder").count();
     EXPECT_LT(dt, 0);
@@ -43,7 +52,7 @@ TEST_F(TimerTest, AccurateAverage) {
 
     for (auto i = 0; i < 5; i++) {
         t.Start("AccurateAverage");
-        std::this_thread::sleep_for(std::chrono::milliseconds(delay_millis));
+        block_for_millis(delay_millis);
         t.End("AccurateAverage");
     }
 
@@ -55,7 +64,7 @@ TEST_F(TimerTest, AccurateAverage) {
 TEST_F(TimerTest, AccurateTime) {
     Timer t;
     t.Start("AccurateTime");
-    std::this_thread::sleep_for(std::chrono::milliseconds(delay_millis));
+    block_for_millis(delay_millis);
     t.End("AccurateTime");
     auto dt = t.GetMeasurement("AccurateTime").count();
     auto diff = dt - delay_millis;
@@ -65,7 +74,7 @@ TEST_F(TimerTest, AccurateTime) {
 TEST_F(TimerTest, ClearWorks) {
     Timer t;
     t.Start("ClearWorks");
-    std::this_thread::sleep_for(std::chrono::milliseconds(delay_millis));
+    block_for_millis(delay_millis);
     t.End("ClearWorks");
     t.Clear("ClearWorks");
     auto dt = t.GetMeasurement("ClearWorks").count();
@@ -75,7 +84,7 @@ TEST_F(TimerTest, ClearWorks) {
 TEST_F(TimerTest, ClearAllWorks) {
     Timer t;
     t.Start("ClearAllWorks");
-    std::this_thread::sleep_for(std::chrono::milliseconds(delay_millis));
+    block_for_millis(delay_millis);
     t.End("ClearAllWorks");
     t.Clear();
     auto dt = t.GetMeasurement("ClearAllWorks").count();
@@ -85,9 +94,9 @@ TEST_F(TimerTest, ClearAllWorks) {
 TEST_F(TimerTest, MeasurementStringWorks) {
     Timer t;
     t.Start("MeasurementStringWorks");
-    std::this_thread::sleep_for(std::chrono::milliseconds(delay_millis));
+    block_for_millis(delay_millis);
     t.End("MeasurementStringWorks");
-    EXPECT_EQ(t.GetMeasurementString("MeasurementStringWorks").rfind("MeasurementStringWorks: 2"), 0);
+    EXPECT_EQ(t.GetMeasurementString("MeasurementStringWorks").rfind("MeasurementStringWorks: 2.5"), 0);
 
     // Clear after fetching
     t.GetMeasurementString("MeasurementStringWorks", true);


### PR DESCRIPTION
closes #772.

#772 seems to crop up because we're at the mercy of the scheduler when calling `sleep_for`, as this just provides a lower bound. I've switched to busy-waiting instead. This should be far more reliable, and as such I've reduced the timer accuracy requirement down to 0.1 ms.