### PR TITLE
attempt to match required token to cookie, bearer auth header, custom header or query parameter

### DIFF
--- a/src/Main.cc
+++ b/src/Main.cc
@@ -80,21 +80,10 @@ void OnUpgrade(uWS::HttpResponse<false>* http_response, uWS::HttpRequest* http_r
         address = IPAsText(http_response->getRemoteAddress());
     }
 
-    // Check if there's a token to be matched
-    if (!auth_token.empty()) {
-        string req_token = GetAuthToken(http_request);
-
-        if (!req_token.empty()) {
-            if (req_token != auth_token) {
-                spdlog::error("Incorrect auth token supplied! Closing WebSocket connection");
-                http_response->close();
-                return;
-            }
-        } else {
-            spdlog::error("No auth token supplied! Closing WebSocket connection");
-            http_response->close();
-            return;
-        }
+    if (!ValidateAuthToken(http_request, auth_token)) {
+        spdlog::error("Incorrect or missing auth token supplied! Closing WebSocket connection");
+        http_response->close();
+        return;
     }
 
     session_number++;

--- a/src/SimpleFrontendServer/SimpleFrontendServer.cc
+++ b/src/SimpleFrontendServer/SimpleFrontendServer.cc
@@ -126,12 +126,7 @@ bool SimpleFrontendServer::IsValidFrontendFolder(fs::path folder) {
 }
 
 bool SimpleFrontendServer::IsAuthenticated(uWS::HttpRequest* req) {
-    // Always allow if the auth token is empty
-    if (_auth_token.empty()) {
-        return true;
-    }
-
-    return _auth_token == GetAuthToken(req);
+    return ValidateAuthToken(req, _auth_token);
 }
 
 void SimpleFrontendServer::AddNoCacheHeaders(Res* res) {

--- a/src/Util.h
+++ b/src/Util.h
@@ -74,7 +74,7 @@ void FillStatisticsValuesFromMap(
 
 std::string IPAsText(std::string_view binary);
 
-std::string GetAuthToken(uWS::HttpRequest* http_request);
+bool ValidateAuthToken(uWS::HttpRequest* http_request, const std::string& required_token);
 
 // ************ Region Helpers *************
 


### PR DESCRIPTION
Closes #815 by allowing token matching to any of the following:
- The `carta-auth-token` cookie
-The standard `Authorization` header
-The `token` URL query parameter
-The non-standard `carta-auth-token` header

Previously, the first non-empty option of those above was used for token matching. Now auth succeeds if _any_ of the above match the required token.