### PR TITLE
ProgramSettings: add missing setting keyword (#807 and #857)

### DIFF
--- a/src/SessionManager/ProgramSettings.cc
+++ b/src/SessionManager/ProgramSettings.cc
@@ -192,6 +192,7 @@ void ProgramSettings::ApplyCommandLineSettings(int argc, char** argv) {
         ("g,grpc_port", "set gRPC service port", cxxopts::value<int>(), "<port>")
         ("t,omp_threads", "manually set OpenMP thread pool count", cxxopts::value<int>(), "<threads>")
         ("top_level_folder", "set top-level folder for data files", cxxopts::value<string>(), "<dir>")
+        ("starting_folder", "set starting folder for data files", cxxopts::value<string>(), "<dir>")
         ("frontend_folder", "set folder from which frontend files are served", cxxopts::value<string>(), "<dir>")
         ("exit_timeout", "number of seconds to stay alive after last session exits", cxxopts::value<int>(), "<sec>")
         ("initial_timeout", "number of seconds to stay alive at start if no clients connect", cxxopts::value<int>(), "<sec>")
@@ -297,6 +298,7 @@ end.
 
     // base will be overridden by the positional argument if it exists and is a folder
     applyOptionalArgument(starting_folder, "base", result);
+    applyOptionalArgument(starting_folder, "starting_folder", result);
     vector<fs::path> file_paths;
 
     for (const auto& arg : positional_arguments) {

--- a/src/SessionManager/ProgramSettings.cc
+++ b/src/SessionManager/ProgramSettings.cc
@@ -192,7 +192,6 @@ void ProgramSettings::ApplyCommandLineSettings(int argc, char** argv) {
         ("g,grpc_port", "set gRPC service port", cxxopts::value<int>(), "<port>")
         ("t,omp_threads", "manually set OpenMP thread pool count", cxxopts::value<int>(), "<threads>")
         ("top_level_folder", "set top-level folder for data files", cxxopts::value<string>(), "<dir>")
-        ("starting_folder", "set starting folder for data files", cxxopts::value<string>(), "<dir>")
         ("frontend_folder", "set folder from which frontend files are served", cxxopts::value<string>(), "<dir>")
         ("exit_timeout", "number of seconds to stay alive after last session exits", cxxopts::value<int>(), "<sec>")
         ("initial_timeout", "number of seconds to stay alive at start if no clients connect", cxxopts::value<int>(), "<sec>")
@@ -298,7 +297,6 @@ end.
 
     // base will be overridden by the positional argument if it exists and is a folder
     applyOptionalArgument(starting_folder, "base", result);
-    applyOptionalArgument(starting_folder, "starting_folder", result);
     vector<fs::path> file_paths;
 
     for (const auto& arg : positional_arguments) {

--- a/src/SessionManager/ProgramSettings.h
+++ b/src/SessionManager/ProgramSettings.h
@@ -73,6 +73,7 @@ struct ProgramSettings {
     std::unordered_map<std::string, std::string*> strings_keys_map{
         {"host", &host},
         {"top_level_folder", &top_level_folder},
+        {"starting_folder", &starting_folder},
         {"frontend_folder", &frontend_folder},
         {"browser", &browser}
     };


### PR DESCRIPTION
Adds a configuration option for the starting folder and links the `starting_folder` setting with the deprecated option `base`, removing a small bug. Solves #857, and partly #807.