### PR TITLE
Adding ranges information on the file browser

### DIFF
--- a/src/FileList/FileExtInfoLoader.cc
+++ b/src/FileList/FileExtInfoLoader.cc
@@ -1176,11 +1176,14 @@ void FileExtInfoLoader::GetCoordNames(std::string& ctype1, std::string& ctype2, 
 }
 
 void FileExtInfoLoader::FillCoordRanges(CARTA::FileInfoExtended& extended_info) {
+    if (!_loader) {
+        return;
+    }
     auto shape = _loader->GetImage()->shape().asVector();
     if (shape.empty()) {
         return;
     }
-    casacore::CoordinateSystem coord_system(_loader->GetImage()->coordinates());
+    casacore::CoordinateSystem coord_system = _loader->GetImage()->coordinates();
 
     if (coord_system.hasDirectionCoordinate()) {
         auto direction_coord = coord_system.directionCoordinate();

--- a/src/FileList/FileExtInfoLoader.cc
+++ b/src/FileList/FileExtInfoLoader.cc
@@ -191,7 +191,6 @@ bool FileExtInfoLoader::FillFileInfoFromImage(CARTA::FileInfoExtended& extended_
                     std::vector<int> render_axes = _loader->GetRenderAxes();
                     AddShapeEntries(extended_info, image_shape, spectral_axis, depth_axis, stokes_axis, render_axes);
                     AddComputedEntries(extended_info, image.get(), render_axes, use_image_for_entries);
-                    FillCoordRanges(extended_info);
                     info_ok = true;
                 }
             } else { // image failed
@@ -814,6 +813,8 @@ void FileExtInfoLoader::AddComputedEntries(CARTA::FileInfoExtended& extended_inf
         const casacore::ImageBeamSet beam_set = image_info.getBeamSet();
         AddBeamEntry(extended_info, beam_set);
     }
+
+    AddCoordRanges(extended_info, image->coordinates(), image->shape());
 }
 
 void FileExtInfoLoader::AddComputedEntriesFromHeaders(CARTA::FileInfoExtended& extended_info, const std::vector<int>& display_axes) {
@@ -1175,56 +1176,65 @@ void FileExtInfoLoader::GetCoordNames(std::string& ctype1, std::string& ctype2, 
     }
 }
 
-void FileExtInfoLoader::FillCoordRanges(CARTA::FileInfoExtended& extended_info) {
-    if (!_loader) {
+void FileExtInfoLoader::AddCoordRanges(
+    CARTA::FileInfoExtended& extended_info, const casacore::CoordinateSystem& coord_system, const casacore::IPosition& image_shape) {
+    if (image_shape.empty()) {
         return;
     }
-    auto shape = _loader->GetImage()->shape().asVector();
-    if (shape.empty()) {
-        return;
-    }
-    casacore::CoordinateSystem coord_system = _loader->GetImage()->coordinates();
 
     if (coord_system.hasDirectionCoordinate()) {
         auto direction_coord = coord_system.directionCoordinate();
         if (direction_coord.referenceValue().size() == 2) {
             casacore::Vector<int> direction_axes = coord_system.directionAxesNumbers();
+            casacore::Vector<casacore::String> axis_names = coord_system.worldAxisNames();
             casacore::Vector<double> pixels(direction_axes.size(), 0);
             casacore::Vector<double> world(direction_axes.size(), 0);
-            casacore::Vector<double> ra_range_vec(2);
-            casacore::Vector<double> dec_range_vec(2);
+            casacore::Vector<double> x_range_vec(2);
+            casacore::Vector<double> y_range_vec(2);
             casacore::String units;
 
             // Get start world coord
             direction_coord.toWorld(world, pixels);
-            ra_range_vec[0] = world[0];
-            std::string ra_start = direction_coord.format(units, casacore::Coordinate::DEFAULT, world[0], 0, true, true);
-            dec_range_vec[0] = world[1];
-            std::string dec_start = direction_coord.format(units, casacore::Coordinate::DEFAULT, world[1], 1, true, true);
+            x_range_vec[0] = world[0];
+            std::string x_start = direction_coord.format(units, casacore::Coordinate::DEFAULT, world[0], 0, true, true);
+            y_range_vec[0] = world[1];
+            std::string y_start = direction_coord.format(units, casacore::Coordinate::DEFAULT, world[1], 1, true, true);
 
             // Get end world coord
             for (unsigned int i = 0; i < pixels.size(); ++i) {
-                pixels[i] = shape[direction_axes[i]] - 1;
+                pixels[i] = image_shape[direction_axes[i]] - 1;
             }
             direction_coord.toWorld(world, pixels);
-            ra_range_vec[1] = world[0];
-            std::string ra_end = direction_coord.format(units, casacore::Coordinate::DEFAULT, world[0], 0, true, true);
-            dec_range_vec[1] = world[1];
-            std::string dec_end = direction_coord.format(units, casacore::Coordinate::DEFAULT, world[1], 1, true, true);
+            x_range_vec[1] = world[0];
+            std::string x_end = direction_coord.format(units, casacore::Coordinate::DEFAULT, world[0], 0, true, true);
+            y_range_vec[1] = world[1];
+            std::string y_end = direction_coord.format(units, casacore::Coordinate::DEFAULT, world[1], 1, true, true);
 
-            auto* ra_entry = extended_info.add_computed_entries();
-            ra_entry->set_name("Right Ascension Range");
-            ra_entry->set_value(fmt::format("[{}, {}]", ra_start, ra_end));
-            ra_entry->set_entry_type(CARTA::EntryType::STRING);
+            // Set x and y coordinate names
+            if (axis_names(0) == "Right Ascension") {
+                axis_names(0) = "RA";
+            } else if (axis_names(0) == "Longitude") {
+                axis_names(0) = "GLON";
+            }
+            if (axis_names(1) == "Declination") {
+                axis_names(1) = "DEC";
+            } else if (axis_names(1) == "Latitude") {
+                axis_names(1) = "GLAT";
+            }
 
-            auto* dec_entry = extended_info.add_computed_entries();
-            dec_entry->set_name("Declination Range");
-            dec_entry->set_value(fmt::format("[{}, {}]", dec_start, dec_end));
-            dec_entry->set_entry_type(CARTA::EntryType::STRING);
+            auto* x_entry = extended_info.add_computed_entries();
+            x_entry->set_name(fmt::format("{} range", axis_names(0)));
+            x_entry->set_value(fmt::format("[{}, {}]", x_start, x_end));
+            x_entry->set_entry_type(CARTA::EntryType::STRING);
+
+            auto* y_entry = extended_info.add_computed_entries();
+            y_entry->set_name(fmt::format("{} range", axis_names(1)));
+            y_entry->set_value(fmt::format("[{}, {}]", y_start, y_end));
+            y_entry->set_entry_type(CARTA::EntryType::STRING);
         }
     }
 
-    if (coord_system.hasSpectralAxis() && shape[coord_system.spectralAxisNumber()] > 1) {
+    if (coord_system.hasSpectralAxis() && image_shape[coord_system.spectralAxisNumber()] > 1) {
         auto spectral_coord = coord_system.spectralCoordinate();
         casacore::Vector<casacore::String> spectral_units = spectral_coord.worldAxisUnits();
         spectral_units(0) = spectral_units(0) == "Hz" ? "GHz" : spectral_units(0);
@@ -1234,11 +1244,11 @@ void FileExtInfoLoader::FillCoordRanges(CARTA::FileInfoExtended& extended_info) 
         std::vector<double> frequencies(2);
         std::vector<double> velocities(2);
         double start_pixel = 0;
-        double end_pixel = shape[coord_system.spectralAxisNumber()] - 1;
+        double end_pixel = image_shape[coord_system.spectralAxisNumber()] - 1;
 
         if (spectral_coord.toWorld(frequencies[0], start_pixel) && spectral_coord.toWorld(frequencies[1], end_pixel)) {
             auto* frequency_entry = extended_info.add_computed_entries();
-            frequency_entry->set_name("Frequency Range");
+            frequency_entry->set_name("Frequency range");
             frequency_entry->set_value(fmt::format("[{:.4f}, {:.4f}] ({})", frequencies[0], frequencies[1], spectral_units(0)));
             frequency_entry->set_entry_type(CARTA::EntryType::STRING);
         }
@@ -1246,13 +1256,13 @@ void FileExtInfoLoader::FillCoordRanges(CARTA::FileInfoExtended& extended_info) 
         if ((spectral_coord.restFrequency() != 0) && spectral_coord.pixelToVelocity(velocities[0], start_pixel) &&
             spectral_coord.pixelToVelocity(velocities[1], end_pixel)) {
             auto* velocity_entry = extended_info.add_computed_entries();
-            velocity_entry->set_name("Velocity Range");
+            velocity_entry->set_name("Velocity range");
             velocity_entry->set_value(fmt::format("[{:.4f}, {:.4f}] ({})", velocities[0], velocities[1], velocity_units));
             velocity_entry->set_entry_type(CARTA::EntryType::STRING);
         }
     }
 
-    if (coord_system.hasPolarizationAxis() && shape[coord_system.polarizationAxisNumber()] > 0) {
+    if (coord_system.hasPolarizationAxis() && image_shape[coord_system.polarizationAxisNumber()] > 0) {
         auto stokes_indices = _loader->GetStokesIndices();
         std::string stokes;
         for (auto stokes_index : stokes_indices) {
@@ -1263,7 +1273,7 @@ void FileExtInfoLoader::FillCoordRanges(CARTA::FileInfoExtended& extended_info) 
         stokes = stokes.size() > 2 ? stokes.substr(0, stokes.size() - 2) : stokes;
 
         auto* stokes_entry = extended_info.add_computed_entries();
-        stokes_entry->set_name("Stokes Coverage");
+        stokes_entry->set_name("Stokes coverage");
         stokes_entry->set_value(fmt::format("[{}]", stokes));
         stokes_entry->set_entry_type(CARTA::EntryType::STRING);
     }

--- a/src/FileList/FileExtInfoLoader.cc
+++ b/src/FileList/FileExtInfoLoader.cc
@@ -1214,12 +1214,12 @@ void FileExtInfoLoader::AddCoordRanges(
             if (axis_names(0) == "Right Ascension") {
                 axis_names(0) = "RA";
             } else if (axis_names(0) == "Longitude") {
-                axis_names(0) = "GLON";
+                axis_names(0) = "LON";
             }
             if (axis_names(1) == "Declination") {
                 axis_names(1) = "DEC";
             } else if (axis_names(1) == "Latitude") {
-                axis_names(1) = "GLAT";
+                axis_names(1) = "LAT";
             }
 
             auto* x_entry = extended_info.add_computed_entries();

--- a/src/FileList/FileExtInfoLoader.h
+++ b/src/FileList/FileExtInfoLoader.h
@@ -32,8 +32,7 @@ public:
 
     // Fill extended file info for specified hdu
     bool FillFileExtInfo(CARTA::FileInfoExtended& extended_info, const std::string& filename, const std::string& hdu, std::string& message);
-    void GetCoordRanges(std::vector<std::string>& ra_range, std::vector<std::string>& dec_range, std::vector<std::string>& freq_range,
-        std::string& freq_units, std::vector<std::string>& velo_range, std::string& velo_units, std::vector<std::string>& stokes);
+    void FillCoordRanges(CARTA::FileInfoExtended& extended_info);
 
 private:
     bool FillFileInfoFromImage(CARTA::FileInfoExtended& ext_info, const std::string& hdu, std::string& message);

--- a/src/FileList/FileExtInfoLoader.h
+++ b/src/FileList/FileExtInfoLoader.h
@@ -53,7 +53,8 @@ private:
         const std::vector<int>& display_axes, bool use_image_for_entries);
     void AddComputedEntriesFromHeaders(CARTA::FileInfoExtended& extended_info, const std::vector<int>& display_axes);
     void AddBeamEntry(CARTA::FileInfoExtended& extended_info, const casacore::ImageBeamSet& beam_set);
-    void FillCoordRanges(CARTA::FileInfoExtended& extended_info);
+    void AddCoordRanges(
+        CARTA::FileInfoExtended& extended_info, const casacore::CoordinateSystem& coord_system, const casacore::IPosition& image_shape);
 
     // Convert MVAngle to string; returns Quantity string if not direction
     std::string MakeAngleString(const std::string& type, double val, const std::string& unit);

--- a/src/FileList/FileExtInfoLoader.h
+++ b/src/FileList/FileExtInfoLoader.h
@@ -32,6 +32,8 @@ public:
 
     // Fill extended file info for specified hdu
     bool FillFileExtInfo(CARTA::FileInfoExtended& extended_info, const std::string& filename, const std::string& hdu, std::string& message);
+    void GetCoordRanges(std::vector<std::string>& ra_range, std::vector<std::string>& dec_range, std::vector<std::string>& freq_range,
+        std::string& freq_units, std::vector<std::string>& velo_range, std::string& velo_units, std::vector<std::string>& stokes);
 
 private:
     bool FillFileInfoFromImage(CARTA::FileInfoExtended& ext_info, const std::string& hdu, std::string& message);

--- a/src/FileList/FileExtInfoLoader.h
+++ b/src/FileList/FileExtInfoLoader.h
@@ -32,7 +32,6 @@ public:
 
     // Fill extended file info for specified hdu
     bool FillFileExtInfo(CARTA::FileInfoExtended& extended_info, const std::string& filename, const std::string& hdu, std::string& message);
-    void FillCoordRanges(CARTA::FileInfoExtended& extended_info);
 
 private:
     bool FillFileInfoFromImage(CARTA::FileInfoExtended& ext_info, const std::string& hdu, std::string& message);
@@ -54,6 +53,7 @@ private:
         const std::vector<int>& display_axes, bool use_image_for_entries);
     void AddComputedEntriesFromHeaders(CARTA::FileInfoExtended& extended_info, const std::vector<int>& display_axes);
     void AddBeamEntry(CARTA::FileInfoExtended& extended_info, const casacore::ImageBeamSet& beam_set);
+    void FillCoordRanges(CARTA::FileInfoExtended& extended_info);
 
     // Convert MVAngle to string; returns Quantity string if not direction
     std::string MakeAngleString(const std::string& type, double val, const std::string& unit);

--- a/src/ImageData/FileLoader.h
+++ b/src/ImageData/FileLoader.h
@@ -94,6 +94,9 @@ public:
     virtual void SetStokesCrpix(float stokes_crpix);
     virtual void SetStokesCdelt(int stokes_cdelt);
     virtual bool GetStokesTypeIndex(const CARTA::PolarizationType& stokes_type, int& stokes_index);
+    std::unordered_map<CARTA::PolarizationType, int> GetStokesIndices() {
+        return _stokes_indices;
+    };
 
     // Modify time changed
     bool ImageUpdated();

--- a/src/Util/Image.h
+++ b/src/Util/Image.h
@@ -121,6 +121,12 @@ static std::unordered_map<std::string, CARTA::PolarizationType> StokesStringType
     {"LR", CARTA::PolarizationType::LR}, {"XX", CARTA::PolarizationType::XX}, {"YY", CARTA::PolarizationType::YY},
     {"XY", CARTA::PolarizationType::XY}, {"YX", CARTA::PolarizationType::YX}};
 
+static std::unordered_map<CARTA::PolarizationType, std::string> StokesTypesString{{CARTA::PolarizationType::I, "I"},
+    {CARTA::PolarizationType::Q, "Q"}, {CARTA::PolarizationType::U, "U"}, {CARTA::PolarizationType::V, "V"},
+    {CARTA::PolarizationType::RR, "RR"}, {CARTA::PolarizationType::LL, "LL"}, {CARTA::PolarizationType::RL, "RL"},
+    {CARTA::PolarizationType::LR, "LR"}, {CARTA::PolarizationType::XX, "XX"}, {CARTA::PolarizationType::YY, "YY"},
+    {CARTA::PolarizationType::XY, "XY"}, {CARTA::PolarizationType::YX, "YX"}};
+
 int GetStokesValue(const CARTA::PolarizationType& stokes_type);
 CARTA::PolarizationType GetStokesType(int stokes_value);
 

--- a/test/TestFileInfo.cc
+++ b/test/TestFileInfo.cc
@@ -52,16 +52,32 @@ public:
         bool file_info_ok;
         std::string message;
         std::map<std::string, CARTA::FileInfoExtended> file_info_extended_map;
+        std::vector<std::string> ra_range, dec_range, freq_range, velo_range, stokes;
+        std::string freq_units, velo_units;
 
         if (request_file_type == CARTA::FileType::FITS) {
             file_info_ok = ext_info_loader.FillFitsFileInfoMap(file_info_extended_map, fullname, message);
+            ext_info_loader.GetCoordRanges(ra_range, dec_range, freq_range, freq_units, velo_range, velo_units, stokes);
         } else {
             CARTA::FileInfoExtended file_info_ext;
             file_info_ok = ext_info_loader.FillFileExtInfo(file_info_ext, fullname, request_hdu, message);
+            ext_info_loader.GetCoordRanges(ra_range, dec_range, freq_range, freq_units, velo_range, velo_units, stokes);
             if (file_info_ok) {
                 file_info_extended_map[request_hdu] = file_info_ext;
             }
         }
+
+        EXPECT_EQ(ra_range[0], "18:20:25.888");
+        EXPECT_EQ(ra_range[1], "18:20:25.721");
+        EXPECT_EQ(dec_range[0], "-16.13.36.797");
+        EXPECT_EQ(dec_range[1], "-16.13.34.397");
+        EXPECT_EQ(freq_range[0], "86.750419");
+        EXPECT_EQ(freq_range[1], "86.749442");
+        EXPECT_EQ(freq_units, "GHz");
+        EXPECT_EQ(velo_range[0], "13.376000");
+        EXPECT_EQ(velo_range[1], "16.752000");
+        EXPECT_EQ(velo_units, "km/s");
+        EXPECT_TRUE(stokes.empty());
 
         CheckFileInfoExtended(file_info_extended_map, request_filename, request_hdu);
     }

--- a/test/TestFileInfo.cc
+++ b/test/TestFileInfo.cc
@@ -52,32 +52,16 @@ public:
         bool file_info_ok;
         std::string message;
         std::map<std::string, CARTA::FileInfoExtended> file_info_extended_map;
-        std::vector<std::string> ra_range, dec_range, freq_range, velo_range, stokes;
-        std::string freq_units, velo_units;
 
         if (request_file_type == CARTA::FileType::FITS) {
             file_info_ok = ext_info_loader.FillFitsFileInfoMap(file_info_extended_map, fullname, message);
-            ext_info_loader.GetCoordRanges(ra_range, dec_range, freq_range, freq_units, velo_range, velo_units, stokes);
         } else {
             CARTA::FileInfoExtended file_info_ext;
             file_info_ok = ext_info_loader.FillFileExtInfo(file_info_ext, fullname, request_hdu, message);
-            ext_info_loader.GetCoordRanges(ra_range, dec_range, freq_range, freq_units, velo_range, velo_units, stokes);
             if (file_info_ok) {
                 file_info_extended_map[request_hdu] = file_info_ext;
             }
         }
-
-        EXPECT_EQ(ra_range[0], "18:20:25.888");
-        EXPECT_EQ(ra_range[1], "18:20:25.721");
-        EXPECT_EQ(dec_range[0], "-16.13.36.797");
-        EXPECT_EQ(dec_range[1], "-16.13.34.397");
-        EXPECT_EQ(freq_range[0], "86.750419");
-        EXPECT_EQ(freq_range[1], "86.749442");
-        EXPECT_EQ(freq_units, "GHz");
-        EXPECT_EQ(velo_range[0], "13.376000");
-        EXPECT_EQ(velo_range[1], "16.752000");
-        EXPECT_EQ(velo_units, "km/s");
-        EXPECT_TRUE(stokes.empty());
 
         CheckFileInfoExtended(file_info_extended_map, request_filename, request_hdu);
     }
@@ -144,6 +128,16 @@ public:
                 CheckHeaderEntry(computed_entries, "Jy/beam", CARTA::EntryType::STRING);
             } else if (computed_entries.name() == "Pixel increment") {
                 CheckHeaderEntry(computed_entries, "-0.4\", 0.4\"", CARTA::EntryType::STRING);
+            } else if (computed_entries.name() == "Right Ascension Range") {
+                CheckHeaderEntry(computed_entries, "[18:20:25.888, 18:20:25.721]", CARTA::EntryType::STRING);
+            } else if (computed_entries.name() == "Declination Range") {
+                CheckHeaderEntry(computed_entries, "[-16.13.36.797, -16.13.34.397]", CARTA::EntryType::STRING);
+            } else if (computed_entries.name() == "Frequency Range") {
+                CheckHeaderEntry(computed_entries, "[86.7504, 86.7494] (GHz)", CARTA::EntryType::STRING);
+            } else if (computed_entries.name() == "Velocity Range") {
+                CheckHeaderEntry(computed_entries, "[13.3760, 16.7520] (km/s)", CARTA::EntryType::STRING);
+            } else if (computed_entries.name() == "Stokes Coverage") {
+                CheckHeaderEntry(computed_entries, "[I]", CARTA::EntryType::STRING);
             }
         }
     }

--- a/test/TestFileInfo.cc
+++ b/test/TestFileInfo.cc
@@ -128,15 +128,15 @@ public:
                 CheckHeaderEntry(computed_entries, "Jy/beam", CARTA::EntryType::STRING);
             } else if (computed_entries.name() == "Pixel increment") {
                 CheckHeaderEntry(computed_entries, "-0.4\", 0.4\"", CARTA::EntryType::STRING);
-            } else if (computed_entries.name() == "Right Ascension Range") {
+            } else if (computed_entries.name() == "RA range") {
                 CheckHeaderEntry(computed_entries, "[18:20:25.888, 18:20:25.749]", CARTA::EntryType::STRING);
-            } else if (computed_entries.name() == "Declination Range") {
+            } else if (computed_entries.name() == "DEC range") {
                 CheckHeaderEntry(computed_entries, "[-16.13.36.797, -16.13.34.797]", CARTA::EntryType::STRING);
-            } else if (computed_entries.name() == "Frequency Range") {
+            } else if (computed_entries.name() == "Frequency range") {
                 CheckHeaderEntry(computed_entries, "[86.7504, 86.7494] (GHz)", CARTA::EntryType::STRING);
-            } else if (computed_entries.name() == "Velocity Range") {
+            } else if (computed_entries.name() == "Velocity range") {
                 CheckHeaderEntry(computed_entries, "[13.3760, 16.7520] (km/s)", CARTA::EntryType::STRING);
-            } else if (computed_entries.name() == "Stokes Coverage") {
+            } else if (computed_entries.name() == "Stokes coverage") {
                 CheckHeaderEntry(computed_entries, "[I]", CARTA::EntryType::STRING);
             }
         }

--- a/test/TestFileInfo.cc
+++ b/test/TestFileInfo.cc
@@ -129,9 +129,9 @@ public:
             } else if (computed_entries.name() == "Pixel increment") {
                 CheckHeaderEntry(computed_entries, "-0.4\", 0.4\"", CARTA::EntryType::STRING);
             } else if (computed_entries.name() == "Right Ascension Range") {
-                CheckHeaderEntry(computed_entries, "[18:20:25.888, 18:20:25.721]", CARTA::EntryType::STRING);
+                CheckHeaderEntry(computed_entries, "[18:20:25.888, 18:20:25.749]", CARTA::EntryType::STRING);
             } else if (computed_entries.name() == "Declination Range") {
-                CheckHeaderEntry(computed_entries, "[-16.13.36.797, -16.13.34.397]", CARTA::EntryType::STRING);
+                CheckHeaderEntry(computed_entries, "[-16.13.36.797, -16.13.34.797]", CARTA::EntryType::STRING);
             } else if (computed_entries.name() == "Frequency Range") {
                 CheckHeaderEntry(computed_entries, "[86.7504, 86.7494] (GHz)", CARTA::EntryType::STRING);
             } else if (computed_entries.name() == "Velocity Range") {


### PR DESCRIPTION
#845, adding ranges information in the file preview. Including RA, Dec, Frequency, Velocity, and Stokes coverages. As shown below:
![截圖 2022-02-22 上午10 37 32](https://user-images.githubusercontent.com/5379602/155053815-283d01b3-8699-46a8-99b3-3430758fa22b.png)
 
@kswang1029 do we also need ranges information for compressed FITS files in the file preview? If so, I will do it in another separate PR.