### PR TITLE
Fixes region histograms for moment images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+* Fixed region histograms for moment images ([#906](https://github.com/CARTAvis/carta-backend/issues/906)).
+
 ## [3.0.0-beta.1b]
 
 ### Fixed


### PR DESCRIPTION
Fix #906 by using a different way to get region data for an image in memory.