### PR TITLE
Angus/plaftorm info

### DIFF
--- a/src/Session.cc
+++ b/src/Session.cc
@@ -312,9 +312,9 @@ void Session::OnRegisterViewer(const CARTA::RegisterViewer& message, uint16_t ic
     auto& platform_string_map = *ack_message.mutable_platform_strings();
     platform_string_map["release_info"] = GetReleaseInformation();
 #if __APPLE__
-    platform_string_map["plaform"] = "MacOS";
+    platform_string_map["plaform"] = "macOS";
 #else
-    platform_string_map["plaform"] = "Linux";
+    platform_string_map["platform"] = "Linux";
 #endif
 
     uint32_t feature_flags;

--- a/src/Session.cc
+++ b/src/Session.cc
@@ -312,7 +312,7 @@ void Session::OnRegisterViewer(const CARTA::RegisterViewer& message, uint16_t ic
     auto& platform_string_map = *ack_message.mutable_platform_strings();
     platform_string_map["release_info"] = GetReleaseInformation();
 #if __APPLE__
-    platform_string_map["plaform"] = "macOS";
+    platform_string_map["platform"] = "macOS";
 #else
     platform_string_map["platform"] = "Linux";
 #endif

--- a/src/Session.cc
+++ b/src/Session.cc
@@ -40,7 +40,9 @@
 #ifdef _ARM_ARCH_
 #include <sse2neon/sse2neon.h>
 #else
+#include <Util/App.h>
 #include <xmmintrin.h>
+
 #endif
 
 int Session::_num_sessions = 0;
@@ -306,6 +308,14 @@ void Session::OnRegisterViewer(const CARTA::RegisterViewer& message, uint16_t ic
     ack_message.set_success(success);
     ack_message.set_message(status);
     ack_message.set_session_type(type);
+
+    auto& platform_string_map = *ack_message.mutable_platform_strings();
+    platform_string_map["release_info"] = GetReleaseInformation();
+#if __APPLE__
+    platform_string_map["plaform"] = "MacOS";
+#else
+    platform_string_map["plaform"] = "Linux";
+#endif
 
     uint32_t feature_flags;
     if (_read_only_mode) {

--- a/src/Util/App.cc
+++ b/src/Util/App.cc
@@ -8,10 +8,19 @@
 
 #include <unistd.h>
 #include <climits>
+#include <fstream>
+#include <vector>
 
 #ifdef __APPLE__
 #include <mach-o/dyld.h>
+#include <stdio.h>
 #endif
+
+#include "FileSystem.h"
+#include "Logger/Logger.h"
+
+#define MAX_PLATFORM_INFO_LENGTH 1024
+#define MAX_PLATFORM_LINE_LENGTH 256
 
 bool FindExecutablePath(std::string& path) {
     char path_buffer[PATH_MAX + 1];
@@ -32,4 +41,42 @@ bool FindExecutablePath(std::string& path) {
 #endif
     path = path_buffer;
     return true;
+}
+
+std::string GetReleaseInformation() {
+#ifdef __APPLE__
+    // MacOS solution adapted from https://stackoverflow.com/a/44684199/1727322
+    char info_buffer[MAX_PLATFORM_INFO_LENGTH];
+    unsigned buffer_length = 0;
+    char line[MAX_PLATFORM_LINE_LENGTH];
+    auto file_handle = popen("sw_vers", "r");
+    while (fgets(line, sizeof(line), file_handle) != nullptr) {
+        int l = snprintf(info_buffer + buffer_length, sizeof(info_buffer) - buffer_length, "%s", line);
+        buffer_length += l;
+        if (buffer_length > MAX_PLATFORM_INFO_LENGTH) {
+            spdlog::warn("Problem reading platform information");
+            return std::string("Platform information not available");
+        }
+    }
+    pclose(file_handle);
+    return info_buffer;
+#else
+    // Unix solution just attempts to read from common release text files
+    std::vector<fs::path> valid_paths = {{"/etc/lsb-release", "/etc/centos-release", "/etc/redhat-release"}};
+
+    for (const auto& path : valid_paths) {
+        if (fs::exists(path) && fs::is_regular_file(path)) {
+            try {
+                // read the entire release file to string
+                std::ifstream input_file(path);
+                std::stringstream buffer;
+                buffer << input_file.rdbuf();
+                return buffer.str();
+            } catch (std::ifstream::failure e) {
+                spdlog::warn("Problem reading platform information");
+            }
+        }
+    }
+#endif
+    return std::string("Platform information not available");
 }

--- a/src/Util/App.cc
+++ b/src/Util/App.cc
@@ -10,7 +10,6 @@
 #include <climits>
 #include <fstream>
 #include <sstream>
-#include <vector>
 
 #ifdef __APPLE__
 #include <mach-o/dyld.h>
@@ -62,20 +61,19 @@ std::string GetReleaseInformation() {
     pclose(file_handle);
     return info_buffer;
 #else
-    // Unix solution just attempts to read from common release text files
-    std::vector<fs::path> valid_paths = {{"/etc/lsb-release", "/etc/centos-release", "/etc/redhat-release"}};
+    // Unix solution just attempts to read from /etc/os-release. This works with Ubuntu, RedHat, CentOS, Arch, Debian and Fedora,
+    // and should work on any system that has systemd installed
+    fs::path path = "/etc/os-release";
 
-    for (const auto& path : valid_paths) {
-        if (fs::exists(path) && fs::is_regular_file(path)) {
-            try {
-                // read the entire release file to string
-                std::ifstream input_file(path);
-                std::stringstream buffer;
-                buffer << input_file.rdbuf();
-                return buffer.str();
-            } catch (std::ifstream::failure e) {
-                spdlog::warn("Problem reading platform information");
-            }
+    if (fs::exists(path) && fs::is_regular_file(path)) {
+        try {
+            // read the entire release file to string
+            std::ifstream input_file(path);
+            std::stringstream buffer;
+            buffer << input_file.rdbuf();
+            return buffer.str();
+        } catch (std::ifstream::failure e) {
+            spdlog::warn("Problem reading platform information");
         }
     }
 #endif

--- a/src/Util/App.cc
+++ b/src/Util/App.cc
@@ -9,6 +9,7 @@
 #include <unistd.h>
 #include <climits>
 #include <fstream>
+#include <sstream>
 #include <vector>
 
 #ifdef __APPLE__

--- a/src/Util/App.h
+++ b/src/Util/App.h
@@ -13,5 +13,6 @@
 #define VERSION_ID "3.0.0-beta.1b"
 
 bool FindExecutablePath(std::string& path);
+std::string GetReleaseInformation();
 
 #endif // CARTA_BACKEND__UTIL_APP_H_


### PR DESCRIPTION
Fills `plaftorm_strings` map with OS information when sending `RegisterViewerAck` messages.

Protobuf PR [here](https://github.com/CARTAvis/carta-protobuf/pull/57), but changes are non-breaking.

The frontend telemetry PR is https://github.com/CARTAvis/carta-frontend/pull/1670, but this can be merged in before that PR is sorted out.