### PR TITLE
Custom spdlog sink for logging to stdout/stderr from a single sink

### DIFF
--- a/src/Logger/Logger.cc
+++ b/src/Logger/Logger.cc
@@ -17,12 +17,12 @@ void InitLogger(bool no_log_file, int verbosity, bool log_performance, bool log_
     log_protocol_messages = log_protocol_messages_;
 
     // Set the stdout/stderr console
-    auto stdout_console_sink = std::make_shared<spdlog::sinks::carta_sink>();
-    stdout_console_sink->set_pattern(CARTA_LOGGER_PATTERN);
+    auto console_sink = std::make_shared<spdlog::sinks::carta_sink>();
+    console_sink->set_pattern(CARTA_LOGGER_PATTERN);
 
     // Set stdout sinks
-    std::vector<spdlog::sink_ptr> stdout_sinks;
-    stdout_sinks.push_back(stdout_console_sink);
+    std::vector<spdlog::sink_ptr> console_sinks;
+    console_sinks.push_back(console_sink);
 
     // Set a log file with its full name, maximum size and the number of rotated files
     std::string log_fullname;
@@ -30,11 +30,11 @@ void InitLogger(bool no_log_file, int verbosity, bool log_performance, bool log_
         log_fullname = (user_directory / "log/carta.log").string();
         auto stdout_log_file_sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(log_fullname, LOG_FILE_SIZE, ROTATED_LOG_FILES);
         stdout_log_file_sink->set_pattern(CARTA_LOGGER_PATTERN);
-        stdout_sinks.push_back(stdout_log_file_sink);
+        console_sinks.push_back(stdout_log_file_sink);
     }
 
     // Create the stdout logger
-    auto default_logger = std::make_shared<spdlog::logger>(CARTA_LOGGER_TAG, std::begin(stdout_sinks), std::end(stdout_sinks));
+    auto default_logger = std::make_shared<spdlog::logger>(CARTA_LOGGER_TAG, std::begin(console_sinks), std::end(console_sinks));
 
     // Set flush policy on severity
     default_logger->flush_on(spdlog::level::err);

--- a/src/Logger/Logger.cc
+++ b/src/Logger/Logger.cc
@@ -6,14 +6,19 @@
 
 #include "Logger.h"
 
+#include <string>
+
+namespace carta {
+namespace logger {
+
 static bool log_protocol_messages(false);
 
 void InitLogger(bool no_log_file, int verbosity, bool log_performance, bool log_protocol_messages_, fs::path user_directory) {
     log_protocol_messages = log_protocol_messages_;
 
-    // Set the stdout console
-    auto stdout_console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
-    stdout_console_sink->set_pattern(STDOUT_PATTERN);
+    // Set the stdout/stderr console
+    auto stdout_console_sink = std::make_shared<spdlog::sinks::carta_sink>();
+    stdout_console_sink->set_pattern(CARTA_LOGGER_PATTERN);
 
     // Set stdout sinks
     std::vector<spdlog::sink_ptr> stdout_sinks;
@@ -24,12 +29,12 @@ void InitLogger(bool no_log_file, int verbosity, bool log_performance, bool log_
     if (!no_log_file) {
         log_fullname = (user_directory / "log/carta.log").string();
         auto stdout_log_file_sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(log_fullname, LOG_FILE_SIZE, ROTATED_LOG_FILES);
-        stdout_log_file_sink->set_pattern(STDOUT_PATTERN);
+        stdout_log_file_sink->set_pattern(CARTA_LOGGER_PATTERN);
         stdout_sinks.push_back(stdout_log_file_sink);
     }
 
     // Create the stdout logger
-    auto default_logger = std::make_shared<spdlog::logger>(STDOUT_TAG, std::begin(stdout_sinks), std::end(stdout_sinks));
+    auto default_logger = std::make_shared<spdlog::logger>(CARTA_LOGGER_TAG, std::begin(stdout_sinks), std::end(stdout_sinks));
 
     // Set flush policy on severity
     default_logger->flush_on(spdlog::level::err);
@@ -130,3 +135,6 @@ void FlushLogFile() {
         spdlog::get(PERF_TAG)->flush();
     }
 }
+
+} // namespace logger
+} // namespace carta

--- a/src/Logger/Logger.h
+++ b/src/Logger/Logger.h
@@ -7,6 +7,10 @@
 #ifndef CARTA_BACKEND_LOGGER_LOGGER_H_
 #define CARTA_BACKEND_LOGGER_LOGGER_H_
 
+#include <iostream>
+
+#include <spdlog/common.h>
+#include <spdlog/details/log_msg.h>
 #include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
@@ -17,8 +21,8 @@
 
 #define LOG_FILE_SIZE 1024 * 1024 * 5 // (Bytes)
 #define ROTATED_LOG_FILES 5
-#define STDOUT_TAG "stdout"
-#define STDOUT_PATTERN "[%Y-%m-%d %H:%M:%S.%e] [%^%l%$] %v"
+#define CARTA_LOGGER_TAG "CARTA"
+#define CARTA_LOGGER_PATTERN "[%Y-%m-%d %H:%M:%S.%e] [%^%l%$] %v"
 #define PERF_TAG "performance"
 #define PERF_PATTERN "[%Y-%m-%d %H:%M:%S.%e] [%^%l%$] [%n] %v"
 
@@ -30,14 +34,79 @@ constexpr auto performance = [](auto&&... args) {
         perf_log->debug(std::forward<decltype(args)>(args)...);
     }
 };
+
+namespace sinks {
+class carta_sink : public ansicolor_sink<details::console_mutex> {
+public:
+    carta_sink()
+        : ansicolor_sink<details::console_mutex>(stdout, color_mode::automatic),
+          mutex_(details::console_mutex::mutex()),
+          formatter_(details::make_unique<spdlog::pattern_formatter>()) {
+        target_file_ = stdout;
+        colors_[level::trace] = to_string_(white);
+        colors_[level::debug] = to_string_(cyan);
+        colors_[level::info] = to_string_(green);
+        colors_[level::warn] = to_string_(yellow_bold);
+        colors_[level::err] = to_string_(red_bold);
+        colors_[level::critical] = to_string_(bold_on_red);
+        colors_[level::off] = to_string_(reset);
+    }
+
+    void log(const details::log_msg& msg) override {
+        std::lock_guard<mutex_t> lock(mutex_);
+        msg.color_range_start = 0;
+        msg.color_range_end = 0;
+        memory_buf_t formatted;
+        formatter_->format(msg, formatted);
+        target_file_ = msg.level < SPDLOG_LEVEL_ERROR ? stdout : stderr; // floating output
+        if (msg.color_range_end > msg.color_range_start) {
+            // before color range
+            print_range_(formatted, 0, msg.color_range_start);
+            // in color range
+            print_ccode_(colors_[msg.level]);
+            print_range_(formatted, msg.color_range_start, msg.color_range_end);
+            print_ccode_(reset);
+            // after color range
+            print_range_(formatted, msg.color_range_end, formatted.size());
+        } else // no color
+        {
+            print_range_(formatted, 0, formatted.size());
+        }
+        fflush(target_file_);
+    }
+
+    void flush() override {
+        std::lock_guard<mutex_t> lock(mutex_);
+        fflush(target_file_);
+    }
+
+private:
+    FILE* target_file_;
+    mutex_t& mutex_;
+    std::unique_ptr<spdlog::formatter> formatter_;
+    std::array<std::string, level::n_levels> colors_;
+
+    inline void print_range_(const memory_buf_t& formatted, size_t start, size_t end) {
+        fwrite(formatted.data() + start, sizeof(char), end - start, target_file_);
+    }
+    inline void print_ccode_(const string_view_t& color_code) {
+        fwrite(color_code.data(), sizeof(char), color_code.size(), target_file_);
+    }
+    inline std::string to_string_(const string_view_t& sv) {
+        return std::string(sv.data(), sv.size());
+    }
+};
+} // namespace sinks
 } // namespace spdlog
 
+namespace carta {
+namespace logger {
 void InitLogger(bool no_log_file, int verbosity, bool log_performance, bool log_protocol_messages_, fs::path user_directory);
-
 void LogReceivedEventType(const CARTA::EventType& event_type);
-
 void LogSentEventType(const CARTA::EventType& event_type);
-
 void FlushLogFile();
+
+} // namespace logger
+} // namespace carta
 
 #endif // CARTA_BACKEND_LOGGER_LOGGER_H_

--- a/src/Logger/Logger.h
+++ b/src/Logger/Logger.h
@@ -105,7 +105,6 @@ void InitLogger(bool no_log_file, int verbosity, bool log_performance, bool log_
 void LogReceivedEventType(const CARTA::EventType& event_type);
 void LogSentEventType(const CARTA::EventType& event_type);
 void FlushLogFile();
-
 } // namespace logger
 } // namespace carta
 

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -39,7 +39,7 @@ int main(int argc, char* argv[]) {
         sig_handler.sa_handler = [](int s) {
             spdlog::info("Exiting backend.");
             ThreadManager::ExitEventHandlingThreads();
-            FlushLogFile();
+            carta::logger::FlushLogFile();
             exit(0);
         };
 
@@ -54,7 +54,8 @@ int main(int argc, char* argv[]) {
             exit(0);
         }
 
-        InitLogger(settings.no_log, settings.verbosity, settings.log_performance, settings.log_protocol_messages, settings.user_directory);
+        carta::logger::InitLogger(
+            settings.no_log, settings.verbosity, settings.log_performance, settings.log_protocol_messages, settings.user_directory);
         settings.FlushMessages(); // flush log messages produced during Program Settings setup
 
         if (settings.wait_time >= 0) {
@@ -76,7 +77,7 @@ int main(int argc, char* argv[]) {
         spdlog::info("{}: Version {}", executable_path, VERSION_ID);
 
         if (!CheckFolderPaths(settings.top_level_folder, settings.starting_folder)) {
-            FlushLogFile();
+            carta::logger::FlushLogFile();
             return 1;
         }
 
@@ -122,7 +123,7 @@ int main(int argc, char* argv[]) {
                 }
             } else {
                 spdlog::critical("CARTA gRPC service failed to start. Could not bind to port {}. Aborting.", settings.grpc_port);
-                FlushLogFile();
+                carta::logger::FlushLogFile();
                 return 1;
             }
         } else {
@@ -211,14 +212,14 @@ int main(int argc, char* argv[]) {
         }
     } catch (exception& e) {
         spdlog::critical("{}", e.what());
-        FlushLogFile();
+        carta::logger::FlushLogFile();
         return 1;
     } catch (...) {
         spdlog::critical("Unknown error");
-        FlushLogFile();
+        carta::logger::FlushLogFile();
         return 1;
     }
 
-    FlushLogFile();
+    carta::logger::FlushLogFile();
     return 0;
 }

--- a/src/Session.cc
+++ b/src/Session.cc
@@ -136,7 +136,7 @@ void ExitNoSessions(int s) {
         if (!__exit_backend_timer) {
             spdlog::info("No sessions timeout.");
             ThreadManager::ExitEventHandlingThreads();
-            FlushLogFile();
+            logger::FlushLogFile();
             exit(0);
         }
         alarm(1);
@@ -152,7 +152,7 @@ Session::~Session() {
             if (_exit_after_num_seconds == 0) {
                 spdlog::info("Exiting due to no sessions remaining");
                 ThreadManager::ExitEventHandlingThreads();
-                FlushLogFile();
+                logger::FlushLogFile();
                 exit(0);
             }
             __exit_backend_timer = _exit_after_num_seconds;
@@ -164,7 +164,7 @@ Session::~Session() {
             alarm(1);
         }
     }
-    FlushLogFile();
+    logger::FlushLogFile();
 }
 
 void Session::SetInitExitTimeout(int secs) {
@@ -1829,7 +1829,7 @@ void Session::RegionDataStreams(int file_id, int region_id) {
 
 // Sends an event to the client with a given event name (padded/concatenated to 32 characters) and a given ProtoBuf message
 void Session::SendEvent(CARTA::EventType event_type, uint32_t event_id, const google::protobuf::MessageLite& message, bool compress) {
-    LogSentEventType(event_type);
+    logger::LogSentEventType(event_type);
 
     size_t message_length = message.ByteSizeLong();
     size_t required_size = message_length + sizeof(carta::EventHeader);

--- a/src/SessionManager/SessionManager.cc
+++ b/src/SessionManager/SessionManager.cc
@@ -143,7 +143,7 @@ void SessionManager::OnMessage(WSType* ws, std::string_view sv_message, uWS::OpC
             int event_length = sv_message.length() - sizeof(carta::EventHeader);
 
             CARTA::EventType event_type = static_cast<CARTA::EventType>(head.type);
-            LogReceivedEventType(event_type);
+            logger::LogReceivedEventType(event_type);
 
             auto event_type_name = CARTA::EventType_Name(CARTA::EventType(event_type));
             bool message_parsed(false);

--- a/test/BackendModel.cc
+++ b/test/BackendModel.cc
@@ -56,17 +56,17 @@ BackendModel::~BackendModel() {
 }
 
 void BackendModel::Receive(CARTA::RegisterViewer message) {
-    LogReceivedEventType(CARTA::EventType::REGISTER_VIEWER);
+    carta::logger::LogReceivedEventType(CARTA::EventType::REGISTER_VIEWER);
     _session->OnRegisterViewer(message, DUMMY_ICD_VERSION, DUMMY_REQUEST_ID);
 }
 
 void BackendModel::Receive(CARTA::ResumeSession message) {
-    LogReceivedEventType(CARTA::EventType::RESUME_SESSION);
+    carta::logger::LogReceivedEventType(CARTA::EventType::RESUME_SESSION);
     _session->OnResumeSession(message, DUMMY_REQUEST_ID);
 }
 
 void BackendModel::Receive(CARTA::SetImageChannels message) {
-    LogReceivedEventType(CARTA::EventType::SET_IMAGE_CHANNELS);
+    carta::logger::LogReceivedEventType(CARTA::EventType::SET_IMAGE_CHANNELS);
     OnMessageTask* tsk = nullptr;
     _session->ImageChannelLock(message.file_id());
     if (!_session->ImageChannelTaskTestAndSet(message.file_id())) {
@@ -81,14 +81,14 @@ void BackendModel::Receive(CARTA::SetImageChannels message) {
 }
 
 void BackendModel::Receive(CARTA::SetCursor message) {
-    LogReceivedEventType(CARTA::EventType::SET_CURSOR);
+    carta::logger::LogReceivedEventType(CARTA::EventType::SET_CURSOR);
     _session->AddCursorSetting(message, DUMMY_REQUEST_ID);
     OnMessageTask* tsk = new SetCursorTask(_session, message.file_id());
     ThreadManager::QueueTask(tsk);
 }
 
 void BackendModel::Receive(CARTA::SetHistogramRequirements message) {
-    LogReceivedEventType(CARTA::EventType::SET_HISTOGRAM_REQUIREMENTS);
+    carta::logger::LogReceivedEventType(CARTA::EventType::SET_HISTOGRAM_REQUIREMENTS);
     if (message.histograms_size() == 0) {
         _session->CancelSetHistRequirements();
     } else {
@@ -99,12 +99,12 @@ void BackendModel::Receive(CARTA::SetHistogramRequirements message) {
 }
 
 void BackendModel::Receive(CARTA::CloseFile message) {
-    LogReceivedEventType(CARTA::EventType::CLOSE_FILE);
+    carta::logger::LogReceivedEventType(CARTA::EventType::CLOSE_FILE);
     _session->OnCloseFile(message);
 }
 
 void BackendModel::Receive(CARTA::StartAnimation message) {
-    LogReceivedEventType(CARTA::EventType::START_ANIMATION);
+    carta::logger::LogReceivedEventType(CARTA::EventType::START_ANIMATION);
     _session->CancelExistingAnimation();
     _session->BuildAnimationObject(message, DUMMY_REQUEST_ID);
     OnMessageTask* tsk = new AnimationTask(_session);
@@ -112,122 +112,122 @@ void BackendModel::Receive(CARTA::StartAnimation message) {
 }
 
 void BackendModel::Receive(CARTA::StopAnimation message) {
-    LogReceivedEventType(CARTA::EventType::STOP_ANIMATION);
+    carta::logger::LogReceivedEventType(CARTA::EventType::STOP_ANIMATION);
     _session->StopAnimation(message.file_id(), message.end_frame());
 }
 
 void BackendModel::Receive(CARTA::AnimationFlowControl message) {
-    LogReceivedEventType(CARTA::EventType::ANIMATION_FLOW_CONTROL);
+    carta::logger::LogReceivedEventType(CARTA::EventType::ANIMATION_FLOW_CONTROL);
     _session->HandleAnimationFlowControlEvt(message);
 }
 
 void BackendModel::Receive(CARTA::FileInfoRequest message) {
-    LogReceivedEventType(CARTA::EventType::FILE_INFO_REQUEST);
+    carta::logger::LogReceivedEventType(CARTA::EventType::FILE_INFO_REQUEST);
     _session->OnFileInfoRequest(message, DUMMY_REQUEST_ID);
 }
 
 void BackendModel::Receive(CARTA::OpenFile message) {
-    LogReceivedEventType(CARTA::EventType::OPEN_FILE);
+    carta::logger::LogReceivedEventType(CARTA::EventType::OPEN_FILE);
     _session->CloseCachedImage(message.directory(), message.file());
     _session->OnOpenFile(message, DUMMY_REQUEST_ID);
 }
 
 void BackendModel::Receive(CARTA::AddRequiredTiles message) {
-    LogReceivedEventType(CARTA::EventType::ADD_REQUIRED_TILES);
+    carta::logger::LogReceivedEventType(CARTA::EventType::ADD_REQUIRED_TILES);
     OnMessageTask* tsk = new GeneralMessageTask<CARTA::AddRequiredTiles>(_session, message, DUMMY_REQUEST_ID);
     ThreadManager::QueueTask(tsk);
 }
 
 void BackendModel::Receive(CARTA::RegionFileInfoRequest message) {
-    LogReceivedEventType(CARTA::EventType::REGION_FILE_INFO_REQUEST);
+    carta::logger::LogReceivedEventType(CARTA::EventType::REGION_FILE_INFO_REQUEST);
     _session->OnRegionFileInfoRequest(message, DUMMY_REQUEST_ID);
 }
 
 void BackendModel::Receive(CARTA::ImportRegion message) {
-    LogReceivedEventType(CARTA::EventType::IMPORT_REGION);
+    carta::logger::LogReceivedEventType(CARTA::EventType::IMPORT_REGION);
     _session->OnImportRegion(message, DUMMY_REQUEST_ID);
 }
 
 void BackendModel::Receive(CARTA::ExportRegion message) {
-    LogReceivedEventType(CARTA::EventType::EXPORT_REGION);
+    carta::logger::LogReceivedEventType(CARTA::EventType::EXPORT_REGION);
     _session->OnExportRegion(message, DUMMY_REQUEST_ID);
 }
 
 void BackendModel::Receive(CARTA::SetContourParameters message) {
-    LogReceivedEventType(CARTA::EventType::SET_CONTOUR_PARAMETERS);
+    carta::logger::LogReceivedEventType(CARTA::EventType::SET_CONTOUR_PARAMETERS);
     OnMessageTask* tsk = new GeneralMessageTask<CARTA::SetContourParameters>(_session, message, DUMMY_REQUEST_ID);
     ThreadManager::QueueTask(tsk);
 }
 
 void BackendModel::Receive(CARTA::ScriptingResponse message) {
-    LogReceivedEventType(CARTA::EventType::SCRIPTING_RESPONSE);
+    carta::logger::LogReceivedEventType(CARTA::EventType::SCRIPTING_RESPONSE);
     _session->OnScriptingResponse(message, DUMMY_REQUEST_ID);
 }
 
 void BackendModel::Receive(CARTA::SetRegion message) {
-    LogReceivedEventType(CARTA::EventType::SET_REGION);
+    carta::logger::LogReceivedEventType(CARTA::EventType::SET_REGION);
     _session->OnSetRegion(message, DUMMY_REQUEST_ID);
 }
 
 void BackendModel::Receive(CARTA::RemoveRegion message) {
-    LogReceivedEventType(CARTA::EventType::REMOVE_REGION);
+    carta::logger::LogReceivedEventType(CARTA::EventType::REMOVE_REGION);
     _session->OnRemoveRegion(message);
 }
 
 void BackendModel::Receive(CARTA::SetSpectralRequirements message) {
-    LogReceivedEventType(CARTA::EventType::SET_SPECTRAL_REQUIREMENTS);
+    carta::logger::LogReceivedEventType(CARTA::EventType::SET_SPECTRAL_REQUIREMENTS);
     _session->OnSetSpectralRequirements(message);
 }
 
 void BackendModel::Receive(CARTA::CatalogFileInfoRequest message) {
-    LogReceivedEventType(CARTA::EventType::CATALOG_FILE_INFO_REQUEST);
+    carta::logger::LogReceivedEventType(CARTA::EventType::CATALOG_FILE_INFO_REQUEST);
     _session->OnCatalogFileInfo(message, DUMMY_REQUEST_ID);
 }
 
 void BackendModel::Receive(CARTA::OpenCatalogFile message) {
-    LogReceivedEventType(CARTA::EventType::OPEN_CATALOG_FILE);
+    carta::logger::LogReceivedEventType(CARTA::EventType::OPEN_CATALOG_FILE);
     _session->OnOpenCatalogFile(message, DUMMY_REQUEST_ID);
 }
 
 void BackendModel::Receive(CARTA::CloseCatalogFile message) {
-    LogReceivedEventType(CARTA::EventType::CLOSE_CATALOG_FILE);
+    carta::logger::LogReceivedEventType(CARTA::EventType::CLOSE_CATALOG_FILE);
     _session->OnCloseCatalogFile(message);
 }
 
 void BackendModel::Receive(CARTA::CatalogFilterRequest message) {
-    LogReceivedEventType(CARTA::EventType::CATALOG_FILTER_REQUEST);
+    carta::logger::LogReceivedEventType(CARTA::EventType::CATALOG_FILTER_REQUEST);
     _session->OnCatalogFilter(message, DUMMY_REQUEST_ID);
 }
 
 void BackendModel::Receive(CARTA::StopMomentCalc message) {
-    LogReceivedEventType(CARTA::EventType::STOP_MOMENT_CALC);
+    carta::logger::LogReceivedEventType(CARTA::EventType::STOP_MOMENT_CALC);
     _session->OnStopMomentCalc(message);
 }
 
 void BackendModel::Receive(CARTA::SaveFile message) {
-    LogReceivedEventType(CARTA::EventType::SAVE_FILE);
+    carta::logger::LogReceivedEventType(CARTA::EventType::SAVE_FILE);
     _session->OnSaveFile(message, DUMMY_REQUEST_ID);
 }
 
 void BackendModel::Receive(CARTA::SplataloguePing message) {
-    LogReceivedEventType(CARTA::EventType::SPLATALOGUE_PING);
+    carta::logger::LogReceivedEventType(CARTA::EventType::SPLATALOGUE_PING);
     OnMessageTask* tsk = new OnSplataloguePingTask(_session, DUMMY_REQUEST_ID);
     ThreadManager::QueueTask(tsk);
 }
 
 void BackendModel::Receive(CARTA::SpectralLineRequest message) {
-    LogReceivedEventType(CARTA::EventType::SPECTRAL_LINE_REQUEST);
+    carta::logger::LogReceivedEventType(CARTA::EventType::SPECTRAL_LINE_REQUEST);
     OnMessageTask* tsk = new GeneralMessageTask<CARTA::SpectralLineRequest>(_session, message, DUMMY_REQUEST_ID);
     ThreadManager::QueueTask(tsk);
 }
 
 void BackendModel::Receive(CARTA::ConcatStokesFiles message) {
-    LogReceivedEventType(CARTA::EventType::CONCAT_STOKES_FILES);
+    carta::logger::LogReceivedEventType(CARTA::EventType::CONCAT_STOKES_FILES);
     _session->OnConcatStokesFiles(message, DUMMY_REQUEST_ID);
 }
 
 void BackendModel::Receive(CARTA::StopFileList message) {
-    LogReceivedEventType(CARTA::EventType::STOP_FILE_LIST);
+    carta::logger::LogReceivedEventType(CARTA::EventType::STOP_FILE_LIST);
     if (message.file_list_type() == CARTA::Image) {
         _session->StopImageFileList();
     } else {
@@ -236,37 +236,37 @@ void BackendModel::Receive(CARTA::StopFileList message) {
 }
 
 void BackendModel::Receive(CARTA::SetSpatialRequirements message) {
-    LogReceivedEventType(CARTA::EventType::SET_SPATIAL_REQUIREMENTS);
+    carta::logger::LogReceivedEventType(CARTA::EventType::SET_SPATIAL_REQUIREMENTS);
     OnMessageTask* tsk = new GeneralMessageTask<CARTA::SetSpatialRequirements>(_session, message, DUMMY_REQUEST_ID);
     ThreadManager::QueueTask(tsk);
 }
 
 void BackendModel::Receive(CARTA::SetStatsRequirements message) {
-    LogReceivedEventType(CARTA::EventType::SET_STATS_REQUIREMENTS);
+    carta::logger::LogReceivedEventType(CARTA::EventType::SET_STATS_REQUIREMENTS);
     OnMessageTask* tsk = new GeneralMessageTask<CARTA::SetStatsRequirements>(_session, message, DUMMY_REQUEST_ID);
     ThreadManager::QueueTask(tsk);
 }
 
 void BackendModel::Receive(CARTA::MomentRequest message) {
-    LogReceivedEventType(CARTA::EventType::MOMENT_REQUEST);
+    carta::logger::LogReceivedEventType(CARTA::EventType::MOMENT_REQUEST);
     OnMessageTask* tsk = new GeneralMessageTask<CARTA::MomentRequest>(_session, message, DUMMY_REQUEST_ID);
     ThreadManager::QueueTask(tsk);
 }
 
 void BackendModel::Receive(CARTA::FileListRequest message) {
-    LogReceivedEventType(CARTA::EventType::FILE_LIST_REQUEST);
+    carta::logger::LogReceivedEventType(CARTA::EventType::FILE_LIST_REQUEST);
     OnMessageTask* tsk = new GeneralMessageTask<CARTA::FileListRequest>(_session, message, DUMMY_REQUEST_ID);
     ThreadManager::QueueTask(tsk);
 }
 
 void BackendModel::Receive(CARTA::RegionListRequest message) {
-    LogReceivedEventType(CARTA::EventType::REGION_LIST_REQUEST);
+    carta::logger::LogReceivedEventType(CARTA::EventType::REGION_LIST_REQUEST);
     OnMessageTask* tsk = new GeneralMessageTask<CARTA::RegionListRequest>(_session, message, DUMMY_REQUEST_ID);
     ThreadManager::QueueTask(tsk);
 }
 
 void BackendModel::Receive(CARTA::CatalogListRequest message) {
-    LogReceivedEventType(CARTA::EventType::CATALOG_LIST_REQUEST);
+    carta::logger::LogReceivedEventType(CARTA::EventType::CATALOG_LIST_REQUEST);
     OnMessageTask* tsk = new GeneralMessageTask<CARTA::CatalogListRequest>(_session, message, DUMMY_REQUEST_ID);
     ThreadManager::QueueTask(tsk);
 }

--- a/test/TestMain.cc
+++ b/test/TestMain.cc
@@ -63,11 +63,11 @@ int main(int argc, char** argv) {
     carta::ThreadManager::SetThreadLimit(omp_threads);
 
     fs::path user_directory = fs::path(getenv("HOME")) / CARTA_USER_FOLDER_PREFIX;
-    InitLogger(no_log, verbosity, log_performance, log_protocol_messages, user_directory);
+    carta::logger::InitLogger(no_log, verbosity, log_performance, log_protocol_messages, user_directory);
 
     int run_all_tests = RUN_ALL_TESTS();
 
     ThreadManager::ExitEventHandlingThreads();
-    FlushLogFile();
+    carta::logger::FlushLogFile();
     return run_all_tests;
 }


### PR DESCRIPTION
Closes #869.

To get a _rerouting_ to stdout/stderr depending on the message level a custom sink for `spdlog` is introduced. While this is quite direct for a simple sink, it requires some code duplication if fancy colors are wanted, but I think it's ok.

To test it, I added within the main function the following messages after the logger initialization:
```
        spdlog::info("this should appear in stdout");
        spdlog::warn("this should appear in stdout");
        spdlog::error("this should appear in stderr");
        spdlog::critical("this should appear in stderr");
```
Then, I get:
```
$ ./carta_backend > logging.out 2> logging.err
^C$ cat logging.out 
[2022-01-17 15:37:38.224] [CARTA] [info] Writing to the log file: /Users/lopez/.carta/log/carta.log
[2022-01-17 15:37:38.224] [CARTA] [debug] Reading user settings from /Users/lopez/.carta/backend.json.
[2022-01-17 15:37:38.224] [CARTA] [info] this should appear in stdout
[2022-01-17 15:37:38.224] [CARTA] [warning] this should appear in stdout
[2022-01-17 15:37:38.227] [CARTA] [info] /Users/lopez/temp/CARTAvis/carta-backend/build/./carta_backend: Version 3.0.0-beta.2c
[2022-01-17 15:37:38.230] [CARTA] [info] CARTA gRPC service available at 0.0.0.0:50071
[2022-01-17 15:37:38.230] [CARTA] [info] CARTA gRPC token: EE7CC612-A49E-4278-A34E-AFB8B9AA472B
[2022-01-17 15:37:38.232] [CARTA] [info] Serving CARTA frontend from /Users/lopez/temp/CARTAvis/carta-frontend/build
[2022-01-17 15:37:38.232] [CARTA] [info] Listening on port 3020 with top level folder /, starting folder /Users/lopez/temp/CARTAvis/data, and 4 OpenMP worker threads
[2022-01-17 15:37:38.232] [CARTA] [info] CARTA is accessible at http://localhost:3020/?token=EDB898F1-FF87-44F3-A6EA-3E625E5E1D93
[2022-01-17 15:37:39.823] [CARTA] [info] Exiting backend.
$ cat logging.err 
[2022-01-17 15:37:38.224] [CARTA] [error] this should appear in stderr
[2022-01-17 15:37:38.227] [CARTA] [critical] this should appear in stderr
```

The only thing that puzzles me right now is that the `STDOUT_TAG`, now renames `CARTA_LOGGER_TAG` wasn't printed before. I am not sure if that was ok. Now you can see that the log messages come from `CARTA`. I think this is ok to notice the separation between CARTA and CASA logging messages clearly.

![carta_backend_log](https://user-images.githubusercontent.com/3409812/149789605-98416502-59a5-4454-8b66-d7f4ffc943d5.png)

