### PR TITLE
Fix compatibility issue with macOS 10.15

### DIFF
--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -26,16 +26,10 @@
 #include "ImageStats/StatsCalculator.h"
 #include "Logger/Logger.h"
 
-#if defined(__APPLE__) && defined(__MACH__)
-#include <Availability.h>
-#endif
-
-#if defined(__APPLE__) && defined(__MACH__) && defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
-#if __MAC_OS_X_VERSION_MIN_REQUIRED < 110000
-// nothing to define here
+#if defined(__APPLE__) && defined(__MACH__) && defined(__clang__) && defined(__clang_major__) && (__clang_major__ < 12)
+// shared_ptr_array not supported in apple clang < 12
 #else
 #define HAS_SHARED_PTR_ARRAY
-#endif
 #endif
 
 static const int HIGH_COMPRESSION_QUALITY(32);

--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -1124,16 +1124,16 @@ bool Frame::FillSpatialProfileData(PointXy point, std::vector<CARTA::SetSpatialR
             casacore::Slicer section = GetImageSlicer(AxisRange(x), AxisRange(y), AxisRange(CurrentZ()), stokes);
             const auto N = section.length().product();
 #ifdef __MAC_OS_X_VERSION_MIN_REQUIRED
-    #if __MAC_OS_X_VERSION_MIN_REQUIRED < 101100
+#if __MAC_OS_X_VERSION_MIN_REQUIRED < 101100
             std::vector<float> data(N);
             if (GetSlicerData(section, data.data())) {
-    #else
-            std::shared_ptr<float[]> data(new float[N]); // zero initialization
-            if (GetSlicerData(section, data.get())) {
-    #endif
 #else
             std::shared_ptr<float[]> data(new float[N]); // zero initialization
-            if (GetSlicerData(section, data.get())) 
+            if (GetSlicerData(section, data.get())) {
+#endif
+#else
+            std::shared_ptr<float[]> data(new float[N]); // zero initialization
+            if (GetSlicerData(section, data.get()))
 #endif
                 cursor_value = data[0];
             }
@@ -1504,16 +1504,16 @@ bool Frame::FillSpectralProfileData(std::function<void(CARTA::SpectralProfileDat
                     casacore::Slicer slicer(start, count);
                     const auto N = slicer.length().product();
 #ifdef __MAC_OS_X_VERSION_MIN_REQUIRED
-    #if __MAC_OS_X_VERSION_MIN_REQUIRED < 101100
+#if __MAC_OS_X_VERSION_MIN_REQUIRED < 101100
                     std::vector<float> buffer(N);
                     if (!GetSlicerData(slicer, buffer.data())) {
-    #else
-                    std::shared_ptr<float[]> buffer(new float[N]);
-                    if (!GetSlicerData(slicer, buffer.get())) {
-    #endif
 #else
                     std::shared_ptr<float[]> buffer(new float[N]);
-                    if (!GetSlicerData(slicer, buffer.get())) 
+                    if (!GetSlicerData(slicer, buffer.get())) {
+#endif
+#else
+                    std::shared_ptr<float[]> buffer(new float[N]);
+                    if (!GetSlicerData(slicer, buffer.get()))
 #endif
                         return false;
                     }

--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -26,7 +26,6 @@
 #include "ImageStats/StatsCalculator.h"
 #include "Logger/Logger.h"
 
-
 static const int HIGH_COMPRESSION_QUALITY(32);
 
 namespace carta {

--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -1124,7 +1124,7 @@ bool Frame::FillSpatialProfileData(PointXy point, std::vector<CARTA::SetSpatialR
             casacore::Slicer section = GetImageSlicer(AxisRange(x), AxisRange(y), AxisRange(CurrentZ()), stokes);
             const auto N = section.length().product();
 #if defined(__APPLE__) && defined(__MACH__) && defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
-#if __MAC_OS_X_VERSION_MIN_REQUIRED < 101100
+#if __MAC_OS_X_VERSION_MIN_REQUIRED < 110000
             std::vector<float> data(N);
             if (GetSlicerData(section, data.data())) {
 #else
@@ -1504,7 +1504,7 @@ bool Frame::FillSpectralProfileData(std::function<void(CARTA::SpectralProfileDat
                     casacore::Slicer slicer(start, count);
                     const auto N = slicer.length().product();
 #if defined(__APPLE__) && defined(__MACH__) && defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
-#if __MAC_OS_X_VERSION_MIN_REQUIRED < 101100
+#if __MAC_OS_X_VERSION_MIN_REQUIRED < 110000
                     std::vector<float> buffer(N);
                     if (!GetSlicerData(slicer, buffer.data())) {
 #else

--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -1123,7 +1123,7 @@ bool Frame::FillSpatialProfileData(PointXy point, std::vector<CARTA::SetSpatialR
         } else {
             casacore::Slicer section = GetImageSlicer(AxisRange(x), AxisRange(y), AxisRange(CurrentZ()), stokes);
             const auto N = section.length().product();
-#ifdef __MAC_OS_X_VERSION_MIN_REQUIRED
+#if defined(__APPLE__) && defined(__MACH__) && defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
 #if __MAC_OS_X_VERSION_MIN_REQUIRED < 101100
             std::vector<float> data(N);
             if (GetSlicerData(section, data.data())) {
@@ -1503,7 +1503,7 @@ bool Frame::FillSpectralProfileData(std::function<void(CARTA::SpectralProfileDat
                     count(_z_axis) = nz;
                     casacore::Slicer slicer(start, count);
                     const auto N = slicer.length().product();
-#ifdef __MAC_OS_X_VERSION_MIN_REQUIRED
+#if defined(__APPLE__) && defined(__MACH__) && defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
 #if __MAC_OS_X_VERSION_MIN_REQUIRED < 101100
                     std::vector<float> buffer(N);
                     if (!GetSlicerData(slicer, buffer.data())) {

--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -1507,19 +1507,26 @@ bool Frame::FillSpectralProfileData(std::function<void(CARTA::SpectralProfileDat
 #if __MAC_OS_X_VERSION_MIN_REQUIRED < 110000
                     std::vector<float> buffer(N);
                     if (!GetSlicerData(slicer, buffer.data())) {
-#else
-                    std::shared_ptr<float[]> buffer(new float[N]);
-                    if (!GetSlicerData(slicer, buffer.get())) {
-#endif
-#else
-                    std::shared_ptr<float[]> buffer(new float[N]);
-                    if (!GetSlicerData(slicer, buffer.get())) {
-#endif
                         return false;
                     }
-
+                    // copy buffer to spectral_data
+                    memcpy(&spectral_data[start(_z_axis)], buffer.data(), nz * sizeof(float));
+#else
+                    std::shared_ptr<float[]> buffer(new float[N]);
+                    if (!GetSlicerData(slicer, buffer.get())) {
+                        return false;
+                    }
                     // copy buffer to spectral_data
                     memcpy(&spectral_data[start(_z_axis)], buffer.get(), nz * sizeof(float));
+#endif
+#else
+                    std::shared_ptr<float[]> buffer(new float[N]);
+                    if (!GetSlicerData(slicer, buffer.get())) {
+                        return false;
+                    }
+                    // copy buffer to spectral_data
+                    memcpy(&spectral_data[start(_z_axis)], buffer.get(), nz * sizeof(float));
+#endif
 
                     // update start z and determine progress
                     start(_z_axis) += nz;

--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -1124,13 +1124,16 @@ bool Frame::FillSpatialProfileData(PointXy point, std::vector<CARTA::SetSpatialR
             casacore::Slicer section = GetImageSlicer(AxisRange(x), AxisRange(y), AxisRange(CurrentZ()), stokes);
             const auto N = section.length().product();
 #ifdef __MAC_OS_X_VERSION_MIN_REQUIRED
-#if __MAC_OS_X_VERSION_MIN_REQUIRED < 101100
+    #if __MAC_OS_X_VERSION_MIN_REQUIRED < 101100
             std::vector<float> data(N);
             if (GetSlicerData(section, data.data())) {
-#else
+    #else
             std::shared_ptr<float[]> data(new float[N]); // zero initialization
             if (GetSlicerData(section, data.get())) {
-#endif
+    #endif
+#else
+            std::shared_ptr<float[]> data(new float[N]); // zero initialization
+            if (GetSlicerData(section, data.get())) 
 #endif
                 cursor_value = data[0];
             }
@@ -1501,13 +1504,16 @@ bool Frame::FillSpectralProfileData(std::function<void(CARTA::SpectralProfileDat
                     casacore::Slicer slicer(start, count);
                     const auto N = slicer.length().product();
 #ifdef __MAC_OS_X_VERSION_MIN_REQUIRED
-#if __MAC_OS_X_VERSION_MIN_REQUIRED < 101100
+    #if __MAC_OS_X_VERSION_MIN_REQUIRED < 101100
                     std::vector<float> buffer(N);
                     if (!GetSlicerData(slicer, buffer.data())) {
-#else
+    #else
                     std::shared_ptr<float[]> buffer(new float[N]);
                     if (!GetSlicerData(slicer, buffer.get())) {
-#endif
+    #endif
+#else
+                    std::shared_ptr<float[]> buffer(new float[N]);
+                    if (!GetSlicerData(slicer, buffer.get())) 
 #endif
                         return false;
                     }

--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -26,6 +26,10 @@
 #include "ImageStats/StatsCalculator.h"
 #include "Logger/Logger.h"
 
+#if defined(__APPLE__) && defined(__MACH__)
+#include <Availability.h>
+#endif
+
 static const int HIGH_COMPRESSION_QUALITY(32);
 
 namespace carta {
@@ -1119,8 +1123,15 @@ bool Frame::FillSpatialProfileData(PointXy point, std::vector<CARTA::SetSpatialR
         } else {
             casacore::Slicer section = GetImageSlicer(AxisRange(x), AxisRange(y), AxisRange(CurrentZ()), stokes);
             const auto N = section.length().product();
+#ifdef __MAC_OS_X_VERSION_MIN_REQUIRED
+#if __MAC_OS_X_VERSION_MIN_REQUIRED < 101100
+            std::vector<float> data(N);
+            if (GetSlicerData(section, data.data())) {
+#else
             std::shared_ptr<float[]> data(new float[N]); // zero initialization
             if (GetSlicerData(section, data.get())) {
+#endif
+#endif
                 cursor_value = data[0];
             }
         }
@@ -1489,8 +1500,15 @@ bool Frame::FillSpectralProfileData(std::function<void(CARTA::SpectralProfileDat
                     count(_z_axis) = nz;
                     casacore::Slicer slicer(start, count);
                     const auto N = slicer.length().product();
+#ifdef __MAC_OS_X_VERSION_MIN_REQUIRED
+#if __MAC_OS_X_VERSION_MIN_REQUIRED < 101100
+                    std::vector<float> buffer(N);
+                    if (!GetSlicerData(slicer, buffer.data())) {
+#else
                     std::shared_ptr<float[]> buffer(new float[N]);
                     if (!GetSlicerData(slicer, buffer.get())) {
+#endif
+#endif
                         return false;
                     }
 

--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -1133,7 +1133,7 @@ bool Frame::FillSpatialProfileData(PointXy point, std::vector<CARTA::SetSpatialR
 #endif
 #else
             std::shared_ptr<float[]> data(new float[N]); // zero initialization
-            if (GetSlicerData(section, data.get()))
+            if (GetSlicerData(section, data.get())) {
 #endif
                 cursor_value = data[0];
             }
@@ -1513,7 +1513,7 @@ bool Frame::FillSpectralProfileData(std::function<void(CARTA::SpectralProfileDat
 #endif
 #else
                     std::shared_ptr<float[]> buffer(new float[N]);
-                    if (!GetSlicerData(slicer, buffer.get()))
+                    if (!GetSlicerData(slicer, buffer.get())) {
 #endif
                         return false;
                     }


### PR DESCRIPTION
MacOS 10.15 comes with clang 11, which doesn't have shared_ptr array support (see https://en.cppreference.com/w/cpp/compiler_support, under C++17 library features). So, this covers that case just for that OS system. In all others, it should keep using the proposed shared_ptr array for performance gains.

It's important to remark that the current CI can't test this, but @pford can check since she spotted the problem in #1068. 

Another remark is that this is important for our build systems. Maybe @ajm-asiaa can make another cross-check using his macOS 10.15 VM.

These preprocessor directives can be removed once we drop support for macOS 10.15.