### PR TITLE
check that task queue is not empty before attempting to execute task

### DIFF
--- a/src/Threading.cc
+++ b/src/Threading.cc
@@ -44,7 +44,7 @@ void ThreadManager::StartEventHandlingThreads(int num_threads) {
 
         do {
             std::unique_lock<std::mutex> lock(_task_queue_mtx);
-            if (!(tsk = _task_queue.front())) {
+            if (_task_queue.empty() || !(tsk = _task_queue.front())) {
                 _task_queue_cv.wait(lock);
             } else {
                 _task_queue.pop_front();


### PR DESCRIPTION
fixes hard crash on startup with CentOS 7.