### PR TITLE
Fix loading error for the compressed FITS file

### DIFF
--- a/src/FileList/FitsHduList.cc
+++ b/src/FileList/FitsHduList.cc
@@ -22,7 +22,9 @@ void FitsHduList::GetHduList(std::vector<std::string>& hdu_list, std::string& er
 
     // DO NOT USE for compressed FITS, fits_open_file decompresses entire file.
     if (IsCompressedFits(_filename)) {
-        throw(casacore::AipsError("Use CompressedFits for HDU header map."));
+        error = "Should use CompressedFits for HDU header map.";
+        spdlog::debug(error);
+        return;
     }
 
     // Open file read-only

--- a/src/ImageData/CompressedFits.h
+++ b/src/ImageData/CompressedFits.h
@@ -94,6 +94,7 @@ public:
 
     // Headers for file info
     bool GetFitsHeaderInfo(std::map<std::string, CARTA::FileInfoExtended>& hdu_info_map);
+    bool GetFirstImageHdu(string& hduname);
 
     // Beams for file info and opening image
     inline const casacore::ImageBeamSet& GetBeamSet() {

--- a/src/Session.cc
+++ b/src/Session.cc
@@ -213,10 +213,9 @@ bool Session::FillExtendedFileInfo(CARTA::FileInfoExtended& extended_info, CARTA
                 hdu = file_info.hdu_list(0);
             }
 
-            if (hdu.empty() && (file_info.type() == CARTA::FileType::FITS)) {
+            if (hdu.empty() && (file_info.type() == CARTA::FileType::FITS) && !IsCompressedFits(fullname)) {
                 // File info adds empty string for FITS
                 std::vector<std::string> hdu_list;
-                std::string message;
                 FitsHduList fits_hdu_list(fullname);
                 fits_hdu_list.GetHduList(hdu_list, message);
 

--- a/src/Session.cc
+++ b/src/Session.cc
@@ -31,6 +31,7 @@
 #include "FileList/FileExtInfoLoader.h"
 #include "FileList/FileInfoLoader.h"
 #include "FileList/FitsHduList.h"
+#include "ImageData/CompressedFits.h"
 #include "Logger/Logger.h"
 #include "OnMessageTask.h"
 #include "SpectralLine/SpectralLineCrawler.h"
@@ -220,12 +221,10 @@ bool Session::FillExtendedFileInfo(CARTA::FileInfoExtended& extended_info, CARTA
             if (hdu.empty() && (file_info.type() == CARTA::FileType::FITS)) {
                 // File info adds empty string for FITS
                 if (IsCompressedFits(fullname)) {
-                    std::map<std::string, CARTA::FileInfoExtended> hdu_info_map;
-                    file_info_ok = ext_info_loader.FillFitsFileInfoMap(hdu_info_map, fullname, message);
-                    if (hdu_info_map.empty()) {
+                    CompressedFits cfits(fullname);
+                    if (!cfits.GetFirstImageHdu(hdu)) {
                         return file_info_ok;
                     }
-                    hdu = hdu_info_map.begin()->first; // get the key (hdu name) of the first element of a map
                 } else {
                     std::vector<std::string> hdu_list;
                     FitsHduList fits_hdu_list(fullname);

--- a/src/Session.cc
+++ b/src/Session.cc
@@ -223,6 +223,7 @@ bool Session::FillExtendedFileInfo(CARTA::FileInfoExtended& extended_info, CARTA
                 if (IsCompressedFits(fullname)) {
                     CompressedFits cfits(fullname);
                     if (!cfits.GetFirstImageHdu(hdu)) {
+                        message = "No image HDU found for FITS.";
                         return file_info_ok;
                     }
                 } else {
@@ -231,6 +232,7 @@ bool Session::FillExtendedFileInfo(CARTA::FileInfoExtended& extended_info, CARTA
                     fits_hdu_list.GetHduList(hdu_list, message);
 
                     if (hdu_list.empty()) {
+                        message = "No image HDU found for FITS.";
                         return file_info_ok;
                     }
 


### PR DESCRIPTION
This PR tries to fix #924. When loading a compressed FITS file via URL query parameter or double click, the frontend sends an empty HDU string. And the backend tries to get an HDU list through `FitsHduList,` thus an exception throw: `Use CompressedFits for HDU header map.` I just added a condition check that the FitsHduList object can not process the compressed FITS file. @kswang1029 could you please check doest it solve the problem?