### PR TITLE
ajm/switching centos8 to almalinux

### DIFF
--- a/Dockerfiles/Dockerfile-AlmaLinux
+++ b/Dockerfiles/Dockerfile-AlmaLinux
@@ -1,14 +1,13 @@
-FROM centos:8.4.2105
+FROM almalinux:latest
 
 # Install the required packages
 RUN \
   dnf -y install epel-release && \
   dnf -y install 'dnf-command(config-manager)' && \
   dnf -y config-manager --set-enabled powertools && \
-  dnf -y install centos-release-openstack-victoria && \
   dnf -y update && \
   dnf -y install autoconf automake bison blas-devel bzip2 cfitsio-devel cmake curl-devel flex gcc \
-         gcc-c++ git git-lfs gsl-devel hdf5-devel lapack-devel \ 
+         gcc-c++ git git-lfs gsl-devel hdf5-devel lapack-devel \
          libtool libxml2-devel libzstd-devel libuuid-devel make openssl-devel protobuf-devel \
          python36 python3-pip pugixml-devel readline-devel subversion \
          wcslib-devel wget zlib-devel libuuid-devel zfp-devel && \


### PR DESCRIPTION
Although @jolopezl found a way to update the repositories in the CentOS8 Dockerfile due to CentOS8 now being EOL:
```
RUN dnf -y --disablerepo '*' --enablerepo=extras swap centos-linux-repos centos-stream-repos
RUN dnf -y distro-sync
```
maybe it is about time to switch over to AlmaLinux instead?

If you agree, I have modified the Dockerfile to use the `almalinux:latest` base image. 

AlmaLinux is open source and 1:1 binary compatible with RHEL8 (Another alternative could be Rocky Linux, but I chose AlmaLinux because we use the ALMA radio telescope array, even though AlmaLinux has absolutely no relation to ALMA at all).

As in the other Dockerfiles, it creates a development environment for the carta-backend to be built, and run, as well as allowing the unit-tests to be built and run (`cmake .. -Dtest=on`). It does not install the packages for using the Address Sanitizer debugging, if that is OK?