### PR TITLE
Changing the type of reference count from Session to atomic int

### DIFF
--- a/src/Session.h
+++ b/src/Session.h
@@ -327,7 +327,7 @@ protected:
 
     SessionContext _animation_context;
 
-    int _ref_count;
+    std::atomic<int> _ref_count;
     int _animation_id;
     bool _connected;
     static int _num_sessions;

--- a/test/BackendModel.cc
+++ b/test/BackendModel.cc
@@ -283,6 +283,6 @@ void BackendModel::ClearMessagesQueue() {
 
 void BackendModel::WaitForJobFinished() {
     while (_session->GetRefCount() > 1) {
-        std::this_thread::sleep_for(std::chrono::microseconds(1));
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
 }

--- a/test/TestIcd.cc
+++ b/test/TestIcd.cc
@@ -436,6 +436,8 @@ public:
         }
 
         EXPECT_EQ(_message_count, 0); // make sure there is no data stream when animation stopped
+
+        _dummy_backend->WaitForJobFinished();
     }
 
     void RegionRegister() {


### PR DESCRIPTION
It tries to solve #978. The reference count from Session is increased when `OnMessageTask` is created to run in a different thread. It is decreased when the task is done and `OnMessageTask` is destructed. So the type of reference count is better to be atomic int to avoid unexpected behavior in animation.