### PR TITLE
remove int64 workarounds

### DIFF
--- a/src/Table/DataColumn.tcc
+++ b/src/Table/DataColumn.tcc
@@ -270,14 +270,7 @@ void DataColumn<T>::FillColumnData(
     CARTA::ColumnData& column_data, bool fill_subset, const IndexList& indices, int64_t start, int64_t end) const {
     column_data.set_data_type(data_type);
     auto values = GetColumnData(fill_subset, indices, start, end);
-
-    // Workaround to prevent issues with Safari's lack of BigInt support
-    if (data_type == CARTA::Int64 || data_type == CARTA::Uint64) {
-        auto double_values = std::vector<double>(values.begin(), values.end());
-        column_data.set_binary_data(double_values.data(), double_values.size() * sizeof(T));
-    } else {
-        column_data.set_binary_data(values.data(), values.size() * sizeof(T));
-    }
+    column_data.set_binary_data(values.data(), values.size() * sizeof(T));
 }
 
 } // namespace carta


### PR DESCRIPTION
Backend part of https://github.com/CARTAvis/carta/issues/85, just removing the (buggy) workaround for 64-bit columns.

Companion PR of https://github.com/CARTAvis/carta-frontend/pull/1642