### PR TITLE
Refactor messages handlers on the Main and OnMessageTask

### DIFF
--- a/src/Main.cc
+++ b/src/Main.cc
@@ -167,18 +167,20 @@ void OnMessage(uWS::WebSocket<false, true, PerSocketData>* ws, std::string_view 
             carta::EventHeader head = *reinterpret_cast<const carta::EventHeader*>(sv_message.data());
             const char* event_buf = sv_message.data() + sizeof(carta::EventHeader);
             int event_length = sv_message.length() - sizeof(carta::EventHeader);
-            OnMessageTask* tsk = nullptr;
 
             CARTA::EventType event_type = static_cast<CARTA::EventType>(head.type);
             LogReceivedEventType(event_type);
 
-            switch (head.type) {
+            auto event_type_name = CARTA::EventType_Name(CARTA::EventType(event_type));
+            OnMessageTask* tsk = nullptr;
+
+            switch (event_type) {
                 case CARTA::EventType::REGISTER_VIEWER: {
                     CARTA::RegisterViewer message;
                     if (message.ParseFromArray(event_buf, event_length)) {
                         session->OnRegisterViewer(message, head.icd_version, head.request_id);
                     } else {
-                        spdlog::warn("Bad REGISTER_VIEWER message!");
+                        spdlog::warn("Bad {} message!", event_type_name);
                     }
                     break;
                 }
@@ -187,7 +189,7 @@ void OnMessage(uWS::WebSocket<false, true, PerSocketData>* ws, std::string_view 
                     if (message.ParseFromArray(event_buf, event_length)) {
                         session->OnResumeSession(message, head.request_id);
                     } else {
-                        spdlog::warn("Bad RESUME_SESSION message!");
+                        spdlog::warn("Bad {} message!", event_type_name);
                     }
                     break;
                 }
@@ -202,7 +204,7 @@ void OnMessage(uWS::WebSocket<false, true, PerSocketData>* ws, std::string_view 
                         session->AddToSetChannelQueue(message, head.request_id);
                         session->ImageChannelUnlock(message.file_id());
                     } else {
-                        spdlog::warn("Bad SET_IMAGE_CHANNELS message!");
+                        spdlog::warn("Bad {} message!", event_type_name);
                     }
                     break;
                 }
@@ -212,7 +214,7 @@ void OnMessage(uWS::WebSocket<false, true, PerSocketData>* ws, std::string_view 
                         session->AddCursorSetting(message, head.request_id);
                         tsk = new (tbb::task::allocate_root(session->Context())) SetCursorTask(session, message.file_id());
                     } else {
-                        spdlog::warn("Bad SET_CURSOR message!");
+                        spdlog::warn("Bad {} message!", event_type_name);
                     }
                     break;
                 }
@@ -224,10 +226,10 @@ void OnMessage(uWS::WebSocket<false, true, PerSocketData>* ws, std::string_view 
                         } else {
                             session->ResetHistContext();
                             tsk = new (tbb::task::allocate_root(session->HistContext()))
-                                SetHistogramRequirementsTask(session, head, event_length, event_buf);
+                                GeneralMessageTask<CARTA::SetHistogramRequirements>(session, message, head.request_id);
                         }
                     } else {
-                        spdlog::warn("Bad SET_HISTOGRAM_REQUIREMENTS message!");
+                        spdlog::warn("Bad {} message!", event_type_name);
                     }
                     break;
                 }
@@ -236,7 +238,7 @@ void OnMessage(uWS::WebSocket<false, true, PerSocketData>* ws, std::string_view 
                     if (message.ParseFromArray(event_buf, event_length)) {
                         session->OnCloseFile(message);
                     } else {
-                        spdlog::warn("Bad CLOSE_FILE message!");
+                        spdlog::warn("Bad {} message!", event_type_name);
                     }
                     break;
                 }
@@ -247,7 +249,7 @@ void OnMessage(uWS::WebSocket<false, true, PerSocketData>* ws, std::string_view 
                         session->BuildAnimationObject(message, head.request_id);
                         tsk = new (tbb::task::allocate_root(session->AnimationContext())) AnimationTask(session);
                     } else {
-                        spdlog::warn("Bad START_ANIMATION message!");
+                        spdlog::warn("Bad {} message!", event_type_name);
                     }
                     break;
                 }
@@ -256,7 +258,7 @@ void OnMessage(uWS::WebSocket<false, true, PerSocketData>* ws, std::string_view 
                     if (message.ParseFromArray(event_buf, event_length)) {
                         session->StopAnimation(message.file_id(), message.end_frame());
                     } else {
-                        spdlog::warn("Bad STOP_ANIMATION message!");
+                        spdlog::warn("Bad {} message!", event_type_name);
                     }
                     break;
                 }
@@ -265,7 +267,7 @@ void OnMessage(uWS::WebSocket<false, true, PerSocketData>* ws, std::string_view 
                     if (message.ParseFromArray(event_buf, event_length)) {
                         session->HandleAnimationFlowControlEvt(message);
                     } else {
-                        spdlog::warn("Bad ANIMATION_FLOW_CONTROL message!");
+                        spdlog::warn("Bad {} message!", event_type_name);
                     }
                     break;
                 }
@@ -274,27 +276,30 @@ void OnMessage(uWS::WebSocket<false, true, PerSocketData>* ws, std::string_view 
                     if (message.ParseFromArray(event_buf, event_length)) {
                         session->OnFileInfoRequest(message, head.request_id);
                     } else {
-                        spdlog::warn("Bad FILE_INFO_REQUEST message!");
+                        spdlog::warn("Bad {} message!", event_type_name);
                     }
                     break;
                 }
                 case CARTA::EventType::OPEN_FILE: {
                     CARTA::OpenFile message;
                     if (message.ParseFromArray(event_buf, event_length)) {
-                        for (auto& session : sessions) {
-                            session.second->CloseCachedImage(message.directory(), message.file());
+                        for (auto& session_map : sessions) {
+                            session_map.second->CloseCachedImage(message.directory(), message.file());
                         }
-
                         session->OnOpenFile(message, head.request_id);
                     } else {
-                        spdlog::warn("Bad OPEN_FILE message!");
+                        spdlog::warn("Bad {} message!", event_type_name);
                     }
                     break;
                 }
                 case CARTA::EventType::ADD_REQUIRED_TILES: {
                     CARTA::AddRequiredTiles message;
-                    message.ParseFromArray(event_buf, event_length);
-                    tsk = new (tbb::task::allocate_root(session->Context())) OnAddRequiredTilesTask(session, message);
+                    if (message.ParseFromArray(event_buf, event_length)) {
+                        tsk = new (tbb::task::allocate_root(session->Context()))
+                            GeneralMessageTask<CARTA::AddRequiredTiles>(session, message, head.request_id);
+                    } else {
+                        spdlog::warn("Bad {} message!", event_type_name);
+                    }
                     break;
                 }
                 case CARTA::EventType::REGION_FILE_INFO_REQUEST: {
@@ -302,7 +307,7 @@ void OnMessage(uWS::WebSocket<false, true, PerSocketData>* ws, std::string_view 
                     if (message.ParseFromArray(event_buf, event_length)) {
                         session->OnRegionFileInfoRequest(message, head.request_id);
                     } else {
-                        spdlog::warn("Bad REGION_FILE_INFO_REQUEST message!");
+                        spdlog::warn("Bad {} message!", event_type_name);
                     }
                     break;
                 }
@@ -311,7 +316,7 @@ void OnMessage(uWS::WebSocket<false, true, PerSocketData>* ws, std::string_view 
                     if (message.ParseFromArray(event_buf, event_length)) {
                         session->OnImportRegion(message, head.request_id);
                     } else {
-                        spdlog::warn("Bad IMPORT_REGION message!");
+                        spdlog::warn("Bad {} message!", event_type_name);
                     }
                     break;
                 }
@@ -320,14 +325,18 @@ void OnMessage(uWS::WebSocket<false, true, PerSocketData>* ws, std::string_view 
                     if (message.ParseFromArray(event_buf, event_length)) {
                         session->OnExportRegion(message, head.request_id);
                     } else {
-                        spdlog::warn("Bad EXPORT_REGION message!");
+                        spdlog::warn("Bad {} message!", event_type_name);
                     }
                     break;
                 }
                 case CARTA::EventType::SET_CONTOUR_PARAMETERS: {
                     CARTA::SetContourParameters message;
-                    message.ParseFromArray(event_buf, event_length);
-                    tsk = new (tbb::task::allocate_root(session->Context())) OnSetContourParametersTask(session, message);
+                    if (message.ParseFromArray(event_buf, event_length)) {
+                        tsk = new (tbb::task::allocate_root(session->Context()))
+                            GeneralMessageTask<CARTA::SetContourParameters>(session, message, head.request_id);
+                    } else {
+                        spdlog::warn("Bad {} message!", event_type_name);
+                    }
                     break;
                 }
                 case CARTA::EventType::SCRIPTING_RESPONSE: {
@@ -335,7 +344,7 @@ void OnMessage(uWS::WebSocket<false, true, PerSocketData>* ws, std::string_view 
                     if (message.ParseFromArray(event_buf, event_length)) {
                         session->OnScriptingResponse(message, head.request_id);
                     } else {
-                        spdlog::warn("Bad SCRIPTING_RESPONSE message!");
+                        spdlog::warn("Bad {} message!", event_type_name);
                     }
                     break;
                 }
@@ -344,7 +353,7 @@ void OnMessage(uWS::WebSocket<false, true, PerSocketData>* ws, std::string_view 
                     if (message.ParseFromArray(event_buf, event_length)) {
                         session->OnSetRegion(message, head.request_id);
                     } else {
-                        spdlog::warn("Bad SET_REGION message!");
+                        spdlog::warn("Bad {} message!", event_type_name);
                     }
                     break;
                 }
@@ -353,7 +362,7 @@ void OnMessage(uWS::WebSocket<false, true, PerSocketData>* ws, std::string_view 
                     if (message.ParseFromArray(event_buf, event_length)) {
                         session->OnRemoveRegion(message);
                     } else {
-                        spdlog::warn("Bad REMOVE_REGION message!");
+                        spdlog::warn("Bad {} message!", event_type_name);
                     }
                     break;
                 }
@@ -362,7 +371,7 @@ void OnMessage(uWS::WebSocket<false, true, PerSocketData>* ws, std::string_view 
                     if (message.ParseFromArray(event_buf, event_length)) {
                         session->OnSetSpectralRequirements(message);
                     } else {
-                        spdlog::warn("Bad SET_SPECTRAL_REQUIREMENTS message!");
+                        spdlog::warn("Bad {} message!", event_type_name);
                     }
                     break;
                 }
@@ -371,7 +380,7 @@ void OnMessage(uWS::WebSocket<false, true, PerSocketData>* ws, std::string_view 
                     if (message.ParseFromArray(event_buf, event_length)) {
                         session->OnCatalogFileInfo(message, head.request_id);
                     } else {
-                        spdlog::warn("Bad CATALOG_FILE_INFO_REQUEST message!");
+                        spdlog::warn("Bad {} message!", event_type_name);
                     }
                     break;
                 }
@@ -380,7 +389,7 @@ void OnMessage(uWS::WebSocket<false, true, PerSocketData>* ws, std::string_view 
                     if (message.ParseFromArray(event_buf, event_length)) {
                         session->OnOpenCatalogFile(message, head.request_id);
                     } else {
-                        spdlog::warn("Bad OPEN_CATALOG_FILE message!");
+                        spdlog::warn("Bad {} message!", event_type_name);
                     }
                     break;
                 }
@@ -389,7 +398,7 @@ void OnMessage(uWS::WebSocket<false, true, PerSocketData>* ws, std::string_view 
                     if (message.ParseFromArray(event_buf, event_length)) {
                         session->OnCloseCatalogFile(message);
                     } else {
-                        spdlog::warn("Bad CLOSE_CATALOG_FILE message!");
+                        spdlog::warn("Bad {} message!", event_type_name);
                     }
                     break;
                 }
@@ -398,7 +407,7 @@ void OnMessage(uWS::WebSocket<false, true, PerSocketData>* ws, std::string_view 
                     if (message.ParseFromArray(event_buf, event_length)) {
                         session->OnCatalogFilter(message, head.request_id);
                     } else {
-                        spdlog::warn("Bad CLOSE_CATALOG_FILE message!");
+                        spdlog::warn("Bad {} message!", event_type_name);
                     }
                     break;
                 }
@@ -407,7 +416,7 @@ void OnMessage(uWS::WebSocket<false, true, PerSocketData>* ws, std::string_view 
                     if (message.ParseFromArray(event_buf, event_length)) {
                         session->OnStopMomentCalc(message);
                     } else {
-                        spdlog::warn("Bad STOP_MOMENT_CALC message!");
+                        spdlog::warn("Bad {} message!", event_type_name);
                     }
                     break;
                 }
@@ -416,7 +425,7 @@ void OnMessage(uWS::WebSocket<false, true, PerSocketData>* ws, std::string_view 
                     if (message.ParseFromArray(event_buf, event_length)) {
                         session->OnSaveFile(message, head.request_id);
                     } else {
-                        spdlog::warn("Bad SAVE_FILE message!");
+                        spdlog::warn("Bad {} message!", event_type_name);
                     }
                     break;
                 }
@@ -425,17 +434,17 @@ void OnMessage(uWS::WebSocket<false, true, PerSocketData>* ws, std::string_view 
                     if (message.ParseFromArray(event_buf, event_length)) {
                         tsk = new (tbb::task::allocate_root(session->Context())) OnSplataloguePingTask(session, head.request_id);
                     } else {
-                        spdlog::warn("Bad SPLATALOGUE_PING message!\n");
+                        spdlog::warn("Bad {} message!", event_type_name);
                     }
                     break;
                 }
                 case CARTA::EventType::SPECTRAL_LINE_REQUEST: {
                     CARTA::SpectralLineRequest message;
                     if (message.ParseFromArray(event_buf, event_length)) {
-                        tsk =
-                            new (tbb::task::allocate_root(session->Context())) OnSpectralLineRequestTask(session, message, head.request_id);
+                        tsk = new (tbb::task::allocate_root(session->Context()))
+                            GeneralMessageTask<CARTA::SpectralLineRequest>(session, message, head.request_id);
                     } else {
-                        spdlog::warn("Bad SPECTRAL_LINE_REQUEST message!");
+                        spdlog::warn("Bad {} message!", event_type_name);
                     }
                     break;
                 }
@@ -444,7 +453,7 @@ void OnMessage(uWS::WebSocket<false, true, PerSocketData>* ws, std::string_view 
                     if (message.ParseFromArray(event_buf, event_length)) {
                         session->OnConcatStokesFiles(message, head.request_id);
                     } else {
-                        spdlog::warn("Bad CONCAT_STOKES_FILES message!");
+                        spdlog::warn("Bad {} message!", event_type_name);
                     }
                     break;
                 }
@@ -457,15 +466,73 @@ void OnMessage(uWS::WebSocket<false, true, PerSocketData>* ws, std::string_view 
                             session->StopCatalogFileList();
                         }
                     } else {
-                        spdlog::warn("Bad STOP_FILE_LIST message!");
+                        spdlog::warn("Bad {} message!", event_type_name);
+                    }
+                    break;
+                }
+                case CARTA::EventType::SET_SPATIAL_REQUIREMENTS: {
+                    CARTA::SetSpatialRequirements message;
+                    if (message.ParseFromArray(event_buf, event_length)) {
+                        tsk = new (tbb::task::allocate_root(session->Context()))
+                            GeneralMessageTask<CARTA::SetSpatialRequirements>(session, message, head.request_id);
+                    } else {
+                        spdlog::warn("Bad {} message!", event_type_name);
+                    }
+                    break;
+                }
+                case CARTA::EventType::SET_STATS_REQUIREMENTS: {
+                    CARTA::SetStatsRequirements message;
+                    if (message.ParseFromArray(event_buf, event_length)) {
+                        tsk = new (tbb::task::allocate_root(session->Context()))
+                            GeneralMessageTask<CARTA::SetStatsRequirements>(session, message, head.request_id);
+                    } else {
+                        spdlog::warn("Bad {} message!", event_type_name);
+                    }
+                    break;
+                }
+                case CARTA::EventType::MOMENT_REQUEST: {
+                    CARTA::MomentRequest message;
+                    if (message.ParseFromArray(event_buf, event_length)) {
+                        tsk = new (tbb::task::allocate_root(session->Context()))
+                            GeneralMessageTask<CARTA::MomentRequest>(session, message, head.request_id);
+                    } else {
+                        spdlog::warn("Bad {} message!", event_type_name);
+                    }
+                    break;
+                }
+                case CARTA::EventType::FILE_LIST_REQUEST: {
+                    CARTA::FileListRequest message;
+                    if (message.ParseFromArray(event_buf, event_length)) {
+                        tsk = new (tbb::task::allocate_root(session->Context()))
+                            GeneralMessageTask<CARTA::FileListRequest>(session, message, head.request_id);
+                    } else {
+                        spdlog::warn("Bad {} message!", event_type_name);
+                    }
+                    break;
+                }
+                case CARTA::EventType::REGION_LIST_REQUEST: {
+                    CARTA::RegionListRequest message;
+                    if (message.ParseFromArray(event_buf, event_length)) {
+                        tsk = new (tbb::task::allocate_root(session->Context()))
+                            GeneralMessageTask<CARTA::RegionListRequest>(session, message, head.request_id);
+                    } else {
+                        spdlog::warn("Bad {} message!", event_type_name);
+                    }
+                    break;
+                }
+                case CARTA::EventType::CATALOG_LIST_REQUEST: {
+                    CARTA::CatalogListRequest message;
+                    if (message.ParseFromArray(event_buf, event_length)) {
+                        tsk = new (tbb::task::allocate_root(session->Context()))
+                            GeneralMessageTask<CARTA::CatalogListRequest>(session, message, head.request_id);
+                    } else {
+                        spdlog::warn("Bad {} message!", event_type_name);
                     }
                     break;
                 }
                 default: {
-                    // Copy memory into new buffer to be used and disposed by MultiMessageTask::execute
-                    char* message_buffer = new char[event_length];
-                    memcpy(message_buffer, event_buf, event_length);
-                    tsk = new (tbb::task::allocate_root(session->Context())) MultiMessageTask(session, head, event_length, message_buffer);
+                    spdlog::warn("Bad event type {}!", event_type);
+                    break;
                 }
             }
 

--- a/src/OnMessageTask.cc
+++ b/src/OnMessageTask.cc
@@ -7,85 +7,15 @@
 #include "OnMessageTask.h"
 
 #include <algorithm>
-#include <cstring>
-
-#include "EventHeader.h"
-#include "Logger/Logger.h"
-#include "Util.h"
-
-tbb::task* MultiMessageTask::execute() {
-    switch (_header.type) {
-        case CARTA::EventType::SET_SPATIAL_REQUIREMENTS: {
-            CARTA::SetSpatialRequirements message;
-            if (message.ParseFromArray(_event_buffer, _event_length)) {
-                _session->OnSetSpatialRequirements(message);
-            } else {
-                spdlog::warn("Bad SET_SPATIAL_REQUIREMENTS message!");
-            }
-            break;
-        }
-        case CARTA::EventType::SET_STATS_REQUIREMENTS: {
-            CARTA::SetStatsRequirements message;
-            if (message.ParseFromArray(_event_buffer, _event_length)) {
-                _session->OnSetStatsRequirements(message);
-            } else {
-                spdlog::warn("Bad SET_STATS_REQUIREMENTS message!");
-            }
-            break;
-        }
-        case CARTA::EventType::MOMENT_REQUEST: {
-            CARTA::MomentRequest message;
-            if (message.ParseFromArray(_event_buffer, _event_length)) {
-                _session->OnMomentRequest(message, _header.request_id);
-            } else {
-                spdlog::warn("Bad MOMENT_REQUEST message!");
-            }
-            break;
-        }
-        case CARTA::EventType::FILE_LIST_REQUEST: {
-            CARTA::FileListRequest message;
-            if (message.ParseFromArray(_event_buffer, _event_length)) {
-                _session->OnFileListRequest(message, _header.request_id);
-            } else {
-                spdlog::warn("Bad FILE_LIST_REQUEST message!");
-            }
-            break;
-        }
-        case CARTA::EventType::REGION_LIST_REQUEST: {
-            CARTA::RegionListRequest message;
-            if (message.ParseFromArray(_event_buffer, _event_length)) {
-                _session->OnRegionListRequest(message, _header.request_id);
-            } else {
-                spdlog::warn("Bad REGION_LIST_REQUEST message!");
-            }
-            break;
-        }
-        case CARTA::EventType::CATALOG_LIST_REQUEST: {
-            CARTA::CatalogListRequest message;
-            if (message.ParseFromArray(_event_buffer, _event_length)) {
-                _session->OnCatalogFileList(message, _header.request_id);
-            } else {
-                spdlog::warn("Bad CATALOG_LIST_REQUEST message!");
-            }
-            break;
-        }
-        default: {
-            spdlog::warn("Bad event type in MultiMessageType:execute : ({})", _header.type);
-            break;
-        }
-    }
-
-    return nullptr;
-}
 
 tbb::task* SetImageChannelsTask::execute() {
     std::pair<CARTA::SetImageChannels, uint32_t> request_pair;
     bool tester;
 
-    _session->ImageChannelLock(fileId);
-    tester = _session->_set_channel_queues[fileId].try_pop(request_pair);
-    _session->ImageChannelTaskSetIdle(fileId);
-    _session->ImageChannelUnlock(fileId);
+    _session->ImageChannelLock(_file_id);
+    tester = _session->_set_channel_queues[_file_id].try_pop(request_pair);
+    _session->ImageChannelTaskSetIdle(_file_id);
+    _session->ImageChannelUnlock(_file_id);
 
     if (tester) {
         _session->ExecuteSetChannelEvt(request_pair);
@@ -96,15 +26,6 @@ tbb::task* SetImageChannelsTask::execute() {
 
 tbb::task* SetCursorTask::execute() {
     _session->_file_settings.ExecuteOne("SET_CURSOR", _file_id);
-    return nullptr;
-}
-
-tbb::task* SetHistogramRequirementsTask::execute() {
-    CARTA::SetHistogramRequirements message;
-    if (message.ParseFromArray(_event_buffer, _event_length)) {
-        _session->OnSetHistogramRequirements(message, _header.request_id);
-    }
-
     return nullptr;
 }
 
@@ -121,17 +42,6 @@ tbb::task* AnimationTask::execute() {
             _session->CancelAnimation();
         }
     }
-
-    return nullptr;
-}
-
-tbb::task* OnAddRequiredTilesTask::execute() {
-    _session->OnAddRequiredTiles(_message, _session->AnimationRunning());
-    return nullptr;
-}
-
-tbb::task* OnSetContourParametersTask::execute() {
-    _session->OnSetContourParameters(_message);
     return nullptr;
 }
 
@@ -147,10 +57,5 @@ tbb::task* SpectralProfileTask::execute() {
 
 tbb::task* OnSplataloguePingTask::execute() {
     _session->OnSplataloguePing(_request_id);
-    return nullptr;
-}
-
-tbb::task* OnSpectralLineRequestTask::execute() {
-    _session->OnSpectralLineRequest(_message, _request_id);
     return nullptr;
 }

--- a/src/OnMessageTask.h
+++ b/src/OnMessageTask.h
@@ -27,40 +27,61 @@ protected:
     tbb::task* execute() override = 0;
 
 public:
-    OnMessageTask(Session* session) {
-        _session = session;
+    OnMessageTask(Session* session) : _session(session) {
         _session->IncreaseRefCount();
     }
     ~OnMessageTask() {
-        if (!_session->DecreaseRefCount())
+        if (!_session->DecreaseRefCount()) {
             delete _session;
+        }
         _session = nullptr;
     }
 };
 
-class MultiMessageTask : public OnMessageTask {
-    carta::EventHeader _header;
-    int _event_length;
-    char* _event_buffer;
-    tbb::task* execute() override;
+template <typename T>
+class GeneralMessageTask : public OnMessageTask {
+    tbb::task* execute() {
+        if constexpr (std::is_same_v<T, CARTA::SetHistogramRequirements>) {
+            _session->OnSetHistogramRequirements(_message, _request_id);
+        } else if constexpr (std::is_same_v<T, CARTA::AddRequiredTiles>) {
+            _session->OnAddRequiredTiles(_message, _session->AnimationRunning());
+        } else if constexpr (std::is_same_v<T, CARTA::SetContourParameters>) {
+            _session->OnSetContourParameters(_message);
+        } else if constexpr (std::is_same_v<T, CARTA::SpectralLineRequest>) {
+            _session->OnSpectralLineRequest(_message, _request_id);
+        } else if constexpr (std::is_same_v<T, CARTA::SetSpatialRequirements>) {
+            _session->OnSetSpatialRequirements(_message);
+        } else if constexpr (std::is_same_v<T, CARTA::SetStatsRequirements>) {
+            _session->OnSetStatsRequirements(_message);
+        } else if constexpr (std::is_same_v<T, CARTA::MomentRequest>) {
+            _session->OnMomentRequest(_message, _request_id);
+        } else if constexpr (std::is_same_v<T, CARTA::FileListRequest>) {
+            _session->OnFileListRequest(_message, _request_id);
+        } else if constexpr (std::is_same_v<T, CARTA::RegionListRequest>) {
+            _session->OnRegionListRequest(_message, _request_id);
+        } else if constexpr (std::is_same_v<T, CARTA::CatalogListRequest>) {
+            _session->OnCatalogFileList(_message, _request_id);
+        } else {
+            spdlog::warn("Bad event type in GeneralMessageType!");
+        }
+        return nullptr;
+    };
+
+    T _message;
+    uint32_t _request_id;
 
 public:
-    MultiMessageTask(Session* session_, carta::EventHeader& head, int evt_len, char* event_buf) : OnMessageTask(session_) {
-        _header = head;
-        _event_length = evt_len;
-        _event_buffer = event_buf;
-    }
-    ~MultiMessageTask() {
-        delete[] _event_buffer;
-    };
+    GeneralMessageTask(Session* session, T message, uint32_t request_id)
+        : OnMessageTask(session), _message(message), _request_id(request_id) {}
+    ~GeneralMessageTask() = default;
 };
 
 class SetImageChannelsTask : public OnMessageTask {
-    int fileId;
+    int _file_id;
     tbb::task* execute() override;
 
 public:
-    SetImageChannelsTask(Session* session, int fileId) : OnMessageTask(session), fileId(fileId) {}
+    SetImageChannelsTask(Session* session, int file_id) : OnMessageTask(session), _file_id(file_id) {}
     ~SetImageChannelsTask() = default;
 };
 
@@ -69,25 +90,8 @@ class SetCursorTask : public OnMessageTask {
     tbb::task* execute() override;
 
 public:
-    SetCursorTask(Session* session, int file_id) : OnMessageTask(session) {
-        _file_id = file_id;
-    }
+    SetCursorTask(Session* session, int file_id) : OnMessageTask(session), _file_id(file_id) {}
     ~SetCursorTask() = default;
-};
-
-class SetHistogramRequirementsTask : public OnMessageTask {
-    tbb::task* execute();
-    carta::EventHeader _header;
-    int _event_length;
-    const char* _event_buffer;
-
-public:
-    SetHistogramRequirementsTask(Session* session, carta::EventHeader& head, int len, const char* buf) : OnMessageTask(session) {
-        _header = head;
-        _event_length = len;
-        _event_buffer = buf;
-    }
-    ~SetHistogramRequirementsTask() = default;
 };
 
 class AnimationTask : public OnMessageTask {
@@ -98,39 +102,13 @@ public:
     ~AnimationTask() = default;
 };
 
-class OnAddRequiredTilesTask : public OnMessageTask {
-    tbb::task* execute() override;
-    CARTA::AddRequiredTiles _message;
-    int _start, _stride, _end;
-
-public:
-    OnAddRequiredTilesTask(Session* session, CARTA::AddRequiredTiles message) : OnMessageTask(session) {
-        _message = message;
-    }
-    ~OnAddRequiredTilesTask() = default;
-};
-
-class OnSetContourParametersTask : public OnMessageTask {
-    tbb::task* execute() override;
-    CARTA::SetContourParameters _message;
-    int _start, _stride, _end;
-
-public:
-    OnSetContourParametersTask(Session* session, CARTA::SetContourParameters message) : OnMessageTask(session) {
-        _message = message;
-    }
-    ~OnSetContourParametersTask() = default;
-};
-
 class RegionDataStreamsTask : public OnMessageTask {
     tbb::task* execute() override;
     int _file_id, _region_id;
 
 public:
-    RegionDataStreamsTask(Session* session, int file_id, int region_id) : OnMessageTask(session) {
-        _file_id = file_id;
-        _region_id = region_id;
-    }
+    RegionDataStreamsTask(Session* session, int file_id, int region_id)
+        : OnMessageTask(session), _file_id(file_id), _region_id(region_id) {}
     ~RegionDataStreamsTask() = default;
 };
 
@@ -139,10 +117,7 @@ class SpectralProfileTask : public OnMessageTask {
     int _file_id, _region_id;
 
 public:
-    SpectralProfileTask(Session* session, int file_id, int region_id) : OnMessageTask(session) {
-        _file_id = file_id;
-        _region_id = region_id;
-    }
+    SpectralProfileTask(Session* session, int file_id, int region_id) : OnMessageTask(session), _file_id(file_id), _region_id(region_id) {}
     ~SpectralProfileTask() = default;
 };
 
@@ -151,23 +126,8 @@ class OnSplataloguePingTask : public OnMessageTask {
     uint32_t _request_id;
 
 public:
-    OnSplataloguePingTask(Session* session, uint32_t request_id) : OnMessageTask(session) {
-        _request_id = request_id;
-    }
+    OnSplataloguePingTask(Session* session, uint32_t request_id) : OnMessageTask(session), _request_id(request_id) {}
     ~OnSplataloguePingTask() = default;
-};
-
-class OnSpectralLineRequestTask : public OnMessageTask {
-    tbb::task* execute() override;
-    CARTA::SpectralLineRequest _message;
-    uint32_t _request_id;
-
-public:
-    OnSpectralLineRequestTask(Session* session, CARTA::SpectralLineRequest message, uint32_t request_id) : OnMessageTask(session) {
-        _message = message;
-        _request_id = request_id;
-    }
-    ~OnSpectralLineRequestTask() = default;
 };
 
 #endif // CARTA_BACKEND__ONMESSAGETASK_H_

--- a/src/OnMessageTask.h
+++ b/src/OnMessageTask.h
@@ -38,44 +38,6 @@ public:
     }
 };
 
-template <typename T>
-class GeneralMessageTask : public OnMessageTask {
-    tbb::task* execute() {
-        if constexpr (std::is_same_v<T, CARTA::SetHistogramRequirements>) {
-            _session->OnSetHistogramRequirements(_message, _request_id);
-        } else if constexpr (std::is_same_v<T, CARTA::AddRequiredTiles>) {
-            _session->OnAddRequiredTiles(_message, _session->AnimationRunning());
-        } else if constexpr (std::is_same_v<T, CARTA::SetContourParameters>) {
-            _session->OnSetContourParameters(_message);
-        } else if constexpr (std::is_same_v<T, CARTA::SpectralLineRequest>) {
-            _session->OnSpectralLineRequest(_message, _request_id);
-        } else if constexpr (std::is_same_v<T, CARTA::SetSpatialRequirements>) {
-            _session->OnSetSpatialRequirements(_message);
-        } else if constexpr (std::is_same_v<T, CARTA::SetStatsRequirements>) {
-            _session->OnSetStatsRequirements(_message);
-        } else if constexpr (std::is_same_v<T, CARTA::MomentRequest>) {
-            _session->OnMomentRequest(_message, _request_id);
-        } else if constexpr (std::is_same_v<T, CARTA::FileListRequest>) {
-            _session->OnFileListRequest(_message, _request_id);
-        } else if constexpr (std::is_same_v<T, CARTA::RegionListRequest>) {
-            _session->OnRegionListRequest(_message, _request_id);
-        } else if constexpr (std::is_same_v<T, CARTA::CatalogListRequest>) {
-            _session->OnCatalogFileList(_message, _request_id);
-        } else {
-            spdlog::warn("Bad event type in GeneralMessageType!");
-        }
-        return nullptr;
-    };
-
-    T _message;
-    uint32_t _request_id;
-
-public:
-    GeneralMessageTask(Session* session, T message, uint32_t request_id)
-        : OnMessageTask(session), _message(message), _request_id(request_id) {}
-    ~GeneralMessageTask() = default;
-};
-
 class SetImageChannelsTask : public OnMessageTask {
     int _file_id;
     tbb::task* execute() override;
@@ -129,5 +91,7 @@ public:
     OnSplataloguePingTask(Session* session, uint32_t request_id) : OnMessageTask(session), _request_id(request_id) {}
     ~OnSplataloguePingTask() = default;
 };
+
+#include "OnMessageTask.tcc"
 
 #endif // CARTA_BACKEND__ONMESSAGETASK_H_

--- a/src/OnMessageTask.tcc
+++ b/src/OnMessageTask.tcc
@@ -1,0 +1,48 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020, 2021 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+#ifndef CARTA_BACKEND__ONMESSAGETASK_TCC_
+#define CARTA_BACKEND__ONMESSAGETASK_TCC_
+
+template <typename T>
+class GeneralMessageTask : public OnMessageTask {
+    tbb::task* execute() {
+        if constexpr (std::is_same_v<T, CARTA::SetHistogramRequirements>) {
+            _session->OnSetHistogramRequirements(_message, _request_id);
+        } else if constexpr (std::is_same_v<T, CARTA::AddRequiredTiles>) {
+            _session->OnAddRequiredTiles(_message, _session->AnimationRunning());
+        } else if constexpr (std::is_same_v<T, CARTA::SetContourParameters>) {
+            _session->OnSetContourParameters(_message);
+        } else if constexpr (std::is_same_v<T, CARTA::SpectralLineRequest>) {
+            _session->OnSpectralLineRequest(_message, _request_id);
+        } else if constexpr (std::is_same_v<T, CARTA::SetSpatialRequirements>) {
+            _session->OnSetSpatialRequirements(_message);
+        } else if constexpr (std::is_same_v<T, CARTA::SetStatsRequirements>) {
+            _session->OnSetStatsRequirements(_message);
+        } else if constexpr (std::is_same_v<T, CARTA::MomentRequest>) {
+            _session->OnMomentRequest(_message, _request_id);
+        } else if constexpr (std::is_same_v<T, CARTA::FileListRequest>) {
+            _session->OnFileListRequest(_message, _request_id);
+        } else if constexpr (std::is_same_v<T, CARTA::RegionListRequest>) {
+            _session->OnRegionListRequest(_message, _request_id);
+        } else if constexpr (std::is_same_v<T, CARTA::CatalogListRequest>) {
+            _session->OnCatalogFileList(_message, _request_id);
+        } else {
+            spdlog::warn("Bad event type for GeneralMessageTask!");
+        }
+        return nullptr;
+    };
+
+    T _message;
+    uint32_t _request_id;
+
+public:
+    GeneralMessageTask(Session* session, T message, uint32_t request_id)
+        : OnMessageTask(session), _message(message), _request_id(request_id) {}
+    ~GeneralMessageTask() = default;
+};
+
+#endif // CARTA_BACKEND__ONMESSAGETASK_TCC_


### PR DESCRIPTION
This is the part of code changes on #888. I refactored messages handlers from the Main and OnMessageTask. The incoming protobuf messages are decoded only on the Main. And a new `GeneralMessageTask` from the OnMessageTask handles messages based on the protobuf message type. The `MultiMessageTask` is removed. It allows the backend ICD testers to create a testing message without encoding/decoding steps.