### PR TITLE
matrix style Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
         preserveStashes() 
     }
     stages {
-        stage ('Build') {
+        stage('Build') {
             parallel {
                 stage('Ubuntu 18.04') {
                     agent {
@@ -167,7 +167,7 @@ pipeline {
                         }
                     }
                 }
-                stage('Ubuntu 20.04') {          
+                stage('Ubuntu 20.04') {
                     agent {
                         label "focal-docker-agent"
                     }
@@ -301,7 +301,7 @@ pipeline {
                         steps {
                             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                                 unstash "${PLATFORM}-backend"
-                                sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
+                                sh "./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth true --no_http true --verbosity=5 &"
                                 unstash "${PLATFORM}-ICD"
                                 session()
                             }
@@ -314,7 +314,7 @@ pipeline {
                         steps {
                             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                                 unstash "${PLATFORM}-backend"
-                                sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
+                                sh "./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth true --no_http true --verbosity=5 &"
                                 unstash "${PLATFORM}-ICD"
                                 file_browser()
                             }
@@ -327,7 +327,7 @@ pipeline {
                         steps {
                             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                                 unstash "${PLATFORM}-backend"
-                                sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
+                                sh "./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth true --no_http true --verbosity=5 &"
                                 unstash "${PLATFORM}-ICD"
                                 animator()
                             }
@@ -340,7 +340,7 @@ pipeline {
                         steps {
                             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                                 unstash "${PLATFORM}-backend"
-                                sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
+                                sh "./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth true --no_http true --verbosity=5 &"
                                 unstash "${PLATFORM}-ICD"
                                 contour()
                             }
@@ -353,7 +353,7 @@ pipeline {
                         steps {
                             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                                 unstash "${PLATFORM}-backend"
-                                sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
+                                sh "./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth true --no_http true --verbosity=5 &"
                                 unstash "${PLATFORM}-ICD"
                                 region_statistics()
                             }
@@ -366,7 +366,7 @@ pipeline {
                         steps {
                             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                                 unstash "${PLATFORM}-backend"
-                                sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
+                                sh "./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth true --no_http true --verbosity=5 &"
                                 unstash "${PLATFORM}-ICD"
                                 region_manipulation()
                             }
@@ -379,7 +379,7 @@ pipeline {
                         steps {
                             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                                 unstash "${PLATFORM}-backend"
-                                sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
+                                sh "./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth true --no_http true --verbosity=5 &"
                                 unstash "${PLATFORM}-ICD"
                                 cube_histogram()
                             }
@@ -392,7 +392,7 @@ pipeline {
                         steps {
                             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                                 unstash "${PLATFORM}-backend"
-                                sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
+                                sh "./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth true --no_http true --verbosity=5 &"
                                 unstash "${PLATFORM}-ICD"
                                 spatial_profiler()
                             }
@@ -405,7 +405,7 @@ pipeline {
                         steps {
                             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                                 unstash "${PLATFORM}-backend"
-                                sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
+                                sh "./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth true --no_http true --verbosity=5 &"
                                 unstash "${PLATFORM}-ICD"
                                 raster_tiles()
                             }
@@ -418,7 +418,7 @@ pipeline {
                         steps {
                             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                                 unstash "${PLATFORM}-backend"
-                                sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
+                                sh "./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth true --no_http true --verbosity=5 &"
                                 unstash "${PLATFORM}-ICD"
                                 catalog()
                             }
@@ -431,7 +431,7 @@ pipeline {
                         steps {
                             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                                 unstash "${PLATFORM}-backend"
-                                sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
+                                sh "./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth true --no_http true --verbosity=5 &"
                                 unstash "${PLATFORM}-ICD"
                                 moment()
                             }
@@ -444,7 +444,7 @@ pipeline {
                         steps {
                             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                                 unstash "${PLATFORM}-backend"
-                                sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
+                                sh "./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth true --no_http true --verbosity=5 &"
                                 unstash "${PLATFORM}-ICD"
                                 resume()
                             }
@@ -457,7 +457,7 @@ pipeline {
                         steps {
                             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                                 unstash "${PLATFORM}-backend"
-                                sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
+                                sh "./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth true --no_http true --verbosity=5 &"
                                 unstash "${PLATFORM}-ICD"
                                 match()
                             }
@@ -470,7 +470,7 @@ pipeline {
                         steps {
                             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                                 unstash "${PLATFORM}-backend"
-                                sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
+                                sh "./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth true --no_http true --verbosity=5 &"
                                 unstash "${PLATFORM}-ICD"
                                 close_file()
                             }
@@ -481,6 +481,7 @@ pipeline {
         }
     }
 }
+
 def prepare_focal_ICD() {
     catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
         sh "git clone --depth 1 https://github.com/CARTAvis/carta-backend-ICD-test.git"
@@ -493,11 +494,13 @@ def prepare_focal_ICD() {
             dir ('src/test') { 
                 sh "perl -p -i -e 's/serverURL/serverURL1/' config.json"
                 sh "perl -p -i -e 's/serverURL10/serverURL/' config.json"
+                sh "perl -p -i -e 's/3002/3112/' config.json"
             }
         }
         stash includes: "carta-backend-ICD-test/**/*", name: "focal-ICD"
     }
 }
+
 def prepare_bionic_ICD() {
     catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
         sh "git clone --depth 1 https://github.com/CARTAvis/carta-backend-ICD-test.git"
@@ -510,11 +513,13 @@ def prepare_bionic_ICD() {
             dir ('src/test') { 
                 sh "perl -p -i -e 's/serverURL/serverURL1/' config.json"
                 sh "perl -p -i -e 's/serverURL10/serverURL/' config.json"
+                sh "perl -p -i -e 's/3002/3112/' config.json"
             }
         }
         stash includes: "carta-backend-ICD-test/**/*", name: "bionic-ICD"
     }
 }
+
 def prepare_rhel7_ICD() {
     catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
         sh "git clone --depth 1 https://github.com/CARTAvis/carta-backend-ICD-test.git"
@@ -527,11 +532,13 @@ def prepare_rhel7_ICD() {
             dir ('src/test') {
                 sh "perl -p -i -e 's/serverURL/serverURL1/' config.json"
                 sh "perl -p -i -e 's/serverURL10/serverURL/' config.json"
+                sh "perl -p -i -e 's/3002/3112/' config.json"
             }
        }
        stash includes: "carta-backend-ICD-test/**/*", name: "rhel7-ICD"
     }
 }
+
 def prepare_rhel8_ICD() {
     catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
         sh "git clone --depth 1 https://github.com/CARTAvis/carta-backend-ICD-test.git"
@@ -544,11 +551,13 @@ def prepare_rhel8_ICD() {
             dir ('src/test') {
                 sh "perl -p -i -e 's/serverURL/serverURL1/' config.json"
                 sh "perl -p -i -e 's/serverURL10/serverURL/' config.json"
+                sh "perl -p -i -e 's/3002/3112/' config.json"
             }
        }
        stash includes: "carta-backend-ICD-test/**/*", name: "rhel8-ICD"
     }
 }
+
 def prepare_macos11_ICD() {
     catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
         sh "rm -rf carta-backend-ICD-test"
@@ -564,390 +573,377 @@ def prepare_macos11_ICD() {
     }
 }
 
-def focal() {
-    unstash "focal-backend"
-    sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
-    unstash "focal-ICD"
-}
-def bionic() {
-    unstash "bionic-backend"
-    sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
-    unstash "bionic-ICD"
-}
-def rhel7() {
-    unstash "rhel7-backend"
-    sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
-    unstash "rhel7-ICD"
-}
-def rhel8() {
-    unstash "rhel8-backend"
-    sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
-    unstash "rhel8-ICD"
-}
-def macos11() {
-    unstash "macos11-backend"
-    sh "cp ../run.sh . && ./run.sh"
-    unstash "macos11-ICD"
+def session() {
+    script {
+        dir ('carta-backend-ICD-test') {
+            sh "npm install && ./protobuf/build_proto.sh"
+            ret = false
+            retry(3) {
+                if (ret) {
+                    sleep(time:30,unit:"SECONDS")
+                    sh "cat /root/.carta/log/carta.log"
+                    echo "Trying again"
+                } else {
+                    ret = true
+                }
+                sh "pgrep carta_backend"
+                sh "CI=true npm test src/test/ACCESS_CARTA_DEFAULT.test.ts # test 1 of 6"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/ACCESS_CARTA_KNOWN_SESSION.test.ts # test 2 of 6"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/ACCESS_CARTA_NO_CLIENT_FEATURE.test.ts # test 3 of 6"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/ACCESS_CARTA_SAME_ID_TWICE.test.ts # test 4 of 6"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/ACCESS_CARTA_DEFAULT_CONCURRENT.test.ts # test 5 of 6"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/ACCESS_WEBSOCKET.test.ts # test 6 of 6"
+                sh "pgrep carta_backend"
+            }
+        }
+    }
 }
 
-def session() {
-     script {
-         dir ('carta-backend-ICD-test') {
-             sh "npm install && ./protobuf/build_proto.sh"
-             ret = false
-             retry(3) {
-                 if (ret) {
-                     sleep(time:30,unit:"SECONDS")
-                     sh "cat /root/.carta/log/carta.log"
-                     echo "Trying again"
-                 } else {
-                     ret = true
-                 }
-                 sh "pgrep carta_backend"
-                 sh "CI=true npm test src/test/ACCESS_CARTA_DEFAULT.test.ts # test 1 of 6"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/ACCESS_CARTA_KNOWN_SESSION.test.ts # test 2 of 6"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/ACCESS_CARTA_NO_CLIENT_FEATURE.test.ts # test 3 of 6"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/ACCESS_CARTA_SAME_ID_TWICE.test.ts # test 4 of 6"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/ACCESS_CARTA_DEFAULT_CONCURRENT.test.ts # test 5 of 6"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/ACCESS_WEBSOCKET.test.ts # test 6 of 6"
-                 sh "pgrep carta_backend"
-             }
-         }
-     }
-}
 def file_browser() {
-     script {
-         dir ('carta-backend-ICD-test') {
-             sh "npm install && ./protobuf/build_proto.sh"
-             ret = false
-             retry(3) {
-                 if (ret) {
-                     sleep(time:30,unit:"SECONDS")
-                     sh "cat /root/.carta/log/carta.log"
-                     echo "Trying again"
-                 } else {
-                     ret = true
-                 }
-                 sh "pgrep carta_backend"
-                 sh "CI=true npm test src/test/GET_FILELIST.test.ts # test 1 of 9"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/GET_FILELIST_ROOTPATH_CONCURRENT.test.ts # test 2 of 9"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/FILETYPE_PARSER.test.ts # test 3 of 9"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/FILEINFO_FITS.test.ts # test 4 of 9"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/FILEINFO_CASA.test.ts # test 5 of 9"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/FILEINFO_HDF5.test.ts # test 6 of 9"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/FILEINFO_MIRIAD.test.ts # test 7 of 9"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/FILEINFO_FITS_MULTIHDU.test.ts # test 8 of 9"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/FILEINFO_EXCEPTIONS.test.ts # test 9 of 9"
-                 sh "pgrep carta_backend"
-             }
-         }
-     }
+    script {
+        dir ('carta-backend-ICD-test') {
+            sh "npm install && ./protobuf/build_proto.sh"
+            ret = false
+            retry(3) {
+                if (ret) {
+                    sleep(time:30,unit:"SECONDS")
+                    sh "cat /root/.carta/log/carta.log"
+                    echo "Trying again"
+                } else {
+                    ret = true
+                }
+                sh "pgrep carta_backend"
+                sh "CI=true npm test src/test/GET_FILELIST.test.ts # test 1 of 9"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/GET_FILELIST_ROOTPATH_CONCURRENT.test.ts # test 2 of 9"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/FILETYPE_PARSER.test.ts # test 3 of 9"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/FILEINFO_FITS.test.ts # test 4 of 9"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/FILEINFO_CASA.test.ts # test 5 of 9"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/FILEINFO_HDF5.test.ts # test 6 of 9"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/FILEINFO_MIRIAD.test.ts # test 7 of 9"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/FILEINFO_FITS_MULTIHDU.test.ts # test 8 of 9"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/FILEINFO_EXCEPTIONS.test.ts # test 9 of 9"
+                sh "pgrep carta_backend"
+            }
+        }
+    }
 }
+
 def animator() {
-     script {
-         dir ('carta-backend-ICD-test') {
-             sh "npm install && ./protobuf/build_proto.sh"
-             ret = false
-             retry(3) {
-                 if (ret) {
-                     sleep(time:30,unit:"SECONDS")
-                     sh "cat /root/.carta/log/carta.log"
-                     echo "Trying again"
-                 } else {
-                     ret = true
-                 }
-                 sh "pgrep carta_backend"
-                 sh "CI=true npm test src/test/ANIMATOR_DATA_STREAM.test.ts # test 1 of 4"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/ANIMATOR_NAVIGATION.test.ts # test 2 of 4"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/ANIMATOR_CONTOUR_MATCH.test.ts # test 3 of 4"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/ANIMATOR_CONTOUR.test.ts # test 4 of 4"
-                 sh "pgrep carta_backend"
-             }
-         }
-     }
+    script {
+        dir ('carta-backend-ICD-test') {
+            sh "npm install && ./protobuf/build_proto.sh"
+            ret = false
+            retry(3) {
+                if (ret) {
+                    sleep(time:30,unit:"SECONDS")
+                    sh "cat /root/.carta/log/carta.log"
+                    echo "Trying again"
+                } else {
+                    ret = true
+                }
+                sh "pgrep carta_backend"
+                sh "CI=true npm test src/test/ANIMATOR_DATA_STREAM.test.ts # test 1 of 4"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/ANIMATOR_NAVIGATION.test.ts # test 2 of 4"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/ANIMATOR_CONTOUR_MATCH.test.ts # test 3 of 4"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/ANIMATOR_CONTOUR.test.ts # test 4 of 4"
+                sh "pgrep carta_backend"
+            }
+        }
+    }
 }
+
 def contour() {
-     script {
-         dir ('carta-backend-ICD-test') {
-             sh "npm install && ./protobuf/build_proto.sh"
-             ret = false
-             retry(3) {
-                 if (ret) {
-                     sleep(time:30,unit:"SECONDS")
-                     sh "cat /root/.carta/log/carta.log"
-                     echo "Trying again"
-                 } else {
-                     ret = true
-                 }
-                 sh "pgrep carta_backend"
-                 sh "CI=true npm test src/test/CONTOUR_IMAGE_DATA.test.ts # test 1 of 3"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/CONTOUR_IMAGE_DATA_NAN.test.ts # test 2 of 2"
-             }
-         }
-     }
+    script {
+        dir ('carta-backend-ICD-test') {
+            sh "npm install && ./protobuf/build_proto.sh"
+            ret = false
+            retry(3) {
+                if (ret) {
+                    sleep(time:30,unit:"SECONDS")
+                    sh "cat /root/.carta/log/carta.log"
+                    echo "Trying again"
+                } else {
+                    ret = true
+                }
+                sh "pgrep carta_backend"
+                sh "CI=true npm test src/test/CONTOUR_IMAGE_DATA.test.ts # test 1 of 3"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/CONTOUR_IMAGE_DATA_NAN.test.ts # test 2 of 2"
+            }
+        }
+    }
 }
+
 def region_statistics() {
-     script {
-         dir ('carta-backend-ICD-test') {
-             sh "npm install && ./protobuf/build_proto.sh"
-             ret = false
-             retry(3) {
-                 if (ret) {
-                     sleep(time:30,unit:"SECONDS")
-                     sh "cat /root/.carta/log/carta.log"
-                     echo "Trying again"
-                 } else {
-                     ret = true
-                 }
-                 sh "pgrep carta_backend"
-                 sh "CI=true npm test src/test/REGION_STATISTICS_RECTANGLE.test.ts # test 1 of 3"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/REGION_STATISTICS_ELLIPSE.test.ts # test 2 of 3"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/REGION_STATISTICS_POLYGON.test.ts # test 3 of 3"
-                 sh "pgrep carta_backend"
-             }
-         }
-     }
+    script {
+        dir ('carta-backend-ICD-test') {
+            sh "npm install && ./protobuf/build_proto.sh"
+            ret = false
+            retry(3) {
+                if (ret) {
+                    sleep(time:30,unit:"SECONDS")
+                    sh "cat /root/.carta/log/carta.log"
+                    echo "Trying again"
+                } else {
+                    ret = true
+                }
+                sh "pgrep carta_backend"
+                sh "CI=true npm test src/test/REGION_STATISTICS_RECTANGLE.test.ts # test 1 of 3"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/REGION_STATISTICS_ELLIPSE.test.ts # test 2 of 3"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/REGION_STATISTICS_POLYGON.test.ts # test 3 of 3"
+                sh "pgrep carta_backend"
+            }
+        }
+    }
 }
+
 def region_manipulation() {
-     script {
-         dir ('carta-backend-ICD-test') {
-             sh "npm install && ./protobuf/build_proto.sh"
-             ret = false
-             retry(3) {
-                 if (ret) {
-                     sleep(time:30,unit:"SECONDS")
-                     sh "cat /root/.carta/log/carta.log"
-                     echo "Trying again"
-                 } else {
-                     ret = true
-                 }
-                 sh "pgrep carta_backend"
-                 sh "CI=true npm test src/test/REGION_REGISTER.test.ts # test 1 of 9"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/CASA_REGION_INFO.test.ts # test 2 of 9"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/CASA_REGION_IMPORT_INTERNAL.test.ts # test 3 of 9"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/CASA_REGION_IMPORT_EXPORT.test.ts # test 4 of 9"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/CASA_REGION_IMPORT_EXCEPTION.test.ts # test 5 of 9"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/CASA_REGION_EXPORT.test.ts # test 6 of 9"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/DS9_REGION_EXPORT.test.ts # test 7 of 9"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/DS9_REGION_IMPORT_EXCEPTION.test.ts # test 8 of 9"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/DS9_REGION_IMPORT_EXPORT.test.ts # test 9 of 9"
-                 sh "pgrep carta_backend"
-             }
-         }
-     }
+    script {
+        dir ('carta-backend-ICD-test') {
+            sh "npm install && ./protobuf/build_proto.sh"
+            ret = false
+            retry(3) {
+                if (ret) {
+                    sleep(time:30,unit:"SECONDS")
+                    sh "cat /root/.carta/log/carta.log"
+                    echo "Trying again"
+                } else {
+                    ret = true
+                }
+                sh "pgrep carta_backend"
+                sh "CI=true npm test src/test/REGION_REGISTER.test.ts # test 1 of 9"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/CASA_REGION_INFO.test.ts # test 2 of 9"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/CASA_REGION_IMPORT_INTERNAL.test.ts # test 3 of 9"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/CASA_REGION_IMPORT_EXPORT.test.ts # test 4 of 9"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/CASA_REGION_IMPORT_EXCEPTION.test.ts # test 5 of 9"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/CASA_REGION_EXPORT.test.ts # test 6 of 9"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/DS9_REGION_EXPORT.test.ts # test 7 of 9"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/DS9_REGION_IMPORT_EXCEPTION.test.ts # test 8 of 9"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/DS9_REGION_IMPORT_EXPORT.test.ts # test 9 of 9"
+                sh "pgrep carta_backend"
+            }
+        }
+    }
 }
+
 def cube_histogram() {
-     script {
-         dir ('carta-backend-ICD-test') {
-             sh "npm install && ./protobuf/build_proto.sh"
-             ret = false
-             retry(3) {
-                 if (ret) {
-                     sleep(time:30,unit:"SECONDS")
-                     sh "cat /root/.carta/log/carta.log"
-                     echo "Trying again"
-                 } else {
-                     ret = true
-                 }
-                 sh "pgrep carta_backend"
-                 sh "CI=true npm test src/test/PER_CUBE_HISTOGRAM_HDF5.test.ts # test 1 of 1"
-             }
-         }
-     }
+    script {
+        dir ('carta-backend-ICD-test') {
+            sh "npm install && ./protobuf/build_proto.sh"
+            ret = false
+            retry(3) {
+                if (ret) {
+                    sleep(time:30,unit:"SECONDS")
+                    sh "cat /root/.carta/log/carta.log"
+                    echo "Trying again"
+                } else {
+                    ret = true
+                }
+                sh "pgrep carta_backend"
+                sh "CI=true npm test src/test/PER_CUBE_HISTOGRAM_HDF5.test.ts # test 1 of 1"
+            }
+        }
+    }
 }
+
 def spatial_profiler() {
-     script {
-         dir ('carta-backend-ICD-test') {
-             sh "npm install && ./protobuf/build_proto.sh"
-             ret = false
-             retry(3) {
-                 if (ret) {
-                     sleep(time:30,unit:"SECONDS")
-                     sh "cat /root/.carta/log/carta.log"
-                     echo "Trying again"
-                 } else {
-                     ret = true
-                 }
-                 sh "pgrep carta_backend"
-                 sh "CI=true npm test src/test/CURSOR_SPATIAL_PROFILE.test.ts # test 1 of 2"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/CURSOR_SPATIAL_PROFILE_NaN.test.ts # test 2 of 2"
-                 sh "pgrep carta_backend"
-             }
-         }
-     }
+    script {
+        dir ('carta-backend-ICD-test') {
+            sh "npm install && ./protobuf/build_proto.sh"
+            ret = false
+            retry(3) {
+                if (ret) {
+                    sleep(time:30,unit:"SECONDS")
+                    sh "cat /root/.carta/log/carta.log"
+                    echo "Trying again"
+                } else {
+                    ret = true
+                }
+                sh "pgrep carta_backend"
+                sh "CI=true npm test src/test/CURSOR_SPATIAL_PROFILE.test.ts # test 1 of 2"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/CURSOR_SPATIAL_PROFILE_NaN.test.ts # test 2 of 2"
+                sh "pgrep carta_backend"
+            }
+        }
+    }
 }
+
 def raster_tiles() {
-     script {
-         dir ('carta-backend-ICD-test') {
-             sh "npm install && ./protobuf/build_proto.sh"
-             ret = false
-             retry(3) {
-                 if (ret) {
-                     sleep(time:30,unit:"SECONDS")
-                     sh "cat /root/.carta/log/carta.log"
-                     echo "Trying again"
-                 } else {
-                     ret = true
-                 }
-                 sh "pgrep carta_backend"
-                 sh "CI=true npm test src/test/CHECK_RASTER_TILE_DATA.test.ts # test 1 of 2"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/TILE_DATA_REQUEST.test.ts # test 2 of 2"
-                 sh "pgrep carta_backend"
-             }
-         }
-     }
+    script {
+        dir ('carta-backend-ICD-test') {
+            sh "npm install && ./protobuf/build_proto.sh"
+            ret = false
+            retry(3) {
+                if (ret) {
+                    sleep(time:30,unit:"SECONDS")
+                    sh "cat /root/.carta/log/carta.log"
+                    echo "Trying again"
+                } else {
+                    ret = true
+                }
+                sh "pgrep carta_backend"
+                sh "CI=true npm test src/test/CHECK_RASTER_TILE_DATA.test.ts # test 1 of 2"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/TILE_DATA_REQUEST.test.ts # test 2 of 2"
+                sh "pgrep carta_backend"
+            }
+        }
+    }
 }
+
 def catalog() {
-     script {
-         dir ('carta-backend-ICD-test') {
-             sh "npm install && ./protobuf/build_proto.sh"
-             ret = false
-             retry(3) {
-                 if (ret) {
-                     sleep(time:30,unit:"SECONDS")
-                     sh "cat /root/.carta/log/carta.log"
-                     echo "Trying again"
-                 } else {
-                     ret = true
-                 }
-                 sh "pgrep carta_backend"
-                 sh "CI=true npm test src/test/CATALOG_GENERAL.test.ts # test 1 of 1"
-             }
-         }
-     }
+    script {
+        dir ('carta-backend-ICD-test') {
+            sh "npm install && ./protobuf/build_proto.sh"
+            ret = false
+            retry(3) {
+                if (ret) {
+                    sleep(time:30,unit:"SECONDS")
+                    sh "cat /root/.carta/log/carta.log"
+                    echo "Trying again"
+                } else {
+                    ret = true
+                }
+                sh "pgrep carta_backend"
+                sh "CI=true npm test src/test/CATALOG_GENERAL.test.ts # test 1 of 1"
+            }
+        }
+    }
 }
+
 def moment() {
-     script {
-         dir ('carta-backend-ICD-test') {
-             sh "npm install && ./protobuf/build_proto.sh"
-             ret = false
-             retry(3) {
-                 if (ret) {
-                     sleep(time:30,unit:"SECONDS")
-                     sh "cat /root/.carta/log/carta.log"
-                     echo "Trying again"
-                 } else {
-                     ret = true
-                 }
-                 sh "pgrep carta_backend"
-                 sh "CI=true npm test src/test/MOMENTS_GENERATOR_CASA.test.ts # test 1 of 6"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/MOMENTS_GENERATOR_EXCEPTION.test.ts # test 2 of 6"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/MOMENTS_GENERATOR_FITS.test.ts # test 3 of 6"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/MOMENTS_GENERATOR_HDF5.test.ts # test 4 of 6"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/MOMENTS_GENERATOR_SAVE.test.ts # test 5 of 6"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/MOMENTS_GENERATOR_CANCEL.test.ts # test 6 of 6"
-                 sh "pgrep carta_backend"
-             }
-         }
-     }
+    script {
+        dir ('carta-backend-ICD-test') {
+            sh "npm install && ./protobuf/build_proto.sh"
+            ret = false
+            retry(3) {
+                if (ret) {
+                    sleep(time:30,unit:"SECONDS")
+                    sh "cat /root/.carta/log/carta.log"
+                    echo "Trying again"
+                } else {
+                    ret = true
+                }
+                sh "pgrep carta_backend"
+                sh "CI=true npm test src/test/MOMENTS_GENERATOR_CASA.test.ts # test 1 of 6"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/MOMENTS_GENERATOR_EXCEPTION.test.ts # test 2 of 6"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/MOMENTS_GENERATOR_FITS.test.ts # test 3 of 6"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/MOMENTS_GENERATOR_HDF5.test.ts # test 4 of 6"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/MOMENTS_GENERATOR_SAVE.test.ts # test 5 of 6"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/MOMENTS_GENERATOR_CANCEL.test.ts # test 6 of 6"
+                sh "pgrep carta_backend"
+            }
+        }
+    }
 }
+
 def resume() {
-     script {
-         dir ('carta-backend-ICD-test') {
-             sh "npm install && ./protobuf/build_proto.sh"
-             ret = false
-             retry(3) {
-                 if (ret) {
-                     sleep(time:30,unit:"SECONDS")
-                     sh "cat /root/.carta/log/carta.log"
-                     echo "Trying again"
-                 } else {
-                     ret = true
-                 }
-                 sh "pgrep carta_backend"
-                 sh "CI=true npm test src/test/RESUME_CATALOG.test.ts # test 1 of 4"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/RESUME_CONTOUR.test.ts # test 2 of 4"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/RESUME_IMAGE.test.ts # test 3 of 4"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/RESUME_REGION.test.ts # test 4 of 4"
-                 sh "pgrep carta_backend"
-             }
-         }
-     }
+    script {
+        dir ('carta-backend-ICD-test') {
+            sh "npm install && ./protobuf/build_proto.sh"
+            ret = false
+            retry(3) {
+                if (ret) {
+                    sleep(time:30,unit:"SECONDS")
+                    sh "cat /root/.carta/log/carta.log"
+                    echo "Trying again"
+                } else {
+                    ret = true
+                }
+                sh "pgrep carta_backend"
+                sh "CI=true npm test src/test/RESUME_CATALOG.test.ts # test 1 of 4"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/RESUME_CONTOUR.test.ts # test 2 of 4"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/RESUME_IMAGE.test.ts # test 3 of 4"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/RESUME_REGION.test.ts # test 4 of 4"
+                sh "pgrep carta_backend"
+            }
+        }
+    }
 }
+
 def match() {
-     script {
-         dir ('carta-backend-ICD-test') {
-             sh "npm install && ./protobuf/build_proto.sh"
-             ret = false
-             retry(3) {
-                 if (ret) {
-                     sleep(time:30,unit:"SECONDS")
-                     sh "cat /root/.carta/log/carta.log"
-                     echo "Trying again"
-                 } else {
-                      ret = true
-                 }
-                 sh "pgrep carta_backend"
-                 sh "CI=true npm test src/test/MATCH_SPATIAL.test.ts # test 1 of 2"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/MATCH_STATS.test.ts # test 2 of 2"
-                 sh "pgrep carta_backend"
-             }
-         }
-     }
-}
-def close_file() {
-     script {
-         dir ('carta-backend-ICD-test') {
-             sh "npm install && ./protobuf/build_proto.sh"
-             ret = false
-             retry(3) {
-                 if (ret) {
-                     sleep(time:30,unit:"SECONDS")
-                     sh "cat /root/.carta/log/carta.log"
-                     echo "Trying again"
-                 } else {
+    script {
+        dir ('carta-backend-ICD-test') {
+            sh "npm install && ./protobuf/build_proto.sh"
+            ret = false
+            retry(3) {
+                if (ret) {
+                    sleep(time:30,unit:"SECONDS")
+                    sh "cat /root/.carta/log/carta.log"
+                    echo "Trying again"
+                } else {
                      ret = true
-                 }
-                 sh "pgrep carta_backend"
-                 sh "CI=true npm test src/test/CLOSE_FILE_SINGLE.test.ts # test 1 of 5"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/CLOSE_FILE_ANIMATION.test.ts # test 2 of 5"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/CLOSE_FILE_ERROR.test.ts # test 3 of 5"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/CLOSE_FILE_SPECTRAL_PROFILE.test.ts # test 4 of 5"
-                 sh "sleep 3 && pgrep carta_backend"
-                 sh "CI=true npm test src/test/CLOSE_FILE_TILE.test.ts # test 5 of 5"
-                 sh "pgrep carta_backend"
-             }
-         }
-     }
+                }
+                sh "pgrep carta_backend"
+                sh "CI=true npm test src/test/MATCH_SPATIAL.test.ts # test 1 of 2"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/MATCH_STATS.test.ts # test 2 of 2"
+                sh "pgrep carta_backend"
+            }
+        }
+    }
+}
+
+def close_file() {
+    script {
+        dir ('carta-backend-ICD-test') {
+            sh "npm install && ./protobuf/build_proto.sh"
+            ret = false
+            retry(3) {
+                if (ret) {
+                    sleep(time:30,unit:"SECONDS")
+                    sh "cat /root/.carta/log/carta.log"
+                    echo "Trying again"
+                } else {
+                    ret = true
+                }
+                sh "pgrep carta_backend"
+                sh "CI=true npm test src/test/CLOSE_FILE_SINGLE.test.ts # test 1 of 5"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/CLOSE_FILE_ANIMATION.test.ts # test 2 of 5"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/CLOSE_FILE_ERROR.test.ts # test 3 of 5"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/CLOSE_FILE_SPECTRAL_PROFILE.test.ts # test 4 of 5"
+                sh "sleep 3 && pgrep carta_backend"
+                sh "CI=true npm test src/test/CLOSE_FILE_TILE.test.ts # test 5 of 5"
+                sh "pgrep carta_backend"
+            }
+        }
+    }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,960 +9,453 @@ void setBuildStatus(String message, String state) {
 }
 pipeline {
     agent none
+    options {
+        preserveStashes() 
+    }
     stages {
-        stage('Build') {
+        stage ('Build') {
             parallel {
-                stage('CentOS7 build') {
+                stage('Ubuntu 18.04') {
                     agent {
-                        label "centos7-1"
+                        label "bionic-docker-agent"
                     }
                     steps {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        sh "git submodule update --init --recursive"
-                        dir ('build') {
-                           sh "rm -rf *"
-                           sh "cp ../../cmake-command2.sh ."
-                           sh "./cmake-command2.sh"
-                           sh "make -j\$(nproc)"
-                           echo "Preparing for upcoming ICD tests"
-                           sh "rm -rf carta-backend-ICD-test"
-                           sh "git clone --depth 1 https://github.com/CARTAvis/carta-backend-ICD-test.git && cp ../../run.sh ."
-                           dir ('carta-backend-ICD-test') {
-                              sh "git submodule init && git submodule update && yarn install"
-                              dir ('protobuf') {
-                                 sh "./build_proto.sh"
-                              }
-                              sh "cp ../../../ws-config.json src/test/config.json"
-                           }
-                           stash includes: "carta_backend", name: "centos7-1_carta_backend_icd"
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            sh "uname -a"
+                            sh "lsb_release -a"
+                            sh "git submodule update --init --recursive"
+                            dir ('build') {
+                                sh "cmake .. -Dtest=on"
+                                sh "make -j 16"
+                                stash includes: "test/**/*", name: "bionic-unit-tests"
+                                stash includes: "carta_backend", name: "bionic-backend"
+                            }
                         }
                     }
                     post {
                         success {
-                            setBuildStatus("CentOS7 build succeeded", "SUCCESS");
+                            setBuildStatus("build succeeded", "SUCCESS");
                         }
                         failure {
-                            setBuildStatus("CentOS7 build failed", "FAILURE");
+                            setBuildStatus("build failed", "FAILURE");
                         }
                     }
                 }
-                stage('MacOS build') {
+                stage('Ubuntu 20.04') {
                     agent {
-                        label "macos-1"
+                        label "focal-docker-agent"
                     }
                     steps {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        sh "git submodule update --init --recursive"
-                        dir ('build') {
-                           sh "rm -rf *"
-                           sh "cp ../../cmake-command.sh ."
-                           sh "./cmake-command.sh"
-                           sh "make -j 8"
-                           echo "Preparing for upcoming ICD tests"
-                           sh "rm -rf carta-backend-ICD-test"
-                           sh "git clone --depth 1 https://github.com/CARTAvis/carta-backend-ICD-test.git && cp ../../run.sh ."
-                           dir ('carta-backend-ICD-test') {
-                              sh "git submodule init && git submodule update && yarn install"
-                              dir ('protobuf') {
-                                 sh "./build_proto.sh"
-                              }
-                              sh "cp ../../../ws-config.json src/test/config.json"
-                           }
-                           stash includes: "carta_backend", name: "macos-1_carta_backend_icd"
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            sh "uname -a"
+                            sh "lsb_release -a"
+                            sh "git submodule update --init --recursive"
+                            dir ('build') {
+                                sh "cmake .. -Dtest=on -DCMAKE_CXX_FLAGS='--coverage' -DCMAKE_C_FLAGS='--coverage'"
+                                sh "make -j 16"
+                                stash includes: "test/**/*", name: "focal-unit-tests"
+                                stash includes: "carta_backend", name: "focal-backend"
+                            }
                         }
                     }
                     post {
                         success {
-                            setBuildStatus("MacOS build succeeded", "SUCCESS");
+                            setBuildStatus("build succeeded", "SUCCESS");
                         }
                         failure {
-                            setBuildStatus("MacOS build failed", "FAILURE");
+                            setBuildStatus("build failed", "FAILURE");
                         }
                     }
                 }
-                stage('Ubuntu build') {
+                stage('macOS 11') {
                     agent {
-                        label "ubuntu-1"
+                        label "macos11-docker-agent"
                     }
                     steps {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        sh "git submodule update --init --recursive"
-                        dir ('build') {
-                           sh "rm -rf *"
-                           sh "cp ../../cmake-command.sh ."
-                           sh "./cmake-command.sh"
-                           sh "make -j\$(nproc)"
-                           echo "Preparing for upcoming ICD tests"
-                           sh "rm -rf carta-backend-ICD-test"
-                           sh "git clone --depth 1 https://github.com/CARTAvis/carta-backend-ICD-test.git && cp ../../run.sh ."
-                           dir ('carta-backend-ICD-test') {
-                              sh "git submodule init && git submodule update && yarn install"
-                              dir ('protobuf') {
-                                 sh "./build_proto.sh"
-                              }
-                              sh "cp ../../../ws-config.json src/test/config.json"
-                         }
-                         stash includes: "carta_backend", name: "ubuntu-1_carta_backend_icd"
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            sh "export PATH=/usr/local/bin:$PATH"
+                            sh "git submodule update --init --recursive"
+                            dir ('build') {
+                                sh "rm -rf *"
+                                sh "cmake .. -Dtest=on -DEnableAvx=On"
+                                sh "make -j 8"
+                                stash includes: "test/**/*", name: "macos11-unit-tests"
+                                stash includes: "carta_backend", name: "macos11-backend"
+                            }
                         }
                     }
                     post {
                         success {
-                            setBuildStatus("MacOS build succeeded", "SUCCESS");
+                            setBuildStatus("build succeeded", "SUCCESS");
                         }
                         failure {
-                            setBuildStatus("MacOS build failed", "FAILURE");
+                            setBuildStatus("build failed", "FAILURE");
+                        }
+                    }
+                }
+                stage('RHEL7') {
+                    agent {
+                        label "rhel7-docker-agent"
+                    }
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            sh "uname -a"
+                            sh "cat /etc/redhat-release"
+                            sh "git submodule update --init --recursive"
+                            dir ('build') {
+                                sh "source /opt/rh/devtoolset-8/enable && cmake .. -Dtest=on"
+                                sh "source /opt/rh/devtoolset-8/enable && make -j 16"
+                                stash includes: "test/**/*", name: "rhel7-unit-tests"
+                                stash includes: "carta_backend", name: "rhel7-backend"
+                            }
+                        }
+                    }
+                    post {
+                        success {
+                            setBuildStatus("build succeeded", "SUCCESS");
+                        }
+                        failure {
+                            setBuildStatus("build failed", "FAILURE");
+                        }
+                    }
+                }
+                stage('RHEL8') {
+                    agent {
+                        label "rhel8-docker-agent"
+                    }
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            sh "uname -a"
+                            sh "cat /etc/redhat-release"
+                            sh "git submodule update --init --recursive"
+                            dir ('build') {
+                                sh "cmake .. -Dtest=on"
+                                sh "make -j 16"
+                                stash includes: "test/**/*", name: "rhel8-unit-tests"
+                                stash includes: "carta_backend", name: "rhel8-backend"
+                            }
+                        }
+                    }
+                    post {
+                        success {
+                            setBuildStatus("build succeeded", "SUCCESS");
+                        }
+                        failure {
+                            setBuildStatus("build failed", "FAILURE");
                         }
                     }
                 }
             }
-        }
-        stage('Unit Tests') {
-            parallel {
-                stage('Ubuntu') {
+       }
+       stage('Unit Tests') {
+           parallel {
+                stage('Ubuntu 18.04') {
                     agent {
-                        label "ubuntu-1"
+                        label "bionic-docker-agent"
                     }
                     steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        dir ('build/test') {
-                            sh "export PATH=/usr/local/bin:$PATH && ./carta_backend_tests --gtest_output=xml:ubuntu_test_detail.xml"
-                        }
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            unstash "bionic-unit-tests"
+                            dir ('test') {
+                                sh "./carta_backend_tests --gtest_output=xml:ubuntu_bionic_test_detail.xml"
+                            }
                         }
                     }
                     post {
                         always {
-                            junit 'build/test/ubuntu_test_detail.xml'
+                            junit 'test/ubuntu_bionic_test_detail.xml'
                         }
                     }
                 }
-                stage('MacOS') {
+                stage('Ubuntu 20.04') {          
                     agent {
-                        label "macos-1"
+                        label "focal-docker-agent"
                     }
                     steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        dir ('build/test') {
-                            sh "export PATH=/usr/local/bin:$PATH && ./carta_backend_tests --gtest_filter=-SpatialProfileTest.*Hdf5*:SpatialProfileTest.*HDF5*:Hdf5AttributesTest.*:Hdf5ImageTest.* --gtest_output=xml:macos_test_detail.xml"
-                        }
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            unstash "focal-unit-tests"
+                            dir ('test') {
+                                sh "./carta_backend_tests --gtest_output=xml:ubuntu_focal_test_detail.xml"
+                            }
                         }
                     }
                     post {
                         always {
-                            junit 'build/test/macos_test_detail.xml'
+                            junit 'test/ubuntu_focal_test_detail.xml'
+                        }   
+                    }   
+                }
+                stage('RHEL7') {
+                    agent {
+                        label "rhel7-docker-agent"
+                    }
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            unstash "rhel7-unit-tests"
+                            dir ('test') {
+                                sh "./carta_backend_tests --gtest_output=xml:rhel7_test_detail.xml"
+                            }
+                        }
+                    }
+                    post {
+                        always {
+                            junit 'test/rhel7_test_detail.xml'
+                        }
+                    }
+                }
+                stage('RHEL8') {
+                    agent {
+                        label "rhel8-docker-agent"
+                    }
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            unstash "rhel8-unit-tests"
+                            dir ('test') {
+                                sh "./carta_backend_tests --gtest_output=xml:rhel8_test_detail.xml"
+                            }
+                        }
+                    }
+                    post {
+                        always {
+                            junit 'test/rhel8_test_detail.xml'
                         }
                     }
                 }
             }
         }
-        stage('ICD tests: session') {
-            parallel {
-                stage('CentOS7') {
+        stage('Prepare for ICD tests') {
+           parallel {
+                stage('Ubuntu 18.04') {
                     agent {
-                        label "centos7-1"
+                        label "bionic-docker-agent"
                     }
                     steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "centos7-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
+                        prepare_bionic_ICD()
+                    }
+                }
+                stage('Ubuntu 20.04') {
+                    agent {
+                        label "focal-docker-agent"
+                    }
+                    steps {
+                        prepare_focal_ICD()
+                    }
+                }
+                stage('macOS 11') {
+                    agent {
+                        label "macos11-docker-agent"
+                    }
+                    steps {
+                        prepare_macos11_ICD()
+                    }
+                }
+                stage('RHEL7') {
+                    agent {
+                        label "rhel7-docker-agent"
+                    }
+                    steps {
+                        prepare_rhel7_ICD()
+                    }
+                }
+                stage('RHEL8') {
+                    agent {
+                        label "rhel8-docker-agent"
+                    }
+                    steps {
+                        prepare_rhel8_ICD()
+                    }
+                }
+            }
+        }
+        stage('ICD tests') {
+            matrix {
+                axes {
+                    axis {
+                        name 'PLATFORM'
+                        values 'focal', 'bionic', 'rhel7', 'rhel8', 'macos11'
+                    }
+                }
+                stages {
+                    stage('session') {
+                        agent {
+                            label "${PLATFORM}-docker-agent"
+                        }
+                        steps {
+                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                                unstash "${PLATFORM}-backend"
+                                sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
+                                unstash "${PLATFORM}-ICD"
                                 session()
                             }
                         }
+                    }
+                    stage('file_browser') {
+                        agent {
+                            label "${PLATFORM}-docker-agent"
                         }
-                    }
-                }
-                stage('Ubuntu') {
-                    agent {
-                        label "ubuntu-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "ubuntu-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
-                                session()
-                            }
-                        }
-                        }
-                    }
-                }
-                stage('MacOS') {
-                    agent {
-                        label "macos-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "macos-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
-                                session()
-                            }
-                        }
-                        }
-                    }
-                }    
-            }
-        }
-        stage('ICD tests: file-browser') {
-            parallel {
-                stage('CentOS7') {
-                    agent {
-                        label "centos7-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "centos7-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
+                        steps {
+                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                                unstash "${PLATFORM}-backend"
+                                sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
+                                unstash "${PLATFORM}-ICD"
                                 file_browser()
                             }
                         }
+                    }
+                    stage('animator') {
+                        agent {
+                            label "${PLATFORM}-docker-agent"
                         }
-                    }
-                }
-                stage('Ubuntu') {
-                    agent {
-                        label "ubuntu-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "ubuntu-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
-                                file_browser()
-                            }
-                        }
-                        }
-                    }
-                }
-                stage('MacOS') {
-                    agent {
-                        label "macos-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "macos-1_carta_backend_icd" 
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
-                                file_browser()
-                            }
-                        }
-                        }
-                    }
-                }
-            }
-        }
-        stage('ICD tests: animator') {
-            parallel {
-                stage('CentOS7') {
-                    agent {
-                        label "centos7-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "centos7-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
+                        steps {
+                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                                unstash "${PLATFORM}-backend"
+                                sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
+                                unstash "${PLATFORM}-ICD"
                                 animator()
                             }
                         }
+                    }
+                    stage('contour') {
+                        agent {
+                            label "${PLATFORM}-docker-agent"
                         }
-                    }
-                }
-                stage('Ubuntu') {
-                    agent {
-                        label "ubuntu-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "ubuntu-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
-                                animator()
-                            }
-                        }
-                        }
-                    }
-                }
-                stage('MacOS') {
-                    agent {
-                        label "macos-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "macos-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
-                                animator()
-                            }
-                        }
-                        }
-                    }
-                }     
-            }
-        }
-        stage('ICD tests: contour') {
-            parallel {
-                stage('CentOS7') {
-                    agent {
-                        label "centos7-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "centos7-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
+                        steps {
+                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                                unstash "${PLATFORM}-backend"
+                                sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
+                                unstash "${PLATFORM}-ICD"
                                 contour()
                             }
                         }
+                    }
+                    stage('region_statistics') {
+                        agent {
+                            label "${PLATFORM}-docker-agent"
                         }
-                    }
-                }
-                stage('Ubuntu') {
-                    agent {
-                        label "ubuntu-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "ubuntu-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
-                                contour()
-                            }
-                        }
-                        }
-                    }
-                }
-                stage('MacOS') {
-                    agent {
-                        label "macos-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "macos-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
-                                contour()
-                            }
-                        }
-                        }
-                    }
-                }
-            }
-        }
-        stage('ICD tests: region statistics') {
-            parallel {
-                stage('CentOS7') {
-                    agent {
-                        label "centos7-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "centos7-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
+                        steps {
+                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                                unstash "${PLATFORM}-backend"
+                                sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
+                                unstash "${PLATFORM}-ICD"
                                 region_statistics()
                             }
                         }
+                    }
+                    stage('region_manipulation') {
+                        agent {
+                            label "${PLATFORM}-docker-agent"
                         }
-                    }
-                }
-                stage('Ubuntu') {
-                    agent {
-                        label "ubuntu-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "ubuntu-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
-                                region_statistics()
-                            }
-                        }
-                        }
-                    }
-                }
-                stage('MacOS') {
-                    agent {
-                        label "macos-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "macos-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
-                                region_statistics()
-                            }
-                        }
-                        }
-                    }
-                }
-            }
-        }
-        stage('ICD tests: region manipulation') {
-            parallel {
-                stage('CentOS7') {
-                    agent {
-                        label "centos7-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "centos7-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
+                        steps {
+                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                                unstash "${PLATFORM}-backend"
+                                sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
+                                unstash "${PLATFORM}-ICD"
                                 region_manipulation()
                             }
                         }
+                    }
+                    stage('cube_histogram') {
+                        agent {
+                            label "${PLATFORM}-docker-agent"
                         }
-                    }
-                }
-                stage('Ubuntu') {
-                    agent {
-                        label "ubuntu-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "ubuntu-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
-                                region_manipulation()
-                            }
-                        }
-                        }
-                    }
-                }
-                stage('MacOS') {
-                    agent {
-                        label "macos-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "macos-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
-                                region_manipulation()
-                            }
-                        }
-                        }
-                    }
-                }
-            }
-        }
-        stage('ICD tests: cube histogram') {
-            parallel {
-                stage('CentOS7') {
-                    agent {
-                        label "centos7-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "centos7-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
+                        steps {
+                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                                unstash "${PLATFORM}-backend"
+                                sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
+                                unstash "${PLATFORM}-ICD"
                                 cube_histogram()
                             }
                         }
+                    }
+                    stage('spatial_profiler') {
+                        agent {
+                            label "${PLATFORM}-docker-agent"
                         }
-                    }
-                }
-                stage('Ubuntu') {
-                    agent {
-                        label "ubuntu-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "ubuntu-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
-                                cube_histogram()
-                            }
-                        }
-                        }
-                    }
-                }
-                stage('MacOS') {
-                    agent {
-                        label "macos-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "macos-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
-                                cube_histogram()
-                            }
-                        }
-                        }
-                    }
-                }
-            }
-        }
-        stage('ICD tests: spatial profiler') {
-            parallel {
-                stage('CentOS7') {
-                    agent {
-                        label "centos7-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "centos7-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
+                        steps {
+                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                                unstash "${PLATFORM}-backend"
+                                sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
+                                unstash "${PLATFORM}-ICD"
                                 spatial_profiler()
                             }
                         }
+                    }
+                    stage('raster_tiles') {
+                        agent {
+                            label "${PLATFORM}-docker-agent"
                         }
-                    }
-                }
-                stage('Ubuntu') {
-                    agent {
-                        label "ubuntu-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "ubuntu-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
-                                spatial_profiler()
-                            }
-                        }
-                        }
-                    }
-                }
-                stage('MacOS') {
-                    agent {
-                        label "macos-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "macos-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
-                                spatial_profiler()
-                            }
-                        }
-                        }
-                    }
-                }
-            }
-        }
-        stage('ICD tests: raster tiles') {
-            parallel {
-                stage('CentOS7') {
-                    agent {
-                        label "centos7-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "centos7-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
+                        steps {
+                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                                unstash "${PLATFORM}-backend"
+                                sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
+                                unstash "${PLATFORM}-ICD"
                                 raster_tiles()
                             }
                         }
+                    }
+                    stage('catalog') {
+                        agent {
+                            label "${PLATFORM}-docker-agent"
                         }
-                    }
-                }
-                stage('Ubuntu') {
-                    agent {
-                        label "ubuntu-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "ubuntu-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
-                                raster_tiles()
-                            }
-                        }
-                        }
-                    }
-                }
-                stage('MacOS') {
-                    agent {
-                        label "macos-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "macos-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
-                                raster_tiles()
-                            }
-                        }
-                        }
-                    }
-                }
-            }
-        }
-        stage('ICD tests: catalog') {
-            parallel {
-                stage('CentOS7') {
-                    agent {
-                        label "centos7-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "centos7-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
+                        steps {
+                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                                unstash "${PLATFORM}-backend"
+                                sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
+                                unstash "${PLATFORM}-ICD"
                                 catalog()
                             }
                         }
+                    }
+                    stage('moment') {
+                        agent {
+                            label "${PLATFORM}-docker-agent"
                         }
-                    }
-                }
-                stage('Ubuntu') {
-                    agent {
-                        label "ubuntu-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "ubuntu-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
-                                catalog()
+                        steps {
+                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                                unstash "${PLATFORM}-backend"
+                                sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
+                                unstash "${PLATFORM}-ICD"
+                                moment()
                             }
                         }
+                    }
+                    stage('resume') {
+                        agent {
+                            label "${PLATFORM}-docker-agent"
                         }
-                    }
-                }
-                stage('MacOS') {
-                    agent {
-                        label "macos-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "macos-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
-                                catalog()
+                        steps {
+                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                                unstash "${PLATFORM}-backend"
+                                sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
+                                unstash "${PLATFORM}-ICD"
+                                resume()
                             }
                         }
+                    }
+                    stage('match') {
+                        agent {
+                            label "${PLATFORM}-docker-agent"
                         }
-                    }
-                }
-            }
-        }
-        stage('ICD tests: moments') {
-            parallel {
-                stage('CentOS7') {
-                    agent {
-                        label "centos7-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "centos7-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
-                                moment_tests()
+                        steps {
+                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                                unstash "${PLATFORM}-backend"
+                                sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
+                                unstash "${PLATFORM}-ICD"
+                                match()
                             }
                         }
+                    }
+                    stage('close_file') {
+                        agent {
+                            label "${PLATFORM}-docker-agent"
                         }
-                    }
-                }
-                stage('Ubuntu') {
-                    agent {
-                        label "ubuntu-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "ubuntu-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
-                                moment_tests()
+                        steps {
+                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                                unstash "${PLATFORM}-backend"
+                                sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
+                                unstash "${PLATFORM}-ICD"
+                                close_file()
                             }
-                        }
-                        }
-                    }
-                }
-                stage('MacOS') {
-                    agent {
-                        label "macos-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "macos-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
-                                moment_tests()
-                            }
-                        }
-                        }
-                    }
-                }
-            }
-        }
-        stage('ICD tests: resume') {
-            parallel {
-                stage('CentOS7') {
-                    agent {
-                        label "centos7-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "centos7-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
-                                resume_tests()
-                            }
-                        }
-                        }
-                    }
-                }
-                stage('Ubuntu') {
-                    agent {
-                        label "ubuntu-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "ubuntu-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
-                                resume_tests()
-                            }
-                        }
-                        }
-                    }
-                }
-                stage('MacOS') {
-                    agent {
-                        label "macos-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "macos-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
-                                resume_tests()
-                            }
-                        }
-                        }
-                    }
-                }
-            }
-        }
-        stage('ICD tests: match') {
-            parallel {
-                stage('CentOS7') {
-                    agent {
-                        label "centos7-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "centos7-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
-                                match_tests()
-                            }
-                        }
-                        }
-                    }
-                }
-                stage('Ubuntu') {
-                    agent {
-                        label "ubuntu-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "ubuntu-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
-                                match_tests()
-                            }
-                        }
-                        }
-                    }
-                }
-                stage('MacOS') {
-                    agent {
-                        label "macos-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "macos-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
-                                match_tests()
-                            }
-                        }
-                        }
-                    }
-                }
-            }
-        }
-        stage('ICD tests: close_file') {
-            parallel {
-                stage('CentOS7') {
-                    agent {
-                        label "centos7-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "centos7-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
-                                close_file_tests()
-                            }
-                        }
-                        }
-                    }
-                }
-                stage('Ubuntu') {
-                    agent {
-                        label "ubuntu-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "ubuntu-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
-                                close_file_tests()
-                            }
-                        }
-                        }
-                    }
-                }
-                stage('MacOS') {
-                    agent {
-                        label "macos-1"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE')
-                        {
-                        sh "export PATH=/usr/local/bin:$PATH"
-                        dir ('build') {
-                            unstash "macos-1_carta_backend_icd"
-                            sh "./run.sh # run carta_backend in the background"
-                            dir ('carta-backend-ICD-test') {
-                                close_file_tests()
-                            }
-                        }
                         }
                     }
                 }
@@ -970,245 +463,473 @@ pipeline {
         }
     }
 }
-def session(){
-     script {
-         ret = false
-         retry(3) {
-             if (ret) {
-                 sleep(time:30,unit:"SECONDS")
-                 echo "Trying again"
-             } else {
-                 ret = true
-             }
-             sh "CI=true npm test src/test/ACCESS_CARTA_DEFAULT.test.ts # test 1 of 6" 
-             sh "CI=true npm test src/test/ACCESS_CARTA_KNOWN_SESSION.test.ts # test 2 of 6"
-             sh "CI=true npm test src/test/ACCESS_CARTA_NO_CLIENT_FEATURE.test.ts # test 3 of 6"
-             sh "CI=true npm test src/test/ACCESS_CARTA_SAME_ID_TWICE.test.ts # test 4 of 6"
-             sh "CI=true npm test src/test/ACCESS_CARTA_DEFAULT_CONCURRENT.test.ts # test 5 of 6"
-             sh "CI=true npm test src/test/ACCESS_WEBSOCKET.test.ts # test 6 of 6"
-         }
-     }
-}
-def file_browser(){
-     script {
-         ret = false
-         retry(3) {
-             if (ret) {
-                 sleep(time:30,unit:"SECONDS")
-                 echo "Trying again"
-             } else {
-                 ret = true
-             }
-             sh "CI=true npm test src/test/GET_FILELIST.test.ts # test 1 of 9"
-             sh "CI=true npm test src/test/GET_FILELIST_ROOTPATH_CONCURRENT.test.ts # test 2 of 9"
-             sh "CI=true npm test src/test/FILETYPE_PARSER.test.ts # test 3 of 9"
-             sh "CI=true npm test src/test/FILEINFO_FITS.test.ts # test 4 of 9"
-             sh "CI=true npm test src/test/FILEINFO_CASA.test.ts # test 5 of 9"
-             sh "CI=true npm test src/test/FILEINFO_HDF5.test.ts # test 6 of 9"
-             sh "CI=true npm test src/test/FILEINFO_MIRIAD.test.ts # test 7 of 9"
-             sh "CI=true npm test src/test/FILEINFO_FITS_MULTIHDU.test.ts # test 8 of 9"
-             sh "CI=true npm test src/test/FILEINFO_EXCEPTIONS.test.ts # test 9 of 9"
-         }
-     }
-}
-def animator(){
-     script {
-         ret = false
-         retry(3) {
-             if (ret) {
-                 sleep(time:30,unit:"SECONDS")
-                 echo "Trying again"
-             } else {
-                 ret = true
-             }
-             sh "CI=true npm test src/test/ANIMATOR_DATA_STREAM.test.ts # test 1 of 4"
-             sh "CI=true npm test src/test/ANIMATOR_NAVIGATION.test.ts # test 2 of 4"
-             sh "CI=true npm test src/test/ANIMATOR_CONTOUR_MATCH.test.ts # test 3 of 4"
-             sh "CI=true npm test src/test/ANIMATOR_CONTOUR.test.ts # test 4 of 4"
+def prepare_focal_ICD() {
+    catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+        sh "git clone --depth 1 https://github.com/CARTAvis/carta-backend-ICD-test.git"
+        dir ('carta-backend-ICD-test') {
+            sh "sed -i '4 i\\    \"type\": \"module\",' package.json"
+            sh "git submodule init && git submodule update && npm install"
+            dir ('protobuf') {
+                sh "./build_proto.sh"
+            }
+            dir ('src/test') { 
+                sh "perl -p -i -e 's/serverURL/serverURL1/' config.json"
+                sh "perl -p -i -e 's/serverURL10/serverURL/' config.json"
+            }
         }
+        stash includes: "carta-backend-ICD-test/**/*", name: "focal-ICD"
     }
 }
-def contour(){
+def prepare_bionic_ICD() {
+    catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+        sh "git clone --depth 1 https://github.com/CARTAvis/carta-backend-ICD-test.git"
+        dir ('carta-backend-ICD-test') {
+            sh "sed -i '4 i\\    \"type\": \"module\",' package.json"
+            sh "git submodule init && git submodule update && npm install"
+            dir ('protobuf') {
+                sh "./build_proto.sh"
+            }
+            dir ('src/test') { 
+                sh "perl -p -i -e 's/serverURL/serverURL1/' config.json"
+                sh "perl -p -i -e 's/serverURL10/serverURL/' config.json"
+            }
+        }
+        stash includes: "carta-backend-ICD-test/**/*", name: "bionic-ICD"
+    }
+}
+def prepare_rhel7_ICD() {
+    catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+        sh "git clone --depth 1 https://github.com/CARTAvis/carta-backend-ICD-test.git"
+        dir ('carta-backend-ICD-test') {
+            sh "sed -i '4 i\\    \"type\": \"module\",' package.json"
+            sh "git submodule init && git submodule update && npm install"
+            dir ('protobuf') {
+                sh "./build_proto.sh"
+            }
+            dir ('src/test') {
+                sh "perl -p -i -e 's/serverURL/serverURL1/' config.json"
+                sh "perl -p -i -e 's/serverURL10/serverURL/' config.json"
+            }
+       }
+       stash includes: "carta-backend-ICD-test/**/*", name: "rhel7-ICD"
+    }
+}
+def prepare_rhel8_ICD() {
+    catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+        sh "git clone --depth 1 https://github.com/CARTAvis/carta-backend-ICD-test.git"
+        dir ('carta-backend-ICD-test') {
+            sh "sed -i '4 i\\    \"type\": \"module\",' package.json"
+            sh "git submodule init && git submodule update && npm install"
+            dir ('protobuf') {
+                sh "./build_proto.sh"
+            }
+            dir ('src/test') {
+                sh "perl -p -i -e 's/serverURL/serverURL1/' config.json"
+                sh "perl -p -i -e 's/serverURL10/serverURL/' config.json"
+            }
+       }
+       stash includes: "carta-backend-ICD-test/**/*", name: "rhel8-ICD"
+    }
+}
+def prepare_macos11_ICD() {
+    catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+        sh "rm -rf carta-backend-ICD-test"
+        sh "git clone --depth 1 https://github.com/CARTAvis/carta-backend-ICD-test.git"
+        dir ('carta-backend-ICD-test') {
+            sh "git submodule init && git submodule update && npm install"
+            dir ('protobuf') {
+                sh "./build_proto.sh"
+            }
+            sh "cp ../../config.json src/test/config.json"
+        }
+        stash includes: "carta-backend-ICD-test/**/*", name: "macos11-ICD"
+    }
+}
+
+def focal() {
+    unstash "focal-backend"
+    sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
+    unstash "focal-ICD"
+}
+def bionic() {
+    unstash "bionic-backend"
+    sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
+    unstash "bionic-ICD"
+}
+def rhel7() {
+    unstash "rhel7-backend"
+    sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
+    unstash "rhel7-ICD"
+}
+def rhel8() {
+    unstash "rhel8-backend"
+    sh "./carta_backend /images --top_level_folder /images --port 3002 --omp_threads 8 --debug_no_auth true --no_http true &"
+    unstash "rhel8-ICD"
+}
+def macos11() {
+    unstash "macos11-backend"
+    sh "cp ../run.sh . && ./run.sh"
+    unstash "macos11-ICD"
+}
+
+def session() {
      script {
-         ret = false
-         retry(3) {
-             if (ret) {
-                 sleep(time:30,unit:"SECONDS")
-                 echo "Trying again"
-             } else {
-                 ret = true
+         dir ('carta-backend-ICD-test') {
+             sh "npm install && ./protobuf/build_proto.sh"
+             ret = false
+             retry(3) {
+                 if (ret) {
+                     sleep(time:30,unit:"SECONDS")
+                     sh "cat /root/.carta/log/carta.log"
+                     echo "Trying again"
+                 } else {
+                     ret = true
+                 }
+                 sh "pgrep carta_backend"
+                 sh "CI=true npm test src/test/ACCESS_CARTA_DEFAULT.test.ts # test 1 of 6"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/ACCESS_CARTA_KNOWN_SESSION.test.ts # test 2 of 6"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/ACCESS_CARTA_NO_CLIENT_FEATURE.test.ts # test 3 of 6"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/ACCESS_CARTA_SAME_ID_TWICE.test.ts # test 4 of 6"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/ACCESS_CARTA_DEFAULT_CONCURRENT.test.ts # test 5 of 6"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/ACCESS_WEBSOCKET.test.ts # test 6 of 6"
+                 sh "pgrep carta_backend"
              }
-             sh "CI=true npm test src/test/CONTOUR_IMAGE_DATA.test.ts # test 1 of 3"
-             sh "CI=true npm test src/test/CONTOUR_IMAGE_DATA_NAN.test.ts # test 2 of 3"
-             sh "CI=true npm test src/test/CONTOUR_DATA_STREAM.test.ts # test 3 of 3"
          }
      }
 }
-def region_statistics(){
+def file_browser() {
      script {
-         ret = false
-         retry(3) {
-             if (ret) {
-                 sleep(time:30,unit:"SECONDS")
-                 echo "Trying again"
-             } else {
-                 ret = true
+         dir ('carta-backend-ICD-test') {
+             sh "npm install && ./protobuf/build_proto.sh"
+             ret = false
+             retry(3) {
+                 if (ret) {
+                     sleep(time:30,unit:"SECONDS")
+                     sh "cat /root/.carta/log/carta.log"
+                     echo "Trying again"
+                 } else {
+                     ret = true
+                 }
+                 sh "pgrep carta_backend"
+                 sh "CI=true npm test src/test/GET_FILELIST.test.ts # test 1 of 9"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/GET_FILELIST_ROOTPATH_CONCURRENT.test.ts # test 2 of 9"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/FILETYPE_PARSER.test.ts # test 3 of 9"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/FILEINFO_FITS.test.ts # test 4 of 9"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/FILEINFO_CASA.test.ts # test 5 of 9"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/FILEINFO_HDF5.test.ts # test 6 of 9"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/FILEINFO_MIRIAD.test.ts # test 7 of 9"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/FILEINFO_FITS_MULTIHDU.test.ts # test 8 of 9"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/FILEINFO_EXCEPTIONS.test.ts # test 9 of 9"
+                 sh "pgrep carta_backend"
              }
-             sh "CI=true npm test src/test/REGION_STATISTICS_RECTANGLE.test.ts # test 1 of 3"
-             sh "CI=true npm test src/test/REGION_STATISTICS_ELLIPSE.test.ts # test 2 of 3"
-             sh "CI=true npm test src/test/REGION_STATISTICS_POLYGON.test.ts # test 3 of 3"
          }
      }
 }
-def region_manipulation(){
+def animator() {
      script {
-         ret = false
-         retry(3) {
-             if (ret) {
-                 sleep(time:30,unit:"SECONDS")
-                 echo "Trying again"
-             } else {
-                 ret = true
+         dir ('carta-backend-ICD-test') {
+             sh "npm install && ./protobuf/build_proto.sh"
+             ret = false
+             retry(3) {
+                 if (ret) {
+                     sleep(time:30,unit:"SECONDS")
+                     sh "cat /root/.carta/log/carta.log"
+                     echo "Trying again"
+                 } else {
+                     ret = true
+                 }
+                 sh "pgrep carta_backend"
+                 sh "CI=true npm test src/test/ANIMATOR_DATA_STREAM.test.ts # test 1 of 4"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/ANIMATOR_NAVIGATION.test.ts # test 2 of 4"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/ANIMATOR_CONTOUR_MATCH.test.ts # test 3 of 4"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/ANIMATOR_CONTOUR.test.ts # test 4 of 4"
+                 sh "pgrep carta_backend"
              }
-             sh "CI=true npm test src/test/REGION_REGISTER.test.ts # test 1 of 9"
-             sh "CI=true npm test src/test/CASA_REGION_INFO.test.ts # test 2 of 9"
-             sh "CI=true npm test src/test/CASA_REGION_IMPORT_INTERNAL.test.ts # test 3 of 9"
-             sh "CI=true npm test src/test/CASA_REGION_IMPORT_EXPORT.test.ts # test 4 of 9"
-             sh "CI=true npm test src/test/CASA_REGION_IMPORT_EXCEPTION.test.ts # test 5 of 9"
-             sh "CI=true npm test src/test/CASA_REGION_EXPORT.test.ts # test 6 of 9"
-             sh "CI=true npm test src/test/DS9_REGION_EXPORT.test.ts # test 7 of 9"
-             sh "CI=true npm test src/test/DS9_REGION_IMPORT_EXCEPTION.test.ts # test 8 of 9"
-             sh "CI=true npm test src/test/DS9_REGION_IMPORT_EXPORT.test.ts # test 9 of 9"
          }
      }
 }
-def cube_histogram(){
+def contour() {
      script {
-         ret = false
-         retry(3) {
-             if (ret) {
-                 sleep(time:30,unit:"SECONDS")
-                 echo "Trying again"
-             } else {
-                 ret = true
+         dir ('carta-backend-ICD-test') {
+             sh "npm install && ./protobuf/build_proto.sh"
+             ret = false
+             retry(3) {
+                 if (ret) {
+                     sleep(time:30,unit:"SECONDS")
+                     sh "cat /root/.carta/log/carta.log"
+                     echo "Trying again"
+                 } else {
+                     ret = true
+                 }
+                 sh "pgrep carta_backend"
+                 sh "CI=true npm test src/test/CONTOUR_IMAGE_DATA.test.ts # test 1 of 3"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/CONTOUR_IMAGE_DATA_NAN.test.ts # test 2 of 2"
              }
-             sh "CI=true npm test src/test/PER_CUBE_HISTOGRAM.test.ts # test 1 of 3"
-             sh "CI=true npm test src/test/PER_CUBE_HISTOGRAM_HDF5.test.ts # test 2 of 3"
-             sh "CI=true npm test src/test/PER_CUBE_HISTOGRAM_CANCELLATION.test.ts # test 3 of 3"
          }
      }
 }
-def spatial_profiler(){
+def region_statistics() {
      script {
-         ret = false
-         retry(3) {
-             if (ret) {
-                 sleep(time:30,unit:"SECONDS")
-                 echo "Trying again"
-             } else {
-                 ret = true
+         dir ('carta-backend-ICD-test') {
+             sh "npm install && ./protobuf/build_proto.sh"
+             ret = false
+             retry(3) {
+                 if (ret) {
+                     sleep(time:30,unit:"SECONDS")
+                     sh "cat /root/.carta/log/carta.log"
+                     echo "Trying again"
+                 } else {
+                     ret = true
+                 }
+                 sh "pgrep carta_backend"
+                 sh "CI=true npm test src/test/REGION_STATISTICS_RECTANGLE.test.ts # test 1 of 3"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/REGION_STATISTICS_ELLIPSE.test.ts # test 2 of 3"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/REGION_STATISTICS_POLYGON.test.ts # test 3 of 3"
+                 sh "pgrep carta_backend"
              }
-             sh "CI=true npm test src/test/CURSOR_SPATIAL_PROFILE.test.ts # test 1 of 2"
-             sh "CI=true npm test src/test/CURSOR_SPATIAL_PROFILE_NaN.test.ts # test 2 of 2"
          }
      }
 }
-def raster_tiles(){
+def region_manipulation() {
      script {
-         ret = false
-         retry(3) {
-             if (ret) {
-                 sleep(time:30,unit:"SECONDS")
-                 echo "Trying again"
-             } else {
-                 ret = true
+         dir ('carta-backend-ICD-test') {
+             sh "npm install && ./protobuf/build_proto.sh"
+             ret = false
+             retry(3) {
+                 if (ret) {
+                     sleep(time:30,unit:"SECONDS")
+                     sh "cat /root/.carta/log/carta.log"
+                     echo "Trying again"
+                 } else {
+                     ret = true
+                 }
+                 sh "pgrep carta_backend"
+                 sh "CI=true npm test src/test/REGION_REGISTER.test.ts # test 1 of 9"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/CASA_REGION_INFO.test.ts # test 2 of 9"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/CASA_REGION_IMPORT_INTERNAL.test.ts # test 3 of 9"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/CASA_REGION_IMPORT_EXPORT.test.ts # test 4 of 9"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/CASA_REGION_IMPORT_EXCEPTION.test.ts # test 5 of 9"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/CASA_REGION_EXPORT.test.ts # test 6 of 9"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/DS9_REGION_EXPORT.test.ts # test 7 of 9"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/DS9_REGION_IMPORT_EXCEPTION.test.ts # test 8 of 9"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/DS9_REGION_IMPORT_EXPORT.test.ts # test 9 of 9"
+                 sh "pgrep carta_backend"
              }
-             sh "CI=true npm test src/test/CHECK_RASTER_TILE_DATA.test.ts # test 1 of 2"
-             sh "CI=true npm test src/test/TILE_DATA_REQUEST.test.ts # test 2 of 2"
          }
      }
 }
-def catalog(){
+def cube_histogram() {
      script {
-         ret = false
-         retry(3) {
-             if (ret) {
-                 sleep(time:30,unit:"SECONDS")
-                 echo "Trying again"
-             } else {
-                 ret = true
+         dir ('carta-backend-ICD-test') {
+             sh "npm install && ./protobuf/build_proto.sh"
+             ret = false
+             retry(3) {
+                 if (ret) {
+                     sleep(time:30,unit:"SECONDS")
+                     sh "cat /root/.carta/log/carta.log"
+                     echo "Trying again"
+                 } else {
+                     ret = true
+                 }
+                 sh "pgrep carta_backend"
+                 sh "CI=true npm test src/test/PER_CUBE_HISTOGRAM_HDF5.test.ts # test 1 of 1"
              }
-             sh "CI=true npm test src/test/CATALOG_GENERAL.test.ts # test 1 of 2"
-             sh "CI=true npm test src/test/CATALOG_FITS_VOT.test.ts # test 2 of 2"
          }
      }
 }
-def moment_tests(){
+def spatial_profiler() {
      script {
-         ret = false
-         retry(3) {
-             if (ret) {
-                 sleep(time:30,unit:"SECONDS")
-                 echo "Trying again"
-             } else {
-                 ret = true
+         dir ('carta-backend-ICD-test') {
+             sh "npm install && ./protobuf/build_proto.sh"
+             ret = false
+             retry(3) {
+                 if (ret) {
+                     sleep(time:30,unit:"SECONDS")
+                     sh "cat /root/.carta/log/carta.log"
+                     echo "Trying again"
+                 } else {
+                     ret = true
+                 }
+                 sh "pgrep carta_backend"
+                 sh "CI=true npm test src/test/CURSOR_SPATIAL_PROFILE.test.ts # test 1 of 2"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/CURSOR_SPATIAL_PROFILE_NaN.test.ts # test 2 of 2"
+                 sh "pgrep carta_backend"
              }
-             sh "CI=true npm test src/test/MOMENTS_GENERATOR_CASA.test.ts # test 1 of 6"
-             sh "CI=true npm test src/test/MOMENTS_GENERATOR_EXCEPTION.test.ts # test 2 of 6"
-             sh "CI=true npm test src/test/MOMENTS_GENERATOR_FITS.test.ts # test 3 of 6"
-             sh "CI=true npm test src/test/MOMENTS_GENERATOR_HDF5.test.ts # test 4 of 6"
-             sh "CI=true npm test src/test/MOMENTS_GENERATOR_SAVE.test.ts # test 5 of 6"
-             sh "CI=true npm test src/test/MOMENTS_GENERATOR_CANCEL.test.ts # test 6 of 6"
          }
      }
 }
-def resume_tests(){
+def raster_tiles() {
      script {
-         ret = false
-         retry(3) {
-             if (ret) {
-                 sleep(time:30,unit:"SECONDS")
-                 echo "Trying again"
-             } else {
-                 ret = true
+         dir ('carta-backend-ICD-test') {
+             sh "npm install && ./protobuf/build_proto.sh"
+             ret = false
+             retry(3) {
+                 if (ret) {
+                     sleep(time:30,unit:"SECONDS")
+                     sh "cat /root/.carta/log/carta.log"
+                     echo "Trying again"
+                 } else {
+                     ret = true
+                 }
+                 sh "pgrep carta_backend"
+                 sh "CI=true npm test src/test/CHECK_RASTER_TILE_DATA.test.ts # test 1 of 2"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/TILE_DATA_REQUEST.test.ts # test 2 of 2"
+                 sh "pgrep carta_backend"
              }
-             sh "CI=true npm test src/test/RESUME_CATALOG.test.ts # test 1 of 4"
-             sh "CI=true npm test src/test/RESUME_CONTOUR.test.ts # test 2 of 4"
-             sh "CI=true npm test src/test/RESUME_IMAGE.test.ts # test 3 of 4"
-             sh "CI=true npm test src/test/RESUME_REGION.test.ts # test 4 of 4"
          }
      }
 }
-def match_tests(){
+def catalog() {
      script {
-         ret = false
-         retry(3) {
-             if (ret) {
-                 sleep(time:30,unit:"SECONDS")
-                 echo "Trying again"
-             } else {
-                 ret = true
+         dir ('carta-backend-ICD-test') {
+             sh "npm install && ./protobuf/build_proto.sh"
+             ret = false
+             retry(3) {
+                 if (ret) {
+                     sleep(time:30,unit:"SECONDS")
+                     sh "cat /root/.carta/log/carta.log"
+                     echo "Trying again"
+                 } else {
+                     ret = true
+                 }
+                 sh "pgrep carta_backend"
+                 sh "CI=true npm test src/test/CATALOG_GENERAL.test.ts # test 1 of 1"
              }
-             sh "CI=true npm test src/test/MATCH_SPATIAL.test.ts # test 1 of 2"
-             sh "CI=true npm test src/test/MATCH_STATS.test.ts # test 2 of 2"
          }
      }
 }
-def close_file_tests(){
+def moment() {
      script {
-         ret = false
-         retry(3) {
-             if (ret) {
-                 sleep(time:30,unit:"SECONDS")
-                 echo "Trying again"
-             } else {
-                 ret = true
+         dir ('carta-backend-ICD-test') {
+             sh "npm install && ./protobuf/build_proto.sh"
+             ret = false
+             retry(3) {
+                 if (ret) {
+                     sleep(time:30,unit:"SECONDS")
+                     sh "cat /root/.carta/log/carta.log"
+                     echo "Trying again"
+                 } else {
+                     ret = true
+                 }
+                 sh "pgrep carta_backend"
+                 sh "CI=true npm test src/test/MOMENTS_GENERATOR_CASA.test.ts # test 1 of 6"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/MOMENTS_GENERATOR_EXCEPTION.test.ts # test 2 of 6"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/MOMENTS_GENERATOR_FITS.test.ts # test 3 of 6"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/MOMENTS_GENERATOR_HDF5.test.ts # test 4 of 6"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/MOMENTS_GENERATOR_SAVE.test.ts # test 5 of 6"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/MOMENTS_GENERATOR_CANCEL.test.ts # test 6 of 6"
+                 sh "pgrep carta_backend"
              }
-             sh "CI=true npm test src/test/CLOSE_FILE_SINGLE.test.ts # test 1 of 5"
-             sh "CI=true npm test src/test/CLOSE_FILE_ANIMATION.test.ts # test 2 of 5"
-             sh "CI=true npm test src/test/CLOSE_FILE_ERROR.test.ts # test 3 of 5"
-             sh "CI=true npm test src/test/CLOSE_FILE_SPECTRAL_PROFILE.test.ts # test 4 of 5"
-             sh "CI=true npm test src/test/CLOSE_FILE_TILE.test.ts # test 5 of 5"
          }
-     } 
+     }
+}
+def resume() {
+     script {
+         dir ('carta-backend-ICD-test') {
+             sh "npm install && ./protobuf/build_proto.sh"
+             ret = false
+             retry(3) {
+                 if (ret) {
+                     sleep(time:30,unit:"SECONDS")
+                     sh "cat /root/.carta/log/carta.log"
+                     echo "Trying again"
+                 } else {
+                     ret = true
+                 }
+                 sh "pgrep carta_backend"
+                 sh "CI=true npm test src/test/RESUME_CATALOG.test.ts # test 1 of 4"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/RESUME_CONTOUR.test.ts # test 2 of 4"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/RESUME_IMAGE.test.ts # test 3 of 4"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/RESUME_REGION.test.ts # test 4 of 4"
+                 sh "pgrep carta_backend"
+             }
+         }
+     }
+}
+def match() {
+     script {
+         dir ('carta-backend-ICD-test') {
+             sh "npm install && ./protobuf/build_proto.sh"
+             ret = false
+             retry(3) {
+                 if (ret) {
+                     sleep(time:30,unit:"SECONDS")
+                     sh "cat /root/.carta/log/carta.log"
+                     echo "Trying again"
+                 } else {
+                      ret = true
+                 }
+                 sh "pgrep carta_backend"
+                 sh "CI=true npm test src/test/MATCH_SPATIAL.test.ts # test 1 of 2"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/MATCH_STATS.test.ts # test 2 of 2"
+                 sh "pgrep carta_backend"
+             }
+         }
+     }
+}
+def close_file() {
+     script {
+         dir ('carta-backend-ICD-test') {
+             sh "npm install && ./protobuf/build_proto.sh"
+             ret = false
+             retry(3) {
+                 if (ret) {
+                     sleep(time:30,unit:"SECONDS")
+                     sh "cat /root/.carta/log/carta.log"
+                     echo "Trying again"
+                 } else {
+                     ret = true
+                 }
+                 sh "pgrep carta_backend"
+                 sh "CI=true npm test src/test/CLOSE_FILE_SINGLE.test.ts # test 1 of 5"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/CLOSE_FILE_ANIMATION.test.ts # test 2 of 5"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/CLOSE_FILE_ERROR.test.ts # test 3 of 5"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/CLOSE_FILE_SPECTRAL_PROFILE.test.ts # test 4 of 5"
+                 sh "sleep 3 && pgrep carta_backend"
+                 sh "CI=true npm test src/test/CLOSE_FILE_TILE.test.ts # test 5 of 5"
+                 sh "pgrep carta_backend"
+             }
+         }
+     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -185,24 +185,6 @@ pipeline {
                         }   
                     }   
                 }
-                stage('macOS 11') {
-                    agent {
-                        label "macos11-docker-agent"
-                    }
-                    steps {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                            unstash "macos11-unit-tests"
-                            dir ('test') {
-                                sh "./carta_backend_tests --gtest_output=xml:macos11_test_detail.xml"
-                            }
-                        }
-                    }
-                    post {
-                        always {
-                            junit 'test/macos11_test_detail.xml'
-                        }
-                    }
-                }
                 stage('RHEL7') {
                     agent {
                         label "rhel7-docker-agent"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -185,6 +185,24 @@ pipeline {
                         }   
                     }   
                 }
+                stage('macOS 11') {
+                    agent {
+                        label "macos11-docker-agent"
+                    }
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            unstash "macos11-unit-tests"
+                            dir ('test') {
+                                sh "./carta_backend_tests --gtest_output=xml:macos11_test_detail.xml"
+                            }
+                        }
+                    }
+                    post {
+                        always {
+                            junit 'test/macos11_test_detail.xml'
+                        }
+                    }
+                }
                 stage('RHEL7') {
                     agent {
                         label "rhel7-docker-agent"


### PR DESCRIPTION
@veggiesaurus I think it is about time to switch to the new Jenkinsfile. This will free up our existing Ubuntu server so I'll finally be able to upgrade it and use it for frontend ICD testing in parallel. 

Here is some information:

- All the four supported Linux systems are now run through Docker containers on a single AMD server. Test images are read from an internal SSD.

- Due to CentOS8 reaching EOL soon and the fact that things might look complicated if I continue to use CentOS7 with either AlmaLinux or Rocky Linux, I decided to switch to actual RHEL. So now we are using real RHEL7 and RHEL8 Docker containers created from the RedHat Universal Base Images (UBI).

- I know we support two macOS versions, but we only have one Intel MacMini with Big Sur available at present. The backend build, unit tests, and ICD tests run natively on it. We plan to purchase a 2nd Intel MacMini shortly, perhaps for when macOS Monterey comes out as it will be easier to upgrade Monterey rather than downgrade Big Sur to Catalina. At that time we will cover the latest two macOS versions; 11 and 12.

- There is an annoying limit to the size of a declarative pipeline in a Jenkinsfile. Even after moving as many lines as possible into definition blocks, the file is still too large to be parsed when covering the 5 systems. Therefore, I have had to use 'matrix' style of configuration. Unfortunately, it is not visualised very well by Blue Ocean. I have tried to make it as clear as possible. The first 3 stages (Build, Unit Tests, and prepare ICD tests) are kept in the old way. The ICD tests themselves appear in a single stage. Throughout that stage, it is not clear which row represents which OS. They don't line up with those of the first column. But you can find out by inspecting the stage or remembering that they are in alphabetical order (bionic, focal, macos11, rhel7, rhel8). I tried to put the first 3 stages in the same order, but I have their names more explicit e.g. Ubuntu 20.04. I needed to use shorter single word names for the matrix variable.

- As before, if an ICD test fails, it waits 30 seconds and runs the test again, using the same backend process. Also, when a test fails, it runs `cat /root/.carta/log/carta.log`. Hopefully both may be helpful in some cases, but hasn't been useful so far.

- There is a very strange issue where a few ICD tests fail on the Ubuntu 20.04 Docker container when run through Jenkins. They do not fail when I run them manually in the same container. Plus they work fine in the three other Docker containers when Jenkins runs them. I decided to temporarily remove them but I have made an issue in the ICD test repository [#277](https://github.com/CARTAvis/carta-backend-ICD-test/issues/277)

- We have discovered a carta-backend bug occurring only on RHEL8/CentOS8 regarding region files. It causes the backend to crash. We have filed a backend issue [#909](https://github.com/CARTAvis/carta-backend/issues/909).  I thought I would leave the failing test in for now. Hopefully it could be fixed soon.

- I decided to add macOS Unit Tests back. Using the older hdf5@1.10 actually appears to prevent the previous HDF5 problems.

- The list of ICD tests are still hard coded into the Jenkinsfile, so it is not so easy to change tests or add more as it would then need to be merged into every existing branch.

- In the case of @markccchiang's branch [PR#888  ](https://github.com/CARTAvis/carta-backend/pull/888), and future additions, I guess we could modify the Jenkinsfile in the same pull request to remove the duplicated tests from the Jenkinsfile. e.g. Session and Animator.