### PR TITLE
Angus/const time string compare

### DIFF
--- a/src/Util.h
+++ b/src/Util.h
@@ -76,6 +76,7 @@ void FillStatisticsValuesFromMap(
 std::string IPAsText(std::string_view binary);
 
 bool ValidateAuthToken(uWS::HttpRequest* http_request, const std::string& required_token);
+bool ConstantTimeStringCompare(const std::string& a, const std::string& b);
 
 // ************ Region Helpers *************
 

--- a/test/TestUtil.cc
+++ b/test/TestUtil.cc
@@ -86,5 +86,7 @@ TEST(UtilTest, StringCompare) {
     EXPECT_FALSE(ConstantTimeStringCompare("hello w1rld", "hello world"));
     EXPECT_FALSE(ConstantTimeStringCompare("hello w1rld", "hello w2rld"));
     EXPECT_FALSE(ConstantTimeStringCompare("hello w", "hello world"));
-    EXPECT_FALSE(ConstantTimeStringCompare("hello world", "hello w"));
+    EXPECT_TRUE(ConstantTimeStringCompare("", ""));
+    EXPECT_FALSE(ConstantTimeStringCompare("hello world", ""));
+    EXPECT_FALSE(ConstantTimeStringCompare("", "hello world"));
 }

--- a/test/TestUtil.cc
+++ b/test/TestUtil.cc
@@ -80,3 +80,11 @@ TEST(UtilTest, ItemCountMissingFolder) {
     auto pwd = TestRoot();
     EXPECT_EQ(GetNumItems((pwd / "data/missing_folder").string()), -1);
 }
+
+TEST(UtilTest, StringCompare) {
+    EXPECT_TRUE(ConstantTimeStringCompare("hello world", "hello world"));
+    EXPECT_FALSE(ConstantTimeStringCompare("hello w1rld", "hello world"));
+    EXPECT_FALSE(ConstantTimeStringCompare("hello w1rld", "hello w2rld"));
+    EXPECT_FALSE(ConstantTimeStringCompare("hello w", "hello world"));
+    EXPECT_FALSE(ConstantTimeStringCompare("hello world", "hello w"));
+}


### PR DESCRIPTION
Minor PR to mitigate the potential for a timing attack when running the backend in user-driven mode. We were using a simple string comparison operator, which is vulnerable to a timing attack because it early-exits on the first different character.

This PR adds a constant-time string comparison function, which should resolve this vulnerability. at least to a certain extent.