### PR TITLE
Create a protobuf messages wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,6 +249,7 @@ set(SOURCE_FILES
         src/OnMessageTask.cc
         src/FileSettings.cc
         src/Util.cc
+        src/Util/Message.cc
         src/TileCache.cc
         src/Threading.cc
         src/SimpleFrontendServer/SimpleFrontendServer.cc)

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -778,7 +778,7 @@ bool Frame::FillHistogramFromLoaderCache(int z, int stokes, int num_bins, CARTA:
 
             // fill message
             double bin_width = (max_val - min_val) / image_num_bins;
-            double first_bin_center = min_val + (histogram->bin_width() / 2.0);
+            double first_bin_center = min_val + (bin_width / 2.0);
             Message::FillHistogram(histogram, image_num_bins, bin_width, first_bin_center, current_stats.histogram_bins, mean, std_dev);
             // histogram cached in loader
             return true;

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -730,7 +730,7 @@ bool Frame::FillRegionHistogramData(
                 carta::Histogram hist;
                 histogram_filled = CalculateHistogram(region_id, z, stokes, num_bins, stats, hist);
                 if (histogram_filled) {
-                    Message::FillHistogram(histogram, stats, hist);
+                    FillHistogram(histogram, stats, hist);
                     region_histogram_callback(histogram_data); // send region histogram data message
                 }
             }
@@ -779,7 +779,7 @@ bool Frame::FillHistogramFromLoaderCache(int z, int stokes, int num_bins, CARTA:
             // fill message
             double bin_width = (max_val - min_val) / image_num_bins;
             double first_bin_center = min_val + (bin_width / 2.0);
-            Message::FillHistogram(histogram, image_num_bins, bin_width, first_bin_center, current_stats.histogram_bins, mean, std_dev);
+            FillHistogram(histogram, image_num_bins, bin_width, first_bin_center, current_stats.histogram_bins, mean, std_dev);
             // histogram cached in loader
             return true;
         }
@@ -805,7 +805,7 @@ bool Frame::FillHistogramFromFrameCache(int z, int stokes, int num_bins, CARTA::
         // add stats to message
         BasicStats<float> stats;
         if (GetBasicStats(z, stokes, stats)) {
-            Message::FillHistogram(histogram, stats, hist);
+            FillHistogram(histogram, stats, hist);
         }
     }
     return have_histogram;
@@ -980,7 +980,7 @@ bool Frame::FillRegionStatsData(std::function<void(CARTA::RegionStatsData stats_
         // Use loader image stats
         auto& image_stats = _loader->GetImageStats(stokes, z);
         if (image_stats.full) {
-            Message::FillStatisticsValue(stats_data, required_stats, image_stats.basic_stats);
+            FillStatistics(stats_data, required_stats, image_stats.basic_stats);
             stats_data_callback(stats_data);
             continue;
         }
@@ -989,7 +989,7 @@ bool Frame::FillRegionStatsData(std::function<void(CARTA::RegionStatsData stats_
         int cache_key(CacheKey(z, stokes));
         if (_image_stats.count(cache_key)) {
             auto stats_map = _image_stats[cache_key];
-            Message::FillStatisticsValue(stats_data, required_stats, stats_map);
+            FillStatistics(stats_data, required_stats, stats_map);
             stats_data_callback(stats_data);
             continue;
         }
@@ -1008,7 +1008,7 @@ bool Frame::FillRegionStatsData(std::function<void(CARTA::RegionStatsData stats_
             }
 
             // complete message
-            Message::FillStatisticsValue(stats_data, required_stats, stats_map);
+            FillStatistics(stats_data, required_stats, stats_map);
             stats_data_callback(stats_data);
 
             // cache results

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -133,7 +133,6 @@ public:
     bool SetHistogramRequirements(int region_id, const std::vector<CARTA::SetHistogramRequirements_HistogramConfig>& histogram_configs);
     bool FillRegionHistogramData(
         std::function<void(CARTA::RegionHistogramData histogram_data)> region_histogram_callback, int region_id, int file_id);
-    bool FillHistogram(int z, int stokes, int num_bins, carta::BasicStats<float>& stats, CARTA::Histogram* histogram);
     bool GetBasicStats(int z, int stokes, carta::BasicStats<float>& stats);
     bool CalculateHistogram(int region_id, int z, int stokes, int num_bins, carta::BasicStats<float>& stats, carta::Histogram& hist);
     bool GetCubeHistogramConfig(HistogramConfig& config);

--- a/src/Region/RegionHandler.cc
+++ b/src/Region/RegionHandler.cc
@@ -847,7 +847,7 @@ bool RegionHandler::GetRegionHistogramData(
             // region outside image, send default histogram
             auto* default_histogram = histogram_message.mutable_histograms();
             std::vector<int> histogram_bins(1, 0);
-            Message::FillHistogram(default_histogram, 1, 0.0, 0.0, histogram_bins, NAN, NAN);
+            FillHistogram(default_histogram, 1, 0.0, 0.0, histogram_bins, NAN, NAN);
             continue;
         }
 
@@ -868,7 +868,7 @@ bool RegionHandler::GetRegionHistogramData(
                 carta::Histogram hist;
                 if (_histogram_cache[cache_id].GetHistogram(num_bins, hist)) {
                     auto* histogram = histogram_message.mutable_histograms();
-                    Message::FillHistogram(histogram, stats, hist);
+                    FillHistogram(histogram, stats, hist);
 
                     // Fill in the cached message
                     histogram_messages.emplace_back(histogram_message);
@@ -899,7 +899,7 @@ bool RegionHandler::GetRegionHistogramData(
 
         // Complete Histogram submessage
         auto* histogram = histogram_message.mutable_histograms();
-        Message::FillHistogram(histogram, stats, histo);
+        FillHistogram(histogram, stats, histo);
 
         // Fill in the final result
         histogram_messages.emplace_back(histogram_message);
@@ -1318,7 +1318,7 @@ bool RegionHandler::GetRegionStatsData(
     if (_stats_cache.count(cache_id)) {
         std::map<CARTA::StatsType, double> stats_results;
         if (_stats_cache[cache_id].GetStats(stats_results)) {
-            Message::FillStatisticsValue(stats_message, required_stats, stats_results);
+            FillStatistics(stats_message, required_stats, stats_results);
             return true;
         }
     }
@@ -1336,7 +1336,7 @@ bool RegionHandler::GetRegionStatsData(
                 stats_results[carta_stat] = nan("");
             }
         }
-        Message::FillStatisticsValue(stats_message, required_stats, stats_results);
+        FillStatistics(stats_message, required_stats, stats_results);
         // cache results
         _stats_cache[cache_id] = StatsCache(stats_results);
         return true;
@@ -1353,7 +1353,7 @@ bool RegionHandler::GetRegionStatsData(
         }
 
         // add values to message
-        Message::FillStatisticsValue(stats_message, required_stats, stats_results);
+        FillStatistics(stats_message, required_stats, stats_results);
         // cache results
         _stats_cache[cache_id] = StatsCache(stats_results);
 

--- a/src/Region/RegionHandler.cc
+++ b/src/Region/RegionHandler.cc
@@ -21,6 +21,7 @@
 #include "../Util.h"
 #include "CrtfImportExport.h"
 #include "Ds9ImportExport.h"
+#include "Util/Message.h"
 
 namespace carta {
 
@@ -845,13 +846,8 @@ bool RegionHandler::GetRegionHistogramData(
         if (!ApplyRegionToFile(region_id, file_id, z_range, stokes, region)) {
             // region outside image, send default histogram
             auto* default_histogram = histogram_message.mutable_histograms();
-            default_histogram->set_num_bins(1);
-            default_histogram->set_bin_width(0.0);
-            default_histogram->set_first_bin_center(0.0);
-            std::vector<float> histogram_bins(1, 0.0);
-            *default_histogram->mutable_bins() = {histogram_bins.begin(), histogram_bins.end()};
-            default_histogram->set_mean(NAN);
-            default_histogram->set_std_dev(NAN);
+            std::vector<int> histogram_bins(1, 0);
+            Message::FillHistogram(default_histogram, 1, 0.0, 0.0, histogram_bins, NAN, NAN);
             continue;
         }
 
@@ -872,7 +868,7 @@ bool RegionHandler::GetRegionHistogramData(
                 carta::Histogram hist;
                 if (_histogram_cache[cache_id].GetHistogram(num_bins, hist)) {
                     auto* histogram = histogram_message.mutable_histograms();
-                    FillHistogramFromResults(histogram, stats, hist);
+                    Message::FillHistogram(histogram, stats, hist);
 
                     // Fill in the cached message
                     histogram_messages.emplace_back(histogram_message);
@@ -903,7 +899,7 @@ bool RegionHandler::GetRegionHistogramData(
 
         // Complete Histogram submessage
         auto* histogram = histogram_message.mutable_histograms();
-        FillHistogramFromResults(histogram, stats, histo);
+        Message::FillHistogram(histogram, stats, histo);
 
         // Fill in the final result
         histogram_messages.emplace_back(histogram_message);
@@ -984,12 +980,8 @@ bool RegionHandler::FillSpectralProfileData(
                 // Return spectral profile for this requirement
                 profile_ok = GetRegionSpectralData(config_region_id, config_file_id, coordinate, stokes_index, required_stats,
                     [&](std::map<CARTA::StatsType, std::vector<double>> results, float progress) {
-                        CARTA::SpectralProfileData profile_message;
-                        profile_message.set_file_id(config_file_id);
-                        profile_message.set_region_id(config_region_id);
-                        profile_message.set_stokes(stokes_index);
-                        profile_message.set_progress(progress);
-                        FillSpectralProfileDataMessage(profile_message, coordinate, required_stats, results);
+                        CARTA::SpectralProfileData profile_message = Message::SpectralProfileData(
+                            config_file_id, config_region_id, stokes_index, progress, coordinate, required_stats, results);
                         cb(profile_message); // send (partial profile) data
                     });
             }
@@ -1326,7 +1318,7 @@ bool RegionHandler::GetRegionStatsData(
     if (_stats_cache.count(cache_id)) {
         std::map<CARTA::StatsType, double> stats_results;
         if (_stats_cache[cache_id].GetStats(stats_results)) {
-            FillStatisticsValuesFromMap(stats_message, required_stats, stats_results);
+            Message::FillStatisticsValue(stats_message, required_stats, stats_results);
             return true;
         }
     }
@@ -1344,7 +1336,7 @@ bool RegionHandler::GetRegionStatsData(
                 stats_results[carta_stat] = nan("");
             }
         }
-        FillStatisticsValuesFromMap(stats_message, required_stats, stats_results);
+        Message::FillStatisticsValue(stats_message, required_stats, stats_results);
         // cache results
         _stats_cache[cache_id] = StatsCache(stats_results);
         return true;
@@ -1361,7 +1353,7 @@ bool RegionHandler::GetRegionStatsData(
         }
 
         // add values to message
-        FillStatisticsValuesFromMap(stats_message, required_stats, stats_results);
+        Message::FillStatisticsValue(stats_message, required_stats, stats_results);
         // cache results
         _stats_cache[cache_id] = StatsCache(stats_results);
 

--- a/src/Session.cc
+++ b/src/Session.cc
@@ -37,6 +37,7 @@
 #include "Threading.h"
 #include "Timer/Timer.h"
 #include "Util.h"
+#include "Util/Message.h"
 
 #ifdef _ARM_ARCH_
 #include <sse2neon/sse2neon.h>
@@ -1348,13 +1349,7 @@ bool Session::CalculateCubeHistogram(int file_id, CARTA::RegionHistogramData& cu
                         CARTA::RegionHistogramData progress_msg;
                         CreateCubeHistogramMessage(progress_msg, file_id, ALL_Z, stokes, progress);
                         auto* message_histogram = progress_msg.mutable_histograms();
-                        message_histogram->set_num_bins(cube_histogram.GetNbins());
-                        message_histogram->set_bin_width(cube_histogram.GetBinWidth());
-                        message_histogram->set_first_bin_center(cube_histogram.GetBinCenter());
-                        message_histogram->set_mean(cube_stats.mean);
-                        message_histogram->set_std_dev(cube_stats.stdDev);
-                        auto& bins = cube_histogram.GetHistogramBins();
-                        *message_histogram->mutable_bins() = {bins.begin(), bins.end()};
+                        Message::FillHistogram(message_histogram, cube_stats, cube_histogram);
                         SendFileEvent(file_id, CARTA::EventType::REGION_HISTOGRAM_DATA, request_id, progress_msg);
                         t_start = t_end;
                     }
@@ -1370,13 +1365,7 @@ bool Session::CalculateCubeHistogram(int file_id, CARTA::RegionHistogramData& cu
                     // fill histogram fields from last z histogram
                     cube_histogram_message.clear_histograms();
                     auto* message_histogram = cube_histogram_message.mutable_histograms();
-                    message_histogram->set_num_bins(cube_histogram.GetNbins());
-                    message_histogram->set_bin_width(cube_histogram.GetBinWidth());
-                    message_histogram->set_first_bin_center(cube_histogram.GetBinCenter());
-                    message_histogram->set_mean(cube_stats.mean);
-                    message_histogram->set_std_dev(cube_stats.stdDev);
-                    auto& bins = cube_histogram.GetHistogramBins();
-                    *message_histogram->mutable_bins() = {bins.begin(), bins.end()};
+                    Message::FillHistogram(message_histogram, cube_stats, cube_histogram);
 
                     // cache cube histogram
                     _frames.at(file_id)->CacheCubeHistogram(stokes, cube_histogram);

--- a/src/Session.cc
+++ b/src/Session.cc
@@ -1349,7 +1349,7 @@ bool Session::CalculateCubeHistogram(int file_id, CARTA::RegionHistogramData& cu
                         CARTA::RegionHistogramData progress_msg;
                         CreateCubeHistogramMessage(progress_msg, file_id, ALL_Z, stokes, progress);
                         auto* message_histogram = progress_msg.mutable_histograms();
-                        Message::FillHistogram(message_histogram, cube_stats, cube_histogram);
+                        FillHistogram(message_histogram, cube_stats, cube_histogram);
                         SendFileEvent(file_id, CARTA::EventType::REGION_HISTOGRAM_DATA, request_id, progress_msg);
                         t_start = t_end;
                     }
@@ -1365,7 +1365,7 @@ bool Session::CalculateCubeHistogram(int file_id, CARTA::RegionHistogramData& cu
                     // fill histogram fields from last z histogram
                     cube_histogram_message.clear_histograms();
                     auto* message_histogram = cube_histogram_message.mutable_histograms();
-                    Message::FillHistogram(message_histogram, cube_stats, cube_histogram);
+                    FillHistogram(message_histogram, cube_stats, cube_histogram);
 
                     // cache cube histogram
                     _frames.at(file_id)->CacheCubeHistogram(stokes, cube_histogram);

--- a/src/Util.cc
+++ b/src/Util.cc
@@ -256,56 +256,6 @@ void GetSpectralCoordPreferences(
     }
 }
 
-void FillHistogramFromResults(CARTA::Histogram* histogram, const carta::BasicStats<float>& stats, const carta::Histogram& hist) {
-    if (histogram == nullptr) {
-        return;
-    }
-    histogram->set_num_bins(hist.GetNbins());
-    histogram->set_bin_width(hist.GetBinWidth());
-    histogram->set_first_bin_center(hist.GetBinCenter());
-    *histogram->mutable_bins() = {hist.GetHistogramBins().begin(), hist.GetHistogramBins().end()};
-    histogram->set_mean(stats.mean);
-    histogram->set_std_dev(stats.stdDev);
-}
-
-void FillSpectralProfileDataMessage(CARTA::SpectralProfileData& profile_message, string& coordinate,
-    vector<CARTA::StatsType>& required_stats, map<CARTA::StatsType, vector<double>>& spectral_data) {
-    for (auto stats_type : required_stats) {
-        // one SpectralProfile per stats type
-        auto new_profile = profile_message.add_profiles();
-        new_profile->set_coordinate(coordinate);
-        new_profile->set_stats_type(stats_type);
-
-        if (spectral_data.find(stats_type) == spectral_data.end()) { // stat not provided
-            double nan_value = nan("");
-            new_profile->set_raw_values_fp64(&nan_value, sizeof(double));
-        } else {
-            new_profile->set_raw_values_fp64(spectral_data[stats_type].data(), spectral_data[stats_type].size() * sizeof(double));
-        }
-    }
-}
-
-void FillStatisticsValuesFromMap(
-    CARTA::RegionStatsData& stats_data, const vector<CARTA::StatsType>& required_stats, map<CARTA::StatsType, double>& stats_value_map) {
-    // inserts values from map into message StatisticsValue field; needed by Frame and RegionDataHandler
-    for (auto type : required_stats) {
-        double value(0.0); // default
-        auto carta_stats_type = static_cast<CARTA::StatsType>(type);
-        if (stats_value_map.find(carta_stats_type) != stats_value_map.end()) { // stat found
-            value = stats_value_map[carta_stats_type];
-        } else { // stat not provided
-            if (carta_stats_type != CARTA::StatsType::NumPixels) {
-                value = nan("");
-            }
-        }
-
-        // add StatisticsValue to message
-        auto stats_value = stats_data.add_statistics();
-        stats_value->set_stats_type(carta_stats_type);
-        stats_value->set_value(value);
-    }
-}
-
 int GetStokesValue(const CARTA::StokesType& stokes_type) {
     int stokes_value(-1);
     switch (stokes_type) {

--- a/src/Util.h
+++ b/src/Util.h
@@ -71,16 +71,6 @@ CARTA::StokesType GetStokesType(int stokes_value);
 void GetSpectralCoordPreferences(
     casacore::ImageInterface<float>* image, bool& prefer_velocity, bool& optical_velocity, bool& prefer_wavelength, bool& air_wavelength);
 
-// ************ Data Stream Helpers *************
-
-void FillHistogramFromResults(CARTA::Histogram* histogram, const carta::BasicStats<float>& stats, const carta::Histogram& hist);
-
-void FillSpectralProfileDataMessage(CARTA::SpectralProfileData& profile_message, std::string& coordinate,
-    std::vector<CARTA::StatsType>& required_stats, std::map<CARTA::StatsType, std::vector<double>>& spectral_data);
-
-void FillStatisticsValuesFromMap(CARTA::RegionStatsData& stats_data, const std::vector<CARTA::StatsType>& required_stats,
-    std::map<CARTA::StatsType, double>& stats_value_map);
-
 std::string IPAsText(std::string_view binary);
 
 bool ValidateAuthToken(uWS::HttpRequest* http_request, const std::string& required_token);

--- a/src/Util/Message.cc
+++ b/src/Util/Message.cc
@@ -278,22 +278,6 @@ CARTA::EventType Message::EventType(std::vector<char>& message) {
     return static_cast<CARTA::EventType>(head.type);
 }
 
-void Message::FillHistogram(CARTA::Histogram* histogram, const carta::BasicStats<float>& stats, const carta::Histogram& hist) {
-    FillHistogram(histogram, hist.GetNbins(), hist.GetBinWidth(), hist.GetBinCenter(), hist.GetHistogramBins(), stats.mean, stats.stdDev);
-}
-
-void Message::FillHistogram(CARTA::Histogram* histogram, int num_bins, double bin_width, double first_bin_center,
-    const std::vector<int>& bins, double mean, double std_dev) {
-    if (histogram) {
-        histogram->set_num_bins(num_bins);
-        histogram->set_bin_width(bin_width);
-        histogram->set_first_bin_center(first_bin_center);
-        *histogram->mutable_bins() = {bins.begin(), bins.end()};
-        histogram->set_mean(mean);
-        histogram->set_std_dev(std_dev);
-    }
-}
-
 CARTA::SpectralProfileData Message::SpectralProfileData(int32_t file_id, int32_t region_id, int32_t stokes, float progress,
     string& coordinate, vector<CARTA::StatsType>& required_stats, map<CARTA::StatsType, vector<double>>& spectral_data) {
     CARTA::SpectralProfileData profile_message;
@@ -318,7 +302,23 @@ CARTA::SpectralProfileData Message::SpectralProfileData(int32_t file_id, int32_t
     return profile_message;
 }
 
-void Message::FillStatisticsValue(
+void FillHistogram(CARTA::Histogram* histogram, int num_bins, double bin_width, double first_bin_center, const std::vector<int>& bins,
+    double mean, double std_dev) {
+    if (histogram) {
+        histogram->set_num_bins(num_bins);
+        histogram->set_bin_width(bin_width);
+        histogram->set_first_bin_center(first_bin_center);
+        *histogram->mutable_bins() = {bins.begin(), bins.end()};
+        histogram->set_mean(mean);
+        histogram->set_std_dev(std_dev);
+    }
+}
+
+void FillHistogram(CARTA::Histogram* histogram, const carta::BasicStats<float>& stats, const carta::Histogram& hist) {
+    FillHistogram(histogram, hist.GetNbins(), hist.GetBinWidth(), hist.GetBinCenter(), hist.GetHistogramBins(), stats.mean, stats.stdDev);
+}
+
+void FillStatistics(
     CARTA::RegionStatsData& stats_data, const vector<CARTA::StatsType>& required_stats, map<CARTA::StatsType, double>& stats_value_map) {
     // inserts values from map into message StatisticsValue field; needed by Frame and RegionDataHandler
     for (auto type : required_stats) {

--- a/src/Util/Message.cc
+++ b/src/Util/Message.cc
@@ -1,0 +1,340 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020, 2021 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+#include "Message.h"
+
+CARTA::RegisterViewer Message::RegisterViewer(uint32_t session_id, string api_key, uint32_t client_feature_flags) {
+    CARTA::RegisterViewer register_viewer;
+    register_viewer.set_session_id(session_id);
+    register_viewer.set_api_key(api_key);
+    register_viewer.set_client_feature_flags(client_feature_flags);
+    return register_viewer;
+}
+
+CARTA::CloseFile Message::CloseFile(int32_t file_id) {
+    CARTA::CloseFile close_file;
+    close_file.set_file_id(file_id);
+    return close_file;
+}
+
+CARTA::OpenFile Message::OpenFile(string directory, string file, string hdu, int32_t file_id, CARTA::RenderMode render_mode) {
+    CARTA::OpenFile open_file;
+    open_file.set_directory(directory);
+    open_file.set_file(file);
+    open_file.set_hdu(hdu);
+    open_file.set_file_id(file_id);
+    open_file.set_render_mode(render_mode);
+    return open_file;
+}
+
+CARTA::SetImageChannels Message::SetImageChannels(
+    int32_t file_id, int32_t channel, int32_t stokes, CARTA::CompressionType compression_type, float compression_quality) {
+    CARTA::SetImageChannels set_image_channels;
+    set_image_channels.set_file_id(file_id);
+    set_image_channels.set_channel(channel);
+    set_image_channels.set_stokes(stokes);
+    CARTA::AddRequiredTiles* required_tiles = set_image_channels.mutable_required_tiles();
+    required_tiles->set_file_id(file_id);
+    required_tiles->set_compression_type(compression_type);
+    required_tiles->set_compression_quality(compression_quality);
+    required_tiles->add_tiles(0);
+    return set_image_channels;
+}
+
+CARTA::SetCursor Message::SetCursor(int32_t file_id, float x, float y) {
+    CARTA::SetCursor set_cursor;
+    set_cursor.set_file_id(file_id);
+    auto* point = set_cursor.mutable_point();
+    point->set_x(x);
+    point->set_y(y);
+    return set_cursor;
+}
+
+CARTA::SetSpatialRequirements Message::SetSpatialRequirements(int32_t file_id, int32_t region_id) {
+    CARTA::SetSpatialRequirements set_spatial_requirements;
+    set_spatial_requirements.set_file_id(file_id);
+    set_spatial_requirements.set_region_id(region_id);
+    auto* spatial_requirement_x = set_spatial_requirements.add_spatial_profiles();
+    spatial_requirement_x->set_coordinate("x");
+    auto* spatial_requirement_y = set_spatial_requirements.add_spatial_profiles();
+    spatial_requirement_y->set_coordinate("y");
+    return set_spatial_requirements;
+}
+
+CARTA::SetStatsRequirements Message::SetStatsRequirements(int32_t file_id, int32_t region_id) {
+    CARTA::SetStatsRequirements set_stats_requirements;
+    set_stats_requirements.set_file_id(file_id);
+    set_stats_requirements.set_region_id(region_id);
+    auto* stats_config = set_stats_requirements.add_stats_configs();
+    stats_config->add_stats_types(CARTA::StatsType::NumPixels);
+    stats_config->add_stats_types(CARTA::StatsType::Sum);
+    stats_config->add_stats_types(CARTA::StatsType::Mean);
+    stats_config->add_stats_types(CARTA::StatsType::RMS);
+    stats_config->add_stats_types(CARTA::StatsType::Sigma);
+    stats_config->add_stats_types(CARTA::StatsType::SumSq);
+    stats_config->add_stats_types(CARTA::StatsType::Min);
+    stats_config->add_stats_types(CARTA::StatsType::Max);
+    return set_stats_requirements;
+}
+
+CARTA::SetHistogramRequirements Message::SetHistogramRequirements(int32_t file_id, int32_t region_id, int32_t channel, int32_t num_bins) {
+    CARTA::SetHistogramRequirements set_histogram_requirements;
+    set_histogram_requirements.set_file_id(file_id);
+    set_histogram_requirements.set_region_id(region_id);
+    auto* histograms = set_histogram_requirements.add_histograms();
+    histograms->set_channel(channel);
+    histograms->set_num_bins(num_bins);
+    return set_histogram_requirements;
+}
+
+CARTA::AddRequiredTiles Message::AddRequiredTiles(
+    int32_t file_id, CARTA::CompressionType compression_type, float compression_quality, const std::vector<float>& tiles) {
+    CARTA::AddRequiredTiles add_required_tiles;
+    add_required_tiles.set_file_id(file_id);
+    add_required_tiles.set_compression_type(compression_type);
+    add_required_tiles.set_compression_quality(compression_quality);
+    for (int i = 0; i < tiles.size(); ++i) {
+        add_required_tiles.add_tiles(tiles[i]);
+    }
+    return add_required_tiles;
+}
+
+CARTA::Point Message::Point(int x, int y) {
+    CARTA::Point point;
+    point.set_x(x);
+    point.set_y(y);
+    return point;
+}
+
+CARTA::SetRegion Message::SetRegion(
+    int32_t file_id, int32_t region_id, CARTA::RegionType region_type, vector<CARTA::Point> control_points, float rotation) {
+    CARTA::SetRegion set_region;
+    set_region.set_file_id(file_id);
+    set_region.set_region_id(region_id);
+    auto* region_info = set_region.mutable_region_info();
+    region_info->set_region_type(region_type);
+    region_info->set_rotation(rotation);
+    for (auto control_point : control_points) {
+        auto* point = region_info->add_control_points();
+        point->set_x(control_point.x());
+        point->set_y(control_point.y());
+    }
+    return set_region;
+}
+
+CARTA::SetStatsRequirements Message::SetStatsRequirements(int32_t file_id, int32_t region_id, string coordinate) {
+    CARTA::SetStatsRequirements set_stats_requirements;
+    set_stats_requirements.set_file_id(file_id);
+    set_stats_requirements.set_region_id(region_id);
+    auto* stats_configs = set_stats_requirements.add_stats_configs();
+    stats_configs->set_coordinate(coordinate);
+    stats_configs->add_stats_types(CARTA::StatsType::NumPixels);
+    stats_configs->add_stats_types(CARTA::StatsType::Sum);
+    stats_configs->add_stats_types(CARTA::StatsType::FluxDensity);
+    stats_configs->add_stats_types(CARTA::StatsType::Mean);
+    stats_configs->add_stats_types(CARTA::StatsType::RMS);
+    stats_configs->add_stats_types(CARTA::StatsType::Sigma);
+    stats_configs->add_stats_types(CARTA::StatsType::SumSq);
+    stats_configs->add_stats_types(CARTA::StatsType::Min);
+    stats_configs->add_stats_types(CARTA::StatsType::Max);
+    stats_configs->add_stats_types(CARTA::StatsType::Extrema);
+    return set_stats_requirements;
+}
+
+CARTA::SetSpectralRequirements Message::SetSpectralRequirements(int32_t file_id, int32_t region_id, string coordinate) {
+    CARTA::SetSpectralRequirements set_spectral_requirements;
+    set_spectral_requirements.set_file_id(file_id);
+    set_spectral_requirements.set_region_id(region_id);
+    auto* spectral_profiles = set_spectral_requirements.add_spectral_profiles();
+    spectral_profiles->set_coordinate(coordinate);
+    spectral_profiles->add_stats_types(CARTA::StatsType::NumPixels);
+    spectral_profiles->add_stats_types(CARTA::StatsType::Sum);
+    spectral_profiles->add_stats_types(CARTA::StatsType::FluxDensity);
+    spectral_profiles->add_stats_types(CARTA::StatsType::Mean);
+    spectral_profiles->add_stats_types(CARTA::StatsType::RMS);
+    spectral_profiles->add_stats_types(CARTA::StatsType::Sigma);
+    spectral_profiles->add_stats_types(CARTA::StatsType::SumSq);
+    spectral_profiles->add_stats_types(CARTA::StatsType::Min);
+    spectral_profiles->add_stats_types(CARTA::StatsType::Max);
+    spectral_profiles->add_stats_types(CARTA::StatsType::Extrema);
+    return set_spectral_requirements;
+}
+
+CARTA::StartAnimation Message::StartAnimation(int32_t file_id, std::pair<int32_t, int32_t> first_frame,
+    std::pair<int32_t, int32_t> start_frame, std::pair<int32_t, int32_t> last_frame, std::pair<int32_t, int32_t> delta_frame,
+    CARTA::CompressionType compression_type, float compression_quality, const std::vector<float>& tiles, int32_t frame_rate) {
+    CARTA::StartAnimation start_animation;
+    auto* mutable_first_frame = start_animation.mutable_first_frame();
+    mutable_first_frame->set_channel(first_frame.first);
+    mutable_first_frame->set_stokes(first_frame.second);
+
+    auto* mutable_start_frame = start_animation.mutable_start_frame();
+    mutable_start_frame->set_channel(start_frame.first);
+    mutable_start_frame->set_stokes(start_frame.second);
+
+    auto* mutable_last_frame = start_animation.mutable_last_frame();
+    mutable_last_frame->set_channel(last_frame.first);
+    mutable_last_frame->set_stokes(last_frame.second);
+
+    auto* mutable_delta_frame = start_animation.mutable_delta_frame();
+    mutable_delta_frame->set_channel(delta_frame.first);
+    mutable_delta_frame->set_stokes(delta_frame.second);
+
+    auto* mutable_required_tiles = start_animation.mutable_required_tiles();
+    mutable_required_tiles->set_file_id(file_id);
+    mutable_required_tiles->set_compression_type(compression_type);
+    mutable_required_tiles->set_compression_quality(compression_quality);
+
+    for (int i = 0; i < tiles.size(); ++i) {
+        mutable_required_tiles->add_tiles(tiles[i]);
+    }
+
+    start_animation.set_frame_rate(frame_rate);
+
+    return start_animation;
+}
+
+CARTA::AnimationFlowControl Message::AnimationFlowControl(int32_t file_id, std::pair<int32_t, int32_t> received_frame) {
+    CARTA::AnimationFlowControl animation_flow_control;
+    animation_flow_control.set_file_id(file_id);
+    auto* mutable_received_frame = animation_flow_control.mutable_received_frame();
+    mutable_received_frame->set_channel(received_frame.first);
+    mutable_received_frame->set_stokes(received_frame.second);
+    animation_flow_control.set_animation_id(1);
+
+    const auto t_now = std::chrono::system_clock::now();
+    animation_flow_control.set_timestamp(t_now.time_since_epoch().count());
+
+    return animation_flow_control;
+}
+
+CARTA::StopAnimation Message::StopAnimation(int32_t file_id, std::pair<int32_t, int32_t> end_frame) {
+    CARTA::StopAnimation stop_animation;
+    stop_animation.set_file_id(file_id);
+    auto* mutable_end_frame = stop_animation.mutable_end_frame();
+    mutable_end_frame->set_channel(end_frame.first);
+    mutable_end_frame->set_stokes(end_frame.second);
+
+    return stop_animation;
+}
+
+CARTA::SetSpatialRequirements_SpatialConfig Message::SpatialConfig(std::string coordinate, int start, int end, int mip) {
+    CARTA::SetSpatialRequirements_SpatialConfig spatial_config;
+    spatial_config.set_coordinate(coordinate);
+    spatial_config.set_start(start);
+    spatial_config.set_end(end);
+    spatial_config.set_mip(mip);
+    return spatial_config;
+}
+
+CARTA::IntBounds Message::IntBounds(int min, int max) {
+    CARTA::IntBounds int_bounds;
+    int_bounds.set_min(min);
+    int_bounds.set_max(max);
+    return int_bounds;
+}
+
+CARTA::FloatBounds Message::FloatBounds(float min, float max) {
+    CARTA::FloatBounds float_bounds;
+    float_bounds.set_min(min);
+    float_bounds.set_max(max);
+    return float_bounds;
+}
+
+CARTA::MomentRequest Message::MomentsRequest(int32_t file_id, int32_t region_id, CARTA::MomentAxis moments_axis,
+    CARTA::MomentMask moment_mask, CARTA::IntBounds spectral_range, CARTA::FloatBounds pixel_range) {
+    CARTA::MomentRequest moment_request;
+    moment_request.set_file_id(file_id);
+    moment_request.set_region_id(region_id);
+    moment_request.set_axis(moments_axis);
+    moment_request.set_mask(moment_mask);
+    auto* mutable_spectral_range = moment_request.mutable_spectral_range();
+    mutable_spectral_range->set_min(spectral_range.min());
+    mutable_spectral_range->set_max(spectral_range.max());
+    auto* mutable_pixel_range = moment_request.mutable_pixel_range();
+    mutable_pixel_range->set_min(pixel_range.min());
+    mutable_pixel_range->set_max(pixel_range.max());
+    moment_request.add_moments(CARTA::Moment::MEAN_OF_THE_SPECTRUM);
+    moment_request.add_moments(CARTA::Moment::INTEGRATED_OF_THE_SPECTRUM);
+    moment_request.add_moments(CARTA::Moment::INTENSITY_WEIGHTED_COORD);
+    moment_request.add_moments(CARTA::Moment::INTENSITY_WEIGHTED_DISPERSION_OF_THE_COORD);
+    moment_request.add_moments(CARTA::Moment::MEDIAN_OF_THE_SPECTRUM);
+    moment_request.add_moments(CARTA::Moment::MEDIAN_COORDINATE);
+    moment_request.add_moments(CARTA::Moment::STD_ABOUT_THE_MEAN_OF_THE_SPECTRUM);
+    moment_request.add_moments(CARTA::Moment::RMS_OF_THE_SPECTRUM);
+    moment_request.add_moments(CARTA::Moment::ABS_MEAN_DEVIATION_OF_THE_SPECTRUM);
+    moment_request.add_moments(CARTA::Moment::MAX_OF_THE_SPECTRUM);
+    moment_request.add_moments(CARTA::Moment::COORD_OF_THE_MAX_OF_THE_SPECTRUM);
+    moment_request.add_moments(CARTA::Moment::MIN_OF_THE_SPECTRUM);
+    moment_request.add_moments(CARTA::Moment::COORD_OF_THE_MIN_OF_THE_SPECTRUM);
+    return moment_request;
+}
+
+CARTA::EventType Message::EventType(std::vector<char>& message) {
+    carta::EventHeader head = *reinterpret_cast<const carta::EventHeader*>(message.data());
+    return static_cast<CARTA::EventType>(head.type);
+}
+
+void Message::FillHistogram(CARTA::Histogram* histogram, const carta::BasicStats<float>& stats, const carta::Histogram& hist) {
+    FillHistogram(histogram, hist.GetNbins(), hist.GetBinWidth(), hist.GetBinCenter(), hist.GetHistogramBins(), stats.mean, stats.stdDev);
+}
+
+void Message::FillHistogram(CARTA::Histogram* histogram, int num_bins, double bin_width, double first_bin_center,
+    const std::vector<int>& bins, double mean, double std_dev) {
+    if (histogram) {
+        histogram->set_num_bins(num_bins);
+        histogram->set_bin_width(bin_width);
+        histogram->set_first_bin_center(first_bin_center);
+        *histogram->mutable_bins() = {bins.begin(), bins.end()};
+        histogram->set_mean(mean);
+        histogram->set_std_dev(std_dev);
+    }
+}
+
+CARTA::SpectralProfileData Message::SpectralProfileData(int32_t file_id, int32_t region_id, int32_t stokes, float progress,
+    string& coordinate, vector<CARTA::StatsType>& required_stats, map<CARTA::StatsType, vector<double>>& spectral_data) {
+    CARTA::SpectralProfileData profile_message;
+    profile_message.set_file_id(file_id);
+    profile_message.set_region_id(region_id);
+    profile_message.set_stokes(stokes);
+    profile_message.set_progress(progress);
+
+    for (auto stats_type : required_stats) {
+        // one SpectralProfile per stats type
+        auto new_profile = profile_message.add_profiles();
+        new_profile->set_coordinate(coordinate);
+        new_profile->set_stats_type(stats_type);
+
+        if (spectral_data.find(stats_type) == spectral_data.end()) { // stat not provided
+            double nan_value = nan("");
+            new_profile->set_raw_values_fp64(&nan_value, sizeof(double));
+        } else {
+            new_profile->set_raw_values_fp64(spectral_data[stats_type].data(), spectral_data[stats_type].size() * sizeof(double));
+        }
+    }
+    return profile_message;
+}
+
+void Message::FillStatisticsValue(
+    CARTA::RegionStatsData& stats_data, const vector<CARTA::StatsType>& required_stats, map<CARTA::StatsType, double>& stats_value_map) {
+    // inserts values from map into message StatisticsValue field; needed by Frame and RegionDataHandler
+    for (auto type : required_stats) {
+        double value(0.0); // default
+        auto carta_stats_type = static_cast<CARTA::StatsType>(type);
+        if (stats_value_map.find(carta_stats_type) != stats_value_map.end()) { // stat found
+            value = stats_value_map[carta_stats_type];
+        } else { // stat not provided
+            if (carta_stats_type != CARTA::StatsType::NumPixels) {
+                value = nan("");
+            }
+        }
+
+        // add StatisticsValue to message
+        auto stats_value = stats_data.add_statistics();
+        stats_value->set_stats_type(carta_stats_type);
+        stats_value->set_value(value);
+    }
+}

--- a/src/Util/Message.h
+++ b/src/Util/Message.h
@@ -44,14 +44,9 @@ public:
         CARTA::MomentMask moment_mask, CARTA::IntBounds spectral_range, CARTA::FloatBounds pixel_range);
 
     // Response messages
-    static void FillHistogram(CARTA::Histogram* histogram, const carta::BasicStats<float>& stats, const carta::Histogram& hist);
-    static void FillHistogram(CARTA::Histogram* histogram, int num_bins, double bin_width, double first_bin_center,
-        const std::vector<int>& bins, double mean, double std_dev);
     static CARTA::SpectralProfileData SpectralProfileData(int32_t file_id, int32_t region_id, int32_t stokes, float progress,
         std::string& coordinate, std::vector<CARTA::StatsType>& required_stats,
         std::map<CARTA::StatsType, std::vector<double>>& spectral_data);
-    static void FillStatisticsValue(CARTA::RegionStatsData& stats_data, const std::vector<CARTA::StatsType>& required_stats,
-        std::map<CARTA::StatsType, double>& stats_value_map);
 
     // Decode messages
     static CARTA::EventType EventType(std::vector<char>& message);
@@ -65,5 +60,11 @@ public:
         return decoded_message;
     }
 };
+
+void FillHistogram(CARTA::Histogram* histogram, int num_bins, double bin_width, double first_bin_center, const std::vector<int>& bins,
+    double mean, double std_dev);
+void FillHistogram(CARTA::Histogram* histogram, const carta::BasicStats<float>& stats, const carta::Histogram& hist);
+void FillStatistics(CARTA::RegionStatsData& stats_data, const std::vector<CARTA::StatsType>& required_stats,
+    std::map<CARTA::StatsType, double>& stats_value_map);
 
 #endif // CARTA_BACKEND_UTIL_MESSAGE_H_

--- a/src/Util/Message.h
+++ b/src/Util/Message.h
@@ -1,0 +1,69 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018, 2019, 2020, 2021 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+#ifndef CARTA_BACKEND_UTIL_MESSAGE_H_
+#define CARTA_BACKEND_UTIL_MESSAGE_H_
+
+#include "Session.h"
+
+class Message {
+    Message() {}
+    ~Message() = default;
+
+public:
+    // Request messages
+    static CARTA::RegisterViewer RegisterViewer(uint32_t session_id, string api_key, uint32_t client_feature_flags);
+    static CARTA::CloseFile CloseFile(int32_t file_id);
+    static CARTA::OpenFile OpenFile(string directory, string file, string hdu, int32_t file_id, CARTA::RenderMode render_mode);
+    static CARTA::SetImageChannels SetImageChannels(
+        int32_t file_id, int32_t channel, int32_t stokes, CARTA::CompressionType compression_type, float compression_quality);
+    static CARTA::SetCursor SetCursor(int32_t file_id, float x, float y);
+    static CARTA::SetSpatialRequirements SetSpatialRequirements(int32_t file_id, int32_t region_id);
+    static CARTA::SetStatsRequirements SetStatsRequirements(int32_t file_id, int32_t region_id);
+    static CARTA::SetHistogramRequirements SetHistogramRequirements(
+        int32_t file_id, int32_t region_id, int32_t channel = CURRENT_Z, int32_t num_bins = AUTO_BIN_SIZE);
+    static CARTA::AddRequiredTiles AddRequiredTiles(
+        int32_t file_id, CARTA::CompressionType compression_type, float compression_quality, const std::vector<float>& tiles);
+    static CARTA::Point Point(int x, int y);
+    static CARTA::SetRegion SetRegion(
+        int32_t file_id, int32_t region_id, CARTA::RegionType region_type, vector<CARTA::Point> control_points, float rotation);
+    static CARTA::SetStatsRequirements SetStatsRequirements(int32_t file_id, int32_t region_id, string coordinate);
+    static CARTA::SetSpectralRequirements SetSpectralRequirements(int32_t file_id, int32_t region_id, string coordinate);
+    static CARTA::StartAnimation StartAnimation(int32_t file_id, std::pair<int32_t, int32_t> first_frame,
+        std::pair<int32_t, int32_t> start_frame, std::pair<int32_t, int32_t> last_frame, std::pair<int32_t, int32_t> delta_frame,
+        CARTA::CompressionType compression_type, float compression_quality, const std::vector<float>& tiles, int32_t frame_rate = 5);
+    static CARTA::AnimationFlowControl AnimationFlowControl(int32_t file_id, std::pair<int32_t, int32_t> received_frame);
+    static CARTA::StopAnimation StopAnimation(int32_t file_id, std::pair<int32_t, int32_t> end_frame);
+    static CARTA::SetSpatialRequirements_SpatialConfig SpatialConfig(std::string coordinate, int start = 0, int end = 0, int mip = 0);
+    static CARTA::IntBounds IntBounds(int min, int max);
+    static CARTA::FloatBounds FloatBounds(float min, float max);
+    static CARTA::MomentRequest MomentsRequest(int32_t file_id, int32_t region_id, CARTA::MomentAxis moments_axis,
+        CARTA::MomentMask moment_mask, CARTA::IntBounds spectral_range, CARTA::FloatBounds pixel_range);
+
+    // Response messages
+    static void FillHistogram(CARTA::Histogram* histogram, const carta::BasicStats<float>& stats, const carta::Histogram& hist);
+    static void FillHistogram(CARTA::Histogram* histogram, int num_bins, double bin_width, double first_bin_center,
+        const std::vector<int>& bins, double mean, double std_dev);
+    static CARTA::SpectralProfileData SpectralProfileData(int32_t file_id, int32_t region_id, int32_t stokes, float progress,
+        std::string& coordinate, std::vector<CARTA::StatsType>& required_stats,
+        std::map<CARTA::StatsType, std::vector<double>>& spectral_data);
+    static void FillStatisticsValue(CARTA::RegionStatsData& stats_data, const std::vector<CARTA::StatsType>& required_stats,
+        std::map<CARTA::StatsType, double>& stats_value_map);
+
+    // Decode messages
+    static CARTA::EventType EventType(std::vector<char>& message);
+
+    template <typename T>
+    static T DecodeMessage(std::vector<char>& message) {
+        T decoded_message;
+        char* event_buf = message.data() + sizeof(carta::EventHeader);
+        int event_length = message.size() - sizeof(carta::EventHeader);
+        decoded_message.ParseFromArray(event_buf, event_length);
+        return decoded_message;
+    }
+};
+
+#endif // CARTA_BACKEND_UTIL_MESSAGE_H_

--- a/test/TestSpatialProfiles.cc
+++ b/test/TestSpatialProfiles.cc
@@ -7,10 +7,10 @@
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
+#include "CommonTestUtilities.h"
 #include "Frame.h"
 #include "ImageData/FileLoader.h"
-
-#include "CommonTestUtilities.h"
+#include "Util/Message.h"
 
 using namespace carta;
 
@@ -32,15 +32,6 @@ public:
         std::vector<float> values(buffer.size() / sizeof(float));
         memcpy(values.data(), buffer.data(), buffer.size());
         return values;
-    }
-
-    static CARTA::SetSpatialRequirements_SpatialConfig SpatialConfig(std::string coordinate, int start = 0, int end = 0, int mip = 0) {
-        CARTA::SetSpatialRequirements_SpatialConfig conf;
-        conf.set_coordinate(coordinate);
-        conf.set_start(start);
-        conf.set_end(end);
-        conf.set_mip(mip);
-        return conf;
     }
 
     static std::vector<float> Decimated(std::vector<float> full_resolution, int mip) {
@@ -97,7 +88,7 @@ TEST_F(SpatialProfileTest, SmallFitsProfile) {
     std::unique_ptr<Frame> frame(new Frame(0, carta::FileLoader::GetLoader(path_string), "0"));
     FitsDataReader reader(path_string);
 
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {SpatialConfig("x"), SpatialConfig("y")};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {Message::SpatialConfig("x"), Message::SpatialConfig("y")};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(5, 5);
 
@@ -137,7 +128,7 @@ TEST_F(SpatialProfileTest, SmallHdf5Profile) {
     std::unique_ptr<Frame> frame(new Frame(0, carta::FileLoader::GetLoader(path_string), "0"));
     Hdf5DataReader reader(path_string);
 
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {SpatialConfig("x"), SpatialConfig("y")};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {Message::SpatialConfig("x"), Message::SpatialConfig("y")};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(5, 5);
 
@@ -177,7 +168,8 @@ TEST_F(SpatialProfileTest, LowResFitsProfile) {
     std::unique_ptr<Frame> frame(new Frame(0, carta::FileLoader::GetLoader(path_string), "0"));
     FitsDataReader reader(path_string);
 
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {SpatialConfig("x", 0, 0, 2), SpatialConfig("y", 0, 0, 2)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {
+        Message::SpatialConfig("x", 0, 0, 2), Message::SpatialConfig("y", 0, 0, 2)};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(50, 50);
 
@@ -210,7 +202,8 @@ TEST_F(SpatialProfileTest, LowResHdf5ProfileExactMipAvailable) {
     std::unique_ptr<Frame> frame(new Frame(0, carta::FileLoader::GetLoader(path_string), "0"));
     Hdf5DataReader reader(path_string);
 
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {SpatialConfig("x", 0, 0, 2), SpatialConfig("y", 0, 0, 2)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {
+        Message::SpatialConfig("x", 0, 0, 2), Message::SpatialConfig("y", 0, 0, 2)};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(50, 50);
 
@@ -244,7 +237,8 @@ TEST_F(SpatialProfileTest, LowResHdf5ProfileLowerMipAvailable) {
     Hdf5DataReader reader(path_string);
 
     // mip 4 is requested, but the file only has a dataset for mip 2
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {SpatialConfig("x", 0, 0, 4), SpatialConfig("y", 0, 0, 4)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {
+        Message::SpatialConfig("x", 0, 0, 4), Message::SpatialConfig("y", 0, 0, 4)};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(50, 50);
 
@@ -279,7 +273,8 @@ TEST_F(SpatialProfileTest, LowResHdf5ProfileNoMipAvailable) {
     Hdf5DataReader reader(path_string);
 
     // mip 2 is requested, but this file is too small to have mipmaps
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {SpatialConfig("x", 0, 0, 2), SpatialConfig("y", 0, 0, 2)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {
+        Message::SpatialConfig("x", 0, 0, 2), Message::SpatialConfig("y", 0, 0, 2)};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(50, 50);
 
@@ -313,7 +308,8 @@ TEST_F(SpatialProfileTest, FullResFitsStartEnd) {
     std::unique_ptr<Frame> frame(new Frame(0, carta::FileLoader::GetLoader(path_string), "0"));
     FitsDataReader reader(path_string);
 
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {SpatialConfig("x", 100, 200, 0), SpatialConfig("y", 100, 200, 0)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {
+        Message::SpatialConfig("x", 100, 200, 0), Message::SpatialConfig("y", 100, 200, 0)};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(150, 150);
 
@@ -346,7 +342,8 @@ TEST_F(SpatialProfileTest, FullResHdf5StartEnd) {
     std::unique_ptr<Frame> frame(new Frame(0, carta::FileLoader::GetLoader(path_string), "0"));
     Hdf5DataReader reader(path_string);
 
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {SpatialConfig("x", 100, 200, 0), SpatialConfig("y", 100, 200, 0)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {
+        Message::SpatialConfig("x", 100, 200, 0), Message::SpatialConfig("y", 100, 200, 0)};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(150, 150);
 
@@ -379,7 +376,8 @@ TEST_F(SpatialProfileTest, LowResFitsStartEnd) {
     std::unique_ptr<Frame> frame(new Frame(0, carta::FileLoader::GetLoader(path_string), "0"));
     FitsDataReader reader(path_string);
 
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {SpatialConfig("x", 100, 200, 4), SpatialConfig("y", 100, 200, 4)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {
+        Message::SpatialConfig("x", 100, 200, 4), Message::SpatialConfig("y", 100, 200, 4)};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(150, 150);
 
@@ -414,7 +412,8 @@ TEST_F(SpatialProfileTest, LowResHdf5StartEnd) {
     std::unique_ptr<Frame> frame(new Frame(0, carta::FileLoader::GetLoader(path_string), "0"));
     Hdf5DataReader reader(path_string);
 
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {SpatialConfig("x", 100, 200, 4), SpatialConfig("y", 100, 200, 4)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {
+        Message::SpatialConfig("x", 100, 200, 4), Message::SpatialConfig("y", 100, 200, 4)};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(150, 150);
 
@@ -453,7 +452,7 @@ TEST_F(SpatialProfileTest, Hdf5MultipleChunkFullRes) {
     std::unique_ptr<Frame> frame(new Frame(0, carta::FileLoader::GetLoader(path_string), "0"));
     Hdf5DataReader reader(path_string);
 
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {SpatialConfig("x"), SpatialConfig("y")};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {Message::SpatialConfig("x"), Message::SpatialConfig("y")};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(150, 150);
 
@@ -486,7 +485,8 @@ TEST_F(SpatialProfileTest, Hdf5MultipleChunkFullResStartEnd) {
     std::unique_ptr<Frame> frame(new Frame(0, carta::FileLoader::GetLoader(path_string), "0"));
     Hdf5DataReader reader(path_string);
 
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {SpatialConfig("x", 1000, 1500), SpatialConfig("y", 1000, 1500)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {
+        Message::SpatialConfig("x", 1000, 1500), Message::SpatialConfig("y", 1000, 1500)};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(1250, 1250);
 
@@ -519,7 +519,7 @@ TEST_F(SpatialProfileTest, FitsChannelChange) {
     std::unique_ptr<Frame> frame(new Frame(0, carta::FileLoader::GetLoader(path_string), "0"));
     FitsDataReader reader(path_string);
 
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {SpatialConfig("x"), SpatialConfig("y")};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {Message::SpatialConfig("x"), Message::SpatialConfig("y")};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(5, 5);
     std::string msg;
@@ -567,7 +567,7 @@ TEST_F(SpatialProfileTest, FitsChannelStokesChange) {
     int stokes(0);                // set stokes channel as "I"
     int spatial_config_stokes(1); // set spatial config coordinate = {"Qx", "Qy"}
 
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {SpatialConfig("Qx"), SpatialConfig("Qy")};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {Message::SpatialConfig("Qx"), Message::SpatialConfig("Qy")};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(x, y);
     std::string msg;
@@ -609,7 +609,7 @@ TEST_F(SpatialProfileTest, ContiguousHDF5ChannelChange) {
     std::unique_ptr<Frame> frame(new Frame(0, carta::FileLoader::GetLoader(path_string), "0"));
     Hdf5DataReader reader(path_string);
 
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {SpatialConfig("x"), SpatialConfig("y")};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {Message::SpatialConfig("x"), Message::SpatialConfig("y")};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(5, 5);
     std::string msg;
@@ -651,7 +651,7 @@ TEST_F(SpatialProfileTest, ChunkedHDF5ChannelChange) {
     std::unique_ptr<Frame> frame(new Frame(0, carta::FileLoader::GetLoader(path_string), "0"));
     Hdf5DataReader reader(path_string);
 
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {SpatialConfig("x"), SpatialConfig("y")};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {Message::SpatialConfig("x"), Message::SpatialConfig("y")};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(5, 5);
     std::string msg;
@@ -699,7 +699,7 @@ TEST_F(SpatialProfileTest, ChunkedHDF5ChannelStokesChange) {
     int stokes(0);                // set stokes channel as "I"
     int spatial_config_stokes(1); // set spatial config coordinate = {"Qx", "Qy"}
 
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {SpatialConfig("Qx"), SpatialConfig("Qy")};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {Message::SpatialConfig("Qx"), Message::SpatialConfig("Qy")};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(x, y);
     std::string msg;


### PR DESCRIPTION
This is the part of code changes on #888. I created `src/Util/Message.h/cc` for protobuf messages helpers for creating or filling messages. There are some creating requested messages functions on the `Message` class which will be used in ICD tests.