### PR TITLE
Use the HDU variable with the correct default value when opening mipmap datasets

### DIFF
--- a/src/ImageData/Hdf5Loader.cc
+++ b/src/ImageData/Hdf5Loader.cc
@@ -47,7 +47,7 @@ void Hdf5Loader::OpenFile(const std::string& hdu) {
                 if (std::regex_match(name, match, re) && match.size() > 1) {
                     _mipmaps[std::stoi(match.str(1))] = std::unique_ptr<casacore::HDF5Lattice<float>>(
                         new casacore::HDF5Lattice<float>(casacore::CountedPtr<casacore::HDF5File>(new casacore::HDF5File(_filename)),
-                            fmt::format("MipMaps/DATA/{}", name), hdu));
+                            fmt::format("MipMaps/DATA/{}", name), selected_hdu));
                 }
             }
         }


### PR DESCRIPTION
This probably has no practical effect, since an empty HDU is set to a default value elsewhere, but this should be fixed for consistency.