### PR TITLE
Fix the problem of linear coordinate conversion for matched images

### DIFF
--- a/src/Region/Region.cc
+++ b/src/Region/Region.cc
@@ -1302,11 +1302,17 @@ bool Region::ConvertWorldToPixel(std::vector<casacore::Quantity>& world_point, c
         // Input and output linear frames
         casacore::Vector<casacore::String> output_units = output_csys.worldAxisUnits();
         casacore::Vector<casacore::Double> world_point_value(output_csys.nWorldAxes(), 0);
-        world_point_value(indices[0]) = world_point[0].get(output_units(indices[0])).getValue();
-        world_point_value(indices[1]) = world_point[1].get(output_units(indices[1])).getValue();
+        world_point_value(indices(0)) = world_point[0].get(output_units(indices(0))).getValue();
+        world_point_value(indices(1)) = world_point[1].get(output_units(indices(1))).getValue();
 
         // Convert world point to output pixel point
-        output_csys.toPixel(pixel_point, world_point_value);
+        casacore::Vector<casacore::Double> tmp_pixel_point;
+        output_csys.toPixel(tmp_pixel_point, world_point_value);
+
+        // Only fill the pixel coordinate results
+        pixel_point.resize(2);
+        pixel_point(0) = tmp_pixel_point(indices(0));
+        pixel_point(1) = tmp_pixel_point(indices(1));
         success = true;
     }
 

--- a/src/Region/Region.cc
+++ b/src/Region/Region.cc
@@ -1294,11 +1294,16 @@ bool Region::ConvertWorldToPixel(std::vector<casacore::Quantity>& world_point, c
         output_csys.directionCoordinate().toPixel(pixel_point, world_direction);
         success = true;
     } else if (_coord_sys->hasLinearCoordinate() && output_csys.hasLinearCoordinate()) {
+        // Get linear axes indices
+        auto indices = output_csys.linearAxesNumbers();
+        if (indices.size() != 2) {
+            return false;
+        }
         // Input and output linear frames
         casacore::Vector<casacore::String> output_units = output_csys.worldAxisUnits();
-        casacore::Vector<casacore::Double> world_point_value(2);
-        world_point_value(0) = world_point[0].get(output_units(0)).getValue();
-        world_point_value(1) = world_point[1].get(output_units(1)).getValue();
+        casacore::Vector<casacore::Double> world_point_value(output_csys.nWorldAxes(), 0);
+        world_point_value(indices[0]) = world_point[0].get(output_units(indices[0])).getValue();
+        world_point_value(indices[1]) = world_point[1].get(output_units(indices[1])).getValue();
 
         // Convert world point to output pixel point
         output_csys.toPixel(pixel_point, world_point_value);


### PR DESCRIPTION
Fix #982. According to the error message from casacore, the vector size of the input world point values should be equal to the number of world coordinate axes. If we want to convert the world coordinate to pixel coordinate using a linear coordinate system.