### PR TITLE
remove mentions of boost and add extra condition to link filesystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,13 +146,7 @@ if (DisableContourCompression)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_DISABLE_CONTOUR_COMPRESSION_")
 endif (DisableContourCompression)
 
-option(UseBoostFilesystem "UseBoostFilesystem" OFF)
-
-if (UseBoostFilesystem)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_BOOST_FILESYSTEM_")
-    find_package(Boost 1.56 REQUIRED COMPONENTS filesystem)
-    set(LINK_LIBS ${LINK_LIBS} Boost::filesystem)
-elseif (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_CXX_COMPILER_VERSION LESS 11.2.0)
     set(LINK_LIBS ${LINK_LIBS} stdc++fs)
 endif ()
 

--- a/src/Util/FileSystem.h
+++ b/src/Util/FileSystem.h
@@ -7,12 +7,7 @@
 #ifndef CARTA_BACKEND__UTIL_FILESYSTEM_H_
 #define CARTA_BACKEND__UTIL_FILESYSTEM_H_
 
-#ifdef _BOOST_FILESYSTEM_
-#include <boost/filesystem.hpp>
-namespace fs = boost::filesystem;
-#else
 #include <filesystem>
 namespace fs = std::filesystem;
-#endif
 
 #endif // CARTA_BACKEND__UTIL_FILESYSTEM_H_

--- a/test/CommonTestUtilities.h
+++ b/test/CommonTestUtilities.h
@@ -16,13 +16,8 @@
 
 #include "App.h"
 
-#ifdef _BOOST_FILESYSTEM_
-#include <boost/filesystem.hpp>
-namespace fs = boost::filesystem;
-#else
 #include <filesystem>
 namespace fs = std::filesystem;
-#endif
 
 fs::path TestRoot();
 fs::path UserDirectory();


### PR DESCRIPTION
This came about when I ran into trouble making a Flatpak. The GCC versions in Flatpak (11.2.0 and 10.2.0) were not able to link with `stdc++fs` for some reason:
```
/usr/lib/gcc/x86_64-unknown-linux-gnu/11.2.0/../../../../x86_64-unknown-linux-gnu/bin/ld: cannot find -lstdc++fs
```

Once I commented out the stdc++fs linking line in the CMakeLists.txt, it worked.

It is strange because, for example, GCC 10.2.0 in Ubuntu 21.10, works fine even with the linking line in CMakeLists.txt. 

It seems we do not need to explicitly link to `stdc++fs` since GCC version 9 https://gcc.gnu.org/gcc-9/changes.html :
`Using the types and functions in <filesystem> does not require linking with -lstdc++fs now.`

We still use GCC 8.5 in RHEL8 for example so the linking line is still needed. 

This PR makes two changes.

1. I propose to use `CMAKE_CXX_COMPILER_VERSION` as another condition. Although technically we should be able to reduce it to version 9.0, let's put it to 11.2.0 for now. Then it should only come into effect when using Flatpak (and likely the upcoming Ubuntu 22.04).
```
if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_CXX_COMPILER_VERSION LESS 11.2.0)
    set(LINK_LIBS ${LINK_LIBS} stdc++fs)
endif ()
```

2. As we are modifying that part of the CMakeLists.txt, we can use this opportunity to completely remove the rest of the mentions of boost::filesystem.