### PR TITLE
768 Check file info parameters for duplicate request

### DIFF
--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -424,7 +424,6 @@ void Session::OnFileInfoRequest(const CARTA::FileInfoRequest& request, uint32_t 
     auto file = request.file();
     auto hdu = request.hdu();
     CARTA::FileInfoResponse response;
-    string message;
 
     if (!_requested_file_info.duplicate_request(directory, file, hdu)) {
         spdlog::debug("Responding to FileInfoRequest for {}/{} hdu {}.", directory, file, hdu);
@@ -432,6 +431,7 @@ void Session::OnFileInfoRequest(const CARTA::FileInfoRequest& request, uint32_t 
 
         auto& file_info = *response.mutable_file_info();
         std::map<std::string, CARTA::FileInfoExtended> extended_info_map;
+        string message;
         bool success = FillExtendedFileInfo(extended_info_map, file_info, directory, file, hdu, message);
 
         if (success) {


### PR DESCRIPTION
Closes #768 

Double-click on file list sends FileInfoRequest message twice to the backend.  Added struct to Session to check if same request sent within one minute.

I tried to build on MacOS 10.15 to test this but it did not like the new std::shared_ptr<float[]> data(new float[N]); ("no matching constructor")