### PR TITLE
Replaced mutable with volatile where required.

### DIFF
--- a/src/Session/Session.h
+++ b/src/Session/Session.h
@@ -317,7 +317,7 @@ protected:
 
     // State for animation functions.
     std::unique_ptr<AnimationObject> _animation_object;
-    mutable bool _animation_active;
+    volatile bool _animation_active;
 
     // Individual stokes files connector
     std::unique_ptr<StokesFilesConnector> _stokes_files_connector;

--- a/src/Session/SessionContext.h
+++ b/src/Session/SessionContext.h
@@ -25,7 +25,7 @@ public:
     }
 
 private:
-    mutable bool _cancelled;
+    volatile bool _cancelled;
 };
 
 } // namespace carta


### PR DESCRIPTION
Small fix that hopefully solves the crash problem when an animation stops and restarts immediately in the test code.