### PR TITLE
1271 Change ZFP compression quality with respect to the compressibility

### DIFF
--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -433,7 +433,7 @@ bool Frame::FillRasterTileData(CARTA::RasterTileData& raster_tile_data, const Ti
                         tile_ptr->set_image_data(compression_buffer_hq.data(), compressed_size_hq);
 
                         spdlog::debug("Using high compression quality. Previous compression ratio: {:.3f}", compression_ratio);
-                        compression_ratio = compressed_size_hq;
+                        compression_ratio = compression_ratio_hq;
                         use_high_precision = true;
                     }
                 }

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -410,23 +410,23 @@ bool Frame::FillRasterTileData(CARTA::RasterTileData& raster_tile_data, const Ti
             }
 
             auto t_start_compress_tile_data = std::chrono::high_resolution_clock::now();
-            
+
             // compress the data with the default precision
             std::vector<char> compression_buffer;
             size_t compressed_size;
             int precision = lround(compression_quality);
             Compress(tile_image_data, 0, compression_buffer, compressed_size, tile_width, tile_height, precision);
-            float compression_ratio = (float)compressed_size / (float)tile_image_data_size;
+            float compression_ratio = (float)tile_image_data_size / (float)compressed_size;
             bool use_high_precision(false);
 
-            if (precision < HIGH_COMPRESSION_QUALITY && compression_ratio < 0.05) {
+            if (precision < HIGH_COMPRESSION_QUALITY && compression_ratio > 20) {
                 // re-compress the data with a higher precision
                 std::vector<char> compression_buffer_hq;
                 size_t compressed_size_hq;
                 Compress(tile_image_data, 0, compression_buffer_hq, compressed_size_hq, tile_width, tile_height, HIGH_COMPRESSION_QUALITY);
-                float compression_ratio_hq = (float)compressed_size_hq / (float)tile_image_data_size;
+                float compression_ratio_hq = (float)tile_image_data_size / (float)compressed_size_hq;
 
-                if (compression_ratio_hq < 0.1) {
+                if (compression_ratio_hq > 10) {
                     // set compression data with high precision
                     raster_tile_data.set_compression_quality(HIGH_COMPRESSION_QUALITY);
                     tile_ptr->set_image_data(compression_buffer_hq.data(), compressed_size_hq);

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -418,20 +418,14 @@ bool Frame::FillRasterTileData(CARTA::RasterTileData& raster_tile_data, const Ti
                 float compressed_ratio = (float)compressed_size / (float)tile_image_data_size;
 
                 if (precision < HIGH_COMPRESSION_QUALITY && compressed_ratio < 0.05) {
-                    // re-get the tile image data
-                    std::vector<float> tile_image_data_2;
-                    int tile_width_2;
-                    int tile_height_2;
-                    GetRasterTileData(tile_image_data_2, tile, tile_width_2, tile_height_2);
-
                     // re-get the nan-encoding data
-                    auto nan_encodings_2 = GetNanEncodingsBlock(tile_image_data_2, 0, tile_width_2, tile_height_2);
+                    auto nan_encodings_2 = GetNanEncodingsBlock(tile_image_data, 0, tile_width, tile_height);
 
                     // re-compress the data with a higher precision
                     std::vector<char> compression_buffer_2;
                     size_t compressed_size_2;
-                    Compress(tile_image_data_2, 0, compression_buffer_2, compressed_size_2, tile_width_2, tile_height_2,
-                        HIGH_COMPRESSION_QUALITY);
+                    Compress(
+                        tile_image_data, 0, compression_buffer_2, compressed_size_2, tile_width, tile_height, HIGH_COMPRESSION_QUALITY);
                     float compressed_ratio_2 = (float)compressed_size_2 / (float)tile_image_data_size;
 
                     if (compressed_ratio_2 < 0.1) {

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -415,32 +415,32 @@ bool Frame::FillRasterTileData(CARTA::RasterTileData& raster_tile_data, const Ti
                 size_t compressed_size;
                 int precision = lround(compression_quality);
                 Compress(tile_image_data, 0, compression_buffer, compressed_size, tile_width, tile_height, precision);
-                float compressed_ratio = (float)compressed_size / (float)tile_image_data_size;
+                float compression_ratio = (float)compressed_size / (float)tile_image_data_size;
 
-                if (precision < HIGH_COMPRESSION_QUALITY && compressed_ratio < 0.05) {
+                if (precision < HIGH_COMPRESSION_QUALITY && compression_ratio < 0.05) {
                     // re-compress the data with a higher precision
                     std::vector<char> compression_buffer_2;
                     size_t compressed_size_2;
                     Compress(
                         tile_image_data, 0, compression_buffer_2, compressed_size_2, tile_width, tile_height, HIGH_COMPRESSION_QUALITY);
-                    float compressed_ratio_2 = (float)compressed_size_2 / (float)tile_image_data_size;
+                    float compression_ratio_2 = (float)compressed_size_2 / (float)tile_image_data_size;
 
-                    if (compressed_ratio_2 < 0.1) {
+                    if (compression_ratio_2 < 0.1) {
                         // set compression data with high precision
                         raster_tile_data.set_compression_quality(HIGH_COMPRESSION_QUALITY);
                         tile_ptr->set_nan_encodings(nan_encodings.data(), sizeof(int32_t) * nan_encodings.size());
                         tile_ptr->set_image_data(compression_buffer_2.data(), compressed_size_2);
-                        spdlog::warn(
-                            "Change to higher compression quality: {}->{}. The compressed ratio for tile (layer:{}, x:{}, y:{}) is "
-                            "{:.3f}.",
-                            precision, HIGH_COMPRESSION_QUALITY, tile.layer, tile.x, tile.y, compressed_ratio_2);
+                        spdlog::info(
+                            "Change to high compression quality: {}->{}. The change of compression ratio for tile (layer:{}, x:{}, y:{}) "
+                            "is {:.3f}->{:.3f}.",
+                            precision, HIGH_COMPRESSION_QUALITY, tile.layer, tile.x, tile.y, compression_ratio, compression_ratio_2);
                     } else {
                         // set compression data with default precision
                         raster_tile_data.set_compression_quality(compression_quality);
                         tile_ptr->set_nan_encodings(nan_encodings.data(), sizeof(int32_t) * nan_encodings.size());
                         tile_ptr->set_image_data(compression_buffer.data(), compressed_size);
-                        spdlog::debug("The compressed ratio for tile (layer:{}, x:{}, y:{}) is {:.3f}.", tile.layer, tile.x, tile.y,
-                            compressed_ratio);
+                        spdlog::debug("The compression ratio for tile (layer:{}, x:{}, y:{}) is {:.3f}.", tile.layer, tile.x, tile.y,
+                            compression_ratio);
                     }
                 } else {
                     // set compression data with default precision
@@ -448,7 +448,7 @@ bool Frame::FillRasterTileData(CARTA::RasterTileData& raster_tile_data, const Ti
                     tile_ptr->set_nan_encodings(nan_encodings.data(), sizeof(int32_t) * nan_encodings.size());
                     tile_ptr->set_image_data(compression_buffer.data(), compressed_size);
                     spdlog::debug(
-                        "The compressed ratio for tile (layer:{}, x:{}, y:{}) is {:.3f}.", tile.layer, tile.x, tile.y, compressed_ratio);
+                        "The compression ratio for tile (layer:{}, x:{}, y:{}) is {:.3f}.", tile.layer, tile.x, tile.y, compression_ratio);
                 }
             }
 

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -410,43 +410,41 @@ bool Frame::FillRasterTileData(CARTA::RasterTileData& raster_tile_data, const Ti
             }
 
             auto t_start_compress_tile_data = std::chrono::high_resolution_clock::now();
-            {
-                // compress the data with the default precision
-                std::vector<char> compression_buffer;
-                size_t compressed_size;
-                int precision = lround(compression_quality);
-                Compress(tile_image_data, 0, compression_buffer, compressed_size, tile_width, tile_height, precision);
-                float compression_ratio = (float)compressed_size / (float)tile_image_data_size;
-                bool use_high_precision(false);
+            
+            // compress the data with the default precision
+            std::vector<char> compression_buffer;
+            size_t compressed_size;
+            int precision = lround(compression_quality);
+            Compress(tile_image_data, 0, compression_buffer, compressed_size, tile_width, tile_height, precision);
+            float compression_ratio = (float)compressed_size / (float)tile_image_data_size;
+            bool use_high_precision(false);
 
-                if (precision < HIGH_COMPRESSION_QUALITY && compression_ratio < 0.05) {
-                    // re-compress the data with a higher precision
-                    std::vector<char> compression_buffer_hq;
-                    size_t compressed_size_hq;
-                    Compress(
-                        tile_image_data, 0, compression_buffer_hq, compressed_size_hq, tile_width, tile_height, HIGH_COMPRESSION_QUALITY);
-                    float compression_ratio_hq = (float)compressed_size_hq / (float)tile_image_data_size;
+            if (precision < HIGH_COMPRESSION_QUALITY && compression_ratio < 0.05) {
+                // re-compress the data with a higher precision
+                std::vector<char> compression_buffer_hq;
+                size_t compressed_size_hq;
+                Compress(tile_image_data, 0, compression_buffer_hq, compressed_size_hq, tile_width, tile_height, HIGH_COMPRESSION_QUALITY);
+                float compression_ratio_hq = (float)compressed_size_hq / (float)tile_image_data_size;
 
-                    if (compression_ratio_hq < 0.1) {
-                        // set compression data with high precision
-                        raster_tile_data.set_compression_quality(HIGH_COMPRESSION_QUALITY);
-                        tile_ptr->set_image_data(compression_buffer_hq.data(), compressed_size_hq);
+                if (compression_ratio_hq < 0.1) {
+                    // set compression data with high precision
+                    raster_tile_data.set_compression_quality(HIGH_COMPRESSION_QUALITY);
+                    tile_ptr->set_image_data(compression_buffer_hq.data(), compressed_size_hq);
 
-                        spdlog::debug("Using high compression quality. Previous compression ratio: {:.3f}", compression_ratio);
-                        compression_ratio = compression_ratio_hq;
-                        use_high_precision = true;
-                    }
+                    spdlog::debug("Using high compression quality. Previous compression ratio: {:.3f}", compression_ratio);
+                    compression_ratio = compression_ratio_hq;
+                    use_high_precision = true;
                 }
-
-                if (!use_high_precision) {
-                    // set compression data with default precision
-                    raster_tile_data.set_compression_quality(compression_quality);
-                    tile_ptr->set_image_data(compression_buffer.data(), compressed_size);
-                }
-
-                spdlog::debug(
-                    "The compression ratio for tile (layer:{}, x:{}, y:{}) is {:.3f}.", tile.layer, tile.x, tile.y, compression_ratio);
             }
+
+            if (!use_high_precision) {
+                // set compression data with default precision
+                raster_tile_data.set_compression_quality(compression_quality);
+                tile_ptr->set_image_data(compression_buffer.data(), compressed_size);
+            }
+
+            spdlog::debug(
+                "The compression ratio for tile (layer:{}, x:{}, y:{}) is {:.3f}.", tile.layer, tile.x, tile.y, compression_ratio);
 
             // Measure duration for compress tile data
             auto t_end_compress_tile_data = std::chrono::high_resolution_clock::now();

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -430,7 +430,7 @@ bool Frame::FillRasterTileData(CARTA::RasterTileData& raster_tile_data, const Ti
                         raster_tile_data.set_compression_quality(HIGH_COMPRESSION_QUALITY);
                         tile_ptr->set_nan_encodings(nan_encodings.data(), sizeof(int32_t) * nan_encodings.size());
                         tile_ptr->set_image_data(compression_buffer_2.data(), compressed_size_2);
-                        spdlog::info(
+                        spdlog::debug(
                             "Change to high compression quality: {}->{}. The change of compression ratio for tile (layer:{}, x:{}, y:{}) "
                             "is {:.3f}->{:.3f}.",
                             precision, HIGH_COMPRESSION_QUALITY, tile.layer, tile.x, tile.y, compression_ratio, compression_ratio_2);

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -433,21 +433,25 @@ bool Frame::FillRasterTileData(CARTA::RasterTileData& raster_tile_data, const Ti
                         raster_tile_data.set_compression_quality(HIGH_COMPRESSION_QUALITY);
                         tile_ptr->set_nan_encodings(nan_encodings_2.data(), sizeof(int32_t) * nan_encodings_2.size());
                         tile_ptr->set_image_data(compression_buffer_2.data(), compressed_size_2);
-                        spdlog::warn("Change to higher ZFP compression quality: {}->{}. The compressed ratio for a tile is {:.3f}.",
-                            precision, HIGH_COMPRESSION_QUALITY, compressed_ratio_2);
+                        spdlog::warn(
+                            "Change to higher compression quality: {}->{}. The compressed ratio for tile (layer:{}, x:{}, y:{}) is "
+                            "{:.3f}.",
+                            precision, HIGH_COMPRESSION_QUALITY, tile.layer, tile.x, tile.y, compressed_ratio_2);
                     } else {
                         // set compression data with default precision
                         raster_tile_data.set_compression_quality(compression_quality);
                         tile_ptr->set_nan_encodings(nan_encodings.data(), sizeof(int32_t) * nan_encodings.size());
                         tile_ptr->set_image_data(compression_buffer.data(), compressed_size);
-                        spdlog::debug("The compressed ratio for a tile is {:.3f}.", compressed_ratio);
+                        spdlog::debug("The compressed ratio for tile (layer:{}, x:{}, y:{}) is {:.3f}.", tile.layer, tile.x, tile.y,
+                            compressed_ratio);
                     }
                 } else {
                     // set compression data with default precision
                     raster_tile_data.set_compression_quality(compression_quality);
                     tile_ptr->set_nan_encodings(nan_encodings.data(), sizeof(int32_t) * nan_encodings.size());
                     tile_ptr->set_image_data(compression_buffer.data(), compressed_size);
-                    spdlog::debug("The compressed ratio for a tile is {:.3f}.", compressed_ratio);
+                    spdlog::debug(
+                        "The compressed ratio for tile (layer:{}, x:{}, y:{}) is {:.3f}.", tile.layer, tile.x, tile.y, compressed_ratio);
                 }
             }
 

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -418,9 +418,6 @@ bool Frame::FillRasterTileData(CARTA::RasterTileData& raster_tile_data, const Ti
                 float compressed_ratio = (float)compressed_size / (float)tile_image_data_size;
 
                 if (precision < HIGH_COMPRESSION_QUALITY && compressed_ratio < 0.05) {
-                    // re-get the nan-encoding data
-                    auto nan_encodings_2 = GetNanEncodingsBlock(tile_image_data, 0, tile_width, tile_height);
-
                     // re-compress the data with a higher precision
                     std::vector<char> compression_buffer_2;
                     size_t compressed_size_2;
@@ -431,7 +428,7 @@ bool Frame::FillRasterTileData(CARTA::RasterTileData& raster_tile_data, const Ti
                     if (compressed_ratio_2 < 0.1) {
                         // set compression data with high precision
                         raster_tile_data.set_compression_quality(HIGH_COMPRESSION_QUALITY);
-                        tile_ptr->set_nan_encodings(nan_encodings_2.data(), sizeof(int32_t) * nan_encodings_2.size());
+                        tile_ptr->set_nan_encodings(nan_encodings.data(), sizeof(int32_t) * nan_encodings.size());
                         tile_ptr->set_image_data(compression_buffer_2.data(), compressed_size_2);
                         spdlog::warn(
                             "Change to higher compression quality: {}->{}. The compressed ratio for tile (layer:{}, x:{}, y:{}) is "

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -373,7 +373,7 @@ bool Frame::FillRasterTileData(CARTA::RasterTileData& raster_tile_data, const Ti
     if (ZStokesChanged(z, stokes)) {
         return false;
     }
-    
+
     raster_tile_data.set_channel(z);
     raster_tile_data.set_stokes(stokes);
     raster_tile_data.set_compression_type(compression_type);

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -437,21 +437,21 @@ bool Frame::FillRasterTileData(CARTA::RasterTileData& raster_tile_data, const Ti
                     float compressibility_2 = ((float)nan_encodings_size_2 + (float)compressed_size_2) / (float)tile_image_data_size;
 
                     if (compressibility_2 < 0.1) {
-                        // set high compression data
+                        // set compression data with high precision
                         raster_tile_data.set_compression_quality(HIGH_COMPRESSION_QUALITY);
                         tile_ptr->set_nan_encodings(nan_encodings_2.data(), sizeof(int32_t) * nan_encodings_2.size());
                         tile_ptr->set_image_data(compression_buffer_2.data(), compressed_size_2);
                         spdlog::warn("Change to higher ZFP compression quality: {}->{}. The compressibility for a tile is {:.3f}.",
                             precision, HIGH_COMPRESSION_QUALITY, compressibility_2);
                     } else {
-                        // set default compression data
+                        // set compression data with default precision
                         raster_tile_data.set_compression_quality(compression_quality);
                         tile_ptr->set_nan_encodings(nan_encodings.data(), sizeof(int32_t) * nan_encodings.size());
                         tile_ptr->set_image_data(compression_buffer.data(), compressed_size);
                         spdlog::debug("The compressibility for a tile is {:.3f}.", compressibility);
                     }
                 } else {
-                    // set default compression data
+                    // set compression data with default precision
                     raster_tile_data.set_compression_quality(compression_quality);
                     tile_ptr->set_nan_encodings(nan_encodings.data(), sizeof(int32_t) * nan_encodings.size());
                     tile_ptr->set_image_data(compression_buffer.data(), compressed_size);


### PR DESCRIPTION
This branch is trying to solve [#1271](https://github.com/CARTAvis/carta-frontend/issues/1271) in another way that suggested by @kswang1029. We check ZFP compressibility for each tile of an image. If the compressibility is smaller than `0.05` then we compress the data again with the highest precision (32). If the compressibility for a tile with the highest precision is smaller than `0.1`, then we use such compression data. Otherwise, we use the compression data with the default precision.