### PR TITLE
Program Settings: Custom browser command as command-line option (#806)

### DIFF
--- a/src/Main.cc
+++ b/src/Main.cc
@@ -700,14 +700,23 @@ int main(int argc, char* argv[]) {
                     frontend_url += query_url;
                 }
                 if (!settings.no_browser) {
+                    if (settings.browser.size() > 0) {
+                        auto cmd = settings.ParseBrowserCommand(frontend_url);
+                        spdlog::info("open with {}", cmd);
+                        auto cmd_result = system(cmd.c_str());
+                        if (cmd_result) {
+                            spdlog::warn("Failed to open the browser. Check the custom input at --browser.");
+                        }
+                    } else {
 #if defined(__APPLE__)
-                    string open_command = "open";
+                        string open_command = "open";
 #else
-                    string open_command = "xdg-open";
+                        string open_command = "xdg-open";
 #endif
-                    auto open_result = system(fmt::format("{} \"{}\"", open_command, frontend_url).c_str());
-                    if (open_result) {
-                        spdlog::warn("Failed to open the default browser automatically.");
+                        auto open_result = system(fmt::format("{} \"{}\"", open_command, frontend_url).c_str());
+                        if (open_result) {
+                            spdlog::warn("Failed to open the default browser automatically.");
+                        }
                     }
                 }
                 spdlog::info("CARTA is accessible at {}", frontend_url);

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -701,8 +701,7 @@ int main(int argc, char* argv[]) {
                 }
                 if (!settings.no_browser) {
                     if (settings.browser.size() > 0) {
-                        auto cmd = settings.ParseBrowserCommand(frontend_url);
-                        spdlog::info("open with {}", cmd);
+                        auto cmd = settings.GenerateBrowserCommand(frontend_url);
                         auto cmd_result = system(cmd.c_str());
                         if (cmd_result) {
                             spdlog::warn("Failed to open the browser. Check the custom input at --browser.");

--- a/src/SessionManager/ProgramSettings.cc
+++ b/src/SessionManager/ProgramSettings.cc
@@ -137,7 +137,7 @@ void ProgramSettings::ApplyCommandLineSettings(int argc, char** argv) {
         ("log_protocol_messages", "enable protocol message debug logs", cxxopts::value<bool>())
         ("no_http", "disable frontend HTTP server", cxxopts::value<bool>())
         ("no_browser", "don't open the frontend URL in a browser on startup", cxxopts::value<bool>())
-        ("browser", "user custom browser + args", cxxopts::value<string>(), "<browser>")
+        ("browser", "custom browser command", cxxopts::value<string>(), "<browser>")
         ("host", "only listen on the specified interface (IP address or hostname)", cxxopts::value<string>(), "<interface>")
         ("p,port", fmt::format("manually set the HTTP and WebSocket port (default: {} or nearest available port)", DEFAULT_SOCKET_PORT), cxxopts::value<int>(), "<port>")
         ("g,grpc_port", "set gRPC service port", cxxopts::value<int>(), "<port>")
@@ -198,6 +198,11 @@ written to a separate log file, '{}/log/performance.log'.
 Options are provided to shut the backend down automatically if it is idle (if no 
 clients are connected), and to kill frontend sessions that are idle (no longer 
 sending messages to the backend).
+
+Disabling the browser takes precedence over a custom browser command. The custom 
+browser command may contain the placeholder CARTA_URL, which will be replaced by 
+the frontend URL. If the placeholder is omitted, the URL will be appended to the 
+end.
 )",
         CARTA_DEFAULT_FRONTEND_FOLDER, DEFAULT_SOCKET_PORT, CARTA_USER_FOLDER_PREFIX, log_levels, CARTA_USER_FOLDER_PREFIX);
 

--- a/src/SessionManager/ProgramSettings.cc
+++ b/src/SessionManager/ProgramSettings.cc
@@ -137,6 +137,7 @@ void ProgramSettings::ApplyCommandLineSettings(int argc, char** argv) {
         ("log_protocol_messages", "enable protocol message debug logs", cxxopts::value<bool>())
         ("no_http", "disable frontend HTTP server", cxxopts::value<bool>())
         ("no_browser", "don't open the frontend URL in a browser on startup", cxxopts::value<bool>())
+        ("browser", "user custom browser + args", cxxopts::value<string>(), "<browser>")
         ("host", "only listen on the specified interface (IP address or hostname)", cxxopts::value<string>(), "<interface>")
         ("p,port", fmt::format("manually set the HTTP and WebSocket port (default: {} or nearest available port)", DEFAULT_SOCKET_PORT), cxxopts::value<int>(), "<port>")
         ("g,grpc_port", "set gRPC service port", cxxopts::value<int>(), "<port>")
@@ -237,6 +238,8 @@ sending messages to the backend).
     applyOptionalArgument(init_wait_time, "initial_timeout", result);
 
     applyOptionalArgument(idle_session_wait_time, "idle_timeout", result);
+
+    applyOptionalArgument(browser, "browser", result);
 
     // base will be overridden by the positional argument if it exists and is a folder
     applyOptionalArgument(starting_folder, "base", result);

--- a/src/SessionManager/ProgramSettings.h
+++ b/src/SessionManager/ProgramSettings.h
@@ -102,8 +102,8 @@ struct ProgramSettings {
         debug_msgs.clear();
     }
 
-    std::string ParseBrowserCommand(const std::string& url) {
-        const std::string wildcard = "%url";
+    std::string GenerateBrowserCommand(const std::string& url) {
+        const std::string wildcard = "CARTA_URL";
         auto wildcard_pos = browser.find(wildcard);
         std::string cmd;
         if (wildcard_pos != std::string::npos) {

--- a/src/SessionManager/ProgramSettings.h
+++ b/src/SessionManager/ProgramSettings.h
@@ -42,6 +42,8 @@ struct ProgramSettings {
     int idle_session_wait_time = -1;
     bool read_only_mode = false;
 
+    std::string browser;
+
     bool no_user_config = false;
     bool no_system_config = false;
 
@@ -72,7 +74,8 @@ struct ProgramSettings {
     std::unordered_map<std::string, std::string*> strings_keys_map{
         {"host", &host},
         {"top_level_folder", &top_level_folder},
-        {"frontend_folder", &frontend_folder}
+        {"frontend_folder", &frontend_folder},
+        {"browser", &browser}
     };
     // clang-format on
 
@@ -97,6 +100,19 @@ struct ProgramSettings {
         std::for_each(debug_msgs.begin(), debug_msgs.end(), [](const std::string& msg) { spdlog::debug(msg); });
         warning_msgs.clear();
         debug_msgs.clear();
+    }
+
+    std::string ParseBrowserCommand(const std::string& url) {
+        const std::string wildcard = "%url";
+        auto wildcard_pos = browser.find(wildcard);
+        std::string cmd;
+        if (wildcard_pos != std::string::npos) {
+            cmd = fmt::format(
+                "{0}{2}{1}", browser.substr(0, wildcard_pos), browser.substr(wildcard_pos + wildcard.size(), browser.size()), url);
+        } else {
+            cmd = fmt::format("{} {}", browser, url);
+        }
+        return cmd;
     }
 };
 } // namespace carta


### PR DESCRIPTION
Adds a command-line option to specify a browser and arguments for the browser. Follows #806.

The usage is simple:
```
./carta_backend --browser <browser>
```
where `<browser>` contains the entire system call to open the front end URL. The user can use the placeholder `%url` to add a custom position for the URL, for example, before or after browser arguments. If the `%url` wildcard is not given, the URL default position is at the end. For instance, a general case looks like this:
```
./carta_backend --browser "firefox -CreateProfile CARTAuser %url"
```
The `browser` option can also be passed using system and user JSON configuration files. As with the other command-line settings, just add:
```
{
    "browser" : "open -a firefox"
}
```
Note that for macOS, Google Chrome needs to be spelled `Google\ Chrome`, which means `Google\\ Chrome` in the JSON file; otherwise, the parsing will fail.

**Working/tested**: The following are examples tested and working on macOS:
```
./carta_backend --verbosity 4 --frontend_folder ~/temp/CARTAvis/carta-frontend/build \
 --root ~/temp/CARTAvis/data --base ~/temp/CARTAvis/data --omp_threads 4 \
 --browser "open -a safari"
```
```
./carta_backend --verbosity 4 --frontend_folder ~/temp/CARTAvis/carta-frontend/build \
 --root ~/temp/CARTAvis/data --base ~/temp/CARTAvis/data --omp_threads 4 \
 --browser "open -a firefox"
```
```
./carta_backend --verbosity 4 --frontend_folder ~/temp/CARTAvis/carta-frontend/build \
 --root ~/temp/CARTAvis/data --base ~/temp/CARTAvis/data --omp_threads 4 \
 --browser "open -a Google\ Chrome"
```
**TO DO:**
- [ ] Test functionality on linux.
- [ ] Need a test?

**Open question:**
- [ ] The issued command is the full responsibility of the user. Do we want some minimal checking?