### PR TITLE
Fix the problem of catching stokes information form the header

### DIFF
--- a/src/FileList/FileExtInfoLoader.cc
+++ b/src/FileList/FileExtInfoLoader.cc
@@ -156,7 +156,8 @@ bool FileExtInfoLoader::FillFileInfoFromImage(CARTA::FileInfoExtended& extended_
 
                     // Get the stokes coordinate number
                     casacore::String key_world = fkw->asString();
-                    if (casacore::String(key_world).find("STOKES") != casacore::String::npos) {
+                    std::transform(key_world.begin(), key_world.end(), key_world.begin(), [](unsigned char c) { return std::tolower(c); });
+                    if (casacore::String(key_world).find("stokes") != casacore::String::npos) {
                         stokes_coord_type_num = name.back();
                     }
 

--- a/src/FileList/FileExtInfoLoader.cc
+++ b/src/FileList/FileExtInfoLoader.cc
@@ -155,9 +155,9 @@ bool FileExtInfoLoader::FillFileInfoFromImage(CARTA::FileInfoExtended& extended_
                     }
 
                     // Get the stokes coordinate number
-                    casacore::String key_world = fkw->asString();
-                    std::transform(key_world.begin(), key_world.end(), key_world.begin(), [](unsigned char c) { return std::tolower(c); });
-                    if (casacore::String(key_world).find("stokes") != casacore::String::npos) {
+                    casacore::String keyword = fkw->asString();
+                    std::transform(keyword.begin(), keyword.end(), keyword.begin(), [](unsigned char c) { return std::tolower(c); });
+                    if (casacore::String(keyword).find("stokes") != casacore::String::npos) {
                         stokes_coord_type_num = name.back();
                     }
 


### PR DESCRIPTION
Some image files, like `mini_stokes_cube_noise.fits`, have a `Stokes` keyword from the header that its letters are not all capital.  Therefore the backend can not catch stokes information so that spectral profile of a given Stokes cannot be generated. This PR is to solve such a problem.