### PR TITLE
Check beam headers for casacore::FITSImage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed hard crash when attempting to read files within a read-protected directory ([#945](https://github.com/CARTAvis/carta-backend/issues/945)).
 * Fixed region histograms for moment images ([#906](https://github.com/CARTAvis/carta-backend/issues/906)).
 * Fixed bug of duplicate histogram calculation ([#905](https://github.com/CARTAvis/carta-backend/pull/905)).
+* Fixed restoring beam set from HISTORY ([#935](https://github.com/CARTAvis/carta-backend/issues/935)).
 
 ## [3.0.0-beta.1b]
 

--- a/src/FileList/FileExtInfoLoader.cc
+++ b/src/FileList/FileExtInfoLoader.cc
@@ -321,7 +321,7 @@ bool FileExtInfoLoader::FillFileInfoFromImage(CARTA::FileInfoExtended& extended_
 
                         // Get image headers in FITS format
                         casacore::String error_string, origin_string;
-                        bool stokes_last(false), degenerate_last(false), verbose(false), allow_append(false), history(false);
+                        bool stokes_last(false), degenerate_last(false), verbose(false), allow_append(false), history(true);
                         bool prim_head(hdu == "0");
                         int bit_pix(-32);
                         float min_pix(1.0), max_pix(-1.0);

--- a/src/ImageData/FitsLoader.h
+++ b/src/ImageData/FitsLoader.h
@@ -147,7 +147,7 @@ void FitsLoader::RemoveHistoryBeam(unsigned int hdu_num) {
         status = 0;
         fits_close_file(fptr, &status);
 
-        if (!bmaj_found || !bmin_found || !bpa_found) {
+        if (!(bmaj_found && bmin_found && bpa_found)) {
             // Beam headers missing, remove from image info
             image_info.removeRestoringBeam();
             _image->setImageInfo(image_info);

--- a/src/ImageData/FitsLoader.h
+++ b/src/ImageData/FitsLoader.h
@@ -133,15 +133,19 @@ void FitsLoader::RemoveHistoryBeam(unsigned int hdu_num) {
         fits_movabs_hdu(fptr, hdu, hdutype, &status);
 
         // Read headers
-        char record[80];
+        std::string record(80, 0);
         int key_num(1);
         bool bmaj_found(false), bmin_found(false), bpa_found(false);
 
         while (status == 0 && !(bmaj_found && bmin_found && bpa_found)) {
-            fits_read_record(fptr, key_num++, record, &status);
-            bmaj_found |= strncmp(record, "BMAJ", 4) == 0;
-            bmin_found |= strncmp(record, "BMIN", 4) == 0;
-            bpa_found |= strncmp(record, "BPA", 3) == 0;
+            fits_read_record(fptr, key_num++, record.data(), &status);
+
+            if (status == 0) {
+                std::string keyword = record.substr(0, 4);
+                bmaj_found |= keyword.compare("BMAJ") == 0;
+                bmin_found |= keyword.compare("BMIN") == 0;
+                bpa_found |= keyword.compare("BPA ") == 0;
+            }
         }
 
         // Close file

--- a/src/ImageData/FitsLoader.h
+++ b/src/ImageData/FitsLoader.h
@@ -142,9 +142,9 @@ void FitsLoader::RemoveHistoryBeam(unsigned int hdu_num) {
 
             if (status == 0) {
                 std::string keyword = record.substr(0, 4);
-                bmaj_found |= keyword.compare("BMAJ") == 0;
-                bmin_found |= keyword.compare("BMIN") == 0;
-                bpa_found |= keyword.compare("BPA ") == 0;
+                bmaj_found |= (keyword == "BMAJ");
+                bmin_found |= (keyword == "BMIN");
+                bpa_found |= (keyword == "BPA ");
             }
         }
 


### PR DESCRIPTION
Closes #935 .

casacore::FITSImage uses the HISTORY headers for BMAJ, BMIN, and BPA when not set in regular headers.  This is because the AIPS package stores beam info in HISTORY.

When FitsLoader loads a casacore::FITSImage with a single beam, it will use cfitsio to retrieve the non-history headers and, if not found, remove the restoring beam in the FITSImage (stored in its ImageInfo).

There is a bit of a performance hit (when there are numerous headers) while these headers are being checked for a FITSImage, used to generate the file info and to load the image.  Any better ideas?