### PR TITLE
Program Settings: make test values consistent with realistic values

### DIFF
--- a/test/TestProgramSettings.cc
+++ b/test/TestProgramSettings.cc
@@ -267,7 +267,7 @@ TEST_F(ProgramSettingsTest, ValidateJSONFromFileWithGoodFields) {
     carta::ProgramSettings settings;
     auto j = settings.JSONSettingsFromFile(input);
     EXPECT_EQ(j.size(), 13);
-    EXPECT_EQ(j["verbosity"], 6);
+    EXPECT_EQ(j["verbosity"], 5);
     EXPECT_EQ(j["port"], 1234);
     EXPECT_EQ(j["grpc_port"], 5678);
     EXPECT_EQ(j["omp_threads"], 10);
@@ -295,7 +295,7 @@ TEST_F(ProgramSettingsTest, TestValuesFromGoodSettings) {
     carta::ProgramSettings settings;
     auto j = settings.JSONSettingsFromFile(input);
     settings.SetSettingsFromJSON(j);
-    EXPECT_EQ(settings.verbosity, 6);
+    EXPECT_EQ(settings.verbosity, 5);
     EXPECT_EQ(settings.no_log, true);
     EXPECT_EQ(settings.no_http, true);
     EXPECT_EQ(settings.no_browser, true);

--- a/test/data/settings-good-fields.json
+++ b/test/data/settings-good-fields.json
@@ -1,5 +1,5 @@
 {
-    "verbosity": 6,
+    "verbosity": 5,
     "no_log": true,
     "no_http": true,
     "no_browser": true,


### PR DESCRIPTION
Just a minor change to make the testing values actually compatible with reasonable values used in the code. This is one good reason to use a schema-validator.