### PR TITLE
auth adjustments: fallback to query token

### DIFF
--- a/src/Util.cc
+++ b/src/Util.cc
@@ -327,7 +327,6 @@ string IPAsText(string_view binary) {
 }
 
 string GetAuthToken(uWS::HttpRequest* http_request) {
-    string req_token;
     // First try the cookie auth token
     string cookie_header = string(http_request->getHeader("cookie"));
     if (!cookie_header.empty()) {
@@ -346,8 +345,12 @@ string GetAuthToken(uWS::HttpRequest* http_request) {
         return sm[1].str();
     }
 
+    // Try the URL query
+    auto query_token = http_request->getQuery("token");
+    if (!query_token.empty()) {
+        return string(query_token);
+    }
     // Finally, fall back to the non-standard auth token header
-    // TODO: Should this be supported any more? Where is it used?
     return string(http_request->getHeader("carta-auth-token"));
 }
 


### PR DESCRIPTION
Attempts to authenticate using URL query token if cookies or auth headers aren't available. This solves the issue of authenticating when the frontend and backend are hosted in separate locations. 

