### PR TITLE
774 Add a mutex lock on setting image channels

### DIFF
--- a/src/Session.cc
+++ b/src/Session.cc
@@ -584,6 +584,7 @@ void Session::OnAddRequiredTiles(const CARTA::AddRequiredTiles& message, bool sk
 
 void Session::OnSetImageChannels(const CARTA::SetImageChannels& message) {
     auto file_id(message.file_id());
+    std::unique_lock<std::mutex> lock(_frame_mutex);
     if (_frames.count(file_id)) {
         auto frame = _frames.at(file_id);
         std::string err_message;


### PR DESCRIPTION
It is to fix #774. The backend crashes if we delete a Frame when its animation process is not finished yet. This could be solved by simply adding a mutex lock on setting image channels.