### PR TITLE
adding chrono include

### DIFF
--- a/src/Util/Message.cc
+++ b/src/Util/Message.cc
@@ -5,6 +5,7 @@
 */
 
 #include "Message.h"
+#include <chrono>
 
 CARTA::RegisterViewer Message::RegisterViewer(uint32_t session_id, std::string api_key, uint32_t client_feature_flags) {
     CARTA::RegisterViewer register_viewer;


### PR DESCRIPTION
I notice that carta-backend fails to build on AlmaLinux 8.5 with GCC 8.5

```
/root/carta-backend/src/Util/Message.cc: In static member function ‘static CARTA::AnimationFlowControl Message::AnimationFlowControl(int32_t, std::pair<int, int>’:
 /root/carta-backend/src/Util/Message.cc:209:29: error: ‘std::chrono’ has not been declared
      const auto t_now = std::chrono::system_clock::now();
                              ^~~~~~ 
```

It can be fixed by adding `#include <chrono>` to `src/Util/Message.cc`

We haven't noticed this yet because the new Jenkins system that builds RHEL8 isn't live yet.