### PR TITLE
Add security token to gRPC interface

### DIFF
--- a/src/GrpcServer/CartaGrpcService.cc
+++ b/src/GrpcServer/CartaGrpcService.cc
@@ -21,9 +21,7 @@
 
 uint32_t CartaGrpcService::_scripting_request_id = 0;
 
-CartaGrpcService::CartaGrpcService() : _auth_token(""), _debug_no_auth(true) {}
-
-CartaGrpcService::CartaGrpcService(std::string auth_token) : _auth_token(auth_token), _debug_no_auth(false) {}
+CartaGrpcService::CartaGrpcService(std::string auth_token) : _auth_token(auth_token) {}
 
 void CartaGrpcService::AddSession(Session* session) {
     // Map session to its ID, set connected to false
@@ -54,7 +52,7 @@ grpc::Status CartaGrpcService::CallAction(
 
     std::string token;
 
-    if (!_debug_no_auth) {
+    if (!_auth_token.empty()) {
         for (auto& m : metadata) {
             if (m.first == "token") {
                 token = std::string(m.second.begin(), m.second.size());
@@ -65,7 +63,7 @@ grpc::Status CartaGrpcService::CallAction(
 
     grpc::Status status(grpc::Status::OK);
 
-    if (!_debug_no_auth && token != _auth_token) {
+    if (!_auth_token.empty() && token != _auth_token) {
         status = grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "Invalid token.");
     } else if (_sessions.find(session_id) == _sessions.end()) {
         status = grpc::Status(grpc::StatusCode::OUT_OF_RANGE, fmt::format("Invalid session ID {}.", session_id));

--- a/src/GrpcServer/CartaGrpcService.cc
+++ b/src/GrpcServer/CartaGrpcService.cc
@@ -21,7 +21,7 @@
 
 uint32_t CartaGrpcService::_scripting_request_id = 0;
 
-CartaGrpcService::CartaGrpcService() {}
+CartaGrpcService::CartaGrpcService(std::string auth_token) : _auth_token(auth_token) {}
 
 void CartaGrpcService::AddSession(Session* session) {
     // Map session to its ID, set connected to false
@@ -47,9 +47,22 @@ grpc::Status CartaGrpcService::CallAction(
     auto parameters = request->parameters();
     auto async = request->async();
 
+    auto metadata = context->client_metadata();
+
+    std::string token;
+
+    for (auto& m : metadata) {
+        if (m.first == "token") {
+            token = std::string(m.second.begin(), m.second.size());
+            break;
+        }
+    }
+
     grpc::Status status(grpc::Status::OK);
 
-    if (_sessions.find(session_id) == _sessions.end()) {
+    if (token != _auth_token) {
+        status = grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "Invalid token.");
+    } else if (_sessions.find(session_id) == _sessions.end()) {
         status = grpc::Status(grpc::StatusCode::OUT_OF_RANGE, fmt::format("Invalid session ID {}.", session_id));
     } else {
         _scripting_request_id++;

--- a/src/GrpcServer/CartaGrpcService.cc
+++ b/src/GrpcServer/CartaGrpcService.cc
@@ -21,7 +21,9 @@
 
 uint32_t CartaGrpcService::_scripting_request_id = 0;
 
-CartaGrpcService::CartaGrpcService(std::string auth_token) : _auth_token(auth_token) {}
+CartaGrpcService::CartaGrpcService() : _auth_token(""), _debug_no_auth(true) {}
+
+CartaGrpcService::CartaGrpcService(std::string auth_token) : _auth_token(auth_token), _debug_no_auth(false) {}
 
 void CartaGrpcService::AddSession(Session* session) {
     // Map session to its ID, set connected to false
@@ -52,16 +54,18 @@ grpc::Status CartaGrpcService::CallAction(
 
     std::string token;
 
-    for (auto& m : metadata) {
-        if (m.first == "token") {
-            token = std::string(m.second.begin(), m.second.size());
-            break;
+    if (!_debug_no_auth) {
+        for (auto& m : metadata) {
+            if (m.first == "token") {
+                token = std::string(m.second.begin(), m.second.size());
+                break;
+            }
         }
     }
 
     grpc::Status status(grpc::Status::OK);
 
-    if (token != _auth_token) {
+    if (!_debug_no_auth && token != _auth_token) {
         status = grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "Invalid token.");
     } else if (_sessions.find(session_id) == _sessions.end()) {
         status = grpc::Status(grpc::StatusCode::OUT_OF_RANGE, fmt::format("Invalid session ID {}.", session_id));

--- a/src/GrpcServer/CartaGrpcService.h
+++ b/src/GrpcServer/CartaGrpcService.h
@@ -19,7 +19,7 @@
 
 class CartaGrpcService : public CARTA::script::CartaBackend::Service {
 public:
-    CartaGrpcService();
+    CartaGrpcService(std::string auth_token);
     void AddSession(Session* session);
     void RemoveSession(Session* session);
 
@@ -30,6 +30,7 @@ private:
     std::unordered_map<int, std::pair<Session*, bool>> _sessions;
 
     static uint32_t _scripting_request_id;
+    std::string _auth_token;
 };
 
 #endif // CARTA_BACKEND_GRPCSERVER_CARTAGRPCSERVICE_H_

--- a/src/GrpcServer/CartaGrpcService.h
+++ b/src/GrpcServer/CartaGrpcService.h
@@ -19,7 +19,6 @@
 
 class CartaGrpcService : public CARTA::script::CartaBackend::Service {
 public:
-    CartaGrpcService();
     CartaGrpcService(std::string auth_token);
     void AddSession(Session* session);
     void RemoveSession(Session* session);
@@ -32,7 +31,6 @@ private:
 
     static uint32_t _scripting_request_id;
     std::string _auth_token;
-    bool _debug_no_auth;
 };
 
 #endif // CARTA_BACKEND_GRPCSERVER_CARTAGRPCSERVICE_H_

--- a/src/GrpcServer/CartaGrpcService.h
+++ b/src/GrpcServer/CartaGrpcService.h
@@ -19,6 +19,7 @@
 
 class CartaGrpcService : public CARTA::script::CartaBackend::Service {
 public:
+    CartaGrpcService();
     CartaGrpcService(std::string auth_token);
     void AddSession(Session* session);
     void RemoveSession(Session* session);
@@ -31,6 +32,7 @@ private:
 
     static uint32_t _scripting_request_id;
     std::string _auth_token;
+    bool _debug_no_auth;
 };
 
 #endif // CARTA_BACKEND_GRPCSERVER_CARTAGRPCSERVICE_H_

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -525,11 +525,7 @@ int StartGrpcService(int grpc_port) {
     }
 
     // Register and start carta grpc server
-    if (settings.debug_no_auth) {
-        carta_grpc_service = std::unique_ptr<CartaGrpcService>(new CartaGrpcService());
-    } else {
-        carta_grpc_service = std::unique_ptr<CartaGrpcService>(new CartaGrpcService(grpc_token));
-    }
+    carta_grpc_service = std::unique_ptr<CartaGrpcService>(new CartaGrpcService(grpc_token));
     builder.RegisterService(carta_grpc_service.get());
     // By default ports can be reused; we don't want this
     builder.AddChannelArgument(GRPC_ARG_ALLOW_REUSEPORT, 0);

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -502,8 +502,24 @@ int StartGrpcService(int grpc_port) {
     // Listen on the given address without any authentication mechanism.
     builder.AddListeningPort(server_address, grpc::InsecureServerCredentials(), &selected_port);
 
+    std::string grpc_token = "";
+    bool fixed_grpc_token(false);
+
+    auto env_entry = getenv("CARTA_GRPC_TOKEN");
+
+    if (env_entry) {
+        grpc_token = env_entry;
+        fixed_grpc_token = true;
+    } else {
+        uuid_t token;
+        char token_string[37];
+        uuid_generate_random(token);
+        uuid_unparse(token, token_string);
+        grpc_token += token_string;
+    }
+
     // Register and start carta grpc server
-    carta_grpc_service = std::unique_ptr<CartaGrpcService>(new CartaGrpcService());
+    carta_grpc_service = std::unique_ptr<CartaGrpcService>(new CartaGrpcService(grpc_token));
     builder.RegisterService(carta_grpc_service.get());
     // By default ports can be reused; we don't want this
     builder.AddChannelArgument(GRPC_ARG_ALLOW_REUSEPORT, 0);
@@ -511,6 +527,9 @@ int StartGrpcService(int grpc_port) {
 
     if (selected_port > 0) { // available port found
         spdlog::info("CARTA gRPC service available at 0.0.0.0:{}", selected_port);
+        if (!fixed_grpc_token) {
+            spdlog::info("CARTA gRPC token: {}", grpc_token);
+        }
         // Turn logging back on
         gpr_set_log_function(gpr_default_log);
         return 0;

--- a/src/SessionManager/ProgramSettings.cc
+++ b/src/SessionManager/ProgramSettings.cc
@@ -202,7 +202,7 @@ void ProgramSettings::ApplyCommandLineSettings(int argc, char** argv) {
         ("no_system_config", "ignore system configuration file", cxxopts::value<bool>());
 
     options.add_options("Deprecated and debug")
-        ("debug_no_auth", "accept all incoming WebSocket connections on the specified port (not secure; use with caution!)", cxxopts::value<bool>())
+        ("debug_no_auth", "accept all incoming WebSocket and gRPC connections on the specified port(s) (not secure; use with caution!)", cxxopts::value<bool>())
         ("threads", "[deprecated] no longer supported", cxxopts::value<int>(), "<threads>")
         ("base", "[deprecated] set starting folder for data files (use the positional parameter instead)", cxxopts::value<string>(), "<dir>")
         ("root", "[deprecated] use 'top_level_folder' instead", cxxopts::value<string>(), "<dir>");


### PR DESCRIPTION
This implements #840. However, we do not currently use an encrypted gRPC channel between the wrapper and the backend, so the token is sent unencrypted. We would have to implement SSL at both ends in order to encrypt the connection. Is the current solution sufficient for UDM? When we add SDM support we could handle this in the controller, and have the option of using a secure connection in the wrapper.

This has a [companion wrapper PR](https://github.com/idia-astro/carta-python/pull/18).