### PR TITLE
Adding coordinate ranges information for compressed FITS files

### DIFF
--- a/src/FileList/FileExtInfoLoader.cc
+++ b/src/FileList/FileExtInfoLoader.cc
@@ -1138,17 +1138,19 @@ void FileExtInfoLoader::AddComputedEntriesFromHeaders(
         // Make a spectral coordinate and add it to the coordinate system if any
         casacore::MFrequency::Types spec_type;
         if (calc_spec_range && casacore::MFrequency::getType(spec_type, specsys)) {
-            if (ctype3 == "VRAD") {
+            if (ctype3 == "VRAD") { // For radio velocity
                 crval3 = rest_freq * (1 - crval3 / casacore::C::c);
                 cdelt3 = -rest_freq * (cdelt3 / casacore::C::c);
-            } else if (ctype3 == "VOPT") {
+            } else if (ctype3 == "VOPT") { // For optical velocity
                 crval3 = rest_freq / (1 + crval3 / casacore::C::c);
                 cdelt3 = rest_freq / (1 + cdelt3 / casacore::C::c);
             }
             casacore::SpectralCoordinate spec_coord(spec_type, crval3, cdelt3, crpix3, rest_freq);
-            casacore::Vector<casacore::String> units(1);
-            units = cunit3;
-            spec_coord.setWorldAxisUnits(units);
+            if (!cunit3.empty()) {
+                casacore::Vector<casacore::String> units(1);
+                units = cunit3;
+                spec_coord.setWorldAxisUnits(units);
+            }
             coordsys.addCoordinate(spec_coord);
         }
 
@@ -1157,7 +1159,7 @@ void FileExtInfoLoader::AddComputedEntriesFromHeaders(
             int stokes_axis = std::stoi(suffix4) - 1;
             int stokes_size = shape[stokes_axis];
             casacore::Vector<casacore::Int> stokes_types(stokes_size);
-            if (crpix4 != 1) {
+            if (crpix4 != 1) { // Get the stokes type for the first pixel
                 crval4 -= cdelt4 * (crpix4 - 1);
             }
             for (int i = 0; i < shape[stokes_axis]; ++i) {

--- a/src/FileList/FileExtInfoLoader.h
+++ b/src/FileList/FileExtInfoLoader.h
@@ -18,7 +18,8 @@
 #include <casacore/images/Images/ImageInterface.h>
 
 #include <carta-protobuf/file_info.pb.h>
-#include "../ImageData/FileLoader.h"
+#include "ImageData/CompressedFits.h"
+#include "ImageData/FileLoader.h"
 
 namespace carta {
 
@@ -47,11 +48,12 @@ private:
     // Computed entries
     void AddShapeEntries(CARTA::FileInfoExtended& extended_info, const casacore::IPosition& shape, int chan_axis, int depth_axis,
         int stokes_axis, const std::vector<int>& render_axes);
-    void AddInitialComputedEntries(
-        const std::string& hdu, CARTA::FileInfoExtended& extended_info, const std::string& filename, const std::vector<int>& render_axes);
+    void AddInitialComputedEntries(const std::string& hdu, CARTA::FileInfoExtended& extended_info, const std::string& filename,
+        const std::vector<int>& render_axes, CompressedFits* compressed_fits = nullptr);
     void AddComputedEntries(CARTA::FileInfoExtended& extended_info, casacore::ImageInterface<float>* image,
         const std::vector<int>& display_axes, bool use_image_for_entries);
-    void AddComputedEntriesFromHeaders(CARTA::FileInfoExtended& extended_info, const std::vector<int>& display_axes);
+    void AddComputedEntriesFromHeaders(
+        CARTA::FileInfoExtended& extended_info, const std::vector<int>& display_axes, CompressedFits* compressed_fits = nullptr);
     void AddBeamEntry(CARTA::FileInfoExtended& extended_info, const casacore::ImageBeamSet& beam_set);
     void AddCoordRanges(
         CARTA::FileInfoExtended& extended_info, const casacore::CoordinateSystem& coord_system, const casacore::IPosition& image_shape);

--- a/src/ImageData/CompressedFits.cc
+++ b/src/ImageData/CompressedFits.cc
@@ -19,6 +19,13 @@
 
 using namespace carta;
 
+CompressedFits::CompressedFits(const std::string& filename) : _filename(filename) {
+    // Initialize linear transformation matrix between the pixel and world axes
+    _xform.resize(2, 2);
+    _xform = 0.0;
+    _xform.diagonal() = 1.0;
+}
+
 bool CompressedFits::GetFitsHeaderInfo(std::map<std::string, CARTA::FileInfoExtended>& hdu_info_map) {
     // Read compressed file headers to fill map
     auto zip_file = OpenGzFile();
@@ -129,6 +136,25 @@ bool CompressedFits::GetFitsHeaderInfo(std::map<std::string, CARTA::FileInfoExte
                     beam_info.bmin = value + beam_unit;
                 } else if (keyword == "BPA") {
                     beam_info.bpa = value + beam_unit;
+                }
+
+                // Set linear transformation matrix between the pixel and world axes
+                if (keyword.startsWith("PC") || keyword.startsWith("CD")) {
+                    auto found = keyword.find("_");
+                    if (found != casacore::String::npos) {
+                        if (keyword.at(found - 1) == '1' && keyword.at(keyword.length() - 1) == '1') {
+                            _xform(0, 0) = casacore::String::toDouble(value);
+                        }
+                        if (keyword.at(found - 1) == '1' && keyword.at(keyword.length() - 1) == '2') {
+                            _xform(0, 1) = casacore::String::toDouble(value);
+                        }
+                        if (keyword.at(found - 1) == '2' && keyword.at(keyword.length() - 1) == '1') {
+                            _xform(1, 0) = casacore::String::toDouble(value);
+                        }
+                        if (keyword.at(found - 1) == '2' && keyword.at(keyword.length() - 1) == '2') {
+                            _xform(1, 1) = casacore::String::toDouble(value);
+                        }
+                    }
                 }
             } else {
                 // END of header

--- a/src/ImageData/CompressedFits.cc
+++ b/src/ImageData/CompressedFits.cc
@@ -20,7 +20,7 @@
 using namespace carta;
 
 CompressedFits::CompressedFits(const std::string& filename) : _filename(filename) {
-    // Initialize linear transformation matrix between the pixel and world axes
+    // Initialize linear transformation matrix for the direction coordinate
     _xform.resize(2, 2);
     _xform = 0.0;
     _xform.diagonal() = 1.0;
@@ -144,14 +144,11 @@ bool CompressedFits::GetFitsHeaderInfo(std::map<std::string, CARTA::FileInfoExte
                     if (found != casacore::String::npos) {
                         if (keyword.at(found - 1) == '1' && keyword.at(keyword.length() - 1) == '1') {
                             _xform(0, 0) = casacore::String::toDouble(value);
-                        }
-                        if (keyword.at(found - 1) == '1' && keyword.at(keyword.length() - 1) == '2') {
+                        } else if (keyword.at(found - 1) == '1' && keyword.at(keyword.length() - 1) == '2') {
                             _xform(0, 1) = casacore::String::toDouble(value);
-                        }
-                        if (keyword.at(found - 1) == '2' && keyword.at(keyword.length() - 1) == '1') {
+                        } else if (keyword.at(found - 1) == '2' && keyword.at(keyword.length() - 1) == '1') {
                             _xform(1, 0) = casacore::String::toDouble(value);
-                        }
-                        if (keyword.at(found - 1) == '2' && keyword.at(keyword.length() - 1) == '2') {
+                        } else if (keyword.at(found - 1) == '2' && keyword.at(keyword.length() - 1) == '2') {
                             _xform(1, 1) = casacore::String::toDouble(value);
                         }
                     }

--- a/src/ImageData/CompressedFits.h
+++ b/src/ImageData/CompressedFits.h
@@ -146,10 +146,10 @@ private:
     std::string _filename;
     std::string _unzip_filename;
     casacore::ImageBeamSet _beam_set;
-    casacore::Matrix<casacore::Double> _xform;
-    casacore::IPosition _shape;
-    std::string _spec_suffix;
-    std::string _stokes_suffix;
+    casacore::Matrix<casacore::Double> _xform; // Linear transform matrix for the direction coordinate
+    casacore::IPosition _shape;                // Image shape
+    std::string _spec_suffix;                  // Spectral suffix from the header
+    std::string _stokes_suffix;                // Stokes suffix from the header
 };
 
 } // namespace carta

--- a/src/ImageData/CompressedFits.h
+++ b/src/ImageData/CompressedFits.h
@@ -110,6 +110,18 @@ public:
     casacore::IPosition& GetShape() {
         return _shape;
     }
+    void SetSpecSuffix(int spec_axis) {
+        _spec_suffix = std::to_string(spec_axis + 1);
+    }
+    void SetStokesSuffix(int stokes_axis) {
+        _stokes_suffix = std::to_string(stokes_axis + 1);
+    }
+    std::string GetSpecSuffix() {
+        return _spec_suffix;
+    }
+    std::string GetStokesSuffix() {
+        return _stokes_suffix;
+    }
 
     // File decompression
     unsigned long long GetDecompressSize();
@@ -136,6 +148,8 @@ private:
     casacore::ImageBeamSet _beam_set;
     casacore::Matrix<casacore::Double> _xform;
     casacore::IPosition _shape;
+    std::string _spec_suffix;
+    std::string _stokes_suffix;
 };
 
 } // namespace carta

--- a/src/ImageData/CompressedFits.h
+++ b/src/ImageData/CompressedFits.h
@@ -90,7 +90,7 @@ struct BeamTableInfo {
 
 class CompressedFits {
 public:
-    CompressedFits(const std::string& filename) : _filename(filename) {}
+    CompressedFits(const std::string& filename);
 
     // Headers for file info
     bool GetFitsHeaderInfo(std::map<std::string, CARTA::FileInfoExtended>& hdu_info_map);
@@ -99,6 +99,16 @@ public:
     // Beams for file info and opening image
     inline const casacore::ImageBeamSet& GetBeamSet() {
         return _beam_set;
+    }
+
+    casacore::Matrix<casacore::Double> GetMatrixForm() {
+        return _xform;
+    }
+    void SetShape(casacore::IPosition shape) {
+        _shape = shape;
+    }
+    casacore::IPosition& GetShape() {
+        return _shape;
     }
 
     // File decompression
@@ -124,6 +134,8 @@ private:
     std::string _filename;
     std::string _unzip_filename;
     casacore::ImageBeamSet _beam_set;
+    casacore::Matrix<casacore::Double> _xform;
+    casacore::IPosition _shape;
 };
 
 } // namespace carta

--- a/src/Util/Image.h
+++ b/src/Util/Image.h
@@ -121,12 +121,6 @@ static std::unordered_map<std::string, CARTA::PolarizationType> StokesStringType
     {"LR", CARTA::PolarizationType::LR}, {"XX", CARTA::PolarizationType::XX}, {"YY", CARTA::PolarizationType::YY},
     {"XY", CARTA::PolarizationType::XY}, {"YX", CARTA::PolarizationType::YX}};
 
-static std::unordered_map<CARTA::PolarizationType, std::string> StokesTypesString{{CARTA::PolarizationType::I, "I"},
-    {CARTA::PolarizationType::Q, "Q"}, {CARTA::PolarizationType::U, "U"}, {CARTA::PolarizationType::V, "V"},
-    {CARTA::PolarizationType::RR, "RR"}, {CARTA::PolarizationType::LL, "LL"}, {CARTA::PolarizationType::RL, "RL"},
-    {CARTA::PolarizationType::LR, "LR"}, {CARTA::PolarizationType::XX, "XX"}, {CARTA::PolarizationType::YY, "YY"},
-    {CARTA::PolarizationType::XY, "XY"}, {CARTA::PolarizationType::YX, "YX"}};
-
 int GetStokesValue(const CARTA::PolarizationType& stokes_type);
 CARTA::PolarizationType GetStokesType(int stokes_value);
 


### PR DESCRIPTION
#845, adding coordinate ranges information for compressed FITS files on the file preview stage. Which includes RA, DEC, Frequency, Velocity ranges, and stokes coverage. They are calculated from the header information. These values can be verified with that after opening the compressed FITS file.