### PR TITLE
Fix bug saving 2D image

### DIFF
--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -1792,13 +1792,15 @@ void Frame::SaveFile(const std::string& root_folder, const CARTA::SaveFile& save
         return;
     }
 
-    // Modify image to export
+    // Begin with entire image
     auto image_shape = ImageShape();
+    casacore::ImageInterface<float>* image = _loader->GetImage().get();
 
-    casacore::ImageInterface<float>* image;
+    // Modify image to export
     casacore::SubImage<float> sub_image;
     casacore::LCRegion* image_region;
     casacore::IPosition region_shape;
+
     if (region) {
         image_region = GetImageRegion(file_id, region);
         region_shape = image_region->shape();
@@ -1812,7 +1814,6 @@ void Frame::SaveFile(const std::string& root_folder, const CARTA::SaveFile& save
         }
     } else if (image_shape.size() > 2 && image_shape.size() < 5) {
         try {
-            // If apply region
             if (region) {
                 auto latt_region_holder = LattRegionHolder(image_region);
                 auto slice_sub_image = GetExportRegionSlicer(save_file_msg, image_shape, region_shape, image_region, latt_region_holder);

--- a/src/ImageGenerators/PvGenerator.cc
+++ b/src/ImageGenerators/PvGenerator.cc
@@ -120,6 +120,8 @@ casacore::CoordinateSystem PvGenerator::GetPvCoordinateSystem(
     // Remove second linear axis
     csys.removeWorldAxis(1, 0.0);
 
+    csys.setObsInfo(input_csys.obsInfo());
+
     return csys;
 }
 


### PR DESCRIPTION
Closes #1009 

Saving an image requires a pointer to the image being saved, but this was not set for 2D images without a region specified, including pv images.  The nullptr caused a seg fault when used.

The seg fault happened when trying to copy the image's CoordinateSystem ObsInfo.  I noticed this was not being set for pv images in PvGenerator so fixed that too but not the cause of the crash.