### PR TITLE
579 fix cached image

### DIFF
--- a/src/FileList/FileExtInfoLoader.cc
+++ b/src/FileList/FileExtInfoLoader.cc
@@ -137,7 +137,7 @@ bool FileExtInfoLoader::FillFileInfoFromImage(CARTA::FileInfoExtended& extended_
     if (_loader) {
         try {
             _loader->OpenFile(hdu);
-            casacore::ImageInterface<float>* image = _loader->GetImage();
+            auto image = _loader->GetImage();
 
             if (image) {
                 // Check dimensions
@@ -157,7 +157,7 @@ bool FileExtInfoLoader::FillFileInfoFromImage(CARTA::FileInfoExtended& extended_
 
                 int bitpix(0);
                 if (is_casacore_fits || is_carta_fits) {
-                    bitpix = GetFitsBitpix(image);
+                    bitpix = GetFitsBitpix(image.get());
                 }
 
                 // For computed entries:
@@ -167,7 +167,7 @@ bool FileExtInfoLoader::FillFileInfoFromImage(CARTA::FileInfoExtended& extended_
                 casacore::String stokes_ctype_num; // used to set stokes values in loader
 
                 if (is_carta_hdf5) {
-                    carta::CartaHdf5Image* hdf5_image = dynamic_cast<carta::CartaHdf5Image*>(image);
+                    carta::CartaHdf5Image* hdf5_image = dynamic_cast<carta::CartaHdf5Image*>(image.get());
                     casacore::Vector<casacore::String> headers = hdf5_image->FITSHeaderStrings();
 
                     for (auto& header : headers) {
@@ -324,7 +324,7 @@ bool FileExtInfoLoader::FillFileInfoFromImage(CARTA::FileInfoExtended& extended_
                         }
                     } else {
                         bool prefer_velocity, optical_velocity, prefer_wavelength, air_wavelength;
-                        GetSpectralCoordPreferences(image, prefer_velocity, optical_velocity, prefer_wavelength, air_wavelength);
+                        GetSpectralCoordPreferences(image.get(), prefer_velocity, optical_velocity, prefer_wavelength, air_wavelength);
 
                         // Get image headers in FITS format
                         casacore::String error_string, origin_string;
@@ -333,9 +333,9 @@ bool FileExtInfoLoader::FillFileInfoFromImage(CARTA::FileInfoExtended& extended_
                         int bit_pix(-32);
                         float min_pix(1.0), max_pix(-1.0);
 
-                        if (!casacore::ImageFITSConverter::ImageHeaderToFITS(error_string, fhi, *image, prefer_velocity, optical_velocity,
-                                bit_pix, min_pix, max_pix, degenerate_last, verbose, stokes_last, prefer_wavelength, air_wavelength,
-                                prim_head, allow_append, origin_string, history)) {
+                        if (!casacore::ImageFITSConverter::ImageHeaderToFITS(error_string, fhi, *(image.get()), prefer_velocity,
+                                optical_velocity, bit_pix, min_pix, max_pix, degenerate_last, verbose, stokes_last, prefer_wavelength,
+                                air_wavelength, prim_head, allow_append, origin_string, history)) {
                             message = error_string;
                             return info_ok;
                         }
@@ -349,7 +349,7 @@ bool FileExtInfoLoader::FillFileInfoFromImage(CARTA::FileInfoExtended& extended_
                     // Computed entries for rendered image axes (not always 0 and 1)
                     std::vector<int> render_axes = _loader->GetRenderAxes();
                     AddShapeEntries(extended_info, image_shape, spectral_axis, depth_axis, stokes_axis, render_axes);
-                    AddComputedEntries(extended_info, image, render_axes, radesys, use_image_for_entries);
+                    AddComputedEntries(extended_info, image.get(), render_axes, radesys, use_image_for_entries);
 
                     info_ok = true;
                 }

--- a/src/FileList/FileExtInfoLoader.cc
+++ b/src/FileList/FileExtInfoLoader.cc
@@ -359,7 +359,7 @@ bool FileExtInfoLoader::FillFileInfoFromImage(CARTA::FileInfoExtended& extended_
                 message = "Image could not be opened.";
             }
 
-            _loader->CloseImage();
+            _loader->CloseImageIfUpdated();
         } catch (casacore::AipsError& err) {
             message = err.getMesg();
             if (message.find("diagonal") != std::string::npos) { // "ArrayBase::diagonal() - diagonal out of range"

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -1559,10 +1559,12 @@ bool Frame::CalculateMoments(int file_id, MomentProgressCallback progress_callba
     const CARTA::MomentRequest& moment_request, CARTA::MomentResponse& moment_response,
     std::vector<carta::CollapseResult>& collapse_results) {
     std::shared_lock lock(GetActiveTaskMutex());
+    auto image = GetImage();
 
     if (!_moment_generator) {
-        _moment_generator = std::make_unique<MomentGenerator>(GetFileName(), GetImage());
+        _moment_generator = std::make_unique<MomentGenerator>(GetFileName(), image.get());
     }
+
     if (_moment_generator) {
         std::unique_lock<std::mutex> ulock(_image_mutex); // Must lock the image while doing moment calculations
         _moment_generator->CalculateMoments(
@@ -1614,9 +1616,9 @@ void Frame::SaveFile(const std::string& root_folder, const CARTA::SaveFile& save
     }
 
     // Modify image to export
-    auto image = GetImage();
-    auto image_shape = image->shape();
+    auto image_shape = ImageShape();
 
+    casacore::ImageInterface<float>* image;
     casacore::SubImage<float> sub_image;
     casacore::LCRegion* image_region;
     casacore::IPosition region_shape;

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -121,6 +121,8 @@ Frame::Frame(uint32_t session_id, carta::FileLoader* loader, const std::string& 
         _open_image_error = fmt::format("Problem loading statistics from file: {}", err.getMesg());
         spdlog::warn("Session {}: {}", session_id, _open_image_error);
     }
+
+    _loader->CloseImage();
 }
 
 bool Frame::IsValid() {
@@ -174,9 +176,12 @@ int Frame::StokesAxis() {
 bool Frame::GetBeams(std::vector<CARTA::Beam>& beams) {
     std::string error;
     bool beams_ok = _loader->GetBeams(beams, error);
+    _loader->CloseImage();
+
     if (!beams_ok) {
         spdlog::warn("Session {}: {}", _session_id, error);
     }
+
     return beams_ok;
 }
 
@@ -1508,6 +1513,7 @@ bool Frame::GetSlicerData(const casacore::Slicer& slicer, std::vector<float>& da
     casacore::Array<float> tmp(slicer.length(), data.data(), casacore::StorageInitPolicy::SHARE);
     std::unique_lock<std::mutex> ulock(_image_mutex);
     bool data_ok = _loader->GetSlice(tmp, slicer);
+    _loader->CloseImage();
     ulock.unlock();
     return data_ok;
 }
@@ -1518,11 +1524,14 @@ bool Frame::GetRegionStats(const casacore::LattRegionHolder& region, std::vector
     casacore::SubImage<float> sub_image;
     std::unique_lock<std::mutex> ulock(_image_mutex);
     bool subimage_ok = _loader->GetSubImage(region, sub_image);
+    _loader->CloseImage();
     ulock.unlock();
+
     if (subimage_ok) {
         std::lock_guard<std::mutex> guard(_image_mutex);
         return CalcStatsValues(stats_values, required_stats, sub_image, per_z);
     }
+
     return subimage_ok;
 }
 
@@ -1532,7 +1541,9 @@ bool Frame::GetSlicerStats(const casacore::Slicer& slicer, std::vector<CARTA::St
     casacore::SubImage<float> sub_image;
     std::unique_lock<std::mutex> ulock(_image_mutex);
     bool subimage_ok = _loader->GetSubImage(slicer, sub_image);
+    _loader->CloseImage();
     ulock.unlock();
+
     if (subimage_ok) {
         std::lock_guard<std::mutex> guard(_image_mutex);
         return CalcStatsValues(stats_values, required_stats, sub_image, per_z);
@@ -1559,11 +1570,13 @@ bool Frame::CalculateMoments(int file_id, MomentProgressCallback progress_callba
     const CARTA::MomentRequest& moment_request, CARTA::MomentResponse& moment_response,
     std::vector<carta::CollapseResult>& collapse_results) {
     std::shared_lock lock(GetActiveTaskMutex());
-    auto image = GetImage();
 
     if (!_moment_generator) {
+        auto image = _loader->GetImage();
         _moment_generator = std::make_unique<MomentGenerator>(GetFileName(), image.get());
     }
+
+    _loader->CloseImage();
 
     if (_moment_generator) {
         std::unique_lock<std::mutex> ulock(_image_mutex); // Must lock the image while doing moment calculations
@@ -1631,6 +1644,7 @@ void Frame::SaveFile(const std::string& root_folder, const CARTA::SaveFile& save
         if (region) {
             _loader->GetSubImage(LattRegionHolder(image_region), sub_image);
             image = sub_image.cloneII();
+            _loader->CloseImage();
         }
     } else if (image_shape.size() > 2 && image_shape.size() < 5) {
         try {
@@ -1784,8 +1798,7 @@ bool Frame::ExportFITSImage(casacore::ImageInterface<casacore::Float>& image, fs
 // Input save_file_msg as the parameters from the request, which gives input range
 // Return void
 void Frame::ValidateChannelStokes(std::vector<int>& channels, std::vector<int>& stokes, const CARTA::SaveFile& save_file_msg) {
-    auto image = GetImage();
-    auto image_shape = image->shape();
+    auto image_shape = ImageShape();
 
     // Default for channels
     int channels_max = _z_axis > -1 ? image_shape[_z_axis] : 1;

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -234,7 +234,7 @@ protected:
         return _loader->GetFileName();
     }
     // Get image interface ptr
-    casacore::ImageInterface<float>* GetImage() {
+    std::shared_ptr<casacore::ImageInterface<float>> GetImage() {
         return _loader->GetImage();
     }
     // Setup

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -187,6 +187,8 @@ public:
 
     std::shared_mutex& GetActiveTaskMutex();
 
+    void CloseCachedImage(const std::string& file);
+
 protected:
     // Validate z and stokes index values
     bool CheckZ(int z);

--- a/src/ImageData/CasaLoader.h
+++ b/src/ImageData/CasaLoader.h
@@ -30,8 +30,10 @@ void CasaLoader::OpenFile(const std::string& /*hdu*/) {
             throw(casacore::AipsError("Error opening image"));
         }
 
-        _num_dims = _image->shape().size();
+        _image_shape = _image->shape();
+        _num_dims = _image_shape.size();
         _has_pixel_mask = _image->hasPixelMask();
+        _coord_sys = _image->coordinates();
     }
 }
 

--- a/src/ImageData/CasaLoader.h
+++ b/src/ImageData/CasaLoader.h
@@ -18,12 +18,6 @@ public:
     CasaLoader(const std::string& filename);
 
     void OpenFile(const std::string& hdu) override;
-
-    bool HasData(FileInfo::Data ds) const override;
-    ImageRef GetImage() override;
-
-private:
-    std::unique_ptr<casacore::PagedImage<float>> _image;
 };
 
 CasaLoader::CasaLoader(const std::string& filename) : FileLoader(filename) {}
@@ -31,33 +25,14 @@ CasaLoader::CasaLoader(const std::string& filename) : FileLoader(filename) {}
 void CasaLoader::OpenFile(const std::string& /*hdu*/) {
     if (!_image) {
         _image.reset(new casacore::PagedImage<float>(_filename));
+
         if (!_image) {
             throw(casacore::AipsError("Error opening image"));
         }
+
         _num_dims = _image->shape().size();
+        _has_pixel_mask = _image->hasPixelMask();
     }
-}
-
-bool CasaLoader::HasData(FileInfo::Data dl) const {
-    switch (dl) {
-        case FileInfo::Data::Image:
-            return true;
-        case FileInfo::Data::XY:
-            return _num_dims >= 2;
-        case FileInfo::Data::XYZ:
-            return _num_dims >= 3;
-        case FileInfo::Data::XYZW:
-            return _num_dims >= 4;
-        case FileInfo::Data::MASK:
-            return ((_image != nullptr) && _image->hasPixelMask());
-        default:
-            break;
-    }
-    return false;
-}
-
-typename CasaLoader::ImageRef CasaLoader::GetImage() {
-    return _image.get(); // nullptr if image not opened
 }
 
 } // namespace carta

--- a/src/ImageData/CompListLoader.h
+++ b/src/ImageData/CompListLoader.h
@@ -27,11 +27,15 @@ CompListLoader::CompListLoader(const std::string& filename) : FileLoader(filenam
 void CompListLoader::OpenFile(const std::string& /*hdu*/) {
     if (!_image) {
         _image.reset(new casa::ComponentListImage(_filename));
+
         if (!_image) {
             throw(casacore::AipsError("Error opening image"));
         }
-        _num_dims = _image->shape().size();
+
+        _image_shape = _image->shape();
+        _num_dims = _image_shape.size();
         _has_pixel_mask = _image->hasPixelMask();
+        _coord_sys = _image->coordinates();
     }
 }
 

--- a/src/ImageData/CompListLoader.h
+++ b/src/ImageData/CompListLoader.h
@@ -20,13 +20,6 @@ public:
     CompListLoader(const std::string& filename);
 
     void OpenFile(const std::string& hdu) override;
-
-    bool HasData(FileInfo::Data ds) const override;
-    ImageRef GetImage() override;
-
-private:
-    std::string _filename;
-    std::unique_ptr<casacore::ImageInterface<casacore::Float> > _image;
 };
 
 CompListLoader::CompListLoader(const std::string& filename) : FileLoader(filename) {}
@@ -38,29 +31,8 @@ void CompListLoader::OpenFile(const std::string& /*hdu*/) {
             throw(casacore::AipsError("Error opening image"));
         }
         _num_dims = _image->shape().size();
+        _has_pixel_mask = _image->hasPixelMask();
     }
-}
-
-bool CompListLoader::HasData(FileInfo::Data dl) const {
-    switch (dl) {
-        case FileInfo::Data::Image:
-            return true;
-        case FileInfo::Data::XY:
-            return _num_dims >= 2;
-        case FileInfo::Data::XYZ:
-            return _num_dims >= 3;
-        case FileInfo::Data::XYZW:
-            return _num_dims >= 4;
-        case FileInfo::Data::MASK:
-            return ((_image != nullptr) && _image->hasPixelMask());
-        default:
-            break;
-    }
-    return false;
-}
-
-typename CompListLoader::ImageRef CompListLoader::GetImage() {
-    return _image.get(); // nullptr if image not opened
 }
 
 } // namespace carta

--- a/src/ImageData/ConcatLoader.h
+++ b/src/ImageData/ConcatLoader.h
@@ -28,11 +28,15 @@ void ConcatLoader::OpenFile(const std::string& /*hdu*/) {
     if (!_image) {
         casacore::JsonKVMap _jmap = casacore::JsonParser::parseFile(this->GetFileName() + "/imageconcat.json");
         _image.reset(new casacore::ImageConcat<float>(_jmap, this->GetFileName()));
+
         if (!_image) {
             throw(casacore::AipsError("Error opening image"));
         }
-        _num_dims = _image->shape().size();
+
+        _image_shape = _image->shape();
+        _num_dims = _image_shape.size();
         _has_pixel_mask = _image->hasPixelMask();
+        _coord_sys = _image->coordinates();
     }
 }
 

--- a/src/ImageData/ConcatLoader.h
+++ b/src/ImageData/ConcatLoader.h
@@ -20,13 +20,6 @@ public:
     ConcatLoader(const std::string& filename);
 
     void OpenFile(const std::string& hdu) override;
-
-    bool HasData(FileInfo::Data ds) const override;
-    ImageRef GetImage() override;
-
-private:
-    std::string _filename;
-    std::unique_ptr<casacore::ImageConcat<float>> _image;
 };
 
 ConcatLoader::ConcatLoader(const std::string& filename) : FileLoader(filename) {}
@@ -39,29 +32,8 @@ void ConcatLoader::OpenFile(const std::string& /*hdu*/) {
             throw(casacore::AipsError("Error opening image"));
         }
         _num_dims = _image->shape().size();
+        _has_pixel_mask = _image->hasPixelMask();
     }
-}
-
-bool ConcatLoader::HasData(FileInfo::Data dl) const {
-    switch (dl) {
-        case FileInfo::Data::Image:
-            return true;
-        case FileInfo::Data::XY:
-            return _num_dims >= 2;
-        case FileInfo::Data::XYZ:
-            return _num_dims >= 3;
-        case FileInfo::Data::XYZW:
-            return _num_dims >= 4;
-        case FileInfo::Data::MASK:
-            return ((_image != nullptr) && _image->hasPixelMask());
-        default:
-            break;
-    }
-    return false;
-}
-
-typename ConcatLoader::ImageRef ConcatLoader::GetImage() {
-    return _image.get(); // nullptr if image not opened
 }
 
 } // namespace carta

--- a/src/ImageData/ExprLoader.h
+++ b/src/ImageData/ExprLoader.h
@@ -33,11 +33,15 @@ void ExprLoader::OpenFile(const std::string& /*hdu*/) {
         casacore::PtrBlock<const casacore::ImageRegion*> _regions;
         casacore::LatticeExprNode _node = casacore::ImageExprParse::command(_expr, casacore::Block<casacore::LatticeExprNode>(), _regions);
         _image.reset(new casacore::ImageExpr<float>(_node, _expr, _filename, _jmap));
+
         if (!_image) {
             throw(casacore::AipsError("Error opening image"));
         }
-        _num_dims = _image->shape().size();
+
+        _image_shape = _image->shape();
+        _num_dims = _image_shape.size();
         _has_pixel_mask = _image->hasPixelMask();
+        _coord_sys = _image->coordinates();
     }
 }
 

--- a/src/ImageData/ExprLoader.h
+++ b/src/ImageData/ExprLoader.h
@@ -22,13 +22,6 @@ public:
     ExprLoader(const std::string& filename);
 
     void OpenFile(const std::string& hdu) override;
-
-    bool HasData(FileInfo::Data ds) const override;
-    ImageRef GetImage() override;
-
-private:
-    std::string _filename;
-    std::unique_ptr<casacore::ImageExpr<float>> _image;
 };
 
 ExprLoader::ExprLoader(const std::string& filename) : FileLoader(filename) {}
@@ -44,29 +37,8 @@ void ExprLoader::OpenFile(const std::string& /*hdu*/) {
             throw(casacore::AipsError("Error opening image"));
         }
         _num_dims = _image->shape().size();
+        _has_pixel_mask = _image->hasPixelMask();
     }
-}
-
-bool ExprLoader::HasData(FileInfo::Data dl) const {
-    switch (dl) {
-        case FileInfo::Data::Image:
-            return true;
-        case FileInfo::Data::XY:
-            return _num_dims >= 2;
-        case FileInfo::Data::XYZ:
-            return _num_dims >= 3;
-        case FileInfo::Data::XYZW:
-            return _num_dims >= 4;
-        case FileInfo::Data::MASK:
-            return ((_image != nullptr) && _image->hasPixelMask());
-        default:
-            break;
-    }
-    return false;
-}
-
-typename ExprLoader::ImageRef ExprLoader::GetImage() {
-    return _image.get(); // nullptr if image not opened
 }
 
 } // namespace carta

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -296,7 +296,7 @@ bool FileLoader::GetSlice(casacore::Array<float>& data, const casacore::Slicer& 
     try {
         auto image = GetImage();
 
-        if (!_image) {
+        if (!image) {
             return false;
         }
 
@@ -306,19 +306,19 @@ bool FileLoader::GetSlice(casacore::Array<float>& data, const casacore::Slicer& 
 
         if (image->imageType() == "CartaFitsImage") {
             // Read subset with cfitsio
-            bool ok = _image->doGetSlice(data, slicer);
+            bool ok = image->doGetSlice(data, slicer);
             return ok;
         }
 
         // Get data slice with mask applied.
         // Apply slicer to image first to get appropriate cursor, and use read-only iterator
-        casacore::SubImage<float> subimage(*_image, slicer);
+        casacore::SubImage<float> subimage(*image, slicer);
         casacore::RO_MaskedLatticeIterator<float> lattice_iter(subimage);
 
         for (lattice_iter.reset(); !lattice_iter.atEnd(); ++lattice_iter) {
             casacore::Array<float> cursor_data = lattice_iter.cursor();
 
-            if (_image->isMasked()) {
+            if (image->isMasked()) {
                 casacore::Array<float> masked_data(cursor_data); // reference the same storage
                 const casacore::Array<bool> cursor_mask = lattice_iter.getMask();
 
@@ -357,7 +357,7 @@ bool FileLoader::GetSlice(casacore::Array<float>& data, const casacore::Slicer& 
 bool FileLoader::GetSubImage(const casacore::Slicer& slicer, casacore::SubImage<float>& sub_image) {
     // Get SubImage from Slicer
     auto image = GetImage();
-    if (!_image) {
+    if (!image) {
         return false;
     }
 

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -79,7 +79,7 @@ typename FileLoader::ImageRef FileLoader::GetImage() {
     return _image;
 }
 
-void FileLoader::CloseFile() {
+void FileLoader::CloseImage() {
     // Destroy image if only the loader owns it
     if (_image.unique()) {
         _image.reset();
@@ -107,21 +107,21 @@ bool FileLoader::HasData(FileInfo::Data dl) const {
 }
 
 bool FileLoader::GetShape(IPos& shape) {
-    ImageRef image = GetImage();
-    if (image) {
-        shape = image->shape();
-        return true;
+    if (_image_shape.empty()) {
+        return false;
     }
-    return false;
+
+    shape = _image_shape;
+    return true;
 }
 
 bool FileLoader::GetCoordinateSystem(casacore::CoordinateSystem& coord_sys) {
-    ImageRef image = GetImage();
-    if (image) {
-        coord_sys = image->coordinates();
-        return true;
+    if (_coord_sys.nCoordinates() == 0) {
+        return false;
     }
-    return false;
+
+    coord_sys = _coord_sys;
+    return true;
 }
 
 bool FileLoader::FindCoordinateAxes(IPos& shape, int& spectral_axis, int& z_axis, int& stokes_axis, std::string& message) {
@@ -136,10 +136,7 @@ bool FileLoader::FindCoordinateAxes(IPos& shape, int& spectral_axis, int& z_axis
         return false;
     }
 
-    if (!GetShape(shape)) {
-        message = "Cannot determine image shape.";
-        return false;
-    }
+    shape = _image_shape;
 
     // Dimension check
     _num_dims = shape.size();
@@ -148,14 +145,7 @@ bool FileLoader::FindCoordinateAxes(IPos& shape, int& spectral_axis, int& z_axis
         return false;
     }
 
-    // Coordinate system checks
-    casacore::CoordinateSystem coord_sys;
-    if (!GetCoordinateSystem(coord_sys)) {
-        message = "Invalid coordinate system.";
-        return false;
-    }
-
-    if (coord_sys.nPixelAxes() != _num_dims) {
+    if (_coord_sys.nPixelAxes() != _num_dims) {
         message = "Problem loading image: cannot determine coordinate axes from incomplete header.";
         return false;
     }
@@ -167,8 +157,8 @@ bool FileLoader::FindCoordinateAxes(IPos& shape, int& spectral_axis, int& z_axis
     _image_plane_size = _width * _height;
 
     // Spectral and stokes axis
-    spectral_axis = coord_sys.spectralAxisNumber();
-    stokes_axis = coord_sys.polarizationAxisNumber();
+    spectral_axis = _coord_sys.spectralAxisNumber();
+    stokes_axis = _coord_sys.polarizationAxisNumber();
 
     // 2D image
     if (_num_dims == 2) {
@@ -235,6 +225,7 @@ bool FileLoader::FindCoordinateAxes(IPos& shape, int& spectral_axis, int& z_axis
             _stokes_indices[GetStokesType(stokes_value)] = i;
         }
     }
+
     return true;
 }
 
@@ -250,35 +241,31 @@ std::vector<int> FileLoader::GetRenderAxes() {
     // Default unless PV image
     axes.assign({0, 1});
 
-    casacore::IPosition shape;
-    if (GetShape(shape) && shape.size() > 2) {
-        casacore::CoordinateSystem coord_system;
-        if (GetCoordinateSystem(coord_system)) {
-            // Normally, use direction axes
-            if (coord_system.hasDirectionCoordinate()) {
-                casacore::Vector<casacore::Int> dir_axes = coord_system.directionAxesNumbers();
-                axes[0] = dir_axes[0];
-                axes[1] = dir_axes[1];
-            } else if (coord_system.hasLinearCoordinate()) {
-                // Check for PV image: [Linear, Spectral] axes
-                // Returns -1 if no spectral axis
-                int spectral_axis = coord_system.spectralAxisNumber();
+    if (_image_shape.size() > 2) {
+        // Normally, use direction axes
+        if (_coord_sys.hasDirectionCoordinate()) {
+            casacore::Vector<casacore::Int> dir_axes = _coord_sys.directionAxesNumbers();
+            axes[0] = dir_axes[0];
+            axes[1] = dir_axes[1];
+        } else if (_coord_sys.hasLinearCoordinate()) {
+            // Check for PV image: [Linear, Spectral] axes
+            // Returns -1 if no spectral axis
+            int spectral_axis = _coord_sys.spectralAxisNumber();
 
-                if (spectral_axis >= 0) {
-                    // Find valid (not -1) linear axes
-                    std::vector<int> valid_axes;
-                    casacore::Vector<casacore::Int> lin_axes = coord_system.linearAxesNumbers();
-                    for (auto axis : lin_axes) {
-                        if (axis >= 0) {
-                            valid_axes.push_back(axis);
-                        }
+            if (spectral_axis >= 0) {
+                // Find valid (not -1) linear axes
+                std::vector<int> valid_axes;
+                casacore::Vector<casacore::Int> lin_axes = _coord_sys.linearAxesNumbers();
+                for (auto axis : lin_axes) {
+                    if (axis >= 0) {
+                        valid_axes.push_back(axis);
                     }
+                }
 
-                    // One linear + spectral axis = pV image
-                    if (valid_axes.size() == 1) {
-                        valid_axes.push_back(spectral_axis);
-                        axes = valid_axes;
-                    }
+                // One linear + spectral axis = pV image
+                if (valid_axes.size() == 1) {
+                    valid_axes.push_back(spectral_axis);
+                    axes = valid_axes;
                 }
             }
         }
@@ -289,30 +276,32 @@ std::vector<int> FileLoader::GetRenderAxes() {
 }
 
 bool FileLoader::GetSlice(casacore::Array<float>& data, const casacore::Slicer& slicer) {
-    ImageRef image = GetImage();
-    if (!image) {
-        return false;
-    }
-
     try {
+        auto image = GetImage();
+
+        if (!_image) {
+            return false;
+        }
+
         if (data.shape() != slicer.length()) {
             data.resize(slicer.length());
         }
 
         if (image->imageType() == "CartaFitsImage") {
             // Read subset with cfitsio
-            return image->doGetSlice(data, slicer);
+            bool ok = _image->doGetSlice(data, slicer);
+            return ok;
         }
 
         // Get data slice with mask applied.
         // Apply slicer to image first to get appropriate cursor, and use read-only iterator
-        casacore::SubImage<float> subimage(*image, slicer);
+        casacore::SubImage<float> subimage(*_image, slicer);
         casacore::RO_MaskedLatticeIterator<float> lattice_iter(subimage);
 
         for (lattice_iter.reset(); !lattice_iter.atEnd(); ++lattice_iter) {
             casacore::Array<float> cursor_data = lattice_iter.cursor();
 
-            if (image->isMasked()) {
+            if (_image->isMasked()) {
                 casacore::Array<float> masked_data(cursor_data); // reference the same storage
                 const casacore::Array<bool> cursor_mask = lattice_iter.getMask();
 
@@ -350,43 +339,48 @@ bool FileLoader::GetSlice(casacore::Array<float>& data, const casacore::Slicer& 
 
 bool FileLoader::GetSubImage(const casacore::Slicer& slicer, casacore::SubImage<float>& sub_image) {
     // Get SubImage from Slicer
-    ImageRef image = GetImage();
-    if (!image) {
+    auto image = GetImage();
+    if (!_image) {
         return false;
     }
 
-    sub_image = casacore::SubImage<float>(*image, slicer);
+    sub_image = casacore::SubImage<float>(*(image.get()), slicer);
     return true;
 }
 
 bool FileLoader::GetSubImage(const casacore::LattRegionHolder& region, casacore::SubImage<float>& sub_image) {
     // Get SubImage from image region
-    ImageRef image = GetImage();
+    auto image = GetImage();
     if (!image) {
         return false;
     }
 
-    sub_image = casacore::SubImage<float>(*image, region);
+    sub_image = casacore::SubImage<float>(*(image.get()), region);
     return true;
 }
 
 bool FileLoader::GetSubImage(
     const casacore::Slicer& slicer, const casacore::LattRegionHolder& region, casacore::SubImage<float>& sub_image) {
-    auto result = false;
-    ImageRef image = GetImage();
-    if (image) {
-        auto temp_image = casacore::SubImage<float>(*image, region);
-        sub_image = casacore::SubImage<float>(temp_image, slicer);
-        result = true;
+    auto image = GetImage();
+    if (!image) {
+        return false;
     }
-    return result;
+
+    auto temp_image = casacore::SubImage<float>(*(image.get()), region);
+    sub_image = casacore::SubImage<float>(temp_image, slicer);
+    return true;
 }
 
 bool FileLoader::GetBeams(std::vector<CARTA::Beam>& beams, std::string& error) {
     // Obtains beam table from ImageInfo
     bool success(false);
     try {
-        casacore::ImageInfo image_info = GetImage()->imageInfo();
+        auto image = GetImage();
+        if (!image) {
+            return success;
+        }
+
+        casacore::ImageInfo image_info = image->imageInfo();
         if (!image_info.hasBeam()) {
             error = "Image has no beam information.";
             return success;
@@ -825,15 +819,21 @@ std::string FileLoader::GetFileName() {
 }
 
 double FileLoader::CalculateBeamArea() {
-    ImageRef image = GetImage();
-    auto& info = image->imageInfo();
-    auto& coord = image->coordinates();
-
-    if (!info.hasSingleBeam() || !coord.hasDirectionCoordinate()) {
+    auto image = GetImage();
+    if (!image) {
         return NAN;
     }
 
-    return info.getBeamAreaInPixels(-1, -1, coord.directionCoordinate());
+    auto& info = image->imageInfo();
+
+    image.reset();
+    CloseImage();
+
+    if (!info.hasSingleBeam() || !_coord_sys.hasDirectionCoordinate()) {
+        return NAN;
+    }
+
+    return info.getBeamAreaInPixels(-1, -1, _coord_sys.directionCoordinate());
 }
 
 void FileLoader::SetFirstStokesType(int stokes_value) {

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -65,7 +65,8 @@ FileLoader* FileLoader::GetLoader(std::shared_ptr<casacore::ImageInterface<float
     }
 }
 
-FileLoader::FileLoader(const std::string& filename) : _filename(filename), _num_dims(0), _has_pixel_mask(false) {}
+FileLoader::FileLoader(const std::string& filename, bool is_gz)
+    : _filename(filename), _is_gz(is_gz), _num_dims(0), _has_pixel_mask(false) {}
 
 bool FileLoader::CanOpenFile(std::string& /*error*/) {
     return true;
@@ -80,9 +81,11 @@ typename FileLoader::ImageRef FileLoader::GetImage() {
 }
 
 void FileLoader::CloseImage() {
-    // Destroy image if only the loader owns it
-    if (_image.unique()) {
-        _image.reset();
+    // Destroy image if only the loader owns it unless it has been decompressed
+    if (!_is_gz) {
+        if (_image.unique()) {
+            _image.reset();
+        }
     }
 }
 

--- a/src/ImageData/FileLoader.h
+++ b/src/ImageData/FileLoader.h
@@ -131,7 +131,7 @@ inline casacore::uInt GetFitsHdu(const std::string& hdu) {
 
 class FileLoader {
 public:
-    using ImageRef = casacore::ImageInterface<float>*;
+    using ImageRef = std::shared_ptr<casacore::ImageInterface<float>>;
     using IPos = casacore::IPosition;
 
     FileLoader(const std::string& filename);
@@ -145,9 +145,10 @@ public:
     virtual bool CanOpenFile(std::string& error);
     // Do anything required to open the file at given HDU (set up cache size, Image object)
     virtual void OpenFile(const std::string& hdu) = 0;
+    virtual void CloseFile();
 
     // Return the opened casacore image
-    virtual ImageRef GetImage() = 0;
+    virtual ImageRef GetImage();
 
     // read beam subtable
     bool GetBeams(std::vector<CARTA::Beam>& beams, std::string& error);
@@ -161,7 +162,7 @@ public:
 
     // Image Data
     // Check to see if the file has a particular HDU/group/table/etc
-    virtual bool HasData(FileInfo::Data ds) const = 0;
+    virtual bool HasData(FileInfo::Data ds) const;
     // Slice image data (with mask applied)
     bool GetSlice(casacore::Array<float>& data, const casacore::Slicer& slicer);
 
@@ -201,14 +202,19 @@ public:
     virtual bool GetStokesTypeIndex(const CARTA::StokesType& stokes_type, int& stokes_index);
 
 protected:
-    // Full name of the image file
+    // Full name and hdu of the image file
     std::string _filename;
+    std::string _hdu;
+    std::shared_ptr<casacore::ImageInterface<casacore::Float>> _image;
 
     // Axes, dimension values
     size_t _num_dims, _image_plane_size;
     size_t _width, _height, _depth, _num_stokes;
     int _z_axis, _stokes_axis;
     std::vector<int> _render_axes;
+
+    // Pixel mask
+    bool _has_pixel_mask;
 
     // Storage for z-plane and cube statistics
     std::vector<std::vector<carta::FileInfo::ImageStats>> _z_stats;

--- a/src/ImageData/FileLoader.h
+++ b/src/ImageData/FileLoader.h
@@ -134,7 +134,7 @@ public:
     using ImageRef = std::shared_ptr<casacore::ImageInterface<float>>;
     using IPos = casacore::IPosition;
 
-    FileLoader(const std::string& filename);
+    FileLoader(const std::string& filename, bool is_gz = false);
     virtual ~FileLoader() = default;
 
     static FileLoader* GetLoader(const std::string& filename);
@@ -205,6 +205,7 @@ protected:
     // Full name and hdu of the image file
     std::string _filename;
     std::string _hdu;
+    bool _is_gz;
     std::shared_ptr<casacore::ImageInterface<casacore::Float>> _image;
 
     // Save image properties; only reopen for data or beams

--- a/src/ImageData/FileLoader.h
+++ b/src/ImageData/FileLoader.h
@@ -148,8 +148,8 @@ public:
     // Check to see if the file has a particular HDU/group/table/etc
     virtual bool HasData(FileInfo::Data ds) const;
 
-    // If no use count, destroy image to prevent caching
-    void CloseImage();
+    // If not in use, temp close image to prevent caching
+    void CloseImageIfUpdated();
 
     // Return the opened casacore image or its class name
     ImageRef GetImage();
@@ -206,6 +206,7 @@ protected:
     std::string _filename;
     std::string _hdu;
     bool _is_gz;
+    unsigned int _modify_time;
     std::shared_ptr<casacore::ImageInterface<casacore::Float>> _image;
 
     // Save image properties; only reopen for data or beams
@@ -244,6 +245,9 @@ protected:
 
     // Basic flux density calculation
     double CalculateBeamArea();
+
+    // Modify time changed
+    bool ImageUpdated();
 };
 
 } // namespace carta

--- a/src/ImageData/FileLoader.h
+++ b/src/ImageData/FileLoader.h
@@ -143,12 +143,16 @@ public:
 
     // check for mirlib (MIRIAD) error; returns true for other image types
     virtual bool CanOpenFile(std::string& error);
-    // Do anything required to open the file at given HDU (set up cache size, Image object)
+    // Open and close file
     virtual void OpenFile(const std::string& hdu) = 0;
-    virtual void CloseFile();
+    // Check to see if the file has a particular HDU/group/table/etc
+    virtual bool HasData(FileInfo::Data ds) const;
 
-    // Return the opened casacore image
-    virtual ImageRef GetImage();
+    // If no use count, destroy image to prevent caching
+    void CloseImage();
+
+    // Return the opened casacore image or its class name
+    ImageRef GetImage();
 
     // read beam subtable
     bool GetBeams(std::vector<CARTA::Beam>& beams, std::string& error);
@@ -157,12 +161,8 @@ public:
     bool GetShape(IPos& shape);
     bool GetCoordinateSystem(casacore::CoordinateSystem& coord_sys);
     bool FindCoordinateAxes(IPos& shape, int& spectral_axis, int& z_axis, int& stokes_axis, std::string& message);
-    // Determine axes used for image raster data
-    std::vector<int> GetRenderAxes();
+    std::vector<int> GetRenderAxes(); // Determine axes used for image raster data
 
-    // Image Data
-    // Check to see if the file has a particular HDU/group/table/etc
-    virtual bool HasData(FileInfo::Data ds) const;
     // Slice image data (with mask applied)
     bool GetSlice(casacore::Array<float>& data, const casacore::Slicer& slicer);
 
@@ -194,7 +194,7 @@ public:
     virtual bool UseTileCache() const;
 
     // Get the full name of image file
-    virtual std::string GetFileName();
+    std::string GetFileName();
 
     // Handle stokes type index
     virtual void SetFirstStokesType(int stokes_value);
@@ -207,12 +207,15 @@ protected:
     std::string _hdu;
     std::shared_ptr<casacore::ImageInterface<casacore::Float>> _image;
 
+    // Save image properties; only reopen for data or beams
     // Axes, dimension values
+    casacore::IPosition _image_shape;
     size_t _num_dims, _image_plane_size;
     size_t _width, _height, _depth, _num_stokes;
     int _z_axis, _stokes_axis;
     std::vector<int> _render_axes;
-
+    // Coordinate system
+    casacore::CoordinateSystem _coord_sys;
     // Pixel mask
     bool _has_pixel_mask;
 

--- a/src/ImageData/FitsLoader.h
+++ b/src/ImageData/FitsLoader.h
@@ -33,7 +33,7 @@ public:
 
 private:
     std::string _unzip_file;
-    casacore::uInt _hdunum;
+    casacore::uInt _hdu_num;
 };
 
 FitsLoader::FitsLoader(const std::string& filename, bool is_gz) : FileLoader(filename, is_gz) {}
@@ -50,7 +50,7 @@ void FitsLoader::OpenFile(const std::string& hdu) {
     // Convert string to FITS hdu number
     casacore::uInt hdu_num(FileInfo::GetFitsHdu(hdu));
 
-    if (!_image || (hdu_num != _hdunum)) {
+    if (!_image || (hdu_num != _hdu_num)) {
         bool gz_mem_ok(true);
 
         if (_is_gz) {
@@ -111,7 +111,7 @@ void FitsLoader::OpenFile(const std::string& hdu) {
         }
 
         _hdu = hdu;
-        _hdunum = hdu_num;
+        _hdu_num = hdu_num;
 
         _image_shape = _image->shape();
         _num_dims = _image_shape.size();

--- a/src/ImageData/FitsLoader.h
+++ b/src/ImageData/FitsLoader.h
@@ -113,8 +113,11 @@ void FitsLoader::OpenFile(const std::string& hdu) {
 
         _hdu = hdu;
         _hdunum = hdu_num;
-        _num_dims = _image->shape().size();
+
+        _image_shape = _image->shape();
+        _num_dims = _image_shape.size();
         _has_pixel_mask = _image->hasPixelMask();
+        _coord_sys = _image->coordinates();
     }
 }
 

--- a/src/ImageData/FitsLoader.h
+++ b/src/ImageData/FitsLoader.h
@@ -31,17 +31,13 @@ public:
 
     void OpenFile(const std::string& hdu) override;
 
-    bool HasData(FileInfo::Data ds) const override;
-    ImageRef GetImage() override;
-
 private:
     bool _is_gz;
     std::string _unzip_file;
-    casacore::uInt _hdu;
-    std::unique_ptr<casacore::ImageInterface<float>> _image;
+    casacore::uInt _hdunum;
 };
 
-FitsLoader::FitsLoader(const std::string& filename, bool is_gz) : FileLoader(filename), _is_gz(is_gz), _hdu(-1) {}
+FitsLoader::FitsLoader(const std::string& filename, bool is_gz) : FileLoader(filename), _is_gz(is_gz) {}
 
 FitsLoader::~FitsLoader() {
     // Remove decompressed fits.gz file
@@ -55,7 +51,7 @@ void FitsLoader::OpenFile(const std::string& hdu) {
     // Convert string to FITS hdu number
     casacore::uInt hdu_num(FileInfo::GetFitsHdu(hdu));
 
-    if (!_image || (hdu_num != _hdu)) {
+    if (!_image || (hdu_num != _hdunum)) {
         bool gz_mem_ok(true);
 
         if (_is_gz) {
@@ -115,31 +111,11 @@ void FitsLoader::OpenFile(const std::string& hdu) {
             throw(casacore::AipsError("Error loading FITS image."));
         }
 
-        _hdu = hdu_num;
+        _hdu = hdu;
+        _hdunum = hdu_num;
         _num_dims = _image->shape().size();
+        _has_pixel_mask = _image->hasPixelMask();
     }
-}
-
-bool FitsLoader::HasData(FileInfo::Data dl) const {
-    switch (dl) {
-        case FileInfo::Data::Image:
-            return true;
-        case FileInfo::Data::XY:
-            return _num_dims >= 2;
-        case FileInfo::Data::XYZ:
-            return _num_dims >= 3;
-        case FileInfo::Data::XYZW:
-            return _num_dims >= 4;
-        case FileInfo::Data::MASK:
-            return ((_image != nullptr) && _image->hasPixelMask());
-        default:
-            break;
-    }
-    return false;
-}
-
-typename FitsLoader::ImageRef FitsLoader::GetImage() {
-    return _image.get(); // nullptr if image not opened
 }
 
 } // namespace carta

--- a/src/ImageData/FitsLoader.h
+++ b/src/ImageData/FitsLoader.h
@@ -32,12 +32,11 @@ public:
     void OpenFile(const std::string& hdu) override;
 
 private:
-    bool _is_gz;
     std::string _unzip_file;
     casacore::uInt _hdunum;
 };
 
-FitsLoader::FitsLoader(const std::string& filename, bool is_gz) : FileLoader(filename), _is_gz(is_gz) {}
+FitsLoader::FitsLoader(const std::string& filename, bool is_gz) : FileLoader(filename, is_gz) {}
 
 FitsLoader::~FitsLoader() {
     // Remove decompressed fits.gz file

--- a/src/ImageData/Hdf5Loader.cc
+++ b/src/ImageData/Hdf5Loader.cc
@@ -18,7 +18,8 @@ void Hdf5Loader::OpenFile(const std::string& hdu) {
 
     // Open hdf5 image with specified hdu
     if (!_image || (selected_hdu != _hdu)) {
-        _image.reset(new CartaHdf5Image(_filename, DataSetToString(FileInfo::Data::Image), selected_hdu));
+        auto hdf5_image = new CartaHdf5Image(_filename, DataSetToString(FileInfo::Data::Image), selected_hdu);
+        _image.reset(hdf5_image);
         if (!_image) {
             throw(casacore::AipsError("Error opening image"));
         }
@@ -27,6 +28,7 @@ void Hdf5Loader::OpenFile(const std::string& hdu) {
 
         // We need this immediately because dataSetToString uses it to find the name of the swizzled dataset
         _num_dims = _image->shape().size();
+        _has_pixel_mask = _image->hasPixelMask();
 
         // Load swizzled image lattice
         if (HasData(FileInfo::Data::SWIZZLED)) {
@@ -36,11 +38,11 @@ void Hdf5Loader::OpenFile(const std::string& hdu) {
         }
 
         // save the data layout and known mips
-        auto dset = _image->Lattice().array();
+        auto dset = hdf5_image->Lattice().array();
         _layout = H5Pget_layout(H5Dget_create_plist(dset->getHid()));
 
         if (HasData("MipMaps/DATA")) {
-            casacore::HDF5Group mipmap_group(_image->Group()->getHid(), "MipMaps/DATA", true);
+            casacore::HDF5Group mipmap_group(hdf5_image->Group()->getHid(), "MipMaps/DATA", true);
             for (auto& name : casacore::HDF5Group::linkNames(mipmap_group)) {
                 std::regex re("DATA_XY_(\\d+)");
                 std::smatch match;
@@ -55,7 +57,12 @@ void Hdf5Loader::OpenFile(const std::string& hdu) {
 }
 
 bool Hdf5Loader::HasData(std::string ds_name) const {
-    auto group_ptr = _image->Group();
+    if (!_image) {
+        return false;
+    }
+
+    CartaHdf5Image* hdf5_image = dynamic_cast<CartaHdf5Image*>(_image.get());
+    auto group_ptr = hdf5_image->Group();
     return casacore::HDF5Group::exists(*group_ptr, ds_name);
 }
 
@@ -72,7 +79,7 @@ bool Hdf5Loader::HasData(FileInfo::Data ds) const {
         case FileInfo::Data::XYZW:
             return _num_dims >= 4;
         case FileInfo::Data::MASK:
-            return ((_image != nullptr) && _image->hasPixelMask());
+            return _has_pixel_mask;
         default:
             std::string ds_name(DataSetToString(ds));
             if (ds_name.empty()) {
@@ -80,12 +87,6 @@ bool Hdf5Loader::HasData(FileInfo::Data ds) const {
             }
             return HasData(ds_name);
     }
-}
-
-// TODO: when we fix the typing issue, this should probably return any dataset again, for consistency.
-typename Hdf5Loader::ImageRef Hdf5Loader::GetImage() {
-    // returns opened image as ImageInterface*
-    return _image.get();
 }
 
 casacore::Lattice<float>* Hdf5Loader::LoadSwizzledData() {
@@ -155,7 +156,13 @@ bool Hdf5Loader::HasMip(int mip) const {
 // same type class. We cannot guarantee a particular native type -- e.g. some files use doubles instead of floats. This necessitates this
 // complicated templating, at least for now.
 const Hdf5Loader::IPos Hdf5Loader::GetStatsDataShape(FileInfo::Data ds) {
-    auto data_type = casacore::HDF5DataSet::getDataType(_image->Group()->getHid(), DataSetToString(ds));
+    auto image = GetImage();
+    if (!image) {
+        return IPos();
+    }
+
+    CartaHdf5Image* hdf5_image = dynamic_cast<CartaHdf5Image*>(image.get());
+    auto data_type = casacore::HDF5DataSet::getDataType(hdf5_image->Group()->getHid(), DataSetToString(ds));
 
     switch (data_type) {
         case casacore::TpInt: {
@@ -179,7 +186,13 @@ const Hdf5Loader::IPos Hdf5Loader::GetStatsDataShape(FileInfo::Data ds) {
 // same type class. We cannot guarantee a particular native type -- e.g. some files use doubles instead of floats. This necessitates this
 // complicated templating, at least for now.
 casacore::ArrayBase* Hdf5Loader::GetStatsData(FileInfo::Data ds) {
-    auto data_type = casacore::HDF5DataSet::getDataType(_image->Group()->getHid(), DataSetToString(ds));
+    auto image = GetImage();
+    if (!image) {
+        throw casacore::HDF5Error("Cannot get dataset " + DataSetToString(ds) + " from invalid image.");
+    }
+
+    CartaHdf5Image* hdf5_image = dynamic_cast<CartaHdf5Image*>(image.get());
+    auto data_type = casacore::HDF5DataSet::getDataType(hdf5_image->Group()->getHid(), DataSetToString(ds));
 
     switch (data_type) {
         case casacore::TpInt: {

--- a/src/ImageData/Hdf5Loader.cc
+++ b/src/ImageData/Hdf5Loader.cc
@@ -25,10 +25,10 @@ void Hdf5Loader::OpenFile(const std::string& hdu) {
         }
 
         _hdu = selected_hdu;
-
-        // We need this immediately because dataSetToString uses it to find the name of the swizzled dataset
-        _num_dims = _image->shape().size();
+        _image_shape = _image->shape();
+        _num_dims = _image_shape.size();
         _has_pixel_mask = _image->hasPixelMask();
+        _coord_sys = _image->coordinates();
 
         // Load swizzled image lattice
         if (HasData(FileInfo::Data::SWIZZLED)) {

--- a/src/ImageData/Hdf5Loader.h
+++ b/src/ImageData/Hdf5Loader.h
@@ -28,7 +28,6 @@ public:
     void OpenFile(const std::string& hdu) override;
 
     bool HasData(FileInfo::Data ds) const override;
-    ImageRef GetImage() override;
 
     bool GetCursorSpectralData(
         std::vector<float>& data, int stokes, int cursor_x, int count_x, int cursor_y, int count_y, std::mutex& image_mutex) override;
@@ -46,7 +45,6 @@ public:
 
 private:
     std::string _hdu;
-    std::unique_ptr<CartaHdf5Image> _image;
     std::unique_ptr<casacore::HDF5Lattice<float>> _swizzled_image;
     std::unordered_map<int, std::unique_ptr<casacore::HDF5Lattice<float>>> _mipmaps;
 

--- a/src/ImageData/ImagePtrLoader.h
+++ b/src/ImageData/ImagePtrLoader.h
@@ -20,8 +20,11 @@ public:
 
 ImagePtrLoader::ImagePtrLoader(std::shared_ptr<casacore::ImageInterface<float>> image) : FileLoader("") {
     _image = image;
-    _num_dims = _image->shape().size();
+
+    _image_shape = _image->shape();
+    _num_dims = _image_shape.size();
     _has_pixel_mask = _image->hasPixelMask();
+    _coord_sys = _image->coordinates();
 }
 
 void ImagePtrLoader::OpenFile(const std::string& /*hdu*/) {}

--- a/src/ImageData/ImagePtrLoader.h
+++ b/src/ImageData/ImagePtrLoader.h
@@ -16,43 +16,15 @@ public:
     ImagePtrLoader(std::shared_ptr<casacore::ImageInterface<float>> image);
 
     void OpenFile(const std::string& hdu) override;
-
-    bool HasData(FileInfo::Data ds) const override;
-    ImageRef GetImage() override;
-
-private:
-    std::shared_ptr<casacore::ImageInterface<float>> _image;
 };
 
 ImagePtrLoader::ImagePtrLoader(std::shared_ptr<casacore::ImageInterface<float>> image) : FileLoader("") {
     _image = image;
     _num_dims = _image->shape().size();
+    _has_pixel_mask = _image->hasPixelMask();
 }
 
 void ImagePtrLoader::OpenFile(const std::string& /*hdu*/) {}
-
-bool ImagePtrLoader::HasData(FileInfo::Data dl) const {
-    switch (dl) {
-        case FileInfo::Data::Image:
-            return true;
-        case FileInfo::Data::XY:
-            return _num_dims >= 2;
-        case FileInfo::Data::XYZ:
-            return _num_dims >= 3;
-        case FileInfo::Data::XYZW:
-            return _num_dims >= 4;
-        case FileInfo::Data::MASK:
-            return ((_image != nullptr) && _image->hasPixelMask());
-        default:
-            break;
-    }
-    return false;
-}
-
-typename ImagePtrLoader::ImageRef ImagePtrLoader::GetImage() {
-    return _image.get(); // nullptr if image not opened
-}
-
 } // namespace carta
 
 #endif // CARTA_BACKEND_IMAGEDATA_IMAGEPTRLOADER_H_

--- a/src/ImageData/MiriadLoader.h
+++ b/src/ImageData/MiriadLoader.h
@@ -19,13 +19,8 @@ public:
     MiriadLoader(const std::string& file);
 
     bool CanOpenFile(std::string& error) override;
+
     void OpenFile(const std::string& hdu) override;
-
-    bool HasData(FileInfo::Data ds) const override;
-    ImageRef GetImage() override;
-
-private:
-    std::unique_ptr<casacore::MIRIADImage> _image;
 };
 
 MiriadLoader::MiriadLoader(const std::string& filename) : FileLoader(filename) {}
@@ -64,29 +59,8 @@ void MiriadLoader::OpenFile(const std::string& /*hdu*/) {
             throw(casacore::AipsError("Error opening image"));
         }
         _num_dims = _image->shape().size();
+        _has_pixel_mask = _image->hasPixelMask();
     }
-}
-
-bool MiriadLoader::HasData(FileInfo::Data dl) const {
-    switch (dl) {
-        case FileInfo::Data::Image:
-            return true;
-        case FileInfo::Data::XY:
-            return _num_dims >= 2;
-        case FileInfo::Data::XYZ:
-            return _num_dims >= 3;
-        case FileInfo::Data::XYZW:
-            return _num_dims >= 4;
-        case FileInfo::Data::MASK:
-            return ((_image != nullptr) && _image->hasPixelMask());
-        default:
-            break;
-    }
-    return false;
-}
-
-typename MiriadLoader::ImageRef MiriadLoader::GetImage() {
-    return _image.get(); // nullptr if image not opened
 }
 
 } // namespace carta

--- a/src/ImageData/MiriadLoader.h
+++ b/src/ImageData/MiriadLoader.h
@@ -55,11 +55,15 @@ bool MiriadLoader::CanOpenFile(std::string& error) {
 void MiriadLoader::OpenFile(const std::string& /*hdu*/) {
     if (!_image) {
         _image.reset(new CartaMiriadImage(_filename));
+
         if (!_image) {
             throw(casacore::AipsError("Error opening image"));
         }
-        _num_dims = _image->shape().size();
+
+        _image_shape = _image->shape();
+        _num_dims = _image_shape.size();
         _has_pixel_mask = _image->hasPixelMask();
+        _coord_sys = _image->coordinates();
     }
 }
 

--- a/src/ImageData/StokesFilesConnector.cc
+++ b/src/ImageData/StokesFilesConnector.cc
@@ -116,8 +116,8 @@ bool StokesFilesConnector::DoConcat(const CARTA::ConcatStokesFiles& message, CAR
         for (int i = 1; i <= 4; ++i) { // concatenate stokes file in the order I, Q, U, V (i.e., 1, 2, 3 ,4)
             auto stokes_type = static_cast<CARTA::StokesType>(i);
             if (_loaders.count(stokes_type)) {
-                casacore::StokesCoordinate& stokes_coord =
-                    const_cast<casacore::StokesCoordinate&>(_loaders[stokes_type]->GetImage()->coordinates().stokesCoordinate());
+                auto image = _loaders[stokes_type]->GetImage();
+                casacore::StokesCoordinate& stokes_coord = const_cast<casacore::StokesCoordinate&>(image->coordinates().stokesCoordinate());
                 if (stokes_coord.stokes().size() != 1) {
                     return fail_exit("Stokes coordinate has no or multiple stokes types!");
                 }
@@ -128,7 +128,7 @@ bool StokesFilesConnector::DoConcat(const CARTA::ConcatStokesFiles& message, CAR
                 stokes_coord.setStokes(vec);
 
                 try {
-                    concatenated_image->setImage(*_loaders[stokes_type]->GetImage(), casacore::False);
+                    concatenated_image->setImage(*(image.get()), casacore::False);
                 } catch (const casacore::AipsError& error) {
                     return fail_exit(fmt::format("Failed to concatenate images: {}", error.getMesg()));
                 }

--- a/src/ImageData/StokesFilesConnector.cc
+++ b/src/ImageData/StokesFilesConnector.cc
@@ -85,10 +85,10 @@ bool StokesFilesConnector::DoConcat(const CARTA::ConcatStokesFiles& message, CAR
         // modify the original image and extend the image coordinate system with a stokes coordinate
         for (auto& loader : _loaders) {
             auto stokes_type = loader.first;
-            auto* image = loader.second->GetImage();
+            auto image = loader.second->GetImage();
             try {
                 extended_images[stokes_type] =
-                    std::make_shared<casacore::ExtendImage<float>>(*image, new_image_shape, coord_sys[stokes_type]);
+                    std::make_shared<casacore::ExtendImage<float>>(*(image.get()), new_image_shape, coord_sys[stokes_type]);
             } catch (const casacore::AipsError& error) {
                 return fail_exit(fmt::format("Failed to extend the image: {}", error.getMesg()));
             }

--- a/src/ImageData/StokesFilesConnector.h
+++ b/src/ImageData/StokesFilesConnector.h
@@ -22,12 +22,12 @@ public:
 
     bool DoConcat(const CARTA::ConcatStokesFiles& message, CARTA::ConcatStokesFilesAck& response,
         std::shared_ptr<casacore::ImageConcat<float>>& concatenated_image, std::string& concatenated_name);
+    void ClearCache();
 
 private:
     bool OpenStokesFiles(const CARTA::ConcatStokesFiles& message, std::string& err);
     bool StokesFilesValid(std::string& err, int& stokes_axis);
     static bool GetStokesType(const CARTA::StokesType& stokes_type, casacore::Stokes::StokesTypes& result);
-    void ClearCache();
 
     std::string _top_level_folder;
     std::string _concatenated_name;

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -280,6 +280,10 @@ void OnMessage(uWS::WebSocket<false, true, PerSocketData>* ws, std::string_view 
                 case CARTA::EventType::OPEN_FILE: {
                     CARTA::OpenFile message;
                     if (message.ParseFromArray(event_buf, event_length)) {
+                        for (auto& session : sessions) {
+                            session.second->CloseCachedImage(message.directory(), message.file());
+                        }
+
                         session->OnOpenFile(message, head.request_id);
                     } else {
                         spdlog::warn("Bad OPEN_FILE message!");

--- a/src/Session.cc
+++ b/src/Session.cc
@@ -2052,3 +2052,10 @@ void Session::UpdateLastMessageTimestamp() {
 std::chrono::high_resolution_clock::time_point Session::GetLastMessageTimestamp() {
     return _last_message_timestamp;
 }
+
+void Session::CloseCachedImage(const std::string& directory, const std::string& file) {
+    std::string fullname = GetResolvedFilename(_top_level_folder, directory, file);
+    for (auto& frame : _frames) {
+        frame.second->CloseCachedImage(fullname);
+    }
+}

--- a/src/Session.cc
+++ b/src/Session.cc
@@ -1216,6 +1216,9 @@ bool Session::OnConcatStokesFiles(const CARTA::ConcatStokesFiles& message, uint3
         spdlog::error("Fail to concatenate stokes files!");
     }
 
+    // Clear loaders to free images
+    _stokes_files_connector->ClearCache();
+
     SendEvent(CARTA::EventType::CONCAT_STOKES_FILES_ACK, request_id, response);
     return success;
 }

--- a/src/Session.h
+++ b/src/Session.h
@@ -217,6 +217,9 @@ public:
     void UpdateLastMessageTimestamp();
     std::chrono::high_resolution_clock::time_point GetLastMessageTimestamp();
 
+    // Close cached image if it has been updated
+    void CloseCachedImage(const std::string& directory, const std::string& file);
+
 private:
     // File info for file list (extended info for each hdu_name)
     bool FillExtendedFileInfo(std::map<std::string, CARTA::FileInfoExtended>& hdu_info_map, CARTA::FileInfo& file_info,


### PR DESCRIPTION
Closes #579 .

This solves the issue of the image data being rewritten but the original data is displayed when the image is already opened by CARTA.  The casacore::Table data manager does not detect that the data changed when the headers and columns are unchanged.

Uses shared_ptr for the image in the FileLoader so that when its use count is 1 (image pointer created by the loader), its underlying lattice is closed if the image file has been modified unless it is decompressed FITS.  In normal use, the image lattice will not be closed.

When functions requiring image access are complete, `FileLoader::CloseImageIfUpdated()` is called to temporarily close the image lattice if the modify time has changed.  This check is also done across all sessions from Main when a new file is opened so that outdated cached image data is dropped and new data is reloaded when needed.