### PR TITLE
Migrate 2D image cache away from std::vector<float> using gsl::span (#967)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,12 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     set(LINK_LIBS ${LINK_LIBS} stdc++fs)
 endif ()
 
+include(FetchContent)
+FetchContent_Declare(GSL
+        GIT_REPOSITORY "https://github.com/microsoft/GSL"
+        GIT_TAG "v3.1.0")
+FetchContent_MakeAvailable(GSL)
+
 # Include uWebSockets headers and build the uSockets lib
 include_directories(${CMAKE_SOURCE_DIR}/third-party/include)
 install_uWebSockets()
@@ -181,7 +187,8 @@ set(LINK_LIBS
         casa_imageanalysis
         ${OpenMP_CXX_LIBRARIES}
         ${HDF5_LIBRARIES}
-        ${CMAKE_THREAD_LIBS_INIT})
+        ${CMAKE_THREAD_LIBS_INIT}
+        GSL)
 
 set(SOURCE_FILES
         ${SOURCE_FILES}

--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -608,8 +608,8 @@ bool Frame::ContourImage(ContourCallback& partial_contour_callback) {
         int64_t dest_width = _width - (2 * kernel_width);
         int64_t dest_height = _height - (2 * kernel_width);
         std::unique_ptr<float[]> dest_array(new float[dest_width * dest_height]);
-        smooth_successful = GaussianSmooth(_image_cache.get(), dest_array.get(), source_width, source_height, dest_width, dest_height,
-            _contour_settings.smoothing_factor);
+        smooth_successful = GaussianSmooth(
+            _image_cache.get(), dest_array.get(), source_width, source_height, dest_width, dest_height, _contour_settings.smoothing_factor);
         // Can release lock early, as we're no longer using the image cache
         cache_lock.release();
         if (smooth_successful) {

--- a/src/Frame/Frame.h
+++ b/src/Frame/Frame.h
@@ -279,14 +279,13 @@ protected:
     ContourSettings _contour_settings;
 
     // Image data cache and mutex
-    //    std::vector<float> _image_cache; // image data for current z, stokes
-    long long int _image_cache_size;
-    std::shared_ptr<float[]> _image_cache;
-    bool _image_cache_valid;       // cached image data is valid for current z and stokes
-    queuing_rw_mutex _cache_mutex; // allow concurrent reads but lock for write
-    std::mutex _image_mutex;       // only one disk access at a time
-    bool _cache_loaded;            // channel cache is set
-    TileCache _tile_cache;         // cache for full-resolution image tiles
+    std::shared_ptr<float[]> _image_cache; // image data for current z, stokes
+    size_t _image_cache_size;              // size of image cache
+    bool _image_cache_valid;               // cached image data is valid for current z and stokes
+    queuing_rw_mutex _cache_mutex;         // allow concurrent reads but lock for write
+    std::mutex _image_mutex;               // only one disk access at a time
+    bool _cache_loaded;                    // channel cache is set
+    TileCache _tile_cache;                 // cache for full-resolution image tiles
     std::mutex _ignore_interrupt_X_mutex;
     std::mutex _ignore_interrupt_Y_mutex;
 

--- a/src/Frame/Frame.h
+++ b/src/Frame/Frame.h
@@ -279,14 +279,14 @@ protected:
     ContourSettings _contour_settings;
 
     // Image data cache and mutex
-//    std::vector<float> _image_cache; // image data for current z, stokes
+    //    std::vector<float> _image_cache; // image data for current z, stokes
     long long int _image_cache_size;
     std::shared_ptr<float[]> _image_cache;
-    bool _image_cache_valid;         // cached image data is valid for current z and stokes
-    queuing_rw_mutex _cache_mutex;   // allow concurrent reads but lock for write
-    std::mutex _image_mutex;         // only one disk access at a time
-    bool _cache_loaded;              // channel cache is set
-    TileCache _tile_cache;           // cache for full-resolution image tiles
+    bool _image_cache_valid;       // cached image data is valid for current z and stokes
+    queuing_rw_mutex _cache_mutex; // allow concurrent reads but lock for write
+    std::mutex _image_mutex;       // only one disk access at a time
+    bool _cache_loaded;            // channel cache is set
+    TileCache _tile_cache;         // cache for full-resolution image tiles
     std::mutex _ignore_interrupt_X_mutex;
     std::mutex _ignore_interrupt_Y_mutex;
 

--- a/src/Frame/Frame.h
+++ b/src/Frame/Frame.h
@@ -28,6 +28,8 @@
 #include <carta-protobuf/spectral_profile.pb.h>
 #include <carta-protobuf/tiles.pb.h>
 
+#include <gsl/gsl>
+
 #include "Cache/RequirementsCache.h"
 #include "Cache/TileCache.h"
 #include "DataStream/Contouring.h"
@@ -170,7 +172,7 @@ public:
     casacore::IPosition GetRegionShape(const casacore::LattRegionHolder& region);
     // Returns data vector
     bool GetRegionData(const casacore::LattRegionHolder& region, std::vector<float>& data);
-    bool GetSlicerData(const casacore::Slicer& slicer, std::vector<float>& data);
+    bool GetSlicerData(const casacore::Slicer& slicer, gsl::span<float> data);
     // Returns stats_values map for spectral profiles and stats data
     bool GetRegionStats(const casacore::LattRegionHolder& region, const std::vector<CARTA::StatsType>& required_stats, bool per_z,
         std::map<CARTA::StatsType, std::vector<double>>& stats_values);
@@ -277,7 +279,9 @@ protected:
     ContourSettings _contour_settings;
 
     // Image data cache and mutex
-    std::vector<float> _image_cache; // image data for current z, stokes
+//    std::vector<float> _image_cache; // image data for current z, stokes
+    long long int _image_cache_size;
+    std::shared_ptr<float[]> _image_cache;
     bool _image_cache_valid;         // cached image data is valid for current z and stokes
     queuing_rw_mutex _cache_mutex;   // allow concurrent reads but lock for write
     std::mutex _image_mutex;         // only one disk access at a time

--- a/src/ImageStats/BasicStatsCalculator.h
+++ b/src/ImageStats/BasicStatsCalculator.h
@@ -9,6 +9,8 @@
 
 #include <algorithm>
 
+#include <gsl/gsl>
+
 namespace carta {
 
 template <typename T>
@@ -32,10 +34,10 @@ class BasicStatsCalculator {
     T _min_val, _max_val;
     double _sum, _sum_squares;
     size_t _num_pixels;
-    const std::vector<T>& _data;
+    gsl::span<T const> _data;
 
 public:
-    BasicStatsCalculator(const std::vector<T>& data);
+    BasicStatsCalculator(gsl::span<T const> _data);
 
     void join(BasicStatsCalculator& other); // NOLINT
     void reduce(const size_t start, const size_t end);

--- a/src/ImageStats/BasicStatsCalculator.tcc
+++ b/src/ImageStats/BasicStatsCalculator.tcc
@@ -41,7 +41,7 @@ BasicStats<T>::BasicStats()
       sumSq(0) {}
 
 template <typename T>
-BasicStatsCalculator<T>::BasicStatsCalculator(const std::vector<T>& data)
+BasicStatsCalculator<T>::BasicStatsCalculator(gsl::span<T const> data)
     : _min_val(std::numeric_limits<T>::max()),
       _max_val(std::numeric_limits<T>::lowest()),
       _sum(0),

--- a/src/ImageStats/Histogram.cc
+++ b/src/ImageStats/Histogram.cc
@@ -15,7 +15,7 @@
 
 using namespace carta;
 
-Histogram::Histogram(int num_bins, float min_value, float max_value, const std::vector<float>& data)
+Histogram::Histogram(int num_bins, float min_value, float max_value, gsl::span<float const> data)
     : _bin_width((max_value - min_value) / num_bins),
       _min_val(min_value),
       _max_val(max_value),
@@ -45,7 +45,7 @@ bool Histogram::Add(const Histogram& h) {
     return true;
 }
 
-void Histogram::Fill(const std::vector<float>& data) {
+void Histogram::Fill(gsl::span<float const> data) {
     std::vector<int64_t> temp_bins;
     const auto num_elements = data.size();
     const size_t num_bins = GetNbins();

--- a/src/ImageStats/Histogram.h
+++ b/src/ImageStats/Histogram.h
@@ -10,6 +10,8 @@
 #include <cstddef>
 #include <vector>
 
+#include <gsl/gsl>
+
 namespace carta {
 
 class Histogram {
@@ -19,12 +21,12 @@ class Histogram {
     float _bin_center;                // bin center
     std::vector<int> _histogram_bins; // histogram bin counts
 
-    void Fill(const std::vector<float>&);
+    void Fill(gsl::span<float const> data);
     static bool ConsistencyCheck(const Histogram&, const Histogram&);
 
 public:
     Histogram() = default; // required to create empty histograms used in references
-    Histogram(int num_bins, float min_value, float max_value, const std::vector<float>& data);
+    Histogram(int num_bins, float min_value, float max_value, gsl::span<float const> data);
 
     Histogram(const Histogram& h);
 

--- a/src/ImageStats/StatsCalculator.cc
+++ b/src/ImageStats/StatsCalculator.cc
@@ -16,14 +16,14 @@
 
 namespace carta {
 
-void CalcBasicStats(const std::vector<float>& data, BasicStats<float>& stats) {
+void CalcBasicStats(gsl::span<float const> data, BasicStats<float>& stats) {
     // Calculate stats in BasicStats struct
     BasicStatsCalculator<float> mm(data);
     mm.reduce(0, data.size());
     stats = mm.GetStats();
 }
 
-Histogram CalcHistogram(int num_bins, const BasicStats<float>& stats, const std::vector<float>& data) {
+Histogram CalcHistogram(int num_bins, const BasicStats<float>& stats, gsl::span<float const> data) {
     if ((stats.min_val == std::numeric_limits<float>::max()) || (stats.max_val == std::numeric_limits<float>::min()) || data.empty()) {
         // empty / NaN region
         return Histogram(1, 0, 0, {});

--- a/src/ImageStats/StatsCalculator.h
+++ b/src/ImageStats/StatsCalculator.h
@@ -13,15 +13,17 @@
 
 #include <casacore/images/Images/ImageInterface.h>
 
+#include <gsl/gsl>
+
 #include <carta-protobuf/enums.pb.h>
 #include "BasicStatsCalculator.h"
 #include "Histogram.h"
 
 namespace carta {
 
-void CalcBasicStats(const std::vector<float>& data, BasicStats<float>& stats);
+void CalcBasicStats(gsl::span<float const> data, BasicStats<float>& stats);
 
-Histogram CalcHistogram(int num_bins, const BasicStats<float>& stats, const std::vector<float>& data);
+Histogram CalcHistogram(int num_bins, const BasicStats<float>& stats, gsl::span<float const> data);
 
 bool CalcStatsValues(std::map<CARTA::StatsType, std::vector<double>>& stats_values, const std::vector<CARTA::StatsType>& requested_stats,
     const casacore::ImageInterface<float>& image, bool per_channel = true);

--- a/src/Region/RegionHandler.cc
+++ b/src/Region/RegionHandler.cc
@@ -11,6 +11,8 @@
 #include <chrono>
 #include <cmath>
 
+#include <gsl/gsl>
+
 #include <casacore/lattices/LRegions/LCBox.h>
 #include <casacore/lattices/LRegions/LCExtension.h>
 #include <casacore/lattices/LRegions/LCIntersection.h>
@@ -994,13 +996,13 @@ bool RegionHandler::GetRegionHistogramData(
 
         // Calculate and cache stats
         if (!have_basic_stats) {
-            CalcBasicStats(data[stokes], stats);
+            CalcBasicStats(gsl::span<float>(data[stokes]), stats);
             _histogram_cache[cache_id].SetBasicStats(stats);
             have_basic_stats = true;
         }
 
         // Calculate and cache histogram for number of bins
-        Histogram histo = CalcHistogram(num_bins, stats, data[stokes]);
+        Histogram histo = CalcHistogram(num_bins, stats, gsl::span<float>(data[stokes]));
         _histogram_cache[cache_id].SetHistogram(num_bins, histo);
 
         // Complete Histogram submessage

--- a/src/Util/File.cc
+++ b/src/Util/File.cc
@@ -38,7 +38,7 @@ int GetNumItems(const std::string& path) {
     try {
         int counter = 0;
         auto it = fs::directory_iterator(path);
-        for (const auto &f : it) {
+        for (const auto& f : it) {
             counter++;
         }
         return counter;

--- a/src/Util/File.cc
+++ b/src/Util/File.cc
@@ -38,7 +38,7 @@ int GetNumItems(const std::string& path) {
     try {
         int counter = 0;
         auto it = fs::directory_iterator(path);
-        for (const auto f : it) {
+        for (const auto &f : it) {
             counter++;
         }
         return counter;


### PR DESCRIPTION
Migrate 2D image cache away from `std::vector<float>` introducing `gsl::span` in several other places to avoid resizing `_image_cache` as a `std::vector`, then avoiding the initialization penalty.

- [ ] Other `std::vector`s can be removed?
- [ ] Check performance improvement.
- [ ] Check performance overhead of gsl::span.

This pull request is equivalent to #1034 without the need of using c-style arrays, but it introduces the user of [GSL](https://github.com/microsoft/GSL) that could be eventually removed if we move to C++20.