### PR TITLE
Add basic tests for spatial profiles

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,6 +42,7 @@ set(TEST_SOURCES
         TestMain.cc
         TestMoment.cc
         TestProgramSettings.cc
+        TestSpatialProfiles.cc
         TestTileEncoding.cc
         TestTimer.cc
         TestUtil.cc

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,6 +24,14 @@ enable_testing()
 find_package(GTest)
 include_directories(${GTEST_INCLUDE_DIRS} ${CMAKE_SOURCE_DIR})
 
+find_package(HDF5 REQUIRED COMPONENTS CXX)
+if (HDF5_FOUND)
+    include_directories(${HDF5_INCLUDE_DIR})
+    set(LINK_LIBS ${LINK_LIBS} ${HDF5_LIBRARIES})
+else ()
+    message(FATAL_ERROR "Could not find HDF5.")
+endif ()
+
 ExternalProject_Add(fits2idia
   SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../third-party/fits2idia
   INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}

--- a/test/CommonTestUtilities.cc
+++ b/test/CommonTestUtilities.cc
@@ -78,8 +78,6 @@ std::string FileFinder::XmlTablePath(const std::string& filename) {
     return (TestRoot() / "data" / "tables" / "xml" / filename).string();
 }
 
-FitsDataReader::FitsDataReader() {}
-
 FitsDataReader::FitsDataReader(const std::string& imgpath) {
     int status(0);
 
@@ -131,7 +129,7 @@ FitsDataReader::~FitsDataReader() {
     }
 }
 
-std::vector<float> FitsDataReader::ReadSubset(std::vector<long> start, std::vector<long> end) {
+std::vector<float> FitsDataReader::ReadRegion(std::vector<long> start, std::vector<long> end) {
     int status(0);
     std::vector<float> result;
 
@@ -143,8 +141,9 @@ std::vector<float> FitsDataReader::ReadSubset(std::vector<long> start, std::vect
     for (int d = 0; d < _N; d++) {
         // Truncate or extend the first and last pixel array to the image dimensions
         // ...and convert from 0-indexing to 1-indexing
+        // ...and convert end vector from exclusive to inclusive
         fpixel[d] = d < start.size() ? start[d] + 1 : 1;
-        lpixel[d] = d < end.size() ? end[d] + 1 : 1;
+        lpixel[d] = d < end.size() ? end[d] : 1;
         // Set the increment to 1
         inc[d] = 1;
 
@@ -164,16 +163,40 @@ std::vector<float> FitsDataReader::ReadSubset(std::vector<long> start, std::vect
 }
 
 float FitsDataReader::ReadPointXY(long x, long y, long channel, int stokes) {
-    return ReadSubset({x, y, channel, stokes}, {x, y, channel, stokes})[0];
+    return ReadRegion({x, y, channel, stokes}, {x + 1, y + 1, channel + 1, stokes + 1})[0];
 }
 
 std::vector<float> FitsDataReader::ReadProfileX(long y, long channel, int stokes) {
-    return ReadSubset({0, y, channel, stokes}, {_width - 1, y, channel, stokes});
+    return ReadRegion({0, y, channel, stokes}, {_width, y + 1, channel + 1, stokes + 1});
 }
 
 std::vector<float> FitsDataReader::ReadProfileY(long x, long channel, int stokes) {
-    return ReadSubset({x, 0, channel, stokes}, {x, _height - 1, channel, stokes});
+    return ReadRegion({x, 0, channel, stokes}, {x + 1, _height, channel + 1, stokes + 1});
 }
+
+// Hdf5DataReader(const std::string& imgpath) {
+//     // TODO TODO TODO
+// }
+// 
+// ~Hdf5DataReader() {
+//     // TODO TODO TODO
+// }
+// 
+// std::vector<float> ReadRegion(std::vector<long> start, std::vector<long> end) {
+//     // TODO TODO TODO
+// }
+// 
+// float ReadPointXY(long x, long y, long channel = 0, int stokes = 0) {
+//     // TODO TODO TODO
+// }
+// 
+// std::vector<float> ReadProfileX(long y, long channel = 0, int stokes = 0) {
+//     // TODO TODO TODO
+// }
+// 
+// std::vector<float> ReadProfileY(long x, long channel = 0, int stokes = 0) {
+//     // TODO TODO TODO
+// }
 
 CartaEnvironment::~CartaEnvironment() {}
 

--- a/test/CommonTestUtilities.cc
+++ b/test/CommonTestUtilities.cc
@@ -119,7 +119,7 @@ FitsDataReader::FitsDataReader(const std::string& imgpath) {
     if (_N < 2 || _N > 4) {
         throw std::runtime_error("Currently only supports 2D, 3D and 4D cubes");
     }
-    
+
     std::vector<long> dims(_N);
 
     fits_get_img_size(_imgfile, _N, dims.data(), &status);
@@ -127,7 +127,7 @@ FitsDataReader::FitsDataReader(const std::string& imgpath) {
     if (status != 0) {
         throw std::runtime_error(fmt::format("Could not read image size. Error status: {}", status));
     }
-    
+
     for (auto& d : dims) {
         _dims.push_back(d);
     }
@@ -182,7 +182,7 @@ Hdf5DataReader::Hdf5DataReader(const std::string& imgpath) {
     _imgfile = H5::H5File(imgpath, H5F_ACC_RDONLY);
     auto group = _imgfile.openGroup("0");
     _dataset = group.openDataSet("DATA");
-    
+
     auto data_space = _dataset.getSpace();
     _N = data_space.getSimpleExtentNdims();
     _dims.resize(_N);
@@ -194,8 +194,7 @@ Hdf5DataReader::Hdf5DataReader(const std::string& imgpath) {
     _width = _dims[0];
 }
 
-Hdf5DataReader::~Hdf5DataReader() {
-}
+Hdf5DataReader::~Hdf5DataReader() {}
 
 std::vector<float> Hdf5DataReader::ReadRegion(std::vector<hsize_t> start, std::vector<hsize_t> end) {
     std::vector<float> result;
@@ -209,14 +208,14 @@ std::vector<float> Hdf5DataReader::ReadRegion(std::vector<hsize_t> start, std::v
         h5_count.insert(h5_count.begin(), d < start.size() ? end[d] - start[d] : 1);
         result_size *= end[d] - start[d];
     }
-    
+
     result.resize(result_size);
     H5::DataSpace mem_space(1, &result_size);
-    
+
     auto file_space = _dataset.getSpace();
     file_space.selectHyperslab(H5S_SELECT_SET, h5_count.data(), h5_start.data());
     _dataset.read(result.data(), H5::PredType::NATIVE_FLOAT, mem_space, file_space);
-    
+
     return result;
 }
 

--- a/test/CommonTestUtilities.cc
+++ b/test/CommonTestUtilities.cc
@@ -194,8 +194,6 @@ Hdf5DataReader::Hdf5DataReader(const std::string& imgpath) {
     _width = _dims[0];
 }
 
-Hdf5DataReader::~Hdf5DataReader() {}
-
 std::vector<float> Hdf5DataReader::ReadRegion(std::vector<hsize_t> start, std::vector<hsize_t> end) {
     std::vector<float> result;
     std::vector<hsize_t> h5_start;

--- a/test/CommonTestUtilities.cc
+++ b/test/CommonTestUtilities.cc
@@ -169,7 +169,7 @@ std::vector<float> FitsDataReader::ReadRegion(std::vector<hsize_t> start, std::v
 
     result.resize(result_size);
 
-    fits_read_subset(_imgfile, TFLOAT, fpixel, lpixel, inc, NULL, result.data(), NULL, &status);
+    fits_read_subset(_imgfile, TFLOAT, fpixel, lpixel, inc, nullptr, result.data(), nullptr, &status);
 
     if (status != 0) {
         throw std::runtime_error(fmt::format("Could not read image data. Error status: {}", status));
@@ -186,7 +186,7 @@ Hdf5DataReader::Hdf5DataReader(const std::string& imgpath) {
     auto data_space = _dataset.getSpace();
     _N = data_space.getSimpleExtentNdims();
     _dims.resize(_N);
-    data_space.getSimpleExtentDims(_dims.data(), NULL);
+    data_space.getSimpleExtentDims(_dims.data(), nullptr);
 
     _stokes = _N == 4 ? _dims[3] : 1;
     _depth = _N >= 3 ? _dims[2] : 1;

--- a/test/CommonTestUtilities.h
+++ b/test/CommonTestUtilities.h
@@ -9,8 +9,8 @@
 
 #include <unordered_set>
 
-#include <fitsio.h>
 #include <H5Cpp.h>
+#include <fitsio.h>
 #include <gtest/gtest.h>
 #include <spdlog/fmt/fmt.h>
 
@@ -50,6 +50,7 @@ public:
     float ReadPointXY(hsize_t x, hsize_t y, hsize_t channel = 0, hsize_t stokes = 0);
     std::vector<float> ReadProfileX(hsize_t y, hsize_t channel = 0, hsize_t stokes = 0);
     std::vector<float> ReadProfileY(hsize_t x, hsize_t channel = 0, hsize_t stokes = 0);
+
 protected:
     int _N;
     std::vector<hsize_t> _dims;
@@ -61,6 +62,7 @@ public:
     FitsDataReader(const std::string& imgpath);
     ~FitsDataReader();
     std::vector<float> ReadRegion(std::vector<hsize_t> start, std::vector<hsize_t> end) override;
+
 private:
     fitsfile* _imgfile;
 };
@@ -70,6 +72,7 @@ public:
     Hdf5DataReader(const std::string& imgpath);
     ~Hdf5DataReader();
     std::vector<float> ReadRegion(std::vector<hsize_t> start, std::vector<hsize_t> end) override;
+
 private:
     H5::H5File _imgfile;
     H5::DataSet _dataset;

--- a/test/CommonTestUtilities.h
+++ b/test/CommonTestUtilities.h
@@ -45,10 +45,9 @@ public:
 
 class FitsDataReader {
 public:
-    FitsDataReader();
     FitsDataReader(const std::string& imgpath);
     ~FitsDataReader();
-    std::vector<float> ReadSubset(std::vector<long> start, std::vector<long> end);
+    std::vector<float> ReadRegion(std::vector<long> start, std::vector<long> end);
     float ReadPointXY(long x, long y, long channel = 0, int stokes = 0);
     std::vector<float> ReadProfileX(long y, long channel = 0, int stokes = 0);
     std::vector<float> ReadProfileY(long x, long channel = 0, int stokes = 0);
@@ -58,6 +57,21 @@ private:
     int _N;
     long _stokes, _depth, _height, _width;
 };
+
+// class Hdf5DataReader {
+// public:
+//     Hdf5DataReader(const std::string& imgpath);
+//     ~Hdf5DataReader();
+//     std::vector<float> ReadRegion(std::vector<long> start, std::vector<long> end);
+//     float ReadPointXY(long x, long y, long channel = 0, int stokes = 0);
+//     std::vector<float> ReadProfileX(long y, long channel = 0, int stokes = 0);
+//     std::vector<float> ReadProfileY(long x, long channel = 0, int stokes = 0);
+// 
+// private:
+//     H5::H5File _imgfile;
+//     int _N;
+//     long _stokes, _depth, _height, _width;
+// };
 
 class CartaEnvironment : public ::testing::Environment {
 public:

--- a/test/CommonTestUtilities.h
+++ b/test/CommonTestUtilities.h
@@ -9,6 +9,7 @@
 
 #include <unordered_set>
 
+#include <fitsio.h>
 #include <gtest/gtest.h>
 #include <spdlog/fmt/fmt.h>
 
@@ -40,6 +41,22 @@ public:
     static std::string Hdf5ImagePath(const std::string& filename);
     static std::string FitsTablePath(const std::string& filename);
     static std::string XmlTablePath(const std::string& filename);
+};
+
+class FitsDataReader {
+public:
+    FitsDataReader();
+    FitsDataReader(const std::string& imgpath);
+    ~FitsDataReader();
+    std::vector<float> ReadSubset(std::vector<long> start, std::vector<long> end);
+    float ReadPointXY(long x, long y, long channel = 0, int stokes = 0);
+    std::vector<float> ReadProfileX(long y, long channel = 0, int stokes = 0);
+    std::vector<float> ReadProfileY(long x, long channel = 0, int stokes = 0);
+
+private:
+    fitsfile* _imgfile;
+    int _N;
+    long _stokes, _depth, _height, _width;
 };
 
 class CartaEnvironment : public ::testing::Environment {

--- a/test/CommonTestUtilities.h
+++ b/test/CommonTestUtilities.h
@@ -70,7 +70,7 @@ private:
 class Hdf5DataReader : public DataReader {
 public:
     Hdf5DataReader(const std::string& imgpath);
-    ~Hdf5DataReader();
+    ~Hdf5DataReader() = default;
     std::vector<float> ReadRegion(std::vector<hsize_t> start, std::vector<hsize_t> end) override;
 
 private:

--- a/test/CommonTestUtilities.h
+++ b/test/CommonTestUtilities.h
@@ -10,6 +10,7 @@
 #include <unordered_set>
 
 #include <fitsio.h>
+#include <H5Cpp.h>
 #include <gtest/gtest.h>
 #include <spdlog/fmt/fmt.h>
 
@@ -43,35 +44,36 @@ public:
     static std::string XmlTablePath(const std::string& filename);
 };
 
-class FitsDataReader {
+class DataReader {
+public:
+    virtual std::vector<float> ReadRegion(std::vector<hsize_t> start, std::vector<hsize_t> end) = 0;
+    float ReadPointXY(hsize_t x, hsize_t y, hsize_t channel = 0, hsize_t stokes = 0);
+    std::vector<float> ReadProfileX(hsize_t y, hsize_t channel = 0, hsize_t stokes = 0);
+    std::vector<float> ReadProfileY(hsize_t x, hsize_t channel = 0, hsize_t stokes = 0);
+protected:
+    int _N;
+    std::vector<hsize_t> _dims;
+    hsize_t _stokes, _depth, _height, _width;
+};
+
+class FitsDataReader : public DataReader {
 public:
     FitsDataReader(const std::string& imgpath);
     ~FitsDataReader();
-    std::vector<float> ReadRegion(std::vector<long> start, std::vector<long> end);
-    float ReadPointXY(long x, long y, long channel = 0, int stokes = 0);
-    std::vector<float> ReadProfileX(long y, long channel = 0, int stokes = 0);
-    std::vector<float> ReadProfileY(long x, long channel = 0, int stokes = 0);
-
+    std::vector<float> ReadRegion(std::vector<hsize_t> start, std::vector<hsize_t> end) override;
 private:
     fitsfile* _imgfile;
-    int _N;
-    long _stokes, _depth, _height, _width;
 };
 
-// class Hdf5DataReader {
-// public:
-//     Hdf5DataReader(const std::string& imgpath);
-//     ~Hdf5DataReader();
-//     std::vector<float> ReadRegion(std::vector<long> start, std::vector<long> end);
-//     float ReadPointXY(long x, long y, long channel = 0, int stokes = 0);
-//     std::vector<float> ReadProfileX(long y, long channel = 0, int stokes = 0);
-//     std::vector<float> ReadProfileY(long x, long channel = 0, int stokes = 0);
-// 
-// private:
-//     H5::H5File _imgfile;
-//     int _N;
-//     long _stokes, _depth, _height, _width;
-// };
+class Hdf5DataReader : public DataReader {
+public:
+    Hdf5DataReader(const std::string& imgpath);
+    ~Hdf5DataReader();
+    std::vector<float> ReadRegion(std::vector<hsize_t> start, std::vector<hsize_t> end) override;
+private:
+    H5::H5File _imgfile;
+    H5::DataSet _dataset;
+};
 
 class CartaEnvironment : public ::testing::Environment {
 public:

--- a/test/TestSpatialProfiles.cc
+++ b/test/TestSpatialProfiles.cc
@@ -33,7 +33,7 @@ public:
         memcpy(values.data(), buffer.data(), buffer.size());
         return values;
     }
-    
+
     void SetUp() {
         setenv("HDF5_USE_FILE_LOCKING", "FALSE", 0);
     }

--- a/test/TestSpatialProfiles.cc
+++ b/test/TestSpatialProfiles.cc
@@ -5,6 +5,7 @@
 */
 
 #include <gtest/gtest.h>
+#include <gmock/gmock-matchers.h>
 
 #include "Frame.h"
 #include "ImageData/FileLoader.h"
@@ -12,6 +13,9 @@
 #include "CommonTestUtilities.h"
 
 using namespace carta;
+
+using ::testing::Pointwise;
+using ::testing::FloatNear;
 
 class SpatialProfileTest : public ::testing::Test, public ImageGenerator {
 public:
@@ -59,12 +63,12 @@ TEST_F(SpatialProfileTest, SubTileHdf5Image) {
     EXPECT_EQ(x_profile.end(), 10);
     auto x_vals = ProfileValues(x_profile);
     EXPECT_EQ(x_vals.size(), 10);
+    // TODO use a helper function to get these values dynamically?
+    EXPECT_THAT(x_vals, Pointwise(FloatNear(1e-5), {0.35738, -1.20832, -0.00445413, 0.656475, -1.28836, 0.395122, 0.429864, 0.696043, -1.18412, -0.661703}));
     
     EXPECT_EQ(y_profile.start(), 0);
     EXPECT_EQ(y_profile.end(), 10);
     auto y_vals = ProfileValues(y_profile);
     EXPECT_EQ(y_vals.size(), 10);
-    
-    // TODO content of profiles
-    // TODO helper function for directly accessing the data in an image?
+    EXPECT_THAT(y_vals, Pointwise(FloatNear(1e-5), {0.361595, -0.732267, 0.0940123, 0.355373, -0.313923, 0.395122, -0.258573, -1.32043, 0.630412, 1.03145}));
 }

--- a/test/TestSpatialProfiles.cc
+++ b/test/TestSpatialProfiles.cc
@@ -33,6 +33,10 @@ public:
         memcpy(values.data(), buffer.data(), buffer.size());
         return values;
     }
+    
+    void SetUp() {
+        setenv("HDF5_USE_FILE_LOCKING", "FALSE", 0);
+    }
 };
 
 TEST_F(SpatialProfileTest, SubTileFitsImage) {
@@ -73,7 +77,6 @@ TEST_F(SpatialProfileTest, SubTileFitsImage) {
 }
 
 TEST_F(SpatialProfileTest, SubTileHdf5Image) {
-    setenv("HDF5_USE_FILE_LOCKING", "FALSE", 0); // TODO put this in the test setup
     auto path_string = GeneratedHdf5ImagePath("10 10");
     std::unique_ptr<Frame> frame(new Frame(0, carta::FileLoader::GetLoader(path_string), "0"));
     Hdf5DataReader reader(path_string);

--- a/test/TestSpatialProfiles.cc
+++ b/test/TestSpatialProfiles.cc
@@ -1,0 +1,70 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020, 2021 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+#include <gtest/gtest.h>
+
+#include "Frame.h"
+#include "ImageData/FileLoader.h"
+
+#include "CommonTestUtilities.h"
+
+using namespace carta;
+
+class SpatialProfileTest : public ::testing::Test, public ImageGenerator {
+public:
+    static std::tuple<CARTA::SpatialProfile, CARTA::SpatialProfile> GetProfiles(CARTA::SpatialProfileData& data) {
+        if (data.profiles(0).coordinate() == "x") {
+            return {data.profiles(0), data.profiles(1)};
+        } else {
+            return {data.profiles(1), data.profiles(0)};
+        }
+    }
+    
+    static std::vector<float> ProfileValues(CARTA::SpatialProfile& profile) {
+        std::string buffer = profile.raw_values_fp32();
+        std::vector<float> values(buffer.size() / sizeof(float));
+        memcpy(values.data(), buffer.data(), buffer.size());
+        return values;
+    }
+};
+
+TEST_F(SpatialProfileTest, SubTileHdf5Image) {
+    auto path_string = GeneratedHdf5ImagePath("10 10");
+    std::unique_ptr<Frame> frame(new Frame(0, carta::FileLoader::GetLoader(path_string), "0"));
+    
+    // These will be replaced by objects in the mipmap branch
+    std::vector<std::string> profiles = {"x", "y"};
+    frame->SetSpatialRequirements(CURSOR_REGION_ID, profiles);
+    frame->SetCursor(5, 5);
+    
+    CARTA::SpatialProfileData data;
+    frame->FillSpatialProfileData(CURSOR_REGION_ID, data);
+    
+    EXPECT_EQ(data.file_id(), 0);
+    EXPECT_EQ(data.region_id(), CURSOR_REGION_ID);
+    EXPECT_EQ(data.x(), 5);
+    EXPECT_EQ(data.y(), 5);
+    EXPECT_EQ(data.channel(), 0);
+    EXPECT_EQ(data.stokes(), 0);
+    // TODO use a helper function to get this value dynamically?
+    EXPECT_FLOAT_EQ(data.value(), 0.395122);
+    EXPECT_EQ(data.profiles_size(), 2);
+    
+    auto [x_profile, y_profile] = GetProfiles(data);
+    
+    EXPECT_EQ(x_profile.start(), 0);
+    EXPECT_EQ(x_profile.end(), 10);
+    auto x_vals = ProfileValues(x_profile);
+    EXPECT_EQ(x_vals.size(), 10);
+    
+    EXPECT_EQ(y_profile.start(), 0);
+    EXPECT_EQ(y_profile.end(), 10);
+    auto y_vals = ProfileValues(y_profile);
+    EXPECT_EQ(y_vals.size(), 10);
+    
+    // TODO content of profiles
+    // TODO helper function for directly accessing the data in an image?
+}

--- a/test/TestSpatialProfiles.cc
+++ b/test/TestSpatialProfiles.cc
@@ -71,3 +71,40 @@ TEST_F(SpatialProfileTest, SubTileFitsImage) {
     EXPECT_EQ(y_vals.size(), 10);
     EXPECT_THAT(y_vals, Pointwise(FloatNear(1e-5), reader.ReadProfileY(5)));
 }
+
+// TEST_F(SpatialProfileTest, SubTileHdf5Image) {
+//     auto path_string = GeneratedHdf5ImagePath("10 10");
+//     std::unique_ptr<Frame> frame(new Frame(0, carta::FileLoader::GetLoader(path_string), "0"));
+//     Hdf5DataReader reader(path_string);
+// 
+//     // These will be replaced by objects in the mipmap branch
+//     std::vector<std::string> profiles = {"x", "y"};
+//     frame->SetSpatialRequirements(CURSOR_REGION_ID, profiles);
+//     frame->SetCursor(5, 5);
+// 
+//     CARTA::SpatialProfileData data;
+//     frame->FillSpatialProfileData(CURSOR_REGION_ID, data);
+// 
+//     EXPECT_EQ(data.file_id(), 0);
+//     EXPECT_EQ(data.region_id(), CURSOR_REGION_ID);
+//     EXPECT_EQ(data.x(), 5);
+//     EXPECT_EQ(data.y(), 5);
+//     EXPECT_EQ(data.channel(), 0);
+//     EXPECT_EQ(data.stokes(), 0);
+//     EXPECT_FLOAT_EQ(data.value(), reader.ReadPointXY(5, 5));
+//     EXPECT_EQ(data.profiles_size(), 2);
+// 
+//     auto [x_profile, y_profile] = GetProfiles(data);
+// 
+//     EXPECT_EQ(x_profile.start(), 0);
+//     EXPECT_EQ(x_profile.end(), 10);
+//     auto x_vals = ProfileValues(x_profile);
+//     EXPECT_EQ(x_vals.size(), 10);
+//     EXPECT_THAT(x_vals, Pointwise(FloatNear(1e-5), reader.ReadProfileX(5)));
+// 
+//     EXPECT_EQ(y_profile.start(), 0);
+//     EXPECT_EQ(y_profile.end(), 10);
+//     auto y_vals = ProfileValues(y_profile);
+//     EXPECT_EQ(y_vals.size(), 10);
+//     EXPECT_THAT(y_vals, Pointwise(FloatNear(1e-5), reader.ReadProfileY(5)));
+// }

--- a/test/TestSpatialProfiles.cc
+++ b/test/TestSpatialProfiles.cc
@@ -4,8 +4,8 @@
    SPDX-License-Identifier: GPL-3.0-or-later
 */
 
-#include <gtest/gtest.h>
 #include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
 
 #include "Frame.h"
 #include "ImageData/FileLoader.h"
@@ -14,8 +14,8 @@
 
 using namespace carta;
 
-using ::testing::Pointwise;
 using ::testing::FloatNear;
+using ::testing::Pointwise;
 
 class SpatialProfileTest : public ::testing::Test, public ImageGenerator {
 public:
@@ -26,7 +26,7 @@ public:
             return {data.profiles(1), data.profiles(0)};
         }
     }
-    
+
     static std::vector<float> ProfileValues(CARTA::SpatialProfile& profile) {
         std::string buffer = profile.raw_values_fp32();
         std::vector<float> values(buffer.size() / sizeof(float));
@@ -35,40 +35,39 @@ public:
     }
 };
 
-TEST_F(SpatialProfileTest, SubTileHdf5Image) {
-    auto path_string = GeneratedHdf5ImagePath("10 10");
+TEST_F(SpatialProfileTest, SubTileFitsImage) {
+    auto path_string = GeneratedFitsImagePath("10 10");
     std::unique_ptr<Frame> frame(new Frame(0, carta::FileLoader::GetLoader(path_string), "0"));
-    
+    FitsDataReader reader(path_string);
+
     // These will be replaced by objects in the mipmap branch
     std::vector<std::string> profiles = {"x", "y"};
     frame->SetSpatialRequirements(CURSOR_REGION_ID, profiles);
     frame->SetCursor(5, 5);
-    
+
     CARTA::SpatialProfileData data;
     frame->FillSpatialProfileData(CURSOR_REGION_ID, data);
-    
+
     EXPECT_EQ(data.file_id(), 0);
     EXPECT_EQ(data.region_id(), CURSOR_REGION_ID);
     EXPECT_EQ(data.x(), 5);
     EXPECT_EQ(data.y(), 5);
     EXPECT_EQ(data.channel(), 0);
     EXPECT_EQ(data.stokes(), 0);
-    // TODO use a helper function to get this value dynamically?
-    EXPECT_FLOAT_EQ(data.value(), 0.395122);
+    EXPECT_FLOAT_EQ(data.value(), reader.ReadPointXY(5, 5));
     EXPECT_EQ(data.profiles_size(), 2);
-    
+
     auto [x_profile, y_profile] = GetProfiles(data);
-    
+
     EXPECT_EQ(x_profile.start(), 0);
     EXPECT_EQ(x_profile.end(), 10);
     auto x_vals = ProfileValues(x_profile);
     EXPECT_EQ(x_vals.size(), 10);
-    // TODO use a helper function to get these values dynamically?
-    EXPECT_THAT(x_vals, Pointwise(FloatNear(1e-5), {0.35738, -1.20832, -0.00445413, 0.656475, -1.28836, 0.395122, 0.429864, 0.696043, -1.18412, -0.661703}));
-    
+    EXPECT_THAT(x_vals, Pointwise(FloatNear(1e-5), reader.ReadProfileX(5)));
+
     EXPECT_EQ(y_profile.start(), 0);
     EXPECT_EQ(y_profile.end(), 10);
     auto y_vals = ProfileValues(y_profile);
     EXPECT_EQ(y_vals.size(), 10);
-    EXPECT_THAT(y_vals, Pointwise(FloatNear(1e-5), {0.361595, -0.732267, 0.0940123, 0.355373, -0.313923, 0.395122, -0.258573, -1.32043, 0.630412, 1.03145}));
+    EXPECT_THAT(y_vals, Pointwise(FloatNear(1e-5), reader.ReadProfileY(5)));
 }

--- a/test/TestSpatialProfiles.cc
+++ b/test/TestSpatialProfiles.cc
@@ -72,39 +72,40 @@ TEST_F(SpatialProfileTest, SubTileFitsImage) {
     EXPECT_THAT(y_vals, Pointwise(FloatNear(1e-5), reader.ReadProfileY(5)));
 }
 
-// TEST_F(SpatialProfileTest, SubTileHdf5Image) {
-//     auto path_string = GeneratedHdf5ImagePath("10 10");
-//     std::unique_ptr<Frame> frame(new Frame(0, carta::FileLoader::GetLoader(path_string), "0"));
-//     Hdf5DataReader reader(path_string);
-// 
-//     // These will be replaced by objects in the mipmap branch
-//     std::vector<std::string> profiles = {"x", "y"};
-//     frame->SetSpatialRequirements(CURSOR_REGION_ID, profiles);
-//     frame->SetCursor(5, 5);
-// 
-//     CARTA::SpatialProfileData data;
-//     frame->FillSpatialProfileData(CURSOR_REGION_ID, data);
-// 
-//     EXPECT_EQ(data.file_id(), 0);
-//     EXPECT_EQ(data.region_id(), CURSOR_REGION_ID);
-//     EXPECT_EQ(data.x(), 5);
-//     EXPECT_EQ(data.y(), 5);
-//     EXPECT_EQ(data.channel(), 0);
-//     EXPECT_EQ(data.stokes(), 0);
-//     EXPECT_FLOAT_EQ(data.value(), reader.ReadPointXY(5, 5));
-//     EXPECT_EQ(data.profiles_size(), 2);
-// 
-//     auto [x_profile, y_profile] = GetProfiles(data);
-// 
-//     EXPECT_EQ(x_profile.start(), 0);
-//     EXPECT_EQ(x_profile.end(), 10);
-//     auto x_vals = ProfileValues(x_profile);
-//     EXPECT_EQ(x_vals.size(), 10);
-//     EXPECT_THAT(x_vals, Pointwise(FloatNear(1e-5), reader.ReadProfileX(5)));
-// 
-//     EXPECT_EQ(y_profile.start(), 0);
-//     EXPECT_EQ(y_profile.end(), 10);
-//     auto y_vals = ProfileValues(y_profile);
-//     EXPECT_EQ(y_vals.size(), 10);
-//     EXPECT_THAT(y_vals, Pointwise(FloatNear(1e-5), reader.ReadProfileY(5)));
-// }
+TEST_F(SpatialProfileTest, SubTileHdf5Image) {
+    setenv("HDF5_USE_FILE_LOCKING", "FALSE", 0); // TODO put this in the test setup
+    auto path_string = GeneratedHdf5ImagePath("10 10");
+    std::unique_ptr<Frame> frame(new Frame(0, carta::FileLoader::GetLoader(path_string), "0"));
+    Hdf5DataReader reader(path_string);
+
+    // These will be replaced by objects in the mipmap branch
+    std::vector<std::string> profiles = {"x", "y"};
+    frame->SetSpatialRequirements(CURSOR_REGION_ID, profiles);
+    frame->SetCursor(5, 5);
+
+    CARTA::SpatialProfileData data;
+    frame->FillSpatialProfileData(CURSOR_REGION_ID, data);
+
+    EXPECT_EQ(data.file_id(), 0);
+    EXPECT_EQ(data.region_id(), CURSOR_REGION_ID);
+    EXPECT_EQ(data.x(), 5);
+    EXPECT_EQ(data.y(), 5);
+    EXPECT_EQ(data.channel(), 0);
+    EXPECT_EQ(data.stokes(), 0);
+    EXPECT_FLOAT_EQ(data.value(), reader.ReadPointXY(5, 5));
+    EXPECT_EQ(data.profiles_size(), 2);
+
+    auto [x_profile, y_profile] = GetProfiles(data);
+
+    EXPECT_EQ(x_profile.start(), 0);
+    EXPECT_EQ(x_profile.end(), 10);
+    auto x_vals = ProfileValues(x_profile);
+    EXPECT_EQ(x_vals.size(), 10);
+    EXPECT_THAT(x_vals, Pointwise(FloatNear(1e-5), reader.ReadProfileX(5)));
+
+    EXPECT_EQ(y_profile.start(), 0);
+    EXPECT_EQ(y_profile.end(), 10);
+    auto y_vals = ProfileValues(y_profile);
+    EXPECT_EQ(y_vals.size(), 10);
+    EXPECT_THAT(y_vals, Pointwise(FloatNear(1e-5), reader.ReadProfileY(5)));
+}


### PR DESCRIPTION
The bulk of this PR is the implementation of test helper classes for reading data directly from a FITS or HDF5 file (to provide expected data for tests). For this test I implemented utility functions for reading a point or a spatial profile, but arbitrary regions can also be read and more utility functions can be added (e.g. for spectral profiles).

I have only implemented two basic tests (for a small FITS and HDF5 file) -- I intend to add many more tests in the mipmaps branch, which introduces mip and range to spatial profile requests, as well as decimation or downsampling of the returned data (with diverging behaviour for FITS and HDF5). Are there any other tests that I should add to this branch now?

@ajm-asiaa this code uses Google Mock, which is part of Google Test, but is provided in a separate binary package (`libgmock-dev`) on Ubuntu (and possibly on other platforms). We need to install the appropriate packages in our containers to get this to compile. I'm also linking to the C++ API for HDF5, but that must already be installed if the converter (added earlier) can compile.

(This implements #814.)