### PR TITLE
Use cfitsio for FITS headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed hard crash when attempting to read files within a read-protected directory ([#945](https://github.com/CARTAvis/carta-backend/issues/945)).
 * Fixed region histograms for moment images ([#906](https://github.com/CARTAvis/carta-backend/issues/906)).
 * Fixed bug of duplicate histogram calculation ([#905](https://github.com/CARTAvis/carta-backend/pull/905)).
+* Fixed FITS header bug for dropped keyword index ([#912](https://github.com/CARTAvis/carta-backend/issues/912)).
+
+### Changed
+
 
 ## [3.0.0-beta.1b]
 

--- a/src/FileList/FileExtInfoLoader.cc
+++ b/src/FileList/FileExtInfoLoader.cc
@@ -455,15 +455,14 @@ void FileExtInfoLoader::FitsHeaderInfoToHeaderEntries(casacore::ImageFITSHeaderI
             }
         }
 
-        auto header_entry = extended_info.add_header_entries();
-        header_entry->set_name(name);
-        header_entry->set_comment(comment);
-
         switch (fkw->type()) {
             case casacore::FITS::LOGICAL: {
                 bool value(fkw->asBool());
                 std::string bool_string(value ? "T" : "F");
 
+                auto header_entry = extended_info.add_header_entries();
+                header_entry->set_name(name);
+                header_entry->set_comment(comment);
                 *header_entry->mutable_value() = bool_string;
                 header_entry->set_entry_type(CARTA::EntryType::INT);
                 header_entry->set_numeric_value(value);
@@ -473,6 +472,9 @@ void FileExtInfoLoader::FitsHeaderInfoToHeaderEntries(casacore::ImageFITSHeaderI
                 int value(fkw->asInt());
                 std::string string_value = fmt::format("{:d}", value);
 
+                auto header_entry = extended_info.add_header_entries();
+                header_entry->set_name(name);
+                header_entry->set_comment(comment);
                 *header_entry->mutable_value() = string_value;
                 header_entry->set_entry_type(CARTA::EntryType::INT);
                 header_entry->set_numeric_value(value);
@@ -492,6 +494,9 @@ void FileExtInfoLoader::FitsHeaderInfoToHeaderEntries(casacore::ImageFITSHeaderI
                     string_value = fmt::format("{:.12E}", value);
                 }
 
+                auto header_entry = extended_info.add_header_entries();
+                header_entry->set_name(name);
+                header_entry->set_comment(comment);
                 *header_entry->mutable_value() = string_value;
                 header_entry->set_entry_type(CARTA::EntryType::FLOAT);
                 header_entry->set_numeric_value(value);
@@ -512,6 +517,9 @@ void FileExtInfoLoader::FitsHeaderInfoToHeaderEntries(casacore::ImageFITSHeaderI
                     }
                 }
 
+                auto header_entry = extended_info.add_header_entries();
+                header_entry->set_name(name);
+                header_entry->set_comment(comment);
                 *header_entry->mutable_value() = header_string;
                 header_entry->set_entry_type(CARTA::EntryType::STRING);
                 break;

--- a/src/FileList/FileExtInfoLoader.cc
+++ b/src/FileList/FileExtInfoLoader.cc
@@ -167,7 +167,7 @@ bool FileExtInfoLoader::FillFileInfoFromImage(CARTA::FileInfoExtended& extended_
                     GetSpectralCoordPreferences(image.get(), prefer_velocity, optical_velocity, prefer_wavelength, air_wavelength);
                     casacore::ImageFITSHeaderInfo fhi;
                     casacore::String error_string, origin_string;
-                    bool stokes_last(false), degenerate_last(false), verbose(false), allow_append(false), history(false);
+                    bool stokes_last(false), degenerate_last(false), verbose(false), allow_append(false), history(true);
                     bool prim_head(hdu == "0");
                     int bit_pix(-32);
                     float min_pix(1.0), max_pix(-1.0);
@@ -524,13 +524,43 @@ void FileExtInfoLoader::FitsHeaderInfoToHeaderEntries(casacore::ImageFITSHeaderI
                 header_entry->set_entry_type(CARTA::EntryType::STRING);
                 break;
             }
-            case casacore::FITS::BIT:
-            case casacore::FITS::CHAR:
-            case casacore::FITS::COMPLEX:
-            case casacore::FITS::ICOMPLEX:
-            case casacore::FITS::DCOMPLEX:
-            case casacore::FITS::VADESC:
-            case casacore::FITS::NOVALUE:
+            case casacore::FITS::COMPLEX: {
+                casacore::Complex value = fkw->asComplex();
+                std::string string_value = fmt::format("{} + {}i", value.real(), value.imag());
+
+                auto header_entry = extended_info.add_header_entries();
+                header_entry->set_name(name);
+                header_entry->set_comment(comment);
+                header_entry->set_entry_type(CARTA::EntryType::STRING);
+                break;
+            }
+            case casacore::FITS::ICOMPLEX: {
+                casacore::IComplex value = fkw->asIComplex();
+                std::string string_value = fmt::format("{} + {}i", value.real(), value.imag());
+
+                auto header_entry = extended_info.add_header_entries();
+                header_entry->set_name(name);
+                header_entry->set_comment(comment);
+                header_entry->set_entry_type(CARTA::EntryType::STRING);
+                break;
+            }
+            case casacore::FITS::DCOMPLEX: {
+                casacore::DComplex value = fkw->asDComplex();
+                std::string string_value = fmt::format("{} + {}i", value.real(), value.imag());
+
+                auto header_entry = extended_info.add_header_entries();
+                header_entry->set_name(name);
+                header_entry->set_comment(comment);
+                header_entry->set_entry_type(CARTA::EntryType::STRING);
+                break;
+            }
+            case casacore::FITS::NOVALUE: {
+                auto header_entry = extended_info.add_header_entries();
+                header_entry->set_name(name);
+                header_entry->set_comment(comment);
+                header_entry->set_entry_type(CARTA::EntryType::STRING);
+                break;
+            }
             default:
                 break;
         }

--- a/src/FileList/FileExtInfoLoader.cc
+++ b/src/FileList/FileExtInfoLoader.cc
@@ -1192,7 +1192,7 @@ casacore::Vector<casacore::String> FileExtInfoLoader::FitsHeaderStrings(casacore
     // Open file and move to hdu
     fits_open_file(&fptr, name.c_str(), 0, &status);
     status = 0;
-    fits_movabs_hdu(fptr, hdu, hdutype, &status);
+    fits_movabs_hdu(fptr, hdu + 1, hdutype, &status);
 
     // Get number of headers
     int nkeys(0);

--- a/src/FileList/FileExtInfoLoader.h
+++ b/src/FileList/FileExtInfoLoader.h
@@ -51,6 +51,7 @@ private:
         const std::vector<int>& display_axes, bool use_image_for_entries);
     void AddComputedEntriesFromHeaders(CARTA::FileInfoExtended& extended_info, const std::vector<int>& display_axes);
     void AddBeamEntry(CARTA::FileInfoExtended& extended_info, const casacore::ImageBeamSet& beam_set);
+    bool HaveBeamHeaders(CARTA::FileInfoExtended& extended_info); // casacore adds from HISTORY headers
 
     // Convert MVAngle to string; returns Quantity string if not direction
     std::string MakeAngleString(const std::string& type, double val, const std::string& unit);

--- a/src/FileList/FileExtInfoLoader.h
+++ b/src/FileList/FileExtInfoLoader.h
@@ -51,7 +51,6 @@ private:
         const std::vector<int>& display_axes, bool use_image_for_entries);
     void AddComputedEntriesFromHeaders(CARTA::FileInfoExtended& extended_info, const std::vector<int>& display_axes);
     void AddBeamEntry(CARTA::FileInfoExtended& extended_info, const casacore::ImageBeamSet& beam_set);
-    bool HaveBeamHeaders(CARTA::FileInfoExtended& extended_info); // casacore adds from HISTORY headers
 
     // Convert MVAngle to string; returns Quantity string if not direction
     std::string MakeAngleString(const std::string& type, double val, const std::string& unit);

--- a/src/FileList/FileExtInfoLoader.h
+++ b/src/FileList/FileExtInfoLoader.h
@@ -36,24 +36,21 @@ private:
     void StripHduName(std::string& hdu); // remove extension name
 
     // Header entries
-    void FitsHeaderInfoToHeaderEntries(casacore::ImageFITSHeaderInfo& fhi, bool using_image_header, int bitpix, const std::string& hdu,
-        CARTA::FileInfoExtended& extended_info);
+    casacore::Vector<casacore::String> FitsHeaderStrings(casacore::String& name, unsigned int hdu);
+    void AddEntriesFromHeaderStrings(
+        const casacore::Vector<casacore::String>& headers, const std::string& hdu, CARTA::FileInfoExtended& extended_info);
+    void ConvertHeaderValueToNumeric(const casacore::String& name, casacore::String& value, CARTA::HeaderEntry* entry);
+    void FitsHeaderInfoToHeaderEntries(casacore::ImageFITSHeaderInfo& fhi, CARTA::FileInfoExtended& extended_info);
 
-    // Image shape, nchannels, nstokes entries
+    // Computed entries
     void AddShapeEntries(CARTA::FileInfoExtended& extended_info, const casacore::IPosition& shape, int chan_axis, int depth_axis,
         int stokes_axis, const std::vector<int>& render_axes);
-
-    // Computed entries for direction and spectral axes
     void AddInitialComputedEntries(
         const std::string& hdu, CARTA::FileInfoExtended& extended_info, const std::string& filename, const std::vector<int>& render_axes);
     void AddComputedEntries(CARTA::FileInfoExtended& extended_info, casacore::ImageInterface<float>* image,
-        const std::vector<int>& display_axes, casacore::String& radesys, bool use_image_for_entries);
+        const std::vector<int>& display_axes, bool use_image_for_entries);
     void AddComputedEntriesFromHeaders(CARTA::FileInfoExtended& extended_info, const std::vector<int>& display_axes);
     void AddBeamEntry(CARTA::FileInfoExtended& extended_info, const casacore::ImageBeamSet& beam_set);
-
-    // FITS keyword conversion
-    bool GetFitsKwList(casacore::FitsInput& fits_input, unsigned int hdu, casacore::FitsKeywordList& kwlist);
-    int GetFitsBitpix(casacore::ImageInterface<float>* image);
 
     // Convert MVAngle to string; returns Quantity string if not direction
     std::string MakeAngleString(const std::string& type, double val, const std::string& unit);

--- a/src/ImageData/CartaFitsImage.cc
+++ b/src/ImageData/CartaFitsImage.cc
@@ -346,7 +346,6 @@ void CartaFitsImage::GetFitsHeaders(int& nheaders, std::string& hdrstr) {
     // Read header values into single string, and store some image parameters.
     // Returns string and number of keys contained in string.
     // Throws exception if any headers missing.
-
     fitsfile* fptr = OpenFile();
     int status(0);
 
@@ -441,11 +440,17 @@ casacore::Vector<casacore::String> CartaFitsImage::FitsHeaderStrings(int nheader
         pos += 80;
     }
 
+    _fits_header_strings = header_strings;
+
     return header_strings;
 }
 
 casacore::Vector<casacore::String> CartaFitsImage::FitsHeaderStrings() {
     // Return headers as string vector
+    if (!_fits_header_strings.empty()) {
+        return _fits_header_strings;
+    }
+
     int nheaders;
     std::string fits_headers;
     GetFitsHeaders(nheaders, fits_headers);

--- a/src/ImageData/CartaFitsImage.cc
+++ b/src/ImageData/CartaFitsImage.cc
@@ -271,18 +271,13 @@ void CartaFitsImage::CloseFileIfError(const int& status, const std::string& erro
 
 void CartaFitsImage::SetUpImage() {
     // Set up image parameters and coordinate system from headers
-    // Get headers as single string
+    // Read headers into string
     int nheaders(0);
-    std::string header_str;
-    GetFitsHeaders(nheaders, header_str);
+    std::string header;
+    GetFitsHeaders(nheaders, header);
 
-    // Convert headers to Vector of Strings to pass to casacore converter
-    casacore::Vector<casacore::String> header_strings(nheaders);
-    size_t pos(0);
-    for (int i = 0; i < nheaders; ++i) {
-        header_strings(i) = header_str.substr(pos, 80);
-        pos += 80;
-    }
+    // Headers as String vector to pass to converter
+    casacore::Vector<casacore::String> header_strings = FitsHeaderStrings(nheaders, header);
 
     casacore::Record unused_headers;
     casacore::LogSink sink;
@@ -300,7 +295,7 @@ void CartaFitsImage::SetUpImage() {
             // Spectral axis defined in velocity fails if no rest freq to convert to frequencies
             try {
                 // Set up with wcslib
-                coord_sys = SetCoordinateSystem(nheaders, header_str, unused_headers, stokes_fits_value);
+                coord_sys = SetCoordinateSystem(nheaders, header, unused_headers, stokes_fits_value);
             } catch (const casacore::AipsError& err) {
                 spdlog::debug("Coordinate system setup error: {}", err.getMesg());
                 throw(casacore::AipsError("Coordinate system setup from FITS headers failed."));
@@ -347,13 +342,12 @@ void CartaFitsImage::SetUpImage() {
     }
 }
 
-void CartaFitsImage::GetFitsHeaders(int& nkeys, std::string& hdrstr) {
+void CartaFitsImage::GetFitsHeaders(int& nheaders, std::string& hdrstr) {
     // Read header values into single string, and store some image parameters.
     // Returns string and number of keys contained in string.
     // Throws exception if any headers missing.
 
     fitsfile* fptr = OpenFile();
-
     int status(0);
 
     // Check hdutype
@@ -403,21 +397,21 @@ void CartaFitsImage::GetFitsHeaders(int& nkeys, std::string& hdrstr) {
     CloseFileIfError(status, "Error detecting image compression.");
 
     // Number of headers (keys).  nkeys is function parameter.
-    nkeys = 0;
+    nheaders = 0;
     int* more_keys(nullptr);
     status = 0;
-    fits_get_hdrspace(fptr, &nkeys, more_keys, &status);
+    fits_get_hdrspace(fptr, &nheaders, more_keys, &status);
     CloseFileIfError(status, "Unable to determine FITS headers.");
 
     // Get headers as single string with no exclusions (exclist=nullptr, nexc=0)
     int no_comments(0);
-    char* header[nkeys];
+    char* header[nheaders];
     status = 0;
     if (_is_compressed) {
         // Convert to uncompressed headers
-        fits_convert_hdr2str(fptr, no_comments, nullptr, 0, header, &nkeys, &status);
+        fits_convert_hdr2str(fptr, no_comments, nullptr, 0, header, &nheaders, &status);
     } else {
-        fits_hdr2str(fptr, no_comments, nullptr, 0, header, &nkeys, &status);
+        fits_hdr2str(fptr, no_comments, nullptr, 0, header, &nheaders, &status);
     }
 
     if (status) {
@@ -435,6 +429,27 @@ void CartaFitsImage::GetFitsHeaders(int& nkeys, std::string& hdrstr) {
 
     // Done with file
     CloseFile();
+}
+
+casacore::Vector<casacore::String> CartaFitsImage::FitsHeaderStrings(int nheaders, const std::string& header) {
+    // Return header string as vector of 80-char strings. Also returns number of headers and header string.
+    casacore::Vector<casacore::String> header_strings(nheaders);
+    size_t pos(0);
+
+    for (int i = 0; i < nheaders; ++i) {
+        header_strings(i) = header.substr(pos, 80);
+        pos += 80;
+    }
+
+    return header_strings;
+}
+
+casacore::Vector<casacore::String> CartaFitsImage::FitsHeaderStrings() {
+    // Return headers as string vector
+    int nheaders;
+    std::string fits_headers;
+    GetFitsHeaders(nheaders, fits_headers);
+    return FitsHeaderStrings(nheaders, fits_headers);
 }
 
 casacore::CoordinateSystem CartaFitsImage::SetCoordinateSystem(

--- a/src/ImageData/CartaFitsImage.h
+++ b/src/ImageData/CartaFitsImage.h
@@ -99,6 +99,7 @@ private:
     casacore::IPosition _shape;
     int _datatype; // bitpix value
     bool _has_blanks;
+    casacore::Vector<casacore::String> _fits_header_strings;
 
     casacore::Lattice<bool>* _pixel_mask;
     casacore::TiledShape _tiled_shape;

--- a/src/ImageData/CartaFitsImage.h
+++ b/src/ImageData/CartaFitsImage.h
@@ -52,6 +52,9 @@ public:
 
     casacore::DataType internalDataType() const;
 
+    // Headers accessors
+    casacore::Vector<casacore::String> FitsHeaderStrings();
+
 private:
     // Uses _fptr (nullptr when file is closed)
     fitsfile* OpenFile();
@@ -59,7 +62,8 @@ private:
     void CloseFileIfError(const int& status, const std::string& error);
 
     void SetUpImage();
-    void GetFitsHeaders(int& nkeys, std::string& hdrstr);
+    void GetFitsHeaders(int& nheaders, std::string& hdrstr);
+    casacore::Vector<casacore::String> FitsHeaderStrings(int nheaders, const std::string& header);
 
     // casacore ImageFITSConverter workaround
     casacore::CoordinateSystem SetCoordinateSystem(

--- a/src/ImageData/CartaHdf5Image.cc
+++ b/src/ImageData/CartaHdf5Image.cc
@@ -241,7 +241,7 @@ void CartaHdf5Image::SetUpImage() {
     }
 }
 
-casacore::Vector<casacore::String> CartaHdf5Image::FITSHeaderStrings() {
+casacore::Vector<casacore::String> CartaHdf5Image::FitsHeaderStrings() {
     return _fits_header_strings;
 }
 

--- a/src/ImageData/CartaHdf5Image.h
+++ b/src/ImageData/CartaHdf5Image.h
@@ -57,7 +57,7 @@ public:
     casacore::Lattice<bool>& pixelMask() override;
     casacore::Bool doGetMaskSlice(casacore::Array<bool>& buffer, const casacore::Slicer& section) override;
 
-    casacore::Vector<casacore::String> FITSHeaderStrings();
+    casacore::Vector<casacore::String> FitsHeaderStrings();
 
 private:
     // Function to return the internal HDF5File object to the RegionHandlerHDF5

--- a/src/ImageData/CompressedFits.cc
+++ b/src/ImageData/CompressedFits.cc
@@ -263,6 +263,16 @@ bool CompressedFits::IsImageHdu(const std::string& fits_block, CARTA::FileInfoEx
 void CompressedFits::ParseFitsCard(
     casacore::String& fits_card, casacore::String& keyword, casacore::String& value, casacore::String& comment) {
     // Extract parts of FITS header.
+    if (fits_card.empty()) {
+        return;
+    }
+
+    if (fits_card.startsWith("HISTORY")) {
+        // Do not parse HISTORY
+        keyword = fits_card;
+        return;
+    }
+
     // Split keyword, remainder of line
     std::vector<std::string> keyword_remainder;
     SplitString(fits_card, '=', keyword_remainder);


### PR DESCRIPTION
Closes #912 

Workaround for casacore::ImageFITSConverter::ImageHeaderToFITS, which loses the index _n_ on headers CXXXXn (for example CTYPE1, CRPIX2, CUNIT3, CROTA2).  They are returned in order so we have been incrementing _n_ for each header name each time it appears.  However, there is no way to guess _n_ for CROTAn which is not in order.

Instead, we will use native libraries where possible to create the header entries: (1) HDF5 for HDF5 images (retrieved from CartaHdf5Image) and (2) cfitsio for FITS images (retrieved from CartaFitsImage, and generated in FileExtInfoLoader for casacore::FITSImage),  but continue to convert images to headers using casacore as before for CASA and MIRIAD images.

Tested using the image in issue #912 by verifying the CROTA2 header keyword and the WCS grid on the loaded image.