### PR TITLE
Remove the loader from the cache after opening an image.

### DIFF
--- a/src/Session.cc
+++ b/src/Session.cc
@@ -483,6 +483,9 @@ bool Session::OnOpenFile(const CARTA::OpenFile& message, uint32_t request_id, bo
         // query loader for mipmap dataset
         bool has_mipmaps(loader->HasMip(2));
 
+        // remove loader from the cache (if we open another copy of this file, we will need a new loader object)
+        _loaders.Remove(fullname);
+
         if (frame->IsValid()) {
             // Check if the old _frames[file_id] object exists. If so, delete it.
             if (_frames.count(file_id) > 0) {


### PR DESCRIPTION
Fixes #971. This restores the previous image opening behaviour. Reusing the same loader object when opening the same image multiple times causes problems in casacore (probably race conditions if the same casacore objects are accessed simultaneously).