### PR TITLE
Yuhsuan/issue 798 read only mode

### DIFF
--- a/src/Main.cc
+++ b/src/Main.cc
@@ -123,8 +123,8 @@ void OnConnect(uWS::WebSocket<false, true>* ws) {
     auto* loop = uWS::Loop::get();
 
     // create a Session
-    sessions[session_id] = new Session(
-        ws, loop, session_id, address, settings.top_level_folder, settings.starting_folder, file_list_handler, settings.grpc_port, settings.read_only_mode);
+    sessions[session_id] = new Session(ws, loop, session_id, address, settings.top_level_folder, settings.starting_folder,
+        file_list_handler, settings.grpc_port, settings.read_only_mode);
 
     if (carta_grpc_service) {
         carta_grpc_service->AddSession(sessions[session_id]);

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -639,7 +639,7 @@ int main(int argc, char* argv[]) {
             }
 
             if (!frontend_path.empty()) {
-                http_server = new SimpleFrontendServer(frontend_path, auth_token);
+                http_server = new SimpleFrontendServer(frontend_path, auth_token, settings.read_only_mode);
                 if (http_server->CanServeFrontend()) {
                     http_server->RegisterRoutes(app);
                 } else {

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -124,7 +124,7 @@ void OnConnect(uWS::WebSocket<false, true>* ws) {
 
     // create a Session
     sessions[session_id] = new Session(
-        ws, loop, session_id, address, settings.top_level_folder, settings.starting_folder, file_list_handler, settings.grpc_port);
+        ws, loop, session_id, address, settings.top_level_folder, settings.starting_folder, file_list_handler, settings.grpc_port, settings.read_only_mode);
 
     if (carta_grpc_service) {
         carta_grpc_service->AddSession(sessions[session_id]);

--- a/src/Session.cc
+++ b/src/Session.cc
@@ -288,7 +288,7 @@ void Session::OnRegisterViewer(const CARTA::RegisterViewer& message, uint16_t ic
 
     uint32_t feature_flags;
     if (_read_only_mode) {
-        feature_flags = CARTA::ServerFeatureFlags::REGION_WRITE_ACCESS;
+        feature_flags = CARTA::ServerFeatureFlags::READ_ONLY;
     } else {
         feature_flags = CARTA::ServerFeatureFlags::SERVER_FEATURE_NONE;
     }

--- a/src/Session.cc
+++ b/src/Session.cc
@@ -766,7 +766,7 @@ void Session::OnExportRegion(const CARTA::ExportRegion& message, uint32_t reques
 
             std::map<int, CARTA::RegionStyle> region_styles = {message.region_styles().begin(), message.region_styles().end()};
 
-             _region_handler->ExportRegion(
+            _region_handler->ExportRegion(
                 file_id, _frames.at(file_id), message.type(), message.coord_type(), region_styles, abs_filename, export_ack);
         }
         SendFileEvent(file_id, CARTA::EventType::EXPORT_REGION_ACK, request_id, export_ack);

--- a/src/Session.h
+++ b/src/Session.h
@@ -59,7 +59,7 @@
 class Session {
 public:
     Session(uWS::WebSocket<false, true>* ws, uWS::Loop* loop, uint32_t id, std::string address, std::string top_level_folder,
-        std::string starting_folder, FileListHandler* file_list_handler, int grpc_port = -1);
+        std::string starting_folder, FileListHandler* file_list_handler, int grpc_port = -1, bool read_only_mode = false);
     ~Session();
 
     // CARTA ICD
@@ -246,6 +246,7 @@ private:
     std::string _top_level_folder;
     std::string _starting_folder;
     int _grpc_port;
+    bool _read_only_mode;
 
     // File browser
     FileListHandler* _file_list_handler;

--- a/src/SessionManager/ProgramSettings.cc
+++ b/src/SessionManager/ProgramSettings.cc
@@ -58,6 +58,7 @@ ProgramSettings::ProgramSettings(int argc, char** argv) {
         ("exit_timeout", "number of seconds to stay alive after last session exits", cxxopts::value<int>(), "<sec>")
         ("initial_timeout", "number of seconds to stay alive at start if no clients connect", cxxopts::value<int>(), "<sec>")
         ("idle_timeout", "number of seconds to keep idle sessions alive", cxxopts::value<int>(), "<sec>")
+        ("read_only_mode", "disable write requests", cxxopts::value<bool>())
         ("files", "files to load", cxxopts::value<vector<string>>(positional_arguments));
 
     options.add_options("Deprecated and debug")
@@ -127,6 +128,7 @@ sending messages to the backend).
     no_http = result["no_http"].as<bool>();
     debug_no_auth = result["debug_no_auth"].as<bool>();
     no_browser = result["no_browser"].as<bool>();
+    read_only_mode = result["read_only_mode"].as<bool>();
 
     applyOptionalArgument(top_level_folder, "root", result);
     // Override deprecated "root" argument

--- a/src/SessionManager/ProgramSettings.h
+++ b/src/SessionManager/ProgramSettings.h
@@ -35,6 +35,7 @@ struct ProgramSettings {
     int wait_time = -1;
     int init_wait_time = -1;
     int idle_session_wait_time = -1;
+    bool read_only_mode = false;
 
     ProgramSettings() = default;
     ProgramSettings(int argc, char** argv);

--- a/src/SimpleFrontendServer/SimpleFrontendServer.cc
+++ b/src/SimpleFrontendServer/SimpleFrontendServer.cc
@@ -22,8 +22,8 @@ namespace carta {
 
 const string success_string = json({{"success", true}}).dump();
 
-SimpleFrontendServer::SimpleFrontendServer(fs::path root_folder, string auth_token)
-    : _http_root_folder(root_folder), _auth_token(auth_token) {
+SimpleFrontendServer::SimpleFrontendServer(fs::path root_folder, string auth_token, bool read_only_mode)
+    : _http_root_folder(root_folder), _auth_token(auth_token), _read_only_mode(read_only_mode) {
     _frontend_found = IsValidFrontendFolder(root_folder);
 
     if (_frontend_found) {
@@ -156,6 +156,11 @@ json SimpleFrontendServer::GetExistingPreferences() {
 }
 
 bool SimpleFrontendServer::WritePreferencesFile(nlohmann::json& obj) {
+    if (_read_only_mode) {
+        spdlog::warn("Writing preferences file is not allowed in read-only mode");
+        return false;
+    }
+
     auto preferences_path = _config_folder / "preferences.json";
 
     try {
@@ -379,6 +384,11 @@ nlohmann::json SimpleFrontendServer::GetExistingLayouts() {
 }
 
 bool SimpleFrontendServer::WriteLayoutFile(const string& layout_name, nlohmann::json& obj) {
+    if (_read_only_mode) {
+        spdlog::warn("Writing layouts file is not allowed in read-only mode");
+        return false;
+    }
+
     auto layout_path = _config_folder / "layouts" / (layout_name + ".json");
 
     try {

--- a/src/SimpleFrontendServer/SimpleFrontendServer.cc
+++ b/src/SimpleFrontendServer/SimpleFrontendServer.cc
@@ -426,6 +426,11 @@ std::string_view SimpleFrontendServer::SetLayoutFromString(const string& buffer)
 }
 
 std::string_view SimpleFrontendServer::ClearLayoutFromString(const string& buffer) {
+    if (_read_only_mode) {
+        spdlog::warn("Writing layouts file is not allowed in read-only mode");
+        return HTTP_400;
+    }
+
     try {
         json post_data = json::parse(buffer);
         if (post_data["layoutName"].is_string()) {

--- a/src/SimpleFrontendServer/SimpleFrontendServer.h
+++ b/src/SimpleFrontendServer/SimpleFrontendServer.h
@@ -33,7 +33,7 @@ typedef uWS::HttpResponse<false> Res;
 
 class SimpleFrontendServer {
 public:
-    SimpleFrontendServer(fs::path root_folder, std::string auth_token);
+    SimpleFrontendServer(fs::path root_folder, std::string auth_token, bool read_only_mode);
     bool CanServeFrontend() {
         return _frontend_found;
     }
@@ -70,6 +70,7 @@ private:
     fs::path _config_folder;
     bool _frontend_found;
     std::string _auth_token;
+    bool _read_only_mode;
 };
 
 } // namespace carta

--- a/test/TestProgramSettings.cc
+++ b/test/TestProgramSettings.cc
@@ -57,6 +57,7 @@ TEST_F(ProgramSettingsTest, DefaultConstructor) {
     EXPECT_FALSE(settings.no_log);
     EXPECT_FALSE(settings.no_browser);
     EXPECT_FALSE(settings.debug_no_auth);
+    EXPECT_FALSE(settings.read_only_mode);
 
     EXPECT_TRUE(settings.frontend_folder.empty());
     EXPECT_TRUE(settings.files.empty());
@@ -84,7 +85,7 @@ TEST_F(ProgramSettingsTest, EmptyArugments) {
 TEST_F(ProgramSettingsTest, ExpectedValuesLong) {
     auto settings = SettingsFromString(
         "carta_backend --verbosity 6 --no_log --no_http --no_browser --host helloworld --port 1234 --grpc_port 5678 --omp_threads 10"
-        " --top_level_folder /tmp --frontend_folder /var --exit_timeout 10 --initial_timeout 11 --debug_no_auth");
+        " --top_level_folder /tmp --frontend_folder /var --exit_timeout 10 --initial_timeout 11 --debug_no_auth --read_only_mode");
     EXPECT_EQ(settings.verbosity, 6);
     EXPECT_EQ(settings.no_log, true);
     EXPECT_EQ(settings.no_http, true);
@@ -98,6 +99,7 @@ TEST_F(ProgramSettingsTest, ExpectedValuesLong) {
     EXPECT_EQ(settings.wait_time, 10);
     EXPECT_EQ(settings.init_wait_time, 11);
     EXPECT_EQ(settings.debug_no_auth, true);
+    EXPECT_EQ(settings.read_only_mode, true);
 }
 
 TEST_F(ProgramSettingsTest, ExpectedValuesShort) {

--- a/test/TestRestApi.cc
+++ b/test/TestRestApi.cc
@@ -30,7 +30,7 @@ using json = nlohmann::json;
 // Allows testing of protected methods in SimpleFrontendServer without polluting the original class
 class TestSimpleFrontendServer : public carta::SimpleFrontendServer {
 public:
-    TestSimpleFrontendServer(fs::path root_folder, std::string auth_token) : carta::SimpleFrontendServer(root_folder, auth_token) {}
+    TestSimpleFrontendServer(fs::path root_folder, std::string auth_token) : carta::SimpleFrontendServer(root_folder, auth_token, false) {}
     FRIEND_TEST(RestApiTest, UpdatePreferencesFromString);
     FRIEND_TEST(RestApiTest, EmptyStartingPrefs);
     FRIEND_TEST(RestApiTest, GetExistingPrefs);

--- a/test/TestRestApi.cc
+++ b/test/TestRestApi.cc
@@ -30,7 +30,8 @@ using json = nlohmann::json;
 // Allows testing of protected methods in SimpleFrontendServer without polluting the original class
 class TestSimpleFrontendServer : public carta::SimpleFrontendServer {
 public:
-    TestSimpleFrontendServer(fs::path root_folder, std::string auth_token, bool read_only_mode) : carta::SimpleFrontendServer(root_folder, auth_token, read_only_mode) {}
+    TestSimpleFrontendServer(fs::path root_folder, std::string auth_token, bool read_only_mode)
+        : carta::SimpleFrontendServer(root_folder, auth_token, read_only_mode) {}
     FRIEND_TEST(RestApiTest, UpdatePreferencesFromString);
     FRIEND_TEST(RestApiTest, EmptyStartingPrefs);
     FRIEND_TEST(RestApiTest, GetExistingPrefs);

--- a/test/TestRestApi.cc
+++ b/test/TestRestApi.cc
@@ -30,7 +30,7 @@ using json = nlohmann::json;
 // Allows testing of protected methods in SimpleFrontendServer without polluting the original class
 class TestSimpleFrontendServer : public carta::SimpleFrontendServer {
 public:
-    TestSimpleFrontendServer(fs::path root_folder, std::string auth_token) : carta::SimpleFrontendServer(root_folder, auth_token, false) {}
+    TestSimpleFrontendServer(fs::path root_folder, std::string auth_token, bool read_only_mode) : carta::SimpleFrontendServer(root_folder, auth_token, read_only_mode) {}
     FRIEND_TEST(RestApiTest, UpdatePreferencesFromString);
     FRIEND_TEST(RestApiTest, EmptyStartingPrefs);
     FRIEND_TEST(RestApiTest, GetExistingPrefs);
@@ -48,11 +48,14 @@ public:
     FRIEND_TEST(RestApiTest, DeleteLayoutIgnoresInvalidKeys);
     FRIEND_TEST(RestApiTest, DeleteLayoutMissingName);
     FRIEND_TEST(RestApiTest, SetLayout);
+    FRIEND_TEST(RestApiTest, SetPrefsReadOnly);
+    FRIEND_TEST(RestApiTest, SetLayoutReadOnly);
 };
 
 class RestApiTest : public ::testing::Test {
 public:
     std::unique_ptr<TestSimpleFrontendServer> _frontend_server;
+    std::unique_ptr<TestSimpleFrontendServer> _frontend_server_read_only_mode;
     fs::path preferences_path;
     fs::path layouts_path;
     json example_options;
@@ -87,7 +90,8 @@ public:
         })"_json;
     }
     void SetUp() {
-        _frontend_server.reset(new TestSimpleFrontendServer("/", "my_test_key"));
+        _frontend_server.reset(new TestSimpleFrontendServer("/", "my_test_key", false));
+        _frontend_server_read_only_mode.reset(new TestSimpleFrontendServer("/", "my_test_key", true));
         fs::remove(preferences_path);
         fs::remove_all(layouts_path);
     }
@@ -248,4 +252,30 @@ TEST_F(RestApiTest, SetLayout) {
     auto existing_layouts = _frontend_server->GetExistingLayouts();
     EXPECT_EQ(existing_layouts["created_layout"], example_layout);
     EXPECT_TRUE(existing_layouts["test_layout2"].is_null());
+}
+
+TEST_F(RestApiTest, SetPrefsReadOnly) {
+    json keys = {{"keys"}, example_options};
+    auto status = _frontend_server_read_only_mode->UpdatePreferencesFromString(keys.dump());
+    EXPECT_EQ(status, HTTP_500);
+
+    WriteDefaultPrefs();
+    keys = {{"keys", {"beamType"}}};
+    status = _frontend_server_read_only_mode->ClearPreferencesFromString(keys.dump());
+    EXPECT_EQ(status, HTTP_500);
+
+    keys = {{"keys", {"beamType", "beamColor"}}};
+    status = _frontend_server_read_only_mode->ClearPreferencesFromString(keys.dump());
+    EXPECT_EQ(status, HTTP_500);
+}
+
+TEST_F(RestApiTest, SetLayoutReadOnly) {
+    json body = {{"layoutName", "created_layout"}, {"layout", example_layout}};
+    auto status = _frontend_server_read_only_mode->SetLayoutFromString(body.dump());
+    EXPECT_EQ(status, HTTP_400);
+
+    WriteDefaultLayouts();
+    body = {{"layoutName", "test_layout"}};
+    status = _frontend_server_read_only_mode->ClearLayoutFromString(body.dump());
+    EXPECT_EQ(status, HTTP_400);
 }


### PR DESCRIPTION
This PR is for issue https://github.com/CARTAvis/carta-backend/issues/798. Changes:
* Renamed `ServerFeatureFlags::REGION_WRITE_ACCESS` to `READ_ONLY`.
* Added a `--read_only_mode` flag to enable read-only mode. Blocked writing access, including saving files (images, generated moment maps, ...), exporting regions, and writing preferences/layouts files.