### PR TITLE
Remove ambiguous reference to Timer

### DIFF
--- a/test/TestHistogram.cc
+++ b/test/TestHistogram.cc
@@ -147,7 +147,7 @@ TEST_F(HistogramTest, TestMultithreadingPerformance) {
         v = float_random(mt);
     }
 
-    Timer t;
+    carta::Timer t;
     carta::ThreadManager::SetThreadLimit(1);
 
     t.Start("single_threaded");


### PR DESCRIPTION
Quick fix. Appeared when activating performance tests for Histograms:

```
/Users/lopez/temp/CARTAvis/carta-backend/test/TestHistogram.cc:150:5: error: reference to 'Timer' is ambiguous
    Timer t;
    ^
/opt/carta-casacore/include/casacore/casa/OS/Timer.h:127:7: note: candidate found by name lookup is 'casacore::Timer'
class Timer {
```

I missed adding `carta::` during the reorganization refactoring.