### PR TITLE
Allow sending the cursor value if cursor spatial config is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fixed control points record for polygon / line / polyline ([#891](https://github.com/CARTAvis/carta-backend/issues/891)).
 * Fixed bug causing cube histogram to be generated even if it was available in an HDF5 file ([#899](https://github.com/CARTAvis/carta-backend/issues/899)).
+* Fixed bug of missing cursor values for matched images ([#900](https://github.com/CARTAvis/carta-backend/issues/900))
 
 ## [3.0.0-beta.1]
 

--- a/test/TestSpatialProfiles.cc
+++ b/test/TestSpatialProfiles.cc
@@ -583,7 +583,7 @@ TEST_F(SpatialProfileTest, FitsChannelStokesChange) {
         EXPECT_EQ(data.y(), y);
         EXPECT_EQ(data.channel(), channel);
         EXPECT_EQ(data.stokes(), spatial_config_stokes);
-        EXPECT_FLOAT_EQ(data.value(), reader.ReadPointXY(x, y, channel, stokes));
+        EXPECT_FLOAT_EQ(data.value(), reader.ReadPointXY(x, y, channel, spatial_config_stokes));
         EXPECT_EQ(data.profiles_size(), 2);
 
         auto [x_profile, y_profile] = GetProfiles(data);
@@ -715,7 +715,7 @@ TEST_F(SpatialProfileTest, ChunkedHDF5ChannelStokesChange) {
         EXPECT_EQ(data.y(), y);
         EXPECT_EQ(data.channel(), channel);
         EXPECT_EQ(data.stokes(), spatial_config_stokes);
-        EXPECT_FLOAT_EQ(data.value(), reader.ReadPointXY(x, y, channel, stokes));
+        EXPECT_FLOAT_EQ(data.value(), reader.ReadPointXY(x, y, channel, spatial_config_stokes));
         EXPECT_EQ(data.profiles_size(), 2);
 
         auto [x_profile, y_profile] = GetProfiles(data);


### PR DESCRIPTION
Fixes #900. Allow sending the cursor value if cursor spatial config is empty. Also fixes the cursor value for different stokes if it is required in the spatial config.