### PR TITLE
Stop using namespace std #932

### DIFF
--- a/src/DataStream/Compression.cc
+++ b/src/DataStream/Compression.cc
@@ -17,10 +17,8 @@
 #include <x86intrin.h>
 #endif
 
-using namespace std;
-
-int Compress(vector<float>& array, size_t offset, vector<char>& compression_buffer, size_t& compressed_size, uint32_t nx, uint32_t ny,
-    uint32_t precision) {
+int Compress(std::vector<float>& array, size_t offset, std::vector<char>& compression_buffer, size_t& compressed_size, uint32_t nx,
+    uint32_t ny, uint32_t precision) {
     int status = 0;     /* return value: 0 = success */
     zfp_type type;      /* array scalar type */
     zfp_field* field;   /* array meta data */
@@ -60,14 +58,14 @@ int Compress(vector<float>& array, size_t offset, vector<char>& compression_buff
 }
 
 // Removes NaNs from an array and returns run-length encoded list of NaNs
-vector<int32_t> GetNanEncodingsSimple(vector<float>& array, int offset, int length) {
+std::vector<int32_t> GetNanEncodingsSimple(std::vector<float>& array, int offset, int length) {
     int32_t prev_index = offset;
     bool prev = false;
-    vector<int32_t> encoded_array;
+    std::vector<int32_t> encoded_array;
     // Find first non-NaN number in the array
     float prev_valid_num = 0;
     for (auto i = offset; i < offset + length; i++) {
-        if (!isnan(array[i])) {
+        if (!std::isnan(array[i])) {
             prev_valid_num = array[i];
             break;
         }
@@ -77,7 +75,7 @@ vector<int32_t> GetNanEncodingsSimple(vector<float>& array, int offset, int leng
     // the width and height of the image, and look for neighbouring values in vertical and horizontal directions,
     // but this is only an issue with NaNs right at the edge of images.
     for (auto i = offset; i < offset + length; i++) {
-        bool current = isnan(array[i]);
+        bool current = std::isnan(array[i]);
         if (current != prev) {
             encoded_array.push_back(i - prev_index);
             prev_index = i;
@@ -93,15 +91,15 @@ vector<int32_t> GetNanEncodingsSimple(vector<float>& array, int offset, int leng
     return encoded_array;
 }
 
-vector<int32_t> GetNanEncodingsBlock(vector<float>& array, int offset, int w, int h) {
+std::vector<int32_t> GetNanEncodingsBlock(std::vector<float>& array, int offset, int w, int h) {
     // Generate RLE NaN list
     int length = w * h;
     int32_t prev_index = offset;
     bool prev = false;
-    vector<int32_t> encoded_array;
+    std::vector<int32_t> encoded_array;
 
     for (auto i = offset; i < offset + length; i++) {
-        bool current = isnan(array[i]);
+        bool current = std::isnan(array[i]);
         if (current != prev) {
             encoded_array.push_back(i - prev_index);
             prev_index = i;
@@ -119,12 +117,12 @@ vector<int32_t> GetNanEncodingsBlock(vector<float>& array, int offset, int w, in
                 int valid_count = 0;
                 float sum = 0;
                 // Limit the block size when at the edges of the image
-                int block_width = min(4, w - i);
-                int block_height = min(4, h - j);
+                int block_width = std::min(4, w - i);
+                int block_height = std::min(4, h - j);
                 for (int x = 0; x < block_width; x++) {
                     for (int y = 0; y < block_height; y++) {
                         float v = array[block_start + (y * w) + x];
-                        if (!isnan(v)) {
+                        if (!std::isnan(v)) {
                             valid_count++;
                             sum += v;
                         }
@@ -137,7 +135,7 @@ vector<int32_t> GetNanEncodingsBlock(vector<float>& array, int offset, int w, in
                     for (int x = 0; x < block_width; x++) {
                         for (int y = 0; y < block_height; y++) {
                             float v = array[block_start + (y * w) + x];
-                            if (isnan(v)) {
+                            if (std::isnan(v)) {
                                 array[block_start + (y * w) + x] = average;
                             }
                         }

--- a/src/DataStream/Contouring.cc
+++ b/src/DataStream/Contouring.cc
@@ -14,8 +14,6 @@
 #include "../Logger/Logger.h"
 #include "Threading.h"
 
-using namespace std;
-
 // Contour tracing code adapted from SAOImage DS9: https://github.com/SAOImageDS9/SAOImageDS9
 void TraceSegment(const float* image, std::vector<bool>& visited, int64_t width, int64_t height, double scale, double offset, double level,
     int x_cell, int y_cell, int side, vector<float>& vertices) {

--- a/src/DataStream/Smoothing.cc
+++ b/src/DataStream/Smoothing.cc
@@ -14,8 +14,6 @@
 #include "../Logger/Logger.h"
 #include "Threading.h"
 
-using namespace std;
-
 double NormPdf(double x, double sigma) {
     return exp(-0.5 * x * x / (sigma * sigma)) / sigma;
 }

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -23,10 +23,6 @@
 #include "Util/FileSystem.h"
 #include "Util/Token.h"
 
-#define TBB_TASK_THREAD_COUNT 3
-
-using namespace std;
-
 // Entry point. Parses command line arguments and starts server listening
 int main(int argc, char* argv[]) {
     ProgramSettings settings;

--- a/src/SessionManager/ProgramSettings.cc
+++ b/src/SessionManager/ProgramSettings.cc
@@ -16,7 +16,6 @@
 
 #include "Util/App.h"
 
-using namespace std;
 using json = nlohmann::json;
 
 namespace carta {
@@ -173,7 +172,7 @@ void ProgramSettings::SetSettingsFromJSON(const json& j) {
 }
 
 void ProgramSettings::ApplyCommandLineSettings(int argc, char** argv) {
-    vector<string> positional_arguments;
+    std::vector<string> positional_arguments;
 
     cxxopts::Options options("carta", "Cube Analysis and Rendering Tool for Astronomy");
     // clang-format off
@@ -182,7 +181,7 @@ void ProgramSettings::ApplyCommandLineSettings(int argc, char** argv) {
         ("h,help", "print usage")
         ("v,version", "print version")
         ("verbosity", "display verbose logging from this level",
-         cxxopts::value<int>()->default_value(to_string(verbosity)), "<level>")
+         cxxopts::value<int>()->default_value(std::to_string(verbosity)), "<level>")
         ("no_log", "do not log output to a log file", cxxopts::value<bool>())
         ("log_performance", "enable performance debug logs", cxxopts::value<bool>())
         ("log_protocol_messages", "enable protocol message debug logs", cxxopts::value<bool>())
@@ -199,7 +198,7 @@ void ProgramSettings::ApplyCommandLineSettings(int argc, char** argv) {
         ("initial_timeout", "number of seconds to stay alive at start if no clients connect", cxxopts::value<int>(), "<sec>")
         ("idle_timeout", "number of seconds to keep idle sessions alive", cxxopts::value<int>(), "<sec>")
         ("read_only_mode", "disable write requests", cxxopts::value<bool>())
-        ("files", "files to load", cxxopts::value<vector<string>>(positional_arguments))
+        ("files", "files to load", cxxopts::value<std::vector<string>>(positional_arguments))
         ("no_user_config", "ignore user configuration file", cxxopts::value<bool>())
         ("no_system_config", "ignore system configuration file", cxxopts::value<bool>());
 
@@ -258,11 +257,11 @@ end.
         CARTA_DEFAULT_FRONTEND_FOLDER, DEFAULT_SOCKET_PORT, CARTA_USER_FOLDER_PREFIX, log_levels, CARTA_USER_FOLDER_PREFIX);
 
     if (result.count("version")) {
-        cout << VERSION_ID << endl;
+        std::cout << VERSION_ID << std::endl;
         version = true;
         return;
     } else if (result.count("help")) {
-        cout << options.help() << extra;
+        std::cout << options.help() << extra;
         help = true;
         return;
     }
@@ -299,7 +298,7 @@ end.
 
     // base will be overridden by the positional argument if it exists and is a folder
     applyOptionalArgument(starting_folder, "base", result);
-    vector<fs::path> file_paths;
+    std::vector<fs::path> file_paths;
 
     for (const auto& arg : positional_arguments) {
         fs::path p(arg);

--- a/src/Table/Columns.cc
+++ b/src/Table/Columns.cc
@@ -15,7 +15,6 @@
 #include "Threading.h"
 
 namespace carta {
-using namespace std;
 
 Column::Column(const string& name_chr) {
     name = name_chr;

--- a/src/Table/Table.cc
+++ b/src/Table/Table.cc
@@ -19,7 +19,6 @@
 #include "Util/FileSystem.h"
 
 namespace carta {
-using namespace std;
 
 Table::Table(const string& filename, bool header_only) : _valid(false), _filename(filename), _num_rows(0), _available_rows(0) {
     fs::path file_path(filename);

--- a/src/Table/TableController.cc
+++ b/src/Table/TableController.cc
@@ -17,9 +17,8 @@
 #endif
 
 using namespace carta;
-using namespace std;
 
-TableController::TableController(const string& top_level_folder, const string& starting_folder)
+TableController::TableController(const std::string& top_level_folder, const std::string& starting_folder)
     : _top_level_folder(top_level_folder), _starting_folder(starting_folder) {}
 
 void TableController::OnOpenFileRequest(const CARTA::OpenCatalogFile& open_file_request, CARTA::OpenCatalogFileAck& open_file_response) {
@@ -110,7 +109,7 @@ void TableController::OnFilterRequest(
         auto& view = cache.view;
         std::vector<CARTA::FilterConfig> new_filter_configs = {
             filter_request.filter_configs().begin(), filter_request.filter_configs().end()};
-        string sort_column_name = filter_request.sort_column();
+        std::string sort_column_name = filter_request.sort_column();
         CARTA::SortingType sorting_type = filter_request.sorting_type();
         if (TableController::FilterParamsChanged(new_filter_configs, sort_column_name, sorting_type, cache)) {
             cache.filter_configs = new_filter_configs;
@@ -135,7 +134,7 @@ void TableController::OnFilterRequest(
         int num_results = view.NumRows();
 
         filter_response.set_filter_data_size(num_results);
-        int response_size = min(num_rows, num_results - start_index);
+        int response_size = std::min(num_rows, num_results - start_index);
         filter_response.set_request_end_index(start_index + response_size);
 
         auto num_columns = filter_request.column_indices_size();
@@ -156,7 +155,7 @@ void TableController::OnFilterRequest(
         }
 
         while (num_remaining_rows > 0) {
-            int chunk_size = min(num_remaining_rows, max_chunk_size);
+            int chunk_size = std::min(num_remaining_rows, max_chunk_size);
             int chunk_end_index = chunk_start_index + chunk_size;
             filter_response.set_subset_data_size(chunk_size);
             filter_response.set_subset_end_index(chunk_end_index);
@@ -304,7 +303,7 @@ void TableController::OnFileInfoRequest(
     file_info->set_name(file_path.filename().string());
     file_info->set_type(table.Type());
     file_info->set_file_size(fs::file_size(file_path));
-    string file_info_string = fmt::format("Name: {}\n", file_info->name());
+    std::string file_info_string = fmt::format("Name: {}\n", file_info->name());
     if (table.Description().size()) {
         file_info_string += fmt::format("Description: {}\n", table.Description());
     }
@@ -344,7 +343,7 @@ void TableController::OnFileInfoRequest(
 }
 
 void TableController::ApplyFilter(const CARTA::FilterConfig& filter_config, TableView& view) {
-    string column_name = filter_config.column_name();
+    std::string column_name = filter_config.column_name();
     auto column = view.GetTable()[column_name];
     if (!column) {
         spdlog::error("Could not filter on non-existing column \"{}\"", column_name);
@@ -413,7 +412,7 @@ fs::path TableController::GetPath(std::string directory, std::string name) {
 
         // Remove leading /
         auto start_index = directory.find_first_not_of('/');
-        if (start_index != 0 && start_index != string::npos) {
+        if (start_index != 0 && start_index != std::string::npos) {
             directory = directory.substr(start_index);
         }
 

--- a/src/Table/TableView.cc
+++ b/src/Table/TableView.cc
@@ -14,8 +14,6 @@
 
 namespace carta {
 
-using namespace std;
-
 TableView::TableView(const Table& table) : _table(table) {
     _is_subset = false;
     _ordered = true;


### PR DESCRIPTION
This pull request closes #932. With these changes, we stop importing all symbols from `std::`. A couple of additional changes include a catch statement (as a consequence of removing `std::`) and removing a TBB definition (which isn't used anymore, just as a minor catch while editing the code).