### PR TITLE
Removing tbb from other Dockerfiles

### DIFF
--- a/Dockerfiles/Dockerfile-CentOS7
+++ b/Dockerfiles/Dockerfile-CentOS7
@@ -22,14 +22,6 @@ RUN \
   curl https://packages.cartavis.org/cartavis-el7.repo --output /etc/yum.repos.d/cartavis.repo && \
   yum -y install carta-casacore-devel gtest-devel gmock-devel fits2idia measures-data
 
-# CARTA has a problem with CentOS7 tbb 4.1, so install a newer version:
-RUN \
-  source /etc/bashrc && \
-  cd /root && \
-  git clone https://github.com/wjakob/tbb.git && \
-  cd tbb/build && cmake .. && make && make install && \
-  cd /root && rm -rf tbb
-
 # Forward port so that the webapp can properly access it
 # from outside of the container
 EXPOSE 3002

--- a/Dockerfiles/Dockerfile-CentOS8
+++ b/Dockerfiles/Dockerfile-CentOS8
@@ -10,7 +10,7 @@ RUN \
   dnf -y install autoconf automake bison blas-devel bzip2 cfitsio-devel cmake curl-devel flex gcc \
          gcc-c++ grpc-devel grpc-plugins git git-lfs gsl-devel hdf5-devel lapack-devel \ 
          libtool libxml2-devel libzstd-devel libuuid-devel make openssl-devel protobuf-devel \
-         python36 python3-pip pugixml-devel readline-devel subversion tbb-devel \
+         python36 python3-pip pugixml-devel readline-devel subversion \
          wcslib-devel wget zlib-devel libuuid-devel zfp-devel && \
   pip3 install numpy astropy
 

--- a/Dockerfiles/Dockerfile-ubuntu-18.04
+++ b/Dockerfiles/Dockerfile-ubuntu-18.04
@@ -7,7 +7,7 @@ RUN \
   apt-get install -y apt-utils autoconf bison build-essential byobu cmake curl default-jre dialog emacs \
     fftw3-dev flex gdb g++-8 gcc-8 gfortran git git-lfs htop libblas-dev libcurl4-gnutls-dev \
     libpugixml-dev libcfitsio-dev libhdf5-dev liblapack-dev libncurses-dev libreadline-dev libssl-dev \ 
-    libstarlink-ast-dev libtbb-dev libtool libxml2-dev libzstd-dev libgsl-dev man pkg-config python3-pip \
+    libstarlink-ast-dev libtool libxml2-dev libzstd-dev libgsl-dev man pkg-config python3-pip \
     software-properties-common unzip vim wcslib-dev wget uuid-dev && \
   pip3 install numpy astropy && \
   update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 80 --slave /usr/bin/g++ g++ /usr/bin/g++-8 --slave /usr/bin/gcov gcov /usr/bin/gcov-8


### PR DESCRIPTION
This is very minor. It is just removing tbb from the CentOS7, CentOS8, and Ubuntu 18.04 Dockerfiles.
I checked and the carta-backend and unit-tests can build and run in each of them.