### PR TITLE
Fix leaky unique_ptr

### DIFF
--- a/src/DataStream/Smoothing.cc
+++ b/src/DataStream/Smoothing.cc
@@ -126,7 +126,7 @@ bool GaussianSmooth(const float* src_data, float* dest_data, int64_t src_width, 
         return false;
     }
 
-    vector<float> kernel(mask_size);
+    std::vector<float> kernel(mask_size);
     MakeKernel(kernel, sigma);
 
     double target_pixels = (SMOOTHING_TEMP_BUFFER_SIZE_MB * 1e6) / sizeof(float);
@@ -138,7 +138,7 @@ bool GaussianSmooth(const float* src_data, float* dest_data, int64_t src_width, 
 
     int64_t line_offset = 0;
     auto t_start = std::chrono::high_resolution_clock::now();
-    unique_ptr<float> temp_array(new float[dest_width * buffer_height]);
+    std::unique_ptr<float[]> temp_array(new float[dest_width * buffer_height]);
     auto source_ptr = src_data;
     auto dest_ptr = dest_data;
     const auto temp_ptr = temp_array.get();


### PR DESCRIPTION
While working on something else (related) for which I am using address sanitization (-fsanitize=address) I found the following error:

```
root@9cebf5a4b69d:~/carta-backend/build-ubuntu-docker/test# ./carta_backend_tests 
[==========] Running 232 tests from 21 test suites.
[----------] Global test environment set-up.
[----------] 2 tests from BlockSmoothingTest
[ RUN      ] BlockSmoothingTest.TestControl
[       OK ] BlockSmoothingTest.TestControl (15855 ms)
[ RUN      ] BlockSmoothingTest.TestSSEAccuracy
[       OK ] BlockSmoothingTest.TestSSEAccuracy (16512 ms)
[----------] 2 tests from BlockSmoothingTest (32367 ms total)

[----------] 12 tests from ContourTest
[ RUN      ] ContourTest.NoSmoothingFitsFile
2022-03-03 10:50:35	INFO	FITSCoordinateUtil::fromFITSHeader	passing empty or nonexistant spectral Coordinate axis
[       OK ] ContourTest.NoSmoothingFitsFile (5378 ms)
[ RUN      ] ContourTest.NoSmoothingFitsFileNaN
2022-03-03 10:50:41	INFO	FITSCoordinateUtil::fromFITSHeader	passing empty or nonexistant spectral Coordinate axis
[       OK ] ContourTest.NoSmoothingFitsFileNaN (5027 ms)
[ RUN      ] ContourTest.GaussianBlurFitsFile
2022-03-03 10:50:45	INFO	FITSCoordinateUtil::fromFITSHeader	passing empty or nonexistant spectral Coordinate axis
=================================================================
==7766==ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new [] vs operator delete) on 0x7f8b06b1d800
    #0 0x5f773d in operator delete(void*) (/root/carta-backend/build-ubuntu-docker/test/carta_backend_tests+0x5f773d)
    #1 0x78b1dd in std::default_delete<float>::operator()(float*) const /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/unique_ptr.h:81:2
    #2 0x786ef6 in std::unique_ptr<float, std::default_delete<float> >::~unique_ptr() /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/unique_ptr.h:292:4
    #3 0x780e92 in carta::GaussianSmooth(float const*, float*, long, long, long, long, int) /root/carta-backend/src/DataStream/Smoothing.cc:180:1
    #4 0x81adea in carta::Frame::ContourImage(std::function<void (double, double, std::vector<float, std::allocator<float> > const&, std::vector<int, std::allocator<int> > const&)> const&) /root/carta-backend/src/Frame/Frame.cc:607:29
    #5 0x16dc1df in ContourTest::GenerateContour(int, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, CARTA::FileType const&, CARTA::SmoothingMode const&) /root/carta-backend/test/TestContour.cc:53:9
    #6 0x16d81e8 in ContourTest_GaussianBlurFitsFile_Test::TestBody() /root/carta-backend/test/TestContour.cc:137:5
    #7 0x196f280 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) obj-x86_64-linux-gnu/googletest/./googletest/src/gtest.cc:2433:27
    #8 0x196f280 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) obj-x86_64-linux-gnu/googletest/./googletest/src/gtest.cc:2469:52
    #9 0x1963f05 in testing::Test::Run() obj-x86_64-linux-gnu/googletest/./googletest/src/gtest.cc:2508:50
    #10 0x1963f05 in testing::Test::Run() obj-x86_64-linux-gnu/googletest/./googletest/src/gtest.cc:2498:6
    #11 0x1964064 in testing::TestInfo::Run() obj-x86_64-linux-gnu/googletest/./googletest/src/gtest.cc:2684:14
    #12 0x1964064 in testing::TestInfo::Run() obj-x86_64-linux-gnu/googletest/./googletest/src/gtest.cc:2657:6
    #13 0x196414c in testing::TestSuite::Run() obj-x86_64-linux-gnu/googletest/./googletest/src/gtest.cc:2816:31
    #14 0x196414c in testing::TestSuite::Run() obj-x86_64-linux-gnu/googletest/./googletest/src/gtest.cc:2795:6
    #15 0x196466b in testing::internal::UnitTestImpl::RunAllTests() obj-x86_64-linux-gnu/googletest/./googletest/src/gtest.cc:5338:47
    #16 0x196f7f0 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) obj-x86_64-linux-gnu/googletest/./googletest/src/gtest.cc:2433:27
    #17 0x196f7f0 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) obj-x86_64-linux-gnu/googletest/./googletest/src/gtest.cc:2469:52
    #18 0x196489b in testing::UnitTest::Run() obj-x86_64-linux-gnu/googletest/./googletest/src/gtest.cc:4925:55
    #19 0x17a1d30 in RUN_ALL_TESTS() /usr/include/gtest/gtest.h:2473:46
    #20 0x179f4c1 in main /root/carta-backend/test/TestMain.cc:68:25
    #21 0x7f8b1abe70b2 in __libc_start_main /build/glibc-sMfBJT/glibc-2.31/csu/../csu/libc-start.c:308:16
    #22 0x54f02d in _start (/root/carta-backend/build-ubuntu-docker/test/carta_backend_tests+0x54f02d)

0x7f8b06b1d800 is located 0 bytes inside of 988000-byte region [0x7f8b06b1d800,0x7f8b06c0eb60)
allocated by thread T0 here:
    #0 0x5f6fed in operator new[](unsigned long) (/root/carta-backend/build-ubuntu-docker/test/carta_backend_tests+0x5f6fed)
    #1 0x7805f7 in carta::GaussianSmooth(float const*, float*, long, long, long, long, int) /root/carta-backend/src/DataStream/Smoothing.cc:141:34
    #2 0x81adea in carta::Frame::ContourImage(std::function<void (double, double, std::vector<float, std::allocator<float> > const&, std::vector<int, std::allocator<int> > const&)> const&) /root/carta-backend/src/Frame/Frame.cc:607:29
    #3 0x16dc1df in ContourTest::GenerateContour(int, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, CARTA::FileType const&, CARTA::SmoothingMode const&) /root/carta-backend/test/TestContour.cc:53:9
    #4 0x16d81e8 in ContourTest_GaussianBlurFitsFile_Test::TestBody() /root/carta-backend/test/TestContour.cc:137:5
    #5 0x196f280 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) obj-x86_64-linux-gnu/googletest/./googletest/src/gtest.cc:2433:27
    #6 0x196f280 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) obj-x86_64-linux-gnu/googletest/./googletest/src/gtest.cc:2469:52

SUMMARY: AddressSanitizer: alloc-dealloc-mismatch (/root/carta-backend/build-ubuntu-docker/test/carta_backend_tests+0x5f773d) in operator delete(void*)
==7766==HINT: if you don't care about these errors you may set ASAN_OPTIONS=alloc_dealloc_mismatch=0
==7766==ABORTING
```

The problem is that `unique_ptr<float> temp_array(new float[dest_width * buffer_height]);` will call `delete` on an array created with `new[]`, but needs to call `delete[]`. So, the unique pointer needs to be created with the right type `unique_ptr<float[]> temp_array(new float[dest_width * buffer_height]);`. I really think this should be caught by the compiler.

I preferred to place this quick fix with a prompt pull request for other unrelated commits.


Btw, I don't know how did `vector` and `unique_ptr` compiled with the missing namespace `std::`.