### PR TITLE
ProgramSettings: add starting port setting

### DIFF
--- a/src/Main.cc
+++ b/src/Main.cc
@@ -643,7 +643,7 @@ int main(int argc, char* argv[]) {
             auto port_end = settings.port[1] == -1 ? std::numeric_limits<unsigned short>::max() : settings.port[1];
             int num_listen_retries(0);
             while (!port_ok) {
-                if (num_listen_retries > MAX_SOCKET_PORT_TRIALS || port > port_end) {
+                if ((port_end == -1 && num_listen_retries > MAX_SOCKET_PORT_TRIALS) || port > port_end) {
                     spdlog::error("Unable to listen on the port range {}-{}!", settings.port[0], port - 1);
                     break;
                 }

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -4,6 +4,7 @@
    SPDX-License-Identifier: GPL-3.0-or-later
 */
 
+#include <limits> // for numeric limits
 #include <thread>
 #include <tuple>
 #include <vector>
@@ -636,39 +637,40 @@ int main(int argc, char* argv[]) {
         }
 
         bool port_ok(false);
-
-        if (settings.port < 0) {
-            settings.port = settings.starting_port > 0 ? settings.starting_port : DEFAULT_SOCKET_PORT;
+        int port(-1);
+        if (settings.port.size() > 1) { // a port range was given
+            port = settings.port[0];
+            auto port_end = settings.port[1] == -1 ? std::numeric_limits<unsigned short>::max() : settings.port[1];
             int num_listen_retries(0);
             while (!port_ok) {
-                if (num_listen_retries > MAX_SOCKET_PORT_TRIALS) {
-                    spdlog::error("Unable to listen on the port range {}-{}!",
-                        settings.starting_port > 0 ? settings.starting_port : DEFAULT_SOCKET_PORT, settings.port - 1);
+                if (num_listen_retries > MAX_SOCKET_PORT_TRIALS || port > port_end) {
+                    spdlog::error("Unable to listen on the port range {}-{}!", settings.port[0], port - 1);
                     break;
                 }
-                app.listen(settings.host, settings.port, LIBUS_LISTEN_EXCLUSIVE_PORT, [&](auto* token) {
+                app.listen(settings.host, port, LIBUS_LISTEN_EXCLUSIVE_PORT, [&](auto* token) {
                     if (token) {
                         port_ok = true;
                     } else {
-                        spdlog::warn("Port {} is already in use. Trying next port.", settings.port);
-                        ++settings.port;
+                        spdlog::warn("Port {} is already in use. Trying next port.", port);
+                        ++port;
                         ++num_listen_retries;
                     }
                 });
             }
         } else {
+            port = settings.port.size() == 1 ? settings.port[0] : DEFAULT_SOCKET_PORT;
             // If the user specifies a valid port, we should not try other ports
-            app.listen(settings.host, settings.port, LIBUS_LISTEN_EXCLUSIVE_PORT, [&](auto* token) {
+            app.listen(settings.host, port, LIBUS_LISTEN_EXCLUSIVE_PORT, [&](auto* token) {
                 if (token) {
                     port_ok = true;
                 } else {
-                    spdlog::error("Could not listen on port {}!\n", settings.port);
+                    spdlog::error("Could not listen on port {}!\n", port);
                 }
             });
         }
 
         if (port_ok) {
-            string start_info = fmt::format("Listening on port {} with top level folder {}, starting folder {}", settings.port,
+            string start_info = fmt::format("Listening on port {} with top level folder {}, starting folder {}", port,
                 settings.top_level_folder, settings.starting_folder);
             if (settings.omp_thread_count > 0) {
                 start_info += fmt::format(", and {} OpenMP worker threads", settings.omp_thread_count);
@@ -686,7 +688,7 @@ int main(int argc, char* argv[]) {
                         default_host_string = "localhost";
                     }
                 }
-                string frontend_url = fmt::format("http://{}:{}", default_host_string, settings.port);
+                string frontend_url = fmt::format("http://{}:{}", default_host_string, port);
                 string query_url;
                 if (!auth_token.empty()) {
                     query_url += fmt::format("/?token={}", auth_token);

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -638,11 +638,12 @@ int main(int argc, char* argv[]) {
         bool port_ok(false);
 
         if (settings.port < 0) {
-            settings.port = DEFAULT_SOCKET_PORT;
+            settings.port = settings.starting_port > 0 ? settings.starting_port : DEFAULT_SOCKET_PORT;
             int num_listen_retries(0);
             while (!port_ok) {
                 if (num_listen_retries > MAX_SOCKET_PORT_TRIALS) {
-                    spdlog::error("Unable to listen on the port range {}-{}!", DEFAULT_SOCKET_PORT, settings.port - 1);
+                    spdlog::error("Unable to listen on the port range {}-{}!",
+                        settings.starting_port > 0 ? settings.starting_port : DEFAULT_SOCKET_PORT, settings.port - 1);
                     break;
                 }
                 app.listen(settings.host, settings.port, LIBUS_LISTEN_EXCLUSIVE_PORT, [&](auto* token) {

--- a/src/SessionManager/ProgramSettings.cc
+++ b/src/SessionManager/ProgramSettings.cc
@@ -98,15 +98,14 @@ json ProgramSettings::JSONSettingsFromFile(const std::string& json_file_path) {
         }
     }
 
+    auto msg_and_remove = [&](const std::string& key) {
+        auto msg =
+            fmt::format("Problem in config file {} at key {}: current value is {}, but a number or a list of two numbers is expected.",
+                json_file_path, key, j[key].dump());
+        warning_msgs.push_back(msg);
+        j.erase(key);
+    };
     for (const auto& [key, elem] : vector_int_keys_map) {
-        auto msg_and_remove = [&](const std::string& key) {
-            auto msg =
-                fmt::format("Problem in config file {} at key {}: current value is {}, but a number or a list of two numbers is expected.",
-                    json_file_path, key, j[key].dump());
-            warning_msgs.push_back(msg);
-            j.erase(key);
-        };
-
         if (j.contains(key)) {
             if (j[key].size() == 1 && j[key].is_number()) {
                 continue;
@@ -123,6 +122,7 @@ json ProgramSettings::JSONSettingsFromFile(const std::string& json_file_path) {
                     }
                 } else {
                     // looks like things went well
+                    continue;
                 }
             } else {
                 msg_and_remove(key);

--- a/src/SessionManager/ProgramSettings.cc
+++ b/src/SessionManager/ProgramSettings.cc
@@ -140,6 +140,7 @@ void ProgramSettings::ApplyCommandLineSettings(int argc, char** argv) {
         ("browser", "custom browser command", cxxopts::value<string>(), "<browser>")
         ("host", "only listen on the specified interface (IP address or hostname)", cxxopts::value<string>(), "<interface>")
         ("p,port", fmt::format("manually set the HTTP and WebSocket port (default: {} or nearest available port)", DEFAULT_SOCKET_PORT), cxxopts::value<int>(), "<port>")
+        ("starting_port", "Set the startign port to listen at", cxxopts::value<int>(), "<starting port>")
         ("g,grpc_port", "set gRPC service port", cxxopts::value<int>(), "<port>")
         ("t,omp_threads", "manually set OpenMP thread pool count", cxxopts::value<int>(), "<threads>")
         ("top_level_folder", "set top-level folder for data files", cxxopts::value<string>(), "<dir>")
@@ -236,6 +237,7 @@ end.
     applyOptionalArgument(frontend_folder, "frontend_folder", result);
     applyOptionalArgument(host, "host", result);
     applyOptionalArgument(port, "port", result);
+    applyOptionalArgument(starting_port, "starting_port", result);
     applyOptionalArgument(grpc_port, "grpc_port", result);
 
     applyOptionalArgument(omp_thread_count, "omp_threads", result);

--- a/src/SessionManager/ProgramSettings.h
+++ b/src/SessionManager/ProgramSettings.h
@@ -23,6 +23,7 @@ struct ProgramSettings {
     bool version = false;
     bool help = false;
     int port = -1;
+    int starting_port = -1;
     int grpc_port = -1;
     int omp_thread_count = OMP_THREAD_COUNT;
     std::string top_level_folder = "/";
@@ -55,6 +56,7 @@ struct ProgramSettings {
     std::unordered_map<std::string, int*> int_keys_map{
         {"verbosity", &verbosity},
         {"port", &port},
+        {"starting_port", &starting_port},
         {"grpc_port", &grpc_port},
         {"omp_threads", &omp_thread_count},
         {"exit_timeout", &wait_time},

--- a/src/SessionManager/ProgramSettings.h
+++ b/src/SessionManager/ProgramSettings.h
@@ -22,8 +22,7 @@ namespace carta {
 struct ProgramSettings {
     bool version = false;
     bool help = false;
-    int port = -1;
-    int starting_port = -1;
+    std::vector<int> port;
     int grpc_port = -1;
     int omp_thread_count = OMP_THREAD_COUNT;
     std::string top_level_folder = "/";
@@ -55,8 +54,6 @@ struct ProgramSettings {
     // clang-format off
     std::unordered_map<std::string, int*> int_keys_map{
         {"verbosity", &verbosity},
-        {"port", &port},
-        {"starting_port", &starting_port},
         {"grpc_port", &grpc_port},
         {"omp_threads", &omp_thread_count},
         {"exit_timeout", &wait_time},
@@ -78,6 +75,10 @@ struct ProgramSettings {
         {"top_level_folder", &top_level_folder},
         {"frontend_folder", &frontend_folder},
         {"browser", &browser}
+    };
+
+    std::unordered_map<std::string, std::vector<int>*> vector_int_keys_map {
+        {"port", &port}
     };
     // clang-format on
 

--- a/test/TestProgramSettings.cc
+++ b/test/TestProgramSettings.cc
@@ -69,7 +69,7 @@ TEST_F(ProgramSettingsTest, DefaultConstructor) {
     EXPECT_TRUE(settings.frontend_folder.empty());
     EXPECT_TRUE(settings.files.empty());
 
-    EXPECT_EQ(settings.port, -1);
+    EXPECT_EQ(settings.port.size(), 0);
     EXPECT_EQ(settings.grpc_port, -1);
     EXPECT_EQ(settings.omp_thread_count, -1);
     EXPECT_EQ(settings.top_level_folder, "/");
@@ -98,7 +98,7 @@ TEST_F(ProgramSettingsTest, ExpectedValuesLong) {
     EXPECT_EQ(settings.no_http, true);
     EXPECT_EQ(settings.no_browser, true);
     EXPECT_EQ(settings.host, "helloworld");
-    EXPECT_EQ(settings.port, 1234);
+    EXPECT_EQ(settings.port[0], 1234);
     EXPECT_EQ(settings.grpc_port, 5678);
     EXPECT_EQ(settings.omp_thread_count, 10);
     EXPECT_EQ(settings.top_level_folder, "/tmp");
@@ -111,7 +111,7 @@ TEST_F(ProgramSettingsTest, ExpectedValuesLong) {
 
 TEST_F(ProgramSettingsTest, ExpectedValuesShort) {
     auto settings = SettingsFromString("carta_backend -p 1234 -g 5678 -t 10");
-    EXPECT_EQ(settings.port, 1234);
+    EXPECT_EQ(settings.port[0], 1234);
     EXPECT_EQ(settings.grpc_port, 5678);
     EXPECT_EQ(settings.omp_thread_count, 10);
 }
@@ -233,7 +233,7 @@ TEST_F(ProgramSettingsTest, ExpectedValuesLongJSON) {
         "no_http": true,
         "no_browser": true,
         "host": "helloworld",
-        "port": 1234,
+        "port": [1234],
         "grpc_port": 5678,
         "omp_threads": 10,
         "top_level_folder": "/tmp",
@@ -252,7 +252,7 @@ TEST_F(ProgramSettingsTest, ExpectedValuesLongJSON) {
     EXPECT_EQ(settings.no_http, true);
     EXPECT_EQ(settings.no_browser, true);
     EXPECT_EQ(settings.host, "helloworld");
-    EXPECT_EQ(settings.port, 1234);
+    EXPECT_EQ(settings.port[0], 1234);
     EXPECT_EQ(settings.grpc_port, 5678);
     EXPECT_EQ(settings.omp_thread_count, 10);
     EXPECT_EQ(settings.top_level_folder, "/tmp");
@@ -268,7 +268,7 @@ TEST_F(ProgramSettingsTest, ValidateJSONFromFileWithGoodFields) {
     auto j = settings.JSONSettingsFromFile(input);
     EXPECT_EQ(j.size(), 13);
     EXPECT_EQ(j["verbosity"], 5);
-    EXPECT_EQ(j["port"], 1234);
+    EXPECT_EQ(j["port"][0], 1234);
     EXPECT_EQ(j["grpc_port"], 5678);
     EXPECT_EQ(j["omp_threads"], 10);
     EXPECT_EQ(j["exit_timeout"], 10);
@@ -300,7 +300,7 @@ TEST_F(ProgramSettingsTest, TestValuesFromGoodSettings) {
     EXPECT_EQ(settings.no_http, true);
     EXPECT_EQ(settings.no_browser, true);
     EXPECT_EQ(settings.host, "helloworld");
-    EXPECT_EQ(settings.port, 1234);
+    EXPECT_EQ(settings.port[0], 1234);
     EXPECT_EQ(settings.grpc_port, 5678);
     EXPECT_EQ(settings.omp_thread_count, 10);
     EXPECT_EQ(settings.top_level_folder, "/tmp");
@@ -320,7 +320,7 @@ TEST_F(ProgramSettingsTest, TestDefaultsFallbackFromBadSettings) {
     EXPECT_EQ(settings.no_http, false);
     EXPECT_EQ(settings.no_browser, false);
     EXPECT_EQ(settings.host, "0.0.0.0");
-    EXPECT_EQ(settings.port, -1);
+    EXPECT_EQ(settings.port.size(), 0);
     EXPECT_EQ(settings.grpc_port, -1);
     EXPECT_EQ(settings.omp_thread_count, -1);
     EXPECT_EQ(settings.top_level_folder, "/");

--- a/test/data/settings-good-fields.json
+++ b/test/data/settings-good-fields.json
@@ -4,7 +4,7 @@
     "no_http": true,
     "no_browser": true,
     "host": "helloworld",
-    "port": 1234,
+    "port": [1234],
     "grpc_port": 5678,
     "omp_threads": 10,
     "top_level_folder": "/tmp",


### PR DESCRIPTION
Follow up of #817. 

Adds the possibility of reading a starting port from any kind of settings with the flag `--starting_port`. Now, the backend can start with a user-defined port, with the `--port` setting without moving forward if not available, or starts searching for the next available port starting with `--starting_port`.

For example:
```
./carta_backend --port 5001 # run carta on port 5001, and exit if not available
./carta_backend --starting_port 5001 # run carta on port 5001, and move to the next one if not available, \
                                       and exit after MAX_SOCKET_PORT_TRIALS trials
```

- [x] Add starting port flag to the settings pool.
- [x] Add port search functionality.
- [x] Sync testing to check for the additional parameter.