### PR TITLE
Modify the contour data message

### DIFF
--- a/src/DataStream/Contouring.cc
+++ b/src/DataStream/Contouring.cc
@@ -140,6 +140,7 @@ void TraceLevel(const float* image, int64_t width, int64_t height, double scale,
     vector<bool> visited(num_pixels);
     int64_t i, j;
     bool first_report_done(false);
+    bool is_long_task(false);
 
     auto t_start = std::chrono::high_resolution_clock::now();
 
@@ -149,8 +150,7 @@ void TraceLevel(const float* image, int64_t width, int64_t height, double scale,
             auto dt = std::chrono::duration_cast<std::chrono::microseconds>(t_end - t_start).count();
             double progress = std::min(0.99, checked_pixels / double(num_pixels));
             auto estimated_process_time = 1.0e-6 * dt / progress; // seconds
-            bool is_long_task(false);
-            if (progress > 0 && estimated_process_time > 1.0) {
+            if (progress > 0 && estimated_process_time > 1.0 && !is_long_task) {
                 is_long_task = true;
             }
             if (!first_report_done) {

--- a/src/DataStream/Contouring.cc
+++ b/src/DataStream/Contouring.cc
@@ -14,6 +14,8 @@
 #include "../Logger/Logger.h"
 #include "Threading.h"
 
+static const int64_t NUM_PIXELS_THRESHOLD = 8000 * 8000;
+
 using namespace std;
 
 // Contour tracing code adapted from SAOImage DS9: https://github.com/SAOImageDS9/SAOImageDS9
@@ -139,7 +141,7 @@ void TraceLevel(const float* image, int64_t width, int64_t height, double scale,
     int64_t checked_pixels = 0;
     vector<bool> visited(num_pixels);
     int64_t i, j;
-    bool is_long_task(num_pixels > 1e+6);
+    bool is_long_task(num_pixels > NUM_PIXELS_THRESHOLD);
 
     auto test_for_chunk_overflow = [&]() {
         if (vertex_cutoff && vertices.size() > vertex_cutoff) {
@@ -227,7 +229,7 @@ void TraceContours(float* image, int64_t width, int64_t height, double scale, do
     index_data.resize(levels.size());
 
     // send the first report with zero progress in order to let the frontend starts progress bar
-    bool is_long_task(width * height > 1e+6);
+    bool is_long_task(width * height > NUM_PIXELS_THRESHOLD);
     vector<float> empty_vertices;
     vector<int32_t> empty_indices;
     partial_callback(levels[0], 0.0, empty_vertices, empty_indices, is_long_task);

--- a/src/DataStream/Contouring.cc
+++ b/src/DataStream/Contouring.cc
@@ -229,11 +229,12 @@ void TraceLevel(const float* image, int64_t width, int64_t height, double scale,
             checked_pixels++;
         }
     }
-    if (!first_report_done) { // reset the progress as 0 in order to let the frontend know it is the first partial data report
-        partial_callback(level, 0.0, vertices, indices, false);
-    } else {
-        partial_callback(level, 1.0, vertices, indices, false);
+    if (!first_report_done) { // send the progress 0 in order to let the frontend know it is the first report
+        vector<float> empty_vertices;
+        vector<int32_t> empty_indices;
+        partial_callback(level, 0.0, empty_vertices, empty_indices, false);
     }
+    partial_callback(level, 1.0, vertices, indices, false);
 }
 
 void TraceContours(float* image, int64_t width, int64_t height, double scale, double offset, const std::vector<double>& levels,

--- a/src/DataStream/Contouring.cc
+++ b/src/DataStream/Contouring.cc
@@ -229,7 +229,11 @@ void TraceLevel(const float* image, int64_t width, int64_t height, double scale,
             checked_pixels++;
         }
     }
-    partial_callback(level, 1.0, vertices, indices, false);
+    if (!first_report_done) { // reset the progress as 0 in order to let the frontend know it is the first partial data report
+        partial_callback(level, 0.0, vertices, indices, false);
+    } else {
+        partial_callback(level, 1.0, vertices, indices, false);
+    }
 }
 
 void TraceContours(float* image, int64_t width, int64_t height, double scale, double offset, const std::vector<double>& levels,

--- a/src/DataStream/Contouring.cc
+++ b/src/DataStream/Contouring.cc
@@ -139,6 +139,7 @@ void TraceLevel(const float* image, int64_t width, int64_t height, double scale,
     int64_t checked_pixels = 0;
     vector<bool> visited(num_pixels);
     int64_t i, j;
+    bool first_report_done(false);
 
     auto t_start = std::chrono::high_resolution_clock::now();
 
@@ -152,14 +153,15 @@ void TraceLevel(const float* image, int64_t width, int64_t height, double scale,
             if (progress > 0 && estimated_process_time > 1.0) {
                 is_long_task = true;
             }
+            if (!first_report_done) {
+                progress = 0; // reset the progress as 0 in order to let the frontend know it is the first partial data report
+                first_report_done = true;
+            }
             partial_callback(level, progress, vertices, indices, is_long_task);
             vertices.clear();
             indices.clear();
         }
     };
-
-    // Send the first partial contour data with the zero progress
-    partial_callback(level, 0.0, vertices, indices, false);
 
     // Search TopEdge
     for (j = 0, i = 0; i < width - 1; i++) {

--- a/src/DataStream/Contouring.h
+++ b/src/DataStream/Contouring.h
@@ -16,10 +16,8 @@ typedef const std::function<void(double, double, const std::vector<float>&, cons
 
 enum Edge { TopEdge, RightEdge, BottomEdge, LeftEdge, None };
 
-void TraceContourLevel(float* image, int64_t width, int64_t height, double scale, double offset, double level,
-    std::vector<double>& vertex_data, std::vector<int32_t>& indices);
 void TraceContours(float* image, int64_t width, int64_t height, double scale, double offset, const std::vector<double>& levels,
-    std::vector<std::vector<float>>& vertex_data, std::vector<std::vector<int32_t>>& index_data, int chunk_size,
+    std::vector<std::vector<float>>& vertex_data, std::vector<std::vector<int32_t>>& index_data, int chunk_size, bool use_tile_cache,
     ContourCallback& partial_callback);
 
 #endif // CARTA_BACKEND__CONTOURING_H_

--- a/src/DataStream/Contouring.h
+++ b/src/DataStream/Contouring.h
@@ -11,7 +11,8 @@
 #include <functional>
 #include <vector>
 
-typedef const std::function<void(double, double, const std::vector<float>&, const std::vector<int32_t>&)> ContourCallback;
+typedef const std::function<void(double, double, const std::vector<float>&, const std::vector<int32_t>&, bool is_long_task)>
+    ContourCallback;
 
 enum Edge { TopEdge, RightEdge, BottomEdge, LeftEdge, None };
 

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -581,7 +581,7 @@ bool Frame::ContourImage(ContourCallback& partial_contour_callback) {
 
     if (_contour_settings.smoothing_mode == CARTA::SmoothingMode::NoSmoothing || _contour_settings.smoothing_factor <= 1) {
         TraceContours(_image_cache.data(), _width, _height, scale, offset, _contour_settings.levels, vertex_data, index_data,
-            _contour_settings.chunk_size, partial_contour_callback);
+            _contour_settings.chunk_size, _loader->UseTileCache(), partial_contour_callback);
         return true;
     } else if (_contour_settings.smoothing_mode == CARTA::SmoothingMode::GaussianBlur) {
         // Smooth the image from cache
@@ -601,7 +601,7 @@ bool Frame::ContourImage(ContourCallback& partial_contour_callback) {
             // Perform contouring with an offset based on the Gaussian smoothing apron size
             offset = _contour_settings.smoothing_factor - 1;
             TraceContours(dest_array.get(), dest_width, dest_height, scale, offset, _contour_settings.levels, vertex_data, index_data,
-                _contour_settings.chunk_size, partial_contour_callback);
+                _contour_settings.chunk_size, _loader->UseTileCache(), partial_contour_callback);
             return true;
         }
     } else {
@@ -622,7 +622,7 @@ bool Frame::ContourImage(ContourCallback& partial_contour_callback) {
             size_t dest_width = ceil(double(image_bounds.x_max()) / _contour_settings.smoothing_factor);
             size_t dest_height = ceil(double(image_bounds.y_max()) / _contour_settings.smoothing_factor);
             TraceContours(dest_vector.data(), dest_width, dest_height, scale, offset, _contour_settings.levels, vertex_data, index_data,
-                _contour_settings.chunk_size, partial_contour_callback);
+                _contour_settings.chunk_size, _loader->UseTileCache(), partial_contour_callback);
             return true;
         }
         spdlog::warn("Smoothing mode not implemented yet!");

--- a/src/Session.cc
+++ b/src/Session.cc
@@ -1588,7 +1588,8 @@ bool Session::SendContourData(int file_id, bool ignore_empty) {
 
         int64_t total_vertices = 0;
 
-        auto callback = [&](double level, double progress, const std::vector<float>& vertices, const std::vector<int>& indices) {
+        auto callback = [&](double level, double progress, const std::vector<float>& vertices, const std::vector<int>& indices,
+                            bool is_long_task) {
             CARTA::ContourImageData partial_response;
             partial_response.set_file_id(file_id);
             // Currently only supports identical reference file IDs
@@ -1596,6 +1597,7 @@ bool Session::SendContourData(int file_id, bool ignore_empty) {
             partial_response.set_channel(frame->CurrentZ());
             partial_response.set_stokes(frame->CurrentStokes());
             partial_response.set_progress(progress);
+            partial_response.set_is_long_task(is_long_task);
 
             std::vector<char> compression_buffer;
             const float pixel_rounding = std::max(1, std::min(32, settings.decimation));


### PR DESCRIPTION
It is to fit the frontend requirement in the frontend [PR 1636](https://github.com/CARTAvis/carta-frontend/pull/1636). A new bool variable `is_long_task` is added to the contour data message. `is_long_task=true` if the estimated time of contour process is greater than 1 second. It decides whether to show the contour progress bar in the frontend.