### PR TITLE
sorts out our use of curl_easy_escape

### DIFF
--- a/src/HttpServer/HttpServer.cc
+++ b/src/HttpServer/HttpServer.cc
@@ -10,10 +10,9 @@
 #include <regex>
 #include <vector>
 
-#include <curl/curl.h>
-
 #include "Logger/Logger.h"
 #include "MimeTypes.h"
+#include "Util/String.h"
 #include "Util/Token.h"
 
 using json = nlohmann::json;
@@ -505,7 +504,7 @@ std::string HttpServer::GetFileUrlString(std::vector<std::string> files) {
     if (files.empty()) {
         return std::string();
     } else if (files.size() == 1) {
-        return fmt::format("file={}", curl_easy_escape(nullptr, files[0].c_str(), 0));
+        return fmt::format("file={}", SafeStringEscape(files[0]));
     } else {
         bool in_common_folder = true;
         fs::path common_folder;
@@ -522,7 +521,7 @@ std::string HttpServer::GetFileUrlString(std::vector<std::string> files) {
         }
 
         if (in_common_folder) {
-            url_string += fmt::format("folder={}&", curl_easy_escape(nullptr, common_folder.c_str(), 0));
+            url_string += fmt::format("folder={}&", SafeStringEscape(common_folder));
             // Trim folder from path string
             for (auto& file : files) {
                 fs::path p(file);
@@ -533,7 +532,7 @@ std::string HttpServer::GetFileUrlString(std::vector<std::string> files) {
         int num_files = files.size();
         url_string += "files=";
         for (int i = 0; i < num_files; i++) {
-            url_string += curl_easy_escape(nullptr, files[i].c_str(), 0);
+            url_string += SafeStringEscape(files[i]);
             if (i != num_files - 1) {
                 url_string += ",";
             }

--- a/src/Util/String.cc
+++ b/src/Util/String.cc
@@ -52,6 +52,8 @@ bool ConstantTimeStringCompare(const std::string& a, const std::string& b) {
 }
 
 std::string SafeStringEscape(const std::string& input) {
+    // This is needed to ensure we don't mix malloc/free with new/delete
+    // Reference: https://chromium.googlesource.com/chromium/src/base/+/9b9882fcdabd89115c828acb27020ede8cefee0d/memory/scoped_ptr.h#171
     struct free_deleter {
         void operator()(void* p) {
             free(p);

--- a/src/Util/String.cc
+++ b/src/Util/String.cc
@@ -6,6 +6,8 @@
 
 #include "String.h"
 
+#include <curl/curl.h>
+#include <memory>
 #include <sstream>
 
 void SplitString(std::string& input, char delim, std::vector<std::string>& parts) {
@@ -47,4 +49,15 @@ bool ConstantTimeStringCompare(const std::string& a, const std::string& b) {
     }
 
     return d == 0;
+}
+
+std::string SafeStringEscape(const std::string& input) {
+    struct free_deleter {
+        void operator()(void* p) {
+            free(p);
+        }
+    };
+
+    std::unique_ptr<char, free_deleter> escaped_string(curl_easy_escape(nullptr, input.c_str(), 0));
+    return std::string(escaped_string.get());
 }

--- a/src/Util/String.cc
+++ b/src/Util/String.cc
@@ -7,6 +7,7 @@
 #include "String.h"
 
 #include <curl/curl.h>
+
 #include <memory>
 #include <sstream>
 

--- a/src/Util/String.h
+++ b/src/Util/String.h
@@ -10,6 +10,9 @@
 #include <string>
 #include <vector>
 
+// wrapper for curl_easy_escape function that handles cleaning up char ptrs properly
+std::string SafeStringEscape(const std::string& input);
+
 // split input string into a vector of strings by delimiter
 void SplitString(std::string& input, char delim, std::vector<std::string>& parts);
 

--- a/test/TestProgramSettings.cc
+++ b/test/TestProgramSettings.cc
@@ -10,8 +10,8 @@
 #include "CommonTestUtilities.h"
 #include "HttpServer/HttpServer.h"
 #include "Main/ProgramSettings.h"
+#include "Util/String.h"
 
-#include <curl/curl.h>
 #include <fstream>
 #include <iostream>
 
@@ -342,10 +342,8 @@ TEST_F(ProgramSettingsTest, TestFileQueryStringSingleFile) {
     auto image_root = TestRoot() / "data" / "images";
     std::vector<std::string> files;
     files.push_back(image_root / "fits" / "noise_3d.fits");
-    std::string folder = curl_easy_escape(nullptr, fmt::format("{}/fits/", image_root.string()).c_str(), 0);
-
     auto url_string = carta::HttpServer::GetFileUrlString(files);
-    EXPECT_EQ(url_string, fmt::format("file={}{}", folder, "noise_3d.fits"));
+    EXPECT_EQ(url_string, fmt::format("file={}{}", SafeStringEscape(fmt::format("{}/fits/", image_root.string())), "noise_3d.fits"));
 }
 
 TEST_F(ProgramSettingsTest, TestFileQueryStringTwoFilesSameFolder) {
@@ -353,7 +351,7 @@ TEST_F(ProgramSettingsTest, TestFileQueryStringTwoFilesSameFolder) {
     std::vector<std::string> files;
     files.push_back(image_root / "fits" / "noise_3d.fits");
     files.push_back(image_root / "fits" / "noise_4d.fits");
-    std::string folder = curl_easy_escape(nullptr, fmt::format("{}/fits", image_root.string()).c_str(), 0);
+    auto folder = SafeStringEscape(fmt::format("{}/fits", image_root.string()));
 
     auto url_string = carta::HttpServer::GetFileUrlString(files);
     EXPECT_EQ(url_string, fmt::format("folder={}&files={}", folder, "noise_3d.fits,noise_4d.fits"));
@@ -364,8 +362,8 @@ TEST_F(ProgramSettingsTest, TestFileQueryStringTwoFilesDifferentFolder) {
     std::vector<std::string> files;
     files.push_back(image_root / "fits" / "noise_3d.fits");
     files.push_back(image_root / "hdf5" / "noise_10px_10px.hdf5");
-    std::string folder1 = curl_easy_escape(nullptr, fmt::format("{}/fits/", image_root.string()).c_str(), 0);
-    std::string folder2 = curl_easy_escape(nullptr, fmt::format("{}/hdf5/", image_root.string()).c_str(), 0);
+    auto folder1 = SafeStringEscape(fmt::format("{}/fits/", image_root.string()));
+    auto folder2 = SafeStringEscape(fmt::format("{}/hdf5/", image_root.string()));
 
     auto url_string = carta::HttpServer::GetFileUrlString(files);
     EXPECT_EQ(url_string, fmt::format("files={}{},{}{}", folder1, "noise_3d.fits", folder2, "noise_10px_10px.hdf5"));


### PR DESCRIPTION
Fixes minor memory leaks that occur when calling `curl_easy_escape` and:
- not cleaning up the input string properly.
- not cleaning up the output `char*`.