### PR TITLE
1271 Overwrite a default compression quality with higher precision

### DIFF
--- a/src/Constants.h
+++ b/src/Constants.h
@@ -98,7 +98,4 @@
 #define CARTA_PREFERENCES_SCHEMA_URL "https://cartavis.github.io/schemas/preference_schema_1.json"
 #define CARTA_LAYOUT_SCHEMA_URL "https://cartavis.github.io/schemas/layout_schema_2.json"
 
-// ZFP compression
-#define HIGH_COMPRESSION_QUALITY 20
-
 #endif // CARTA_BACKEND__INTERFACECONSTANTS_H_

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -98,4 +98,7 @@
 #define CARTA_PREFERENCES_SCHEMA_URL "https://cartavis.github.io/schemas/preference_schema_1.json"
 #define CARTA_LAYOUT_SCHEMA_URL "https://cartavis.github.io/schemas/layout_schema_2.json"
 
+// ZFP compression
+#define HIGH_COMPRESSION_QUALITY 20
+
 #endif // CARTA_BACKEND__INTERFACECONSTANTS_H_

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -33,6 +33,8 @@ namespace fs = std::filesystem;
 
 using namespace carta;
 
+static int high_compression_quality(20);
+
 Frame::Frame(uint32_t session_id, carta::FileLoader* loader, const std::string& hdu, int default_channel)
     : _session_id(session_id),
       _valid(true),
@@ -1452,10 +1454,10 @@ void Frame::SaveFile(const std::string& root_folder, const CARTA::SaveFile& save
 void Frame::VerifyCompressionQuality(int channel, int stokes, float& compression_quality) {
     int cache_key(CacheKey(channel, stokes));
     for (auto& image_histogram : _image_histograms[cache_key]) {
-        if (compression_quality < HIGH_COMPRESSION_QUALITY && image_histogram.HasDominantBin()) {
+        if (compression_quality < high_compression_quality && image_histogram.HasDominantBin()) {
             spdlog::warn("Pixel histogram has a dominant bin. Change to higher ZFP compression quality: {}->{}", compression_quality,
-                HIGH_COMPRESSION_QUALITY);
-            compression_quality = HIGH_COMPRESSION_QUALITY;
+                high_compression_quality);
+            compression_quality = high_compression_quality;
             break;
         }
     }

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -1448,3 +1448,14 @@ void Frame::SaveFile(const std::string& root_folder, const CARTA::SaveFile& save
     save_file_ack.set_success(success);
     save_file_ack.set_message(message);
 }
+
+void Frame::VerifyCompressionQuality(int channel, int stokes, float& compression_quality) {
+    int cache_key(CacheKey(channel, stokes));
+    for (auto& image_histogram : _image_histograms[cache_key]) {
+        if (compression_quality < HIGH_COMPRESSION_QUALITY && image_histogram.HasDominantBin()) {
+            compression_quality = HIGH_COMPRESSION_QUALITY; // overwrite the compression quality with higher precision
+            spdlog::warn("Pixel histogram has a dominant bin. Use high compression quality instead of the default one.");
+            break;
+        }
+    }
+}

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -1454,7 +1454,7 @@ void Frame::SaveFile(const std::string& root_folder, const CARTA::SaveFile& save
 void Frame::VerifyCompressionQuality(int channel, int stokes, float& compression_quality) {
     int cache_key(CacheKey(channel, stokes));
     for (auto& image_histogram : _image_histograms[cache_key]) {
-        if (compression_quality < high_compression_quality && image_histogram.HasDominantBin()) {
+        if (compression_quality < high_compression_quality && image_histogram.CheckForDominantBin()) {
             spdlog::warn("Pixel histogram has a dominant bin. Change to higher ZFP compression quality: {}->{}", compression_quality,
                 high_compression_quality);
             compression_quality = high_compression_quality;

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -1453,8 +1453,9 @@ void Frame::VerifyCompressionQuality(int channel, int stokes, float& compression
     int cache_key(CacheKey(channel, stokes));
     for (auto& image_histogram : _image_histograms[cache_key]) {
         if (compression_quality < HIGH_COMPRESSION_QUALITY && image_histogram.HasDominantBin()) {
-            compression_quality = HIGH_COMPRESSION_QUALITY; // overwrite the compression quality with higher precision
-            spdlog::warn("Pixel histogram has a dominant bin. Use high compression quality instead of the default one.");
+            spdlog::warn("Pixel histogram has a dominant bin. Change to higher ZFP compression quality: {}->{}", compression_quality,
+                HIGH_COMPRESSION_QUALITY);
+            compression_quality = HIGH_COMPRESSION_QUALITY;
             break;
         }
     }

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -33,7 +33,7 @@ namespace fs = std::filesystem;
 
 using namespace carta;
 
-static int high_compression_quality(20);
+static const int HIGH_COMPRESSION_QUALITY(20);
 
 Frame::Frame(uint32_t session_id, carta::FileLoader* loader, const std::string& hdu, int default_channel)
     : _session_id(session_id),
@@ -1454,10 +1454,10 @@ void Frame::SaveFile(const std::string& root_folder, const CARTA::SaveFile& save
 void Frame::VerifyCompressionQuality(int channel, int stokes, float& compression_quality) {
     int cache_key(CacheKey(channel, stokes));
     for (auto& image_histogram : _image_histograms[cache_key]) {
-        if (compression_quality < high_compression_quality && image_histogram.CheckForDominantBin()) {
+        if (compression_quality < HIGH_COMPRESSION_QUALITY && image_histogram.CheckForDominantBin()) {
             spdlog::warn("Pixel histogram has a dominant bin. Change to higher ZFP compression quality: {}->{}", compression_quality,
-                high_compression_quality);
-            compression_quality = high_compression_quality;
+                HIGH_COMPRESSION_QUALITY);
+            compression_quality = HIGH_COMPRESSION_QUALITY;
             break;
         }
     }

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -176,6 +176,8 @@ public:
     // Save as a new file or convert it between CASA/FITS formats
     void SaveFile(const std::string& root_folder, const CARTA::SaveFile& save_file_msg, CARTA::SaveFileAck& save_file_ack);
 
+    void VerifyCompressionQuality(int channel, int stokes, float& compression_quality);
+
 private:
     // Validate channel, stokes index values
     bool CheckChannel(int channel);

--- a/src/ImageStats/Histogram.cc
+++ b/src/ImageStats/Histogram.cc
@@ -95,7 +95,7 @@ void Histogram::SetHistogramBins(const std::vector<int>& bins) {
     _histogram_bins = bins;
 }
 
-bool Histogram::HasDominantBin() {
+bool Histogram::CheckForDominantBin() {
     if (_has_dominant_bin < 0) {
         int max_bin = std::numeric_limits<int>::min();
         int sum = 0;

--- a/src/ImageStats/Histogram.cc
+++ b/src/ImageStats/Histogram.cc
@@ -94,3 +94,18 @@ void Histogram::SetHistogramBins(const std::vector<int>& bins) {
     }
     _histogram_bins = bins;
 }
+
+bool Histogram::HasDominantBin() {
+    if (_has_dominant_bin < 0) {
+        int max_bin = std::numeric_limits<int>::min();
+        int sum = 0;
+        for (auto& bin : _histogram_bins) {
+            if (bin > max_bin) {
+                max_bin = bin;
+            }
+            sum += bin;
+        }
+        _has_dominant_bin = ((float(max_bin) / (float)sum) >= 0.9);
+    }
+    return _has_dominant_bin;
+}

--- a/src/ImageStats/Histogram.h
+++ b/src/ImageStats/Histogram.h
@@ -54,7 +54,7 @@ public:
 
     void SetHistogramBins(const std::vector<int>&);
 
-    bool HasDominantBin();
+    bool CheckForDominantBin();
 };
 
 } // namespace carta

--- a/src/ImageStats/Histogram.h
+++ b/src/ImageStats/Histogram.h
@@ -20,6 +20,7 @@ class Histogram {
     float _bin_width;                 // bin width
     float _bin_center;                // bin center
     std::vector<int> _histogram_bins; // histogram bin counts
+    int _has_dominant_bin = -1;       // -1: undetermined, 0: false, 1: true
 
     void Fill(const std::vector<float>&);
     static bool ConsistencyCheck(const Histogram&, const Histogram&);
@@ -52,6 +53,8 @@ public:
     }
 
     void SetHistogramBins(const std::vector<int>&);
+
+    bool HasDominantBin();
 };
 
 } // namespace carta

--- a/src/Session.cc
+++ b/src/Session.cc
@@ -524,6 +524,9 @@ void Session::OnAddRequiredTiles(const CARTA::AddRequiredTiles& message, bool sk
         CARTA::CompressionType compression_type = message.compression_type();
         float compression_quality = message.compression_quality();
 
+        // check do we need to increase the compression quality
+        _frames.at(file_id)->VerifyCompressionQuality(channel, stokes, compression_quality);
+
         auto t_start_get_tile_data = std::chrono::high_resolution_clock::now();
 
         ThreadManager::ApplyThreadLimit();
@@ -1351,7 +1354,6 @@ bool Session::SendRegionHistogramData(int file_id, int region_id) {
 
     if ((region_id > CURSOR_REGION_ID) || (region_id == ALL_REGIONS) || (file_id == ALL_FILES)) {
         // Region histogram
-        CARTA::RegionHistogramData histogram_data;
         data_sent = _region_handler->FillRegionHistogramData(
             [&](CARTA::RegionHistogramData histogram_data) {
                 if (histogram_data.histograms_size() > 0) {


### PR DESCRIPTION
According to the suggestion by @kswang1029 from [#1271](https://github.com/CARTAvis/carta-frontend/issues/1271), the backend will overwrite a default ZFP compression quality with higher precision. If there is a dominant bin in the pixel histograms, i.e., >= 90% of pixels concentrate in a bin.