### PR TITLE
Respect minimum CMake version of 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,11 +271,11 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 endif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
 if (CartaUserFolderPrefix)
-    add_compile_definitions(CARTA_USER_FOLDER_PREFIX="${CartaUserFolderPrefix}")
+    add_definitions(-DCARTA_USER_FOLDER_PREFIX="${CartaUserFolderPrefix}")
 endif (CartaUserFolderPrefix)
 
 if (CartaDefaultFrontendFolder)
-    add_compile_definitions(CARTA_DEFAULT_FRONTEND_FOLDER="${CartaDefaultFrontendFolder}")
+    add_definitions(-DCARTA_DEFAULT_FRONTEND_FOLDER="${CartaDefaultFrontendFolder}")
 endif (CartaDefaultFrontendFolder)
 
 install(TARGETS carta_backend


### PR DESCRIPTION
This should fix #904; as far as I can tell these were the only functions which were too new.