### PR TITLE
Don't calculate the cube histogram if it's available in the HDF5 file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+* Fixed control points record for polygon / line / polyline ([#891](https://github.com/CARTAvis/carta-backend/issues/891)).
+* Fixed bug causing cube histogram to be generated even if it was available in an HDF5 file ([#899](https://github.com/CARTAvis/carta-backend/issues/899)).
+
 ## [3.0.0-beta.1]
 
 ### Added

--- a/src/Session.cc
+++ b/src/Session.cc
@@ -1524,7 +1524,9 @@ bool Session::SendRegionHistogramData(int file_id, int region_id) {
     } else if (region_id < CURSOR_REGION_ID) {
         // Image or cube histogram
         if (_frames.count(file_id)) {
-            if (region_id == CUBE_REGION_ID) { // not in cache, calculate cube histogram
+            bool filled_by_frame(_frames.at(file_id)->FillRegionHistogramData(region_histogram_data_callback, region_id, file_id));
+
+            if (!filled_by_frame && region_id == CUBE_REGION_ID) { // not in cache, calculate cube histogram
                 CARTA::RegionHistogramData histogram_data;
                 histogram_data.set_file_id(file_id);
                 histogram_data.set_region_id(region_id);
@@ -1532,8 +1534,6 @@ bool Session::SendRegionHistogramData(int file_id, int region_id) {
                     SendFileEvent(file_id, CARTA::EventType::REGION_HISTOGRAM_DATA, 0, histogram_data);
                     data_sent = true;
                 }
-            } else {
-                _frames.at(file_id)->FillRegionHistogramData(region_histogram_data_callback, region_id, file_id);
             }
         }
     } else {


### PR DESCRIPTION
Fixes #899.

This reorders the conditions so that the cube histogram isn't always calculated.