### PR TITLE
only export SERVER_IP env variable if its not empty

### DIFF
--- a/scripts/carta
+++ b/scripts/carta
@@ -1,13 +1,14 @@
 #!/bin/bash
 
-if [ "$(uname)" == "Darwin" ]
-then
-    SERVER_IP=$(ipconfig getifaddr en0)
-elif [ "$(uname)" == "Linux" ]
-then
-    SERVER_IP=$(hostname -I | cut -d' ' -f1)
+if [ "$(uname)" == "Darwin" ]; then
+    FIRST_IP=$(ipconfig getifaddr en0)
+elif [ "$(uname)" == "Linux" ]; then
+    FIRST_IP=$(hostname -I | cut -d' ' -f1)
 fi
 
-export SERVER_IP
+# Only export env variable if it's not empty
+if [ ! -z $FIRST_IP ]; then
+    export SERVER_IP=$FIRST_IP
+fi
 
 carta_backend "$@"


### PR DESCRIPTION
To fix an issue with running `carta` on machines without network access, as raised in the helpdesk:

> When I'm disconnected from the internet, "hostname -I" returns
nothing.
>
>If I'm connected to the internet (and Carta works), I get e.g.
> hostname -I
192.168.1.107
>
>(this is my laptop at home w/ wireless router)
>
>The OS is Ubuntu 18.04.5 LTS.
I tried: "carta --host=localhost", and that works whether my internet
connection is on or not. Shouldn't the "localhost" option just be the
default in that case?
>
>michael


With the current `carta` script, we get the following auto-generated URL when no IP is detected:
`CARTA is accessible at http://:3002/?token=0d927379-3513-41e1-a2da-7854b723bd4b`

With the modified script:
`CARTA is accessible at http://localhost:3002/?token=3587a442-b9ff-4cd3-babe-f9db2315dc35`