### PR TITLE
Avoid the file id repetition in generated moments or PV images

### DIFF
--- a/src/ImageGenerators/MomentGenerator.cc
+++ b/src/ImageGenerators/MomentGenerator.cc
@@ -71,7 +71,7 @@ bool MomentGenerator::CalculateMoments(int file_id, const casacore::ImageRegion&
 
                         // Set a temp moment file Id. Todo: find another better way to assign the temp file Id
                         int moment_type = _moments[i];
-                        int moment_file_id = (file_id + 1) * ID_MULTIPLIER + moment_type;
+                        int moment_file_id = (file_id + 1) * ID_MULTIPLIER + moment_type + 1;
 
                         // Fill results
                         std::shared_ptr<casacore::ImageInterface<casacore::Float>> moment_image =


### PR DESCRIPTION
This bug was found by @YuHsuan-Hwang. The file id of the generated moment image is repeated with the PV image if the number of moment type is 0 [(PV generator file id def)](https://github.com/CARTAvis/carta-backend/blob/dev/src/ImageGenerators/PvGenerator.cc#L29). So I increase the file id for moments images by 1 to solve this problem.