### PR TITLE
891 Fix control points record for polygon/line/polyline

### DIFF
--- a/src/Region/Region.cc
+++ b/src/Region/Region.cc
@@ -940,10 +940,6 @@ casacore::TableRecord Region::GetControlPointsRecord(const casacore::IPosition& 
                 y(i) = _region_state.control_points[i].y();
             }
 
-            // LCPolygon::toRecord includes last point as first point to close region
-            x(npoints) = _region_state.control_points[0].x();
-            y(npoints) = _region_state.control_points[0].y();
-
             if (_region_state.type == CARTA::RegionType::POLYGON) {
                 // LCPolygon::toRecord includes first point as last point to close region
                 x.resize(npoints + 1, true);


### PR DESCRIPTION
Closes #891 

Probable merge error.  Polygon region requires adding first point as last point to close the region when creating the record for region export.  This point was being added incorrectly for polygon and line-type regions, but vector was size npoints instead of npoints+1.  Fixed so that vector is resized and point added for polygon only.

@veggiesaurus and @kswang1029 after this is tested, should this be added to v3b1?