### PR TITLE
PV ellipse stats release 2.0

### DIFF
--- a/src/Region/Region.cc
+++ b/src/Region/Region.cc
@@ -880,7 +880,7 @@ casacore::TableRecord Region::GetControlPointsRecord(const casacore::IPosition& 
         }
         case CARTA::RegionType::RECTANGLE: {
             // Rectangle is LCPolygon with 4 corners; calculate from center and width/height
-            casacore::Vector<casacore::Float> x(4), y(4);
+            casacore::Vector<casacore::Float> x(5), y(5);
             float center_x = _region_state.control_points[0].x();
             float center_y = _region_state.control_points[0].y();
             float width = _region_state.control_points[1].x();
@@ -899,6 +899,9 @@ casacore::TableRecord Region::GetControlPointsRecord(const casacore::IPosition& 
             // Top left
             x(3) = x_min;
             y(3) = y_max;
+            // LCPolygon::toRecord includes last point as first point to close region
+            x(4) = x(0);
+            y(4) = y(0);
 
             record.define("name", "LCPolygon");
             record.define("x", x);
@@ -912,7 +915,7 @@ casacore::TableRecord Region::GetControlPointsRecord(const casacore::IPosition& 
                 x(i) = _region_state.control_points[i].x();
                 y(i) = _region_state.control_points[i].y();
             }
-            // LCPolygon::toRecord includes first point as last point to close region
+            // LCPolygon::toRecord includes last point as first point to close region
             x(npoints) = _region_state.control_points[0].x();
             y(npoints) = _region_state.control_points[0].y();
 

--- a/src/Region/Region.cc
+++ b/src/Region/Region.cc
@@ -321,6 +321,11 @@ bool Region::EllipsePointsToWorld(
     casacore::Quantity bmin_world = _coord_sys->toWorldLength(bmin, 1);
     ellipse_rotation = _region_state.rotation;
 
+    // Check if bmaj/bmin units conform (false for pV image: arcsec and Hz)
+    if (!bmaj_world.isConform(bmin_world.getUnit())) {
+        return false;
+    }
+
     // bmaj > bmin (world coords) required for WCEllipsoid; adjust rotation angle
     if (bmaj_world > bmin_world) {
         // carta rotation is from y-axis, ellipse rotation is from x-axis
@@ -783,22 +788,31 @@ casacore::LCRegion* Region::GetConvertedLCRegion(
     int file_id, const casacore::CoordinateSystem& output_csys, const casacore::IPosition& output_shape) {
     // Convert 2D reference WCRegion to LCRegion in output coord_sys and shape
     casacore::LCRegion* lc_region(nullptr);
+    bool is_reference_image(file_id == _region_state.reference_file_id);
 
-    if ((file_id != _region_state.reference_file_id) && IsRotbox()) {
+    if (!is_reference_image && IsRotbox()) {
         // Cannot convert rotbox region, it is a polygon type.
         return lc_region;
     }
 
-    // Convert reference WCRegion to LCRegion using given csys and shape
     try {
-        if (!_reference_region_set) {
-            SetReferenceRegion();
-        }
+        if (is_reference_image) {
+            // Create LCRegion with control points for reference image
+            casacore::TableRecord region_record = GetControlPointsRecord(output_shape);
+            lc_region = casacore::LCRegion::fromRecord(region_record, "");
+        } else {
+            // Convert reference WCRegion to LCRegion in image with output csys and shape
+            // Create reference WCRegion if needed
+            if (!_reference_region_set) {
+                SetReferenceRegion();
+            }
 
-        std::lock_guard<std::mutex> guard(_region_mutex);
-        if (ReferenceRegionValid()) {
-            std::shared_ptr<const casacore::WCRegion> reference_region = std::atomic_load(&_reference_region);
-            lc_region = reference_region->toLCRegion(output_csys, output_shape);
+            // Convert to LCRegion in output csys and shape
+            std::lock_guard<std::mutex> guard(_region_mutex);
+            if (ReferenceRegionValid()) {
+                std::shared_ptr<const casacore::WCRegion> reference_region = std::atomic_load(&_reference_region);
+                lc_region = reference_region->toLCRegion(output_csys, output_shape);
+            }
         }
     } catch (const casacore::AipsError& err) {
         spdlog::error("Error converting {} to file {}: {}", RegionName(_region_state.type), file_id, err.getMesg());
@@ -820,7 +834,7 @@ casacore::TableRecord Region::GetRegionPointsRecord(
     // Convert control points to output coord sys if needed, and return completed record.
     casacore::TableRecord record;
     if (file_id == _region_state.reference_file_id) {
-        record = GetControlPointsRecord(output_shape.size());
+        record = GetControlPointsRecord(output_shape);
     } else {
         switch (_region_state.type) {
             case CARTA::RegionType::POINT:
@@ -839,40 +853,27 @@ casacore::TableRecord Region::GetRegionPointsRecord(
             default:
                 break;
         }
-    }
 
-    if (!record.empty()) {
-        // Complete Record with common fields
-        record.define("isRegion", 1);
-        record.define("comment", "");
-        record.define("oneRel", false);
-        casacore::Vector<casacore::Int> region_shape;
-        if (_region_state.type == CARTA::RegionType::POINT) {
-            region_shape = output_shape.asVector(); // LCBox uses entire image shape
-        } else {
-            region_shape.resize(2);
-            region_shape(0) = output_shape(0);
-            region_shape(1) = output_shape(1);
-        }
-        record.define("shape", region_shape);
+        // Add common record fields
+        CompleteLCRegionRecord(record, output_shape);
     }
 
     return record;
 }
 
-casacore::TableRecord Region::GetControlPointsRecord(int ndim) {
+casacore::TableRecord Region::GetControlPointsRecord(const casacore::IPosition& shape) {
     // Return region Record in pixel coords in format of LCRegion::toRecord(); no conversion (for reference image)
     casacore::TableRecord record;
 
     switch (_region_state.type) {
         case CARTA::RegionType::POINT: {
+            auto ndim = shape.size();
             casacore::Vector<casacore::Float> blc(ndim, 0.0), trc(ndim, 0.0);
             blc(0) = _region_state.control_points[0].x();
             blc(1) = _region_state.control_points[0].y();
             trc(0) = _region_state.control_points[0].x();
             trc(1) = _region_state.control_points[0].y();
 
-            record.define("name", "LCBox");
             record.define("blc", blc);
             record.define("trc", trc);
             break;
@@ -941,7 +942,27 @@ casacore::TableRecord Region::GetControlPointsRecord(int ndim) {
             break;
     }
 
+    CompleteLCRegionRecord(record, shape);
     return record;
+}
+
+void Region::CompleteLCRegionRecord(casacore::TableRecord& record, const casacore::IPosition& shape) {
+    // Add common Record fields for record defining region
+    if (!record.empty()) {
+        record.define("isRegion", casacore::RegionType::LC);
+        record.define("comment", "");
+        record.define("oneRel", false);
+
+        casacore::Vector<casacore::Int> region_shape;
+        if (_region_state.type == CARTA::RegionType::POINT) {
+            region_shape = shape.asVector(); // LCBox uses entire image shape
+        } else {
+            region_shape.resize(2);
+            region_shape(0) = shape(0);
+            region_shape(1) = shape(1);
+        }
+        record.define("shape", region_shape);
+    }
 }
 
 casacore::TableRecord Region::GetPointRecord(const casacore::CoordinateSystem& output_csys, const casacore::IPosition& output_shape) {
@@ -951,7 +972,6 @@ casacore::TableRecord Region::GetPointRecord(const casacore::CoordinateSystem& o
         // wcs control points is single point (x, y)
         casacore::Vector<casacore::Double> pixel_point;
         if (ConvertWorldToPixel(_wcs_control_points, output_csys, pixel_point)) {
-            // Complete record
             casacore::Vector<casacore::Float> blc(output_shape.size(), 0.0), trc(output_shape.asVector());
             blc(0) = pixel_point(0);
             blc(1) = pixel_point(1);

--- a/src/Region/Region.h
+++ b/src/Region/Region.h
@@ -155,7 +155,8 @@ private:
     // Control points converted to pixel coords in output image, returned in LCRegion Record format for export
     casacore::TableRecord GetRegionPointsRecord(
         int file_id, const casacore::CoordinateSystem& output_csys, const casacore::IPosition& output_shape);
-    casacore::TableRecord GetControlPointsRecord(int ndim);
+    casacore::TableRecord GetControlPointsRecord(const casacore::IPosition& shape);
+    void CompleteLCRegionRecord(casacore::TableRecord& record, const casacore::IPosition& shape);
     casacore::TableRecord GetPointRecord(const casacore::CoordinateSystem& output_csys, const casacore::IPosition& output_shape);
     casacore::TableRecord GetPolygonRecord(const casacore::CoordinateSystem& output_csys);
     casacore::TableRecord GetRotboxRecord(const casacore::CoordinateSystem& output_csys);

--- a/src/Region/RegionHandler.cc
+++ b/src/Region/RegionHandler.cc
@@ -673,13 +673,13 @@ bool RegionHandler::ApplyRegionToFile(int region_id, int file_id, const AxisRang
 
     try {
         casacore::LCRegion* applied_region = ApplyRegionToFile(region_id, file_id);
-        casacore::IPosition image_shape(_frames.at(file_id)->ImageShape());
         if (applied_region == nullptr) {
             return false;
         }
 
         // Create LCBox with z range and stokes using a slicer
         casacore::Slicer z_stokes_slicer = _frames.at(file_id)->GetImageSlicer(z_range, stokes);
+        casacore::IPosition image_shape(_frames.at(file_id)->ImageShape());
         casacore::LCBox z_stokes_box(z_stokes_slicer, image_shape);
 
         // Set returned region


### PR DESCRIPTION
When an LCRegion is needed for stats/histograms/profiles, a WCRegion is created then converted to an LCRegion in a given image's coordinate system and shape.  However, WCEllipsoid fails for PV images with the error that the xcenter and ycenter do not have the same base unit (arcsec and Hz).  Instead, the LCEllipsoid for the reference image is created from its control points.

WCRegion is used to convert the region to an LCRegion in another image.  Since the WCEllipsoid cannot be created for PV images, this region type cannot be converted to a non-reference image and will fail.  If this is needed, the conversion would have to be done manually.  