### PR TITLE
Fix pointer memory leaks and add destructor

### DIFF
--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -45,6 +45,9 @@ Frame::Frame(uint32_t session_id, std::shared_ptr<FileLoader> loader, const std:
       _num_stokes(1),
       _image_cache_valid(false),
       _moment_generator(nullptr) {
+    // Initialize for operator==
+    _contour_settings = {std::vector<double>(), CARTA::SmoothingMode::NoSmoothing, 0, 0, 0, 0, 0};
+
     if (!_loader) {
         _open_image_error = fmt::format("Problem loading image: image type not supported.");
         spdlog::error("Session {}: {}", session_id, _open_image_error);
@@ -129,16 +132,12 @@ std::string Frame::GetFileName() {
     return filename;
 }
 
-casacore::CoordinateSystem* Frame::CoordinateSystem() {
-    // Returns pointer to CoordinateSystem clone; caller must delete
-    casacore::CoordinateSystem* csys(nullptr);
+std::shared_ptr<casacore::CoordinateSystem> Frame::CoordinateSystem() {
     if (IsValid()) {
-        std::lock_guard<std::mutex> guard(_image_mutex);
-        casacore::CoordinateSystem image_csys;
-        _loader->GetCoordinateSystem(image_csys);
-        csys = static_cast<casacore::CoordinateSystem*>(image_csys.clone());
+        return _loader->GetCoordinateSystem();
     }
-    return csys;
+
+    return std::make_shared<casacore::CoordinateSystem>();
 }
 
 casacore::IPosition Frame::ImageShape() {
@@ -1573,13 +1572,10 @@ bool Frame::HasSpectralConfig(const SpectralConfig& config) {
 // ****************************************************
 // Region/Slicer Support (Frame manages image mutex)
 
-casacore::LCRegion* Frame::GetImageRegion(int file_id, std::shared_ptr<Region> region, bool report_error) {
+std::shared_ptr<casacore::LCRegion> Frame::GetImageRegion(int file_id, std::shared_ptr<Region> region, bool report_error) {
     // Return LCRegion formed by applying region params to image.
     // Returns nullptr if region outside image
-    casacore::CoordinateSystem* coord_sys = CoordinateSystem();
-    casacore::LCRegion* image_region = region->GetImageRegion(file_id, *coord_sys, ImageShape(), report_error);
-    delete coord_sys;
-    return image_region;
+    return region->GetImageRegion(file_id, CoordinateSystem(), ImageShape(), report_error);
 }
 
 bool Frame::GetImageRegion(int file_id, const AxisRange& z_range, int stokes, casacore::ImageRegion& image_region) {
@@ -1600,9 +1596,8 @@ bool Frame::GetImageRegion(int file_id, const AxisRange& z_range, int stokes, ca
 
 casacore::IPosition Frame::GetRegionShape(const casacore::LattRegionHolder& region) {
     // Returns image shape with a region applied
-    casacore::CoordinateSystem* coord_sys = CoordinateSystem();
-    casacore::LatticeRegion lattice_region = region.toLatticeRegion(*coord_sys, ImageShape());
-    delete coord_sys;
+    auto coord_sys = CoordinateSystem();
+    casacore::LatticeRegion lattice_region = region.toLatticeRegion(*coord_sys.get(), ImageShape());
     return lattice_region.shape();
 }
 
@@ -1796,7 +1791,7 @@ void Frame::SaveFile(const std::string& root_folder, const CARTA::SaveFile& save
 
     // Modify image to export
     casacore::SubImage<float> sub_image;
-    casacore::LCRegion* image_region;
+    std::shared_ptr<casacore::LCRegion> image_region;
     casacore::IPosition region_shape;
 
     if (region) {
@@ -1806,14 +1801,14 @@ void Frame::SaveFile(const std::string& root_folder, const CARTA::SaveFile& save
 
     if (image_shape.size() == 2) {
         if (region) {
-            _loader->GetSubImage(LattRegionHolder(image_region), sub_image);
+            _loader->GetSubImage(LattRegionHolder(image_region.get()), sub_image);
             image = sub_image.cloneII();
             _loader->CloseImageIfUpdated();
         }
     } else if (image_shape.size() > 2 && image_shape.size() < 5) {
         try {
             if (region) {
-                auto latt_region_holder = LattRegionHolder(image_region);
+                auto latt_region_holder = LattRegionHolder(image_region.get());
                 auto slice_sub_image = GetExportRegionSlicer(save_file_msg, image_shape, region_shape, image_region, latt_region_holder);
                 _loader->GetSubImage(slice_sub_image, latt_region_holder, sub_image);
             } else {
@@ -2054,7 +2049,7 @@ casacore::Slicer Frame::GetExportImageSlicer(const CARTA::SaveFile& save_file_ms
 //   If dimension of region does not match the source image, will modify latt_region_holder.
 // Return casacore::Slicer(start, end, stride) for apply subImage()
 casacore::Slicer Frame::GetExportRegionSlicer(const CARTA::SaveFile& save_file_msg, casacore::IPosition image_shape,
-    casacore::IPosition region_shape, casacore::LCRegion* image_region, casacore::LattRegionHolder& latt_region_holder) {
+    casacore::IPosition region_shape, std::shared_ptr<casacore::LCRegion> image_region, casacore::LattRegionHolder& latt_region_holder) {
     auto channels = std::vector<int>();
     auto stokes = std::vector<int>();
     ValidateChannelStokes(channels, stokes, save_file_msg);

--- a/src/Frame/Frame.h
+++ b/src/Frame/Frame.h
@@ -95,8 +95,8 @@ public:
     // Get the full name of image file
     std::string GetFileName();
 
-    // Returns pointer to CoordinateSystem clone; caller must delete
-    casacore::CoordinateSystem* CoordinateSystem();
+    // Returns shared ptr to CoordinateSystem
+    std::shared_ptr<casacore::CoordinateSystem> CoordinateSystem();
 
     // Image/Frame info
     casacore::IPosition ImageShape();
@@ -165,7 +165,7 @@ public:
     bool IsConnected();
 
     // Apply Region/Slicer to image (Frame manages image mutex) and get shape, data, or stats
-    casacore::LCRegion* GetImageRegion(int file_id, std::shared_ptr<Region> region, bool report_error = true);
+    std::shared_ptr<casacore::LCRegion> GetImageRegion(int file_id, std::shared_ptr<Region> region, bool report_error = true);
     bool GetImageRegion(int file_id, const AxisRange& z_range, int stokes, casacore::ImageRegion& image_region);
     casacore::IPosition GetRegionShape(const casacore::LattRegionHolder& region);
     // Returns data vector
@@ -239,7 +239,7 @@ protected:
     void ValidateChannelStokes(std::vector<int>& channels, std::vector<int>& stokes, const CARTA::SaveFile& save_file_msg);
     casacore::Slicer GetExportImageSlicer(const CARTA::SaveFile& save_file_msg, casacore::IPosition image_shape);
     casacore::Slicer GetExportRegionSlicer(const CARTA::SaveFile& save_file_msg, casacore::IPosition image_shape,
-        casacore::IPosition region_shape, casacore::LCRegion* image_region, casacore::LattRegionHolder& latt_region_holder);
+        casacore::IPosition region_shape, std::shared_ptr<casacore::LCRegion> image_region, casacore::LattRegionHolder& latt_region_holder);
 
     void InitImageHistogramConfigs();
 

--- a/src/ImageData/CasaLoader.h
+++ b/src/ImageData/CasaLoader.h
@@ -33,7 +33,7 @@ void CasaLoader::OpenFile(const std::string& /*hdu*/) {
         _image_shape = _image->shape();
         _num_dims = _image_shape.size();
         _has_pixel_mask = _image->hasPixelMask();
-        _coord_sys = _image->coordinates();
+        _coord_sys = std::shared_ptr<casacore::CoordinateSystem>(static_cast<casacore::CoordinateSystem*>(_image->coordinates().clone()));
     }
 }
 

--- a/src/ImageData/CompListLoader.h
+++ b/src/ImageData/CompListLoader.h
@@ -35,7 +35,7 @@ void CompListLoader::OpenFile(const std::string& /*hdu*/) {
         _image_shape = _image->shape();
         _num_dims = _image_shape.size();
         _has_pixel_mask = _image->hasPixelMask();
-        _coord_sys = _image->coordinates();
+        _coord_sys = std::shared_ptr<casacore::CoordinateSystem>(static_cast<casacore::CoordinateSystem*>(_image->coordinates().clone()));
     }
 }
 

--- a/src/ImageData/ConcatLoader.h
+++ b/src/ImageData/ConcatLoader.h
@@ -36,7 +36,7 @@ void ConcatLoader::OpenFile(const std::string& /*hdu*/) {
         _image_shape = _image->shape();
         _num_dims = _image_shape.size();
         _has_pixel_mask = _image->hasPixelMask();
-        _coord_sys = _image->coordinates();
+        _coord_sys = std::shared_ptr<casacore::CoordinateSystem>(static_cast<casacore::CoordinateSystem*>(_image->coordinates().clone()));
     }
 }
 

--- a/src/ImageData/ExprLoader.h
+++ b/src/ImageData/ExprLoader.h
@@ -60,7 +60,7 @@ void ExprLoader::OpenFile(const std::string& /*hdu*/) {
         _image_shape = _image->shape();
         _num_dims = _image_shape.size();
         _has_pixel_mask = _image->hasPixelMask();
-        _coord_sys = _image->coordinates();
+        _coord_sys = std::shared_ptr<casacore::CoordinateSystem>(static_cast<casacore::CoordinateSystem*>(_image->coordinates().clone()));
     }
 }
 

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -70,7 +70,7 @@ FileLoader* FileLoader::GetLoader(std::shared_ptr<casacore::ImageInterface<float
 }
 
 FileLoader::FileLoader(const std::string& filename, const std::string& directory, bool is_gz)
-    : _filename(filename), _directory(directory), _is_gz(is_gz), _modify_time(0), _num_dims(0), _has_pixel_mask(false) {
+    : _filename(filename), _directory(directory), _is_gz(is_gz), _modify_time(0), _num_dims(0), _has_pixel_mask(false), _stokes_cdelt(0) {
     // Set initial modify time if filename is not LEL expression for file in directory
     if (directory.empty()) {
         ImageUpdated();
@@ -135,25 +135,15 @@ bool FileLoader::HasData(FileInfo::Data dl) const {
     return false;
 }
 
-bool FileLoader::GetShape(IPos& shape) {
-    if (_image_shape.empty()) {
-        return false;
-    }
-
-    shape = _image_shape;
-    return true;
+casacore::IPosition FileLoader::GetShape() {
+    return _image_shape;
 }
 
-bool FileLoader::GetCoordinateSystem(casacore::CoordinateSystem& coord_sys) {
-    if (_coord_sys.nCoordinates() == 0) {
-        return false;
-    }
-
-    coord_sys = _coord_sys;
-    return true;
+std::shared_ptr<casacore::CoordinateSystem> FileLoader::GetCoordinateSystem() {
+    return _coord_sys;
 }
 
-bool FileLoader::FindCoordinateAxes(IPos& shape, int& spectral_axis, int& z_axis, int& stokes_axis, std::string& message) {
+bool FileLoader::FindCoordinateAxes(casacore::IPosition& shape, int& spectral_axis, int& z_axis, int& stokes_axis, std::string& message) {
     // Return image shape and axes for image. Spectral axis may or may not be z axis.
     // All parameters are return values.
     spectral_axis = -1;
@@ -174,7 +164,7 @@ bool FileLoader::FindCoordinateAxes(IPos& shape, int& spectral_axis, int& z_axis
         return false;
     }
 
-    if (_coord_sys.nPixelAxes() != _num_dims) {
+    if (_coord_sys->nPixelAxes() != _num_dims) {
         message = "Problem loading image: cannot determine coordinate axes from incomplete header.";
         return false;
     }
@@ -186,8 +176,8 @@ bool FileLoader::FindCoordinateAxes(IPos& shape, int& spectral_axis, int& z_axis
     _image_plane_size = _width * _height;
 
     // Spectral and stokes axis
-    spectral_axis = _coord_sys.spectralAxisNumber();
-    stokes_axis = _coord_sys.polarizationAxisNumber();
+    spectral_axis = _coord_sys->spectralAxisNumber();
+    stokes_axis = _coord_sys->polarizationAxisNumber();
 
     // 2D image
     if (_num_dims == 2) {
@@ -274,19 +264,19 @@ std::vector<int> FileLoader::GetRenderAxes() {
 
     if (_image_shape.size() > 2) {
         // Normally, use direction axes
-        if (_coord_sys.hasDirectionCoordinate()) {
-            casacore::Vector<casacore::Int> dir_axes = _coord_sys.directionAxesNumbers();
+        if (_coord_sys->hasDirectionCoordinate()) {
+            casacore::Vector<casacore::Int> dir_axes = _coord_sys->directionAxesNumbers();
             axes[0] = dir_axes[0];
             axes[1] = dir_axes[1];
-        } else if (_coord_sys.hasLinearCoordinate()) {
+        } else if (_coord_sys->hasLinearCoordinate()) {
             // Check for PV image: [Linear, Spectral] axes
             // Returns -1 if no spectral axis
-            int spectral_axis = _coord_sys.spectralAxisNumber();
+            int spectral_axis = _coord_sys->spectralAxisNumber();
 
             if (spectral_axis >= 0) {
                 // Find valid (not -1) linear axes
                 std::vector<int> valid_axes;
-                casacore::Vector<casacore::Int> lin_axes = _coord_sys.linearAxesNumbers();
+                casacore::Vector<casacore::Int> lin_axes = _coord_sys->linearAxesNumbers();
                 for (auto axis : lin_axes) {
                     if (axis >= 0) {
                         valid_axes.push_back(axis);
@@ -455,26 +445,26 @@ bool FileLoader::GetBeams(std::vector<CARTA::Beam>& beams, std::string& error) {
     return success;
 }
 
-const FileLoader::IPos FileLoader::GetStatsDataShape(FileInfo::Data ds) {
+const casacore::IPosition FileLoader::GetStatsDataShape(FileInfo::Data ds) {
     throw casacore::AipsError("getStatsDataShape not implemented in this loader");
 }
 
-casacore::ArrayBase* FileLoader::GetStatsData(FileInfo::Data ds) {
+std::unique_ptr<casacore::ArrayBase> FileLoader::GetStatsData(FileInfo::Data ds) {
     throw casacore::AipsError("getStatsData not implemented in this loader");
 }
 
 void FileLoader::LoadStats2DBasic(FileInfo::Data ds) {
     if (HasData(ds)) {
-        const IPos& stat_dims = GetStatsDataShape(ds);
+        const casacore::IPosition& stat_dims = GetStatsDataShape(ds);
 
         // We can handle 2D, 3D and 4D in the same way
-        if ((_num_dims == 2 && stat_dims.size() == 0) || (_num_dims == 3 && stat_dims.isEqual(IPos(1, _depth))) ||
-            (_num_dims == 4 && stat_dims.isEqual(IPos(2, _depth, _num_stokes)))) {
+        if ((_num_dims == 2 && stat_dims.size() == 0) || (_num_dims == 3 && stat_dims.isEqual(casacore::IPosition(1, _depth))) ||
+            (_num_dims == 4 && stat_dims.isEqual(casacore::IPosition(2, _depth, _num_stokes)))) {
             auto data = GetStatsData(ds);
 
             switch (ds) {
                 case FileInfo::Data::STATS_2D_MAX: {
-                    auto it = static_cast<casacore::Array<casacore::Float>*>(data)->begin();
+                    auto it = static_cast<casacore::Array<casacore::Float>*>(data.get())->begin();
                     for (size_t s = 0; s < _num_stokes; s++) {
                         for (size_t z = 0; z < _depth; z++) {
                             _z_stats[s][z].basic_stats[CARTA::StatsType::Max] = *it++;
@@ -483,7 +473,7 @@ void FileLoader::LoadStats2DBasic(FileInfo::Data ds) {
                     break;
                 }
                 case FileInfo::Data::STATS_2D_MIN: {
-                    auto it = static_cast<casacore::Array<casacore::Float>*>(data)->begin();
+                    auto it = static_cast<casacore::Array<casacore::Float>*>(data.get())->begin();
                     for (size_t s = 0; s < _num_stokes; s++) {
                         for (size_t z = 0; z < _depth; z++) {
                             _z_stats[s][z].basic_stats[CARTA::StatsType::Min] = *it++;
@@ -492,7 +482,7 @@ void FileLoader::LoadStats2DBasic(FileInfo::Data ds) {
                     break;
                 }
                 case FileInfo::Data::STATS_2D_SUM: {
-                    auto it = static_cast<casacore::Array<casacore::Float>*>(data)->begin();
+                    auto it = static_cast<casacore::Array<casacore::Float>*>(data.get())->begin();
                     for (size_t s = 0; s < _num_stokes; s++) {
                         for (size_t z = 0; z < _depth; z++) {
                             _z_stats[s][z].basic_stats[CARTA::StatsType::Sum] = *it++;
@@ -501,7 +491,7 @@ void FileLoader::LoadStats2DBasic(FileInfo::Data ds) {
                     break;
                 }
                 case FileInfo::Data::STATS_2D_SUMSQ: {
-                    auto it = static_cast<casacore::Array<casacore::Float>*>(data)->begin();
+                    auto it = static_cast<casacore::Array<casacore::Float>*>(data.get())->begin();
                     for (size_t s = 0; s < _num_stokes; s++) {
                         for (size_t z = 0; z < _depth; z++) {
                             _z_stats[s][z].basic_stats[CARTA::StatsType::SumSq] = *it++;
@@ -510,7 +500,7 @@ void FileLoader::LoadStats2DBasic(FileInfo::Data ds) {
                     break;
                 }
                 case FileInfo::Data::STATS_2D_NANS: {
-                    auto it = static_cast<casacore::Array<casacore::Int64>*>(data)->begin();
+                    auto it = static_cast<casacore::Array<casacore::Int64>*>(data.get())->begin();
                     for (size_t s = 0; s < _num_stokes; s++) {
                         for (size_t z = 0; z < _depth; z++) {
                             _z_stats[s][z].basic_stats[CARTA::StatsType::NanCount] = *it++;
@@ -521,8 +511,6 @@ void FileLoader::LoadStats2DBasic(FileInfo::Data ds) {
                 default:
                     break;
             }
-
-            delete data;
         }
     }
 }
@@ -531,14 +519,16 @@ void FileLoader::LoadStats2DHist() {
     FileInfo::Data ds = FileInfo::Data::STATS_2D_HIST;
 
     if (HasData(ds)) {
-        const IPos& stat_dims = GetStatsDataShape(ds);
+        const casacore::IPosition& stat_dims = GetStatsDataShape(ds);
         size_t num_bins = stat_dims[0];
 
         // We can handle 2D, 3D and 4D in the same way
-        if ((_num_dims == 2 && stat_dims.isEqual(IPos(1, num_bins))) || (_num_dims == 3 && stat_dims.isEqual(IPos(2, num_bins, _depth))) ||
-            (_num_dims == 4 && stat_dims.isEqual(IPos(3, num_bins, _depth, _num_stokes)))) {
-            auto data = static_cast<casacore::Array<casacore::Int64>*>(GetStatsData(ds));
-            auto it = data->begin();
+        if ((_num_dims == 2 && stat_dims.isEqual(casacore::IPosition(1, num_bins))) ||
+            (_num_dims == 3 && stat_dims.isEqual(casacore::IPosition(2, num_bins, _depth))) ||
+            (_num_dims == 4 && stat_dims.isEqual(casacore::IPosition(3, num_bins, _depth, _num_stokes)))) {
+            auto data = GetStatsData(ds);
+            auto stats_data = static_cast<casacore::Array<casacore::Int64>*>(data.get());
+            auto it = stats_data->begin();
 
             for (size_t s = 0; s < _num_stokes; s++) {
                 for (size_t z = 0; z < _depth; z++) {
@@ -548,8 +538,6 @@ void FileLoader::LoadStats2DHist() {
                     }
                 }
             }
-
-            delete data;
         }
     }
 }
@@ -561,17 +549,19 @@ void FileLoader::LoadStats2DPercent() {
     FileInfo::Data dsp = FileInfo::Data::STATS_2D_PERCENT;
 
     if (HasData(dsp) && HasData(dsr)) {
-        const IPos& dims_vals = GetStatsDataShape(dsp);
-        const IPos& dims_ranks = GetStatsDataShape(dsr);
+        const casacore::IPosition& dims_vals = GetStatsDataShape(dsp);
+        const casacore::IPosition& dims_ranks = GetStatsDataShape(dsr);
 
         size_t num_ranks = dims_ranks[0];
 
         // We can handle 2D, 3D and 4D in the same way
-        if ((_num_dims == 2 && dims_vals.isEqual(IPos(1, num_ranks))) ||
-            (_num_dims == 3 && dims_vals.isEqual(IPos(2, num_ranks, _depth))) ||
-            (_num_dims == 4 && dims_vals.isEqual(IPos(3, num_ranks, _depth, _num_stokes)))) {
-            auto ranks = static_cast<casacore::Array<casacore::Float>*>(GetStatsData(dsr));
-            auto data = static_cast<casacore::Array<casacore::Float>*>(GetStatsData(dsp));
+        if ((_num_dims == 2 && dims_vals.isEqual(casacore::IPosition(1, num_ranks))) ||
+            (_num_dims == 3 && dims_vals.isEqual(casacore::IPosition(2, num_ranks, _depth))) ||
+            (_num_dims == 4 && dims_vals.isEqual(casacore::IPosition(3, num_ranks, _depth, _num_stokes)))) {
+            auto ranks_data = GetStatsData(dsr);
+            auto ranks = static_cast<casacore::Array<casacore::Float>*>(ranks_data.get());
+            auto stats_data = GetStatsData(dsp);
+            auto data = static_cast<casacore::Array<casacore::Float>*>(stats_data.get());
 
             auto it = data->begin();
             auto itr = ranks->begin();
@@ -586,52 +576,49 @@ void FileLoader::LoadStats2DPercent() {
                     }
                 }
             }
-
-            delete ranks;
-            delete data;
         }
     }
 }
 
 void FileLoader::LoadStats3DBasic(FileInfo::Data ds) {
     if (HasData(ds)) {
-        const IPos& stat_dims = GetStatsDataShape(ds);
+        const casacore::IPosition& stat_dims = GetStatsDataShape(ds);
 
         // We can handle 3D and 4D in the same way
-        if ((_num_dims == 3 && stat_dims.size() == 0) || (_num_dims == 4 && stat_dims.isEqual(IPos(1, _num_stokes)))) {
+        if ((_num_dims == 3 && stat_dims.size() == 0) || (_num_dims == 4 && stat_dims.isEqual(casacore::IPosition(1, _num_stokes)))) {
             auto data = GetStatsData(ds);
 
             switch (ds) {
                 case FileInfo::Data::STATS_3D_MAX: {
-                    auto it = static_cast<casacore::Array<casacore::Float>*>(data)->begin();
+                    auto it = static_cast<casacore::Array<casacore::Float>*>(data.get())->begin();
                     for (size_t s = 0; s < _num_stokes; s++) {
                         _cube_stats[s].basic_stats[CARTA::StatsType::Max] = *it++;
                     }
                     break;
                 }
                 case FileInfo::Data::STATS_3D_MIN: {
-                    auto it = static_cast<casacore::Array<casacore::Float>*>(data)->begin();
+                    auto it = static_cast<casacore::Array<casacore::Float>*>(data.get())->begin();
                     for (size_t s = 0; s < _num_stokes; s++) {
                         _cube_stats[s].basic_stats[CARTA::StatsType::Min] = *it++;
                     }
                     break;
                 }
                 case FileInfo::Data::STATS_3D_SUM: {
-                    auto it = static_cast<casacore::Array<casacore::Float>*>(data)->begin();
+                    auto it = static_cast<casacore::Array<casacore::Float>*>(data.get())->begin();
                     for (size_t s = 0; s < _num_stokes; s++) {
                         _cube_stats[s].basic_stats[CARTA::StatsType::Sum] = *it++;
                     }
                     break;
                 }
                 case FileInfo::Data::STATS_3D_SUMSQ: {
-                    auto it = static_cast<casacore::Array<casacore::Float>*>(data)->begin();
+                    auto it = static_cast<casacore::Array<casacore::Float>*>(data.get())->begin();
                     for (size_t s = 0; s < _num_stokes; s++) {
                         _cube_stats[s].basic_stats[CARTA::StatsType::SumSq] = *it++;
                     }
                     break;
                 }
                 case FileInfo::Data::STATS_3D_NANS: {
-                    auto it = static_cast<casacore::Array<casacore::Int64>*>(data)->begin();
+                    auto it = static_cast<casacore::Array<casacore::Int64>*>(data.get())->begin();
                     for (size_t s = 0; s < _num_stokes; s++) {
                         _cube_stats[s].basic_stats[CARTA::StatsType::NanCount] = *it++;
                     }
@@ -640,8 +627,6 @@ void FileLoader::LoadStats3DBasic(FileInfo::Data ds) {
                 default:
                     break;
             }
-
-            delete data;
         }
     }
 }
@@ -650,13 +635,14 @@ void FileLoader::LoadStats3DHist() {
     FileInfo::Data ds = FileInfo::Data::STATS_3D_HIST;
 
     if (HasData(ds)) {
-        const IPos& stat_dims = GetStatsDataShape(ds);
+        const casacore::IPosition& stat_dims = GetStatsDataShape(ds);
         size_t num_bins = stat_dims[0];
 
         // We can handle 3D and 4D in the same way
-        if ((_num_dims == 3 && stat_dims.isEqual(IPos(1, num_bins))) ||
-            (_num_dims == 4 && stat_dims.isEqual(IPos(2, num_bins, _num_stokes)))) {
-            auto data = static_cast<casacore::Array<casacore::Int64>*>(GetStatsData(ds));
+        if ((_num_dims == 3 && stat_dims.isEqual(casacore::IPosition(1, num_bins))) ||
+            (_num_dims == 4 && stat_dims.isEqual(casacore::IPosition(2, num_bins, _num_stokes)))) {
+            auto stats_data = GetStatsData(ds);
+            auto data = static_cast<casacore::Array<casacore::Int64>*>(stats_data.get());
             auto it = data->begin();
 
             for (size_t s = 0; s < _num_stokes; s++) {
@@ -665,8 +651,6 @@ void FileLoader::LoadStats3DHist() {
                     _cube_stats[s].histogram_bins[b] = *it++;
                 }
             }
-
-            delete data;
         }
     }
 }
@@ -678,15 +662,18 @@ void FileLoader::LoadStats3DPercent() {
     FileInfo::Data dsp = FileInfo::Data::STATS_2D_PERCENT;
 
     if (HasData(dsp) && HasData(dsr)) {
-        const IPos& dims_vals = GetStatsDataShape(dsp);
-        const IPos& dims_ranks = GetStatsDataShape(dsr);
+        const casacore::IPosition& dims_vals = GetStatsDataShape(dsp);
+        const casacore::IPosition& dims_ranks = GetStatsDataShape(dsr);
 
         size_t nranks = dims_ranks[0];
 
         // We can handle 3D and 4D in the same way
-        if ((_num_dims == 3 && dims_vals.isEqual(IPos(1, nranks))) || (_num_dims == 4 && dims_vals.isEqual(IPos(2, nranks, _num_stokes)))) {
-            auto ranks = static_cast<casacore::Array<casacore::Float>*>(GetStatsData(dsr));
-            auto data = static_cast<casacore::Array<casacore::Float>*>(GetStatsData(dsp));
+        if ((_num_dims == 3 && dims_vals.isEqual(casacore::IPosition(1, nranks))) ||
+            (_num_dims == 4 && dims_vals.isEqual(casacore::IPosition(2, nranks, _num_stokes)))) {
+            auto ranks_data = GetStatsData(dsr);
+            auto ranks = static_cast<casacore::Array<casacore::Float>*>(ranks_data.get());
+            auto stats_data = GetStatsData(dsp);
+            auto data = static_cast<casacore::Array<casacore::Float>*>(stats_data.get());
 
             auto it = data->begin();
             auto itr = ranks->begin();
@@ -699,9 +686,6 @@ void FileLoader::LoadStats3DPercent() {
                     _cube_stats[s].percentile_ranks[r] = *itr++;
                 }
             }
-
-            delete ranks;
-            delete data;
         }
     }
 }
@@ -865,11 +849,11 @@ double FileLoader::CalculateBeamArea() {
 
     CloseImageIfUpdated();
 
-    if (!info.hasSingleBeam() || !_coord_sys.hasDirectionCoordinate()) {
+    if (!info.hasSingleBeam() || !_coord_sys->hasDirectionCoordinate()) {
         return NAN;
     }
 
-    return info.getBeamAreaInPixels(-1, -1, _coord_sys.directionCoordinate());
+    return info.getBeamAreaInPixels(-1, -1, _coord_sys->directionCoordinate());
 }
 
 bool FileLoader::GetStokesTypeIndex(const CARTA::PolarizationType& stokes_type, int& stokes_index) {

--- a/src/ImageData/FileLoader.h
+++ b/src/ImageData/FileLoader.h
@@ -25,7 +25,6 @@ class Frame;
 class FileLoader {
 public:
     using ImageRef = std::shared_ptr<casacore::ImageInterface<float>>;
-    using IPos = casacore::IPosition;
 
     // directory only for ExprLoader, is_gz only for FitsLoader
     FileLoader(const std::string& filename, const std::string& directory = "", bool is_gz = false);
@@ -52,9 +51,9 @@ public:
     bool GetBeams(std::vector<CARTA::Beam>& beams, std::string& error);
 
     // Image shape and coordinate system axes
-    bool GetShape(IPos& shape);
-    bool GetCoordinateSystem(casacore::CoordinateSystem& coord_sys);
-    bool FindCoordinateAxes(IPos& shape, int& spectral_axis, int& z_axis, int& stokes_axis, std::string& message);
+    casacore::IPosition GetShape();
+    std::shared_ptr<casacore::CoordinateSystem> GetCoordinateSystem();
+    bool FindCoordinateAxes(casacore::IPosition& shape, int& spectral_axis, int& z_axis, int& stokes_axis, std::string& message);
     std::vector<int> GetRenderAxes(); // Determine axes used for image raster data
 
     // Slice image data (with mask applied)
@@ -122,7 +121,7 @@ protected:
     int _z_axis, _stokes_axis;
     std::vector<int> _render_axes;
     // Coordinate system
-    casacore::CoordinateSystem _coord_sys;
+    std::shared_ptr<casacore::CoordinateSystem> _coord_sys;
     // Pixel mask
     bool _has_pixel_mask;
 
@@ -137,10 +136,10 @@ protected:
     int _stokes_cdelt;
 
     // Return the shape of the specified stats dataset
-    virtual const IPos GetStatsDataShape(FileInfo::Data ds);
+    virtual const casacore::IPosition GetStatsDataShape(FileInfo::Data ds);
 
     // Return stats data as a casacore::Array of type casacore::Float or casacore::Int64
-    virtual casacore::ArrayBase* GetStatsData(FileInfo::Data ds);
+    virtual std::unique_ptr<casacore::ArrayBase> GetStatsData(FileInfo::Data ds);
 
     // Functions for loading individual types of statistics
     virtual void LoadStats2DBasic(FileInfo::Data ds);

--- a/src/ImageData/FitsLoader.h
+++ b/src/ImageData/FitsLoader.h
@@ -115,7 +115,7 @@ void FitsLoader::OpenFile(const std::string& hdu) {
         _image_shape = _image->shape();
         _num_dims = _image_shape.size();
         _has_pixel_mask = _image->hasPixelMask();
-        _coord_sys = _image->coordinates();
+        _coord_sys = std::shared_ptr<casacore::CoordinateSystem>(static_cast<casacore::CoordinateSystem*>(_image->coordinates().clone()));
     }
 }
 

--- a/src/ImageData/Hdf5Loader.cc
+++ b/src/ImageData/Hdf5Loader.cc
@@ -29,7 +29,7 @@ void Hdf5Loader::OpenFile(const std::string& hdu) {
         _image_shape = _image->shape();
         _num_dims = _image_shape.size();
         _has_pixel_mask = _image->hasPixelMask();
-        _coord_sys = _image->coordinates();
+        _coord_sys = std::shared_ptr<casacore::CoordinateSystem>(static_cast<casacore::CoordinateSystem*>(_image->coordinates().clone()));
 
         // Load swizzled image lattice
         if (HasData(FileInfo::Data::SWIZZLED)) {
@@ -156,10 +156,10 @@ bool Hdf5Loader::HasMip(int mip) const {
 // TODO: The datatype used to create the HDF5DataSet has to match the native type exactly, but the data can be read into an array of the
 // same type class. We cannot guarantee a particular native type -- e.g. some files use doubles instead of floats. This necessitates this
 // complicated templating, at least for now.
-const Hdf5Loader::IPos Hdf5Loader::GetStatsDataShape(FileInfo::Data ds) {
+const casacore::IPosition Hdf5Loader::GetStatsDataShape(FileInfo::Data ds) {
     auto image = GetImage();
     if (!image) {
-        return IPos();
+        return casacore::IPosition();
     }
 
     CartaHdf5Image* hdf5_image = dynamic_cast<CartaHdf5Image*>(image.get());
@@ -186,7 +186,7 @@ const Hdf5Loader::IPos Hdf5Loader::GetStatsDataShape(FileInfo::Data ds) {
 // TODO: The datatype used to create the HDF5DataSet has to match the native type exactly, but the data can be read into an array of the
 // same type class. We cannot guarantee a particular native type -- e.g. some files use doubles instead of floats. This necessitates this
 // complicated templating, at least for now.
-casacore::ArrayBase* Hdf5Loader::GetStatsData(FileInfo::Data ds) {
+std::unique_ptr<casacore::ArrayBase> Hdf5Loader::GetStatsData(FileInfo::Data ds) {
     auto image = GetImage();
     if (!image) {
         throw casacore::HDF5Error("Cannot get dataset " + DataSetToString(ds) + " from invalid image.");
@@ -222,9 +222,10 @@ bool Hdf5Loader::GetCursorSpectralData(
     if (has_swizzled) {
         casacore::Slicer slicer;
         if (_num_dims == 4) {
-            slicer = casacore::Slicer(IPos(4, 0, cursor_y, cursor_x, stokes), IPos(4, _depth, count_y, count_x, 1));
+            slicer = casacore::Slicer(
+                casacore::IPosition(4, 0, cursor_y, cursor_x, stokes), casacore::IPosition(4, _depth, count_y, count_x, 1));
         } else if (_num_dims == 3) {
-            slicer = casacore::Slicer(IPos(3, 0, cursor_y, cursor_x), IPos(3, _depth, count_y, count_x));
+            slicer = casacore::Slicer(casacore::IPosition(3, 0, cursor_y, cursor_x), casacore::IPosition(3, _depth, count_y, count_x));
         }
 
         data.resize(_depth * count_y * count_x);
@@ -240,7 +241,7 @@ bool Hdf5Loader::GetCursorSpectralData(
     return data_ok;
 }
 
-bool Hdf5Loader::UseRegionSpectralData(const IPos& region_shape, std::mutex& image_mutex) {
+bool Hdf5Loader::UseRegionSpectralData(const casacore::IPosition& region_shape, std::mutex& image_mutex) {
     std::unique_lock<std::mutex> ulock(image_mutex);
     bool has_swizzled = HasData(FileInfo::Data::SWIZZLED);
     ulock.unlock();
@@ -261,8 +262,8 @@ bool Hdf5Loader::UseRegionSpectralData(const IPos& region_shape, std::mutex& ima
     return true;
 }
 
-bool Hdf5Loader::GetRegionSpectralData(int region_id, int stokes, const casacore::ArrayLattice<casacore::Bool>& mask, const IPos& origin,
-    std::mutex& image_mutex, std::map<CARTA::StatsType, std::vector<double>>& results, float& progress) {
+bool Hdf5Loader::GetRegionSpectralData(int region_id, int stokes, const casacore::ArrayLattice<casacore::Bool>& mask,
+    const casacore::IPosition& origin, std::mutex& image_mutex, std::map<CARTA::StatsType, std::vector<double>>& results, float& progress) {
     // Return calculated stats if valid and complete,
     // or return accumulated stats for the next incomplete "x" slice of swizzled data (chan vs y).
     // Calling function should check for complete progress when x-range of region is complete
@@ -277,7 +278,7 @@ bool Hdf5Loader::GetRegionSpectralData(int region_id, int stokes, const casacore
 
     // Check if region stats calculated
     auto region_stats_id = FileInfo::RegionStatsId(region_id, stokes);
-    IPos mask_shape(mask.shape());
+    casacore::IPosition mask_shape(mask.shape());
     if (_region_stats.count(region_stats_id) && _region_stats[region_stats_id].IsValid(origin, mask_shape) &&
         _region_stats[region_stats_id].IsCompleted()) {
         results = _region_stats[region_stats_id].stats;
@@ -381,7 +382,7 @@ bool Hdf5Loader::GetRegionSpectralData(int region_id, int stokes, const casacore
 
         for (size_t y = 0; y < height; y++) {
             // skip all Z values for masked pixels
-            if (!mask.getAt(IPos(2, x, y))) {
+            if (!mask.getAt(casacore::IPosition(2, x, y))) {
                 continue;
             }
 
@@ -444,11 +445,11 @@ bool Hdf5Loader::GetDownsampledRasterData(
 
     casacore::Slicer slicer;
     if (_num_dims == 4) {
-        slicer = casacore::Slicer(IPos(4, xmin, ymin, z, stokes), IPos(4, w, h, 1, 1));
+        slicer = casacore::Slicer(casacore::IPosition(4, xmin, ymin, z, stokes), casacore::IPosition(4, w, h, 1, 1));
     } else if (_num_dims == 3) {
-        slicer = casacore::Slicer(IPos(3, xmin, ymin, z), IPos(3, w, h, 1));
+        slicer = casacore::Slicer(casacore::IPosition(3, xmin, ymin, z), casacore::IPosition(3, w, h, 1));
     } else if (_num_dims == 2) {
-        slicer = casacore::Slicer(IPos(2, xmin, ymin), IPos(2, w, h));
+        slicer = casacore::Slicer(casacore::IPosition(2, xmin, ymin), casacore::IPosition(2, w, h));
     } else {
         return false;
     }
@@ -476,11 +477,11 @@ bool Hdf5Loader::GetChunk(
 
     casacore::Slicer slicer;
     if (_num_dims == 4) {
-        slicer = casacore::Slicer(IPos(4, min_x, min_y, z, stokes), IPos(4, data_width, data_height, 1, 1));
+        slicer = casacore::Slicer(casacore::IPosition(4, min_x, min_y, z, stokes), casacore::IPosition(4, data_width, data_height, 1, 1));
     } else if (_num_dims == 3) {
-        slicer = casacore::Slicer(IPos(3, min_x, min_y, z), IPos(3, data_width, data_height, 1));
+        slicer = casacore::Slicer(casacore::IPosition(3, min_x, min_y, z), casacore::IPosition(3, data_width, data_height, 1));
     } else if (_num_dims == 2) {
-        slicer = casacore::Slicer(IPos(2, min_x, min_y), IPos(2, data_width, data_height));
+        slicer = casacore::Slicer(casacore::IPosition(2, min_x, min_y), casacore::IPosition(2, data_width, data_height));
     }
 
     data.resize(data_width * data_height);

--- a/src/ImageData/Hdf5Loader.h
+++ b/src/ImageData/Hdf5Loader.h
@@ -32,9 +32,10 @@ public:
     bool GetCursorSpectralData(
         std::vector<float>& data, int stokes, int cursor_x, int count_x, int cursor_y, int count_y, std::mutex& image_mutex) override;
 
-    bool UseRegionSpectralData(const IPos& region_shape, std::mutex& image_mutex) override;
-    bool GetRegionSpectralData(int region_id, int stokes, const casacore::ArrayLattice<casacore::Bool>& mask, const IPos& origin,
-        std::mutex& image_mutex, std::map<CARTA::StatsType, std::vector<double>>& results, float& progress) override;
+    bool UseRegionSpectralData(const casacore::IPosition& region_shape, std::mutex& image_mutex) override;
+    bool GetRegionSpectralData(int region_id, int stokes, const casacore::ArrayLattice<casacore::Bool>& mask,
+        const casacore::IPosition& origin, std::mutex& image_mutex, std::map<CARTA::StatsType, std::vector<double>>& results,
+        float& progress) override;
     bool GetDownsampledRasterData(
         std::vector<float>& data, int z, int stokes, CARTA::ImageBounds& bounds, int mip, std::mutex& image_mutex) override;
     bool GetChunk(std::vector<float>& data, int& data_width, int& data_height, int min_x, int min_y, int z, int stokes,
@@ -56,12 +57,12 @@ private:
     bool HasData(std::string ds_name) const;
 
     template <typename T>
-    const IPos GetStatsDataShapeTyped(FileInfo::Data ds);
+    const casacore::IPosition GetStatsDataShapeTyped(FileInfo::Data ds);
     template <typename S, typename D>
-    casacore::ArrayBase* GetStatsDataTyped(FileInfo::Data ds);
+    std::unique_ptr<casacore::ArrayBase> GetStatsDataTyped(FileInfo::Data ds);
 
-    const IPos GetStatsDataShape(FileInfo::Data ds) override;
-    casacore::ArrayBase* GetStatsData(FileInfo::Data ds) override;
+    const casacore::IPosition GetStatsDataShape(FileInfo::Data ds) override;
+    std::unique_ptr<casacore::ArrayBase> GetStatsData(FileInfo::Data ds) override;
 
     casacore::Lattice<float>* LoadSwizzledData();
     casacore::Lattice<float>* LoadMipMapData(int mip);

--- a/src/ImageData/ImagePtrLoader.h
+++ b/src/ImageData/ImagePtrLoader.h
@@ -24,7 +24,7 @@ ImagePtrLoader::ImagePtrLoader(std::shared_ptr<casacore::ImageInterface<float>> 
     _image_shape = _image->shape();
     _num_dims = _image_shape.size();
     _has_pixel_mask = _image->hasPixelMask();
-    _coord_sys = _image->coordinates();
+    _coord_sys = std::shared_ptr<casacore::CoordinateSystem>(static_cast<casacore::CoordinateSystem*>(_image->coordinates().clone()));
 }
 
 void ImagePtrLoader::OpenFile(const std::string& /*hdu*/) {}

--- a/src/ImageData/MiriadLoader.h
+++ b/src/ImageData/MiriadLoader.h
@@ -63,7 +63,7 @@ void MiriadLoader::OpenFile(const std::string& /*hdu*/) {
         _image_shape = _image->shape();
         _num_dims = _image_shape.size();
         _has_pixel_mask = _image->hasPixelMask();
-        _coord_sys = _image->coordinates();
+        _coord_sys = std::shared_ptr<casacore::CoordinateSystem>(static_cast<casacore::CoordinateSystem*>(_image->coordinates().clone()));
     }
 }
 

--- a/src/ImageData/StokesFilesConnector.cc
+++ b/src/ImageData/StokesFilesConnector.cc
@@ -47,44 +47,34 @@ bool StokesFilesConnector::DoConcat(const CARTA::ConcatStokesFiles& message, CAR
 
     if (stokes_axis < 0) { // create a stokes coordinate and add it to the coordinate system
         std::unordered_map<CARTA::PolarizationType, std::shared_ptr<casacore::ExtendImage<float>>> extended_images;
-        std::unordered_map<CARTA::PolarizationType, casacore::CoordinateSystem> coord_sys;
+        std::unordered_map<CARTA::PolarizationType, std::shared_ptr<casacore::CoordinateSystem>> coord_sys;
         CARTA::PolarizationType carta_stokes_type;
 
         // modify the coordinate system and add a stokes coordinate
         for (auto& loader : _loaders) {
             carta_stokes_type = loader.first;
-            casacore::CoordinateSystem tmp_coord_sys;
+            std::shared_ptr<casacore::CoordinateSystem> tmp_coord_sys = loader.second->GetCoordinateSystem();
 
-            if (loader.second->GetCoordinateSystem(tmp_coord_sys)) {
-                casacore::Vector<casacore::Int> vec(1);
-                casacore::Stokes::StokesTypes stokes_type;
+            casacore::Vector<casacore::Int> vec(1);
+            casacore::Stokes::StokesTypes stokes_type;
 
-                if (GetCasaStokesType(carta_stokes_type, stokes_type)) {
-                    vec(0) = stokes_type;                         // set stokes type
-                    casacore::StokesCoordinate stokes_coord(vec); // set stokes coordinate
-                    tmp_coord_sys.addCoordinate(stokes_coord);    // add stokes coordinate to the coordinate system
-                    coord_sys[carta_stokes_type] = tmp_coord_sys; // fill the new coordinate system map
-                } else {
-                    return fail_exit("Failed to set the stokes coordinate system!");
-                }
+            if (GetCasaStokesType(carta_stokes_type, stokes_type)) {
+                vec(0) = stokes_type;                         // set stokes type
+                casacore::StokesCoordinate stokes_coord(vec); // set stokes coordinate
+                tmp_coord_sys->addCoordinate(stokes_coord);   // add stokes coordinate to the coordinate system
+                coord_sys[carta_stokes_type] = tmp_coord_sys; // fill the new coordinate system map
             } else {
-                return fail_exit("Failed to get the coordinate system!");
+                return fail_exit("Failed to set the stokes coordinate system!");
             }
         }
 
         // extend the image shapes
         auto& sample_loader = _loaders[carta_stokes_type];
-        casacore::IPosition old_image_shape;
-        casacore::IPosition new_image_shape;
-
-        if (sample_loader->GetShape(old_image_shape)) {
-            new_image_shape.resize(old_image_shape.size() + 1);
-            new_image_shape = 1;
-            for (int i = 0; i < old_image_shape.size(); ++i) {
-                new_image_shape(i) = old_image_shape(i);
-            }
-        } else {
-            return fail_exit("Failed to extend the image shape!");
+        casacore::IPosition old_image_shape = sample_loader->GetShape();
+        casacore::IPosition new_image_shape(old_image_shape.size() + 1);
+        new_image_shape = 1;
+        for (int i = 0; i < old_image_shape.size(); ++i) {
+            new_image_shape(i) = old_image_shape(i);
         }
 
         // modify the original image and extend the image coordinate system with a stokes coordinate
@@ -93,14 +83,14 @@ bool StokesFilesConnector::DoConcat(const CARTA::ConcatStokesFiles& message, CAR
             auto image = loader.second->GetImage();
             try {
                 extended_images[stokes_type] =
-                    std::make_shared<casacore::ExtendImage<float>>(*(image.get()), new_image_shape, coord_sys[stokes_type]);
+                    std::make_shared<casacore::ExtendImage<float>>(*(image.get()), new_image_shape, *coord_sys[stokes_type]);
             } catch (const casacore::AipsError& error) {
                 return fail_exit(fmt::format("Failed to extend the image: {}", error.getMesg()));
             }
         }
 
         // get stokes axis
-        stokes_axis = coord_sys[carta_stokes_type].polarizationAxisNumber();
+        stokes_axis = coord_sys[carta_stokes_type]->polarizationAxisNumber();
 
         // concatenate images along the stokes axis
         concatenated_image = std::make_shared<casacore::ImageConcat<float>>(stokes_axis);

--- a/src/Region/CrtfImportExport.cc
+++ b/src/Region/CrtfImportExport.cc
@@ -30,8 +30,8 @@
 
 using namespace carta;
 
-CrtfImportExport::CrtfImportExport(casacore::CoordinateSystem* image_coord_sys, const casacore::IPosition& image_shape, int stokes_axis,
-    int file_id, const std::string& file, bool file_is_filename)
+CrtfImportExport::CrtfImportExport(std::shared_ptr<casacore::CoordinateSystem> image_coord_sys, const casacore::IPosition& image_shape,
+    int stokes_axis, int file_id, const std::string& file, bool file_is_filename)
     : RegionImportExport(image_coord_sys, image_shape, file_id), _stokes_axis(stokes_axis) {
     // Import regions from CRTF region file
     // Set delimiters for parsing file lines
@@ -88,14 +88,11 @@ CrtfImportExport::CrtfImportExport(casacore::CoordinateSystem* image_coord_sys, 
     }
 }
 
-CrtfImportExport::CrtfImportExport(casacore::CoordinateSystem* image_coord_sys, const casacore::IPosition& image_shape, int stokes_axis)
+CrtfImportExport::CrtfImportExport(
+    std::shared_ptr<casacore::CoordinateSystem> image_coord_sys, const casacore::IPosition& image_shape, int stokes_axis)
     : RegionImportExport(image_coord_sys, image_shape), _stokes_axis(stokes_axis) {
     // Export regions; will add each region to RegionTextList
     _region_list = casa::RegionTextList(*image_coord_sys, image_shape);
-}
-
-CrtfImportExport::~CrtfImportExport() {
-    delete _coord_sys;
 }
 
 // Public: for exporting regions

--- a/src/Region/CrtfImportExport.h
+++ b/src/Region/CrtfImportExport.h
@@ -22,20 +22,16 @@ namespace carta {
 
 class CrtfImportExport : public RegionImportExport {
 public:
-    CrtfImportExport() {}
-
     // Import constructor
     // Use casa::RegionTextList to create casa::Annotation AnnRegions for RegionState parameters
     // file_is_filename : indicates whether file parameter contains file name or file contents.
-    CrtfImportExport(casacore::CoordinateSystem* image_coord_sys, const casacore::IPosition& image_shape, int stokes_axis, int file_id,
-        const std::string& file, bool file_is_filename);
+    CrtfImportExport(std::shared_ptr<casacore::CoordinateSystem> image_coord_sys, const casacore::IPosition& image_shape, int stokes_axis,
+        int file_id, const std::string& file, bool file_is_filename);
 
     // Export constructor
     // Creates casa::RegionTextList to which casa::AnnRegion/AnnSymbol regions are added with AddExportRegion.
     // ExportRegions prints these regions to a file or vector of strings.
-    CrtfImportExport(casacore::CoordinateSystem* image_coord_sys, const casacore::IPosition& image_shape, int stokes_axis);
-
-    ~CrtfImportExport() override;
+    CrtfImportExport(std::shared_ptr<casacore::CoordinateSystem> image_coord_sys, const casacore::IPosition& image_shape, int stokes_axis);
 
     // Export regions
     // Export using RegionState pixel control points

--- a/src/Region/Ds9ImportExport.cc
+++ b/src/Region/Ds9ImportExport.cc
@@ -20,8 +20,8 @@
 
 using namespace carta;
 
-Ds9ImportExport::Ds9ImportExport(casacore::CoordinateSystem* image_coord_sys, const casacore::IPosition& image_shape, int file_id,
-    const std::string& file, bool file_is_filename)
+Ds9ImportExport::Ds9ImportExport(std::shared_ptr<casacore::CoordinateSystem> image_coord_sys, const casacore::IPosition& image_shape,
+    int file_id, const std::string& file, bool file_is_filename)
     : RegionImportExport(image_coord_sys, image_shape, file_id), _file_ref_frame("physical"), _pixel_coord(true) {
     // Import regions in DS9 format
     SetParserDelim(" ,()#");
@@ -29,7 +29,8 @@ Ds9ImportExport::Ds9ImportExport(casacore::CoordinateSystem* image_coord_sys, co
     ProcessFileLines(lines);
 }
 
-Ds9ImportExport::Ds9ImportExport(casacore::CoordinateSystem* image_coord_sys, const casacore::IPosition& image_shape, bool pixel_coord)
+Ds9ImportExport::Ds9ImportExport(
+    std::shared_ptr<casacore::CoordinateSystem> image_coord_sys, const casacore::IPosition& image_shape, bool pixel_coord)
     : RegionImportExport(image_coord_sys, image_shape), _pixel_coord(pixel_coord) {
     // Export regions to DS9 format
     // Set coordinate system for file header
@@ -55,10 +56,6 @@ Ds9ImportExport::Ds9ImportExport(casacore::CoordinateSystem* image_coord_sys, co
     }
 
     AddHeader();
-}
-
-Ds9ImportExport::~Ds9ImportExport() {
-    delete _coord_sys;
 }
 
 void Ds9ImportExport::InitGlobalProperties() {

--- a/src/Region/Ds9ImportExport.h
+++ b/src/Region/Ds9ImportExport.h
@@ -19,19 +19,15 @@ namespace carta {
 
 class Ds9ImportExport : public RegionImportExport {
 public:
-    Ds9ImportExport() {}
-
     // Import constructor
     // Parse input file and convert region parameters to RegionProperties for given image
     // file_is_filename : indicates whether file parameter contains file name or file contents.
-    Ds9ImportExport(casacore::CoordinateSystem* image_coord_sys, const casacore::IPosition& image_shape, int file_id,
+    Ds9ImportExport(std::shared_ptr<casacore::CoordinateSystem> image_coord_sys, const casacore::IPosition& image_shape, int file_id,
         const std::string& file, bool file_is_filename);
 
     // Export constructor
     // Each export region will be converted to a string in DS9 format and added to string vector
-    Ds9ImportExport(casacore::CoordinateSystem* image_coord_sys, const casacore::IPosition& image_shape, bool pixel_coord);
-
-    ~Ds9ImportExport() override;
+    Ds9ImportExport(std::shared_ptr<casacore::CoordinateSystem> image_coord_sys, const casacore::IPosition& image_shape, bool pixel_coord);
 
     // Export regions
     // RegionState control points for pixel coords in reference image

--- a/src/Region/Region.cc
+++ b/src/Region/Region.cc
@@ -28,13 +28,9 @@
 
 using namespace carta;
 
-Region::Region(const RegionState& state, casacore::CoordinateSystem* csys)
+Region::Region(const RegionState& state, std::shared_ptr<casacore::CoordinateSystem> csys)
     : _coord_sys(csys), _valid(false), _region_changed(false), _reference_region_set(false), _region_state(state) {
     _valid = CheckPoints(state.control_points, state.type);
-}
-
-Region::~Region() {
-    delete _coord_sys;
 }
 
 // *************************************************************************
@@ -350,11 +346,11 @@ bool Region::EllipsePointsToWorld(
 // *************************************************************************
 // Apply region to any image
 
-casacore::LCRegion* Region::GetImageRegion(
-    int file_id, const casacore::CoordinateSystem& output_csys, const casacore::IPosition& output_shape, bool report_error) {
+std::shared_ptr<casacore::LCRegion> Region::GetImageRegion(
+    int file_id, std::shared_ptr<casacore::CoordinateSystem> output_csys, const casacore::IPosition& output_shape, bool report_error) {
     // Apply region to non-reference image as converted polygon vertices
     // Will return nullptr if outside image or is not a closed LCRegion (line or polyline)
-    casacore::LCRegion* lc_region(nullptr);
+    std::shared_ptr<casacore::LCRegion> lc_region;
     if (IsAnnotation()) {
         return lc_region;
     }
@@ -383,9 +379,7 @@ casacore::LCRegion* Region::GetImageRegion(
 
                 // Cache converted polygon
                 if (lc_region) {
-                    casacore::LCRegion* region_copy = lc_region->cloneRegion();
-                    auto polygon_region = std::shared_ptr<casacore::LCRegion>(region_copy);
-                    _polygon_regions[file_id] = std::move(polygon_region);
+                    _polygon_regions[file_id] = lc_region;
                 }
             }
         }
@@ -394,7 +388,7 @@ casacore::LCRegion* Region::GetImageRegion(
     return lc_region;
 }
 
-bool Region::UseApproximatePolygon(const casacore::CoordinateSystem& output_csys) {
+bool Region::UseApproximatePolygon(std::shared_ptr<casacore::CoordinateSystem> output_csys) {
     // Determine whether to convert region directly, or approximate it as a polygon in the output image.
     bool use_polygon(true);
     CARTA::RegionType region_type = _region_state.type;
@@ -486,21 +480,20 @@ std::vector<CARTA::Point> Region::GetRectangleMidpoints() {
     return midpoints;
 }
 
-casacore::LCRegion* Region::GetCachedPolygonRegion(int file_id) {
+std::shared_ptr<casacore::LCRegion> Region::GetCachedPolygonRegion(int file_id) {
     // Return cached polygon region applied to image with file_id
-    casacore::LCRegion* lc_polygon(nullptr);
     if (_polygon_regions.count(file_id)) {
-        std::unique_lock<std::mutex> ulock(_region_mutex);
-        lc_polygon = _polygon_regions.at(file_id)->cloneRegion();
-        ulock.unlock();
+        std::lock_guard<std::mutex> guard(_region_mutex);
+        return _polygon_regions.at(file_id);
     }
-    return lc_polygon;
+
+    return std::shared_ptr<casacore::LCRegion>();
 }
 
-casacore::LCRegion* Region::GetAppliedPolygonRegion(
-    int file_id, const casacore::CoordinateSystem& output_csys, const casacore::IPosition& output_shape) {
+std::shared_ptr<casacore::LCRegion> Region::GetAppliedPolygonRegion(
+    int file_id, std::shared_ptr<casacore::CoordinateSystem> output_csys, const casacore::IPosition& output_shape) {
     // Approximate region as polygon pixel vertices, and convert to given csys
-    casacore::LCRegion* lc_region(nullptr);
+    std::shared_ptr<casacore::LCRegion> lc_region;
 
     bool is_point(_region_state.type == CARTA::RegionType::POINT);
     size_t nvertices(is_point ? 1 : DEFAULT_VERTEX_COUNT);
@@ -527,12 +520,12 @@ casacore::LCRegion* Region::GetAppliedPolygonRegion(
                     trc(i) = output_shape(i) - 1;
                 }
 
-                lc_region = new casacore::LCBox(blc, trc, output_shape);
+                lc_region.reset(new casacore::LCBox(blc, trc, output_shape));
             } else {
                 // Need 2-dim shape
                 casacore::IPosition keep_axes(2, 0, 1);
                 casacore::IPosition region_shape(output_shape.keepAxes(keep_axes));
-                lc_region = new casacore::LCPolygon(x, y, region_shape);
+                lc_region.reset(new casacore::LCPolygon(x, y, region_shape));
             }
         } catch (const casacore::AipsError& err) {
             spdlog::error("Cannot apply {} to file {}: {}", RegionName(_region_state.type), file_id, err.getMesg());
@@ -670,7 +663,7 @@ double Region::GetTotalSegmentLength(std::vector<CARTA::Point>& points) {
     return total_length;
 }
 
-bool Region::ConvertPointsToImagePixels(const std::vector<CARTA::Point>& points, const casacore::CoordinateSystem& output_csys,
+bool Region::ConvertPointsToImagePixels(const std::vector<CARTA::Point>& points, std::shared_ptr<casacore::CoordinateSystem> output_csys,
     casacore::Vector<casacore::Double>& x, casacore::Vector<casacore::Double>& y) {
     // Convert pixel coords in reference image (points) to pixel coords in output image
     // Coordinates returned in x and y vectors
@@ -713,32 +706,32 @@ casacore::ArrayLattice<casacore::Bool> Region::GetImageRegionMask(int file_id) {
     // Return pixel mask for this region; requires that lcregion for this file id has been set.
     // Otherwise mask is empty array.
     casacore::ArrayLattice<casacore::Bool> mask;
-    casacore::LCRegion* lcregion(nullptr);
     if (IsAnnotation()) {
         return mask;
     }
 
+    std::shared_ptr<casacore::LCRegion> lcregion;
     if ((file_id == _region_state.reference_file_id) && _applied_regions.count(file_id)) {
         if (_applied_regions.at(file_id)) {
             std::lock_guard<std::mutex> guard(_region_mutex);
-            lcregion = _applied_regions.at(file_id)->cloneRegion();
+            lcregion = _applied_regions.at(file_id);
         }
     } else if (_polygon_regions.count(file_id)) {
         if (_polygon_regions.at(file_id)) {
             std::lock_guard<std::mutex> guard(_region_mutex);
-            lcregion = _polygon_regions.at(file_id)->cloneRegion();
+            lcregion = _polygon_regions.at(file_id);
         }
     }
 
     if (lcregion) {
         std::lock_guard<std::mutex> guard(_region_mutex);
         // Region can either be an extension region or a fixed region, depending on whether image is matched or not
-        auto extended_region = dynamic_cast<casacore::LCExtension*>(lcregion);
+        auto extended_region = dynamic_cast<casacore::LCExtension*>(lcregion.get());
         if (extended_region) {
             auto& fixed_region = static_cast<const casacore::LCRegionFixed&>(extended_region->region());
             mask = fixed_region.getMask();
         } else {
-            auto fixed_region = dynamic_cast<casacore::LCRegionFixed*>(lcregion);
+            auto fixed_region = dynamic_cast<casacore::LCRegionFixed*>(lcregion.get());
             if (fixed_region) {
                 mask = fixed_region->getMask();
             }
@@ -752,7 +745,7 @@ casacore::ArrayLattice<casacore::Bool> Region::GetImageRegionMask(int file_id) {
 // Apply region to any image and return LCRegion Record for export
 
 casacore::TableRecord Region::GetImageRegionRecord(
-    int file_id, const casacore::CoordinateSystem& output_csys, const casacore::IPosition& output_shape) {
+    int file_id, std::shared_ptr<casacore::CoordinateSystem> output_csys, const casacore::IPosition& output_shape) {
     // Return Record describing Region applied to output coord sys and image_shape in pixel coordinates
     casacore::TableRecord record;
 
@@ -761,7 +754,7 @@ casacore::TableRecord Region::GetImageRegionRecord(
     } else {
         // Get converted LCRegion
         // Check applied regions cache
-        casacore::LCRegion* lc_region = GetCachedLCRegion(file_id);
+        std::shared_ptr<casacore::LCRegion> lc_region = GetCachedLCRegion(file_id);
 
         if (!lc_region) {
             // Convert reference region to output image
@@ -786,23 +779,20 @@ casacore::TableRecord Region::GetImageRegionRecord(
     return record;
 }
 
-casacore::LCRegion* Region::GetCachedLCRegion(int file_id) {
+std::shared_ptr<casacore::LCRegion> Region::GetCachedLCRegion(int file_id) {
     // Return cached region applied to image with file_id
-    casacore::LCRegion* lc_region(nullptr);
-
     if (_applied_regions.count(file_id)) {
-        std::unique_lock<std::mutex> ulock(_region_mutex);
-        lc_region = _applied_regions.at(file_id)->cloneRegion();
-        ulock.unlock();
+        std::lock_guard<std::mutex> ulock(_region_mutex);
+        return _applied_regions.at(file_id);
     }
 
-    return lc_region;
+    return std::shared_ptr<casacore::LCRegion>();
 }
 
-casacore::LCRegion* Region::GetConvertedLCRegion(
-    int file_id, const casacore::CoordinateSystem& output_csys, const casacore::IPosition& output_shape, bool report_error) {
+std::shared_ptr<casacore::LCRegion> Region::GetConvertedLCRegion(
+    int file_id, std::shared_ptr<casacore::CoordinateSystem> output_csys, const casacore::IPosition& output_shape, bool report_error) {
     // Convert 2D reference WCRegion to LCRegion in output coord_sys and shape
-    casacore::LCRegion* lc_region(nullptr);
+    std::shared_ptr<casacore::LCRegion> lc_region;
     bool is_reference_image(file_id == _region_state.reference_file_id);
 
     if (!is_reference_image && IsRotbox()) {
@@ -821,11 +811,11 @@ casacore::LCRegion* Region::GetConvertedLCRegion(
         std::lock_guard<std::mutex> guard(_region_mutex);
         if (ReferenceRegionValid()) {
             std::shared_ptr<const casacore::WCRegion> reference_region = std::atomic_load(&_reference_region);
-            lc_region = reference_region->toLCRegion(output_csys, output_shape);
+            lc_region.reset(reference_region->toLCRegion(*output_csys.get(), output_shape));
         } else if (is_reference_image) {
             // Create LCRegion with control points for reference image
             casacore::TableRecord region_record = GetControlPointsRecord(output_shape);
-            lc_region = casacore::LCRegion::fromRecord(region_record, "");
+            lc_region.reset(casacore::LCRegion::fromRecord(region_record, ""));
         }
     } catch (const casacore::AipsError& err) {
         if (report_error) {
@@ -836,16 +826,14 @@ casacore::LCRegion* Region::GetConvertedLCRegion(
     if (lc_region) {
         // Make a copy and cache LCRegion in map
         std::lock_guard<std::mutex> guard(_region_mutex);
-        casacore::LCRegion* region_copy = lc_region->cloneRegion();
-        auto applied_region = std::shared_ptr<casacore::LCRegion>(region_copy);
-        _applied_regions[file_id] = std::move(applied_region);
+        _applied_regions[file_id] = lc_region;
     }
 
     return lc_region;
 }
 
 casacore::TableRecord Region::GetRegionPointsRecord(
-    int file_id, const casacore::CoordinateSystem& output_csys, const casacore::IPosition& output_shape) {
+    int file_id, std::shared_ptr<casacore::CoordinateSystem> output_csys, const casacore::IPosition& output_shape) {
     // Convert control points to output coord sys if needed, and return completed record.
     casacore::TableRecord record;
     if (file_id == _region_state.reference_file_id) {
@@ -1000,7 +988,8 @@ void Region::CompleteLCRegionRecord(casacore::TableRecord& record, const casacor
     }
 }
 
-casacore::TableRecord Region::GetPointRecord(const casacore::CoordinateSystem& output_csys, const casacore::IPosition& output_shape) {
+casacore::TableRecord Region::GetPointRecord(
+    std::shared_ptr<casacore::CoordinateSystem> output_csys, const casacore::IPosition& output_shape) {
     // Return point applied to output_csys in format of LCBox::toRecord()
     casacore::TableRecord record;
     try {
@@ -1026,7 +1015,7 @@ casacore::TableRecord Region::GetPointRecord(const casacore::CoordinateSystem& o
     return record;
 }
 
-casacore::TableRecord Region::GetPolygonRecord(const casacore::CoordinateSystem& output_csys) {
+casacore::TableRecord Region::GetPolygonRecord(std::shared_ptr<casacore::CoordinateSystem> output_csys) {
     // Return region applied to output_csys in format of LCPolygon::toRecord()
     // This is for POLYGON or RECTANGLE (points are four corners of box)
     casacore::TableRecord record;
@@ -1071,7 +1060,7 @@ casacore::TableRecord Region::GetPolygonRecord(const casacore::CoordinateSystem&
     return record;
 }
 
-casacore::TableRecord Region::GetRotboxRecord(const casacore::CoordinateSystem& output_csys) {
+casacore::TableRecord Region::GetRotboxRecord(std::shared_ptr<casacore::CoordinateSystem> output_csys) {
     // Determine corners of unrotated box (control points) applied to output_csys.
     // Return region applied to output_csys in format of LCPolygon::toRecord()
     casacore::TableRecord record;
@@ -1114,7 +1103,7 @@ casacore::TableRecord Region::GetRotboxRecord(const casacore::CoordinateSystem& 
         casacore::Vector<casacore::Double> y_wcs = world_coords.row(1);
 
         // Units for Quantities
-        casacore::Vector<casacore::String> world_units = output_csys.worldAxisUnits();
+        casacore::Vector<casacore::String> world_units = output_csys->worldAxisUnits();
         casacore::Vector<casacore::Float> corner_x(num_points), corner_y(num_points);
         for (size_t i = 0; i < num_points; i++) {
             // Convert x and y reference world coords to Quantity
@@ -1145,7 +1134,7 @@ casacore::TableRecord Region::GetRotboxRecord(const casacore::CoordinateSystem& 
     return record;
 }
 
-casacore::TableRecord Region::GetEllipseRecord(const casacore::CoordinateSystem& output_csys) {
+casacore::TableRecord Region::GetEllipseRecord(std::shared_ptr<casacore::CoordinateSystem> output_csys) {
     // Return region applied to output_csys in format of LCEllipsoid::toRecord()
     casacore::TableRecord record;
 
@@ -1163,8 +1152,8 @@ casacore::TableRecord Region::GetEllipseRecord(const casacore::CoordinateSystem&
             center(1) = pixel_point(1);
 
             // Convert radii to output world units, then to pixels
-            casacore::Vector<casacore::Double> increments(output_csys.increment());
-            casacore::Vector<casacore::String> world_units = output_csys.worldAxisUnits();
+            casacore::Vector<casacore::Double> increments(output_csys->increment());
+            casacore::Vector<casacore::String> world_units = output_csys->worldAxisUnits();
             casacore::Quantity bmaj = _wcs_control_points[2];
             bmaj.convert(world_units(0));
             casacore::Quantity bmin = _wcs_control_points[3];
@@ -1193,7 +1182,7 @@ casacore::TableRecord Region::GetEllipseRecord(const casacore::CoordinateSystem&
 }
 
 casacore::TableRecord Region::GetAnnotationRegionRecord(
-    int file_id, const casacore::CoordinateSystem& image_csys, const casacore::IPosition& image_shape) {
+    int file_id, std::shared_ptr<casacore::CoordinateSystem> image_csys, const casacore::IPosition& image_shape) {
     // Return annotation region (not closed LCRegion) in pixel coords
     // for region applied to input image_csys with input image_shape
     casacore::TableRecord record;
@@ -1273,16 +1262,16 @@ bool Region::ConvertCartaPointToWorld(const CARTA::Point& point, std::vector<cas
     return true;
 }
 
-bool Region::ConvertWorldToPixel(std::vector<casacore::Quantity>& world_point, const casacore::CoordinateSystem& output_csys,
+bool Region::ConvertWorldToPixel(std::vector<casacore::Quantity>& world_point, std::shared_ptr<casacore::CoordinateSystem> output_csys,
     casacore::Vector<casacore::Double>& pixel_point) {
     // Convert input reference world coord to output world coord, then to pixel coord
     // Exception should be caught in calling function for creating error message
     bool success(false);
 
-    if (_coord_sys->hasDirectionCoordinate() && output_csys.hasDirectionCoordinate()) {
+    if (_coord_sys->hasDirectionCoordinate() && output_csys->hasDirectionCoordinate()) {
         // Input and output direction reference frames
         casacore::MDirection::Types reference_dir_type = _coord_sys->directionCoordinate().directionType();
-        casacore::MDirection::Types output_dir_type = output_csys.directionCoordinate().directionType();
+        casacore::MDirection::Types output_dir_type = output_csys->directionCoordinate().directionType();
 
         // Convert world point from reference to output coord sys
         casacore::MDirection world_direction(world_point[0], world_point[1], reference_dir_type);
@@ -1291,23 +1280,23 @@ bool Region::ConvertWorldToPixel(std::vector<casacore::Quantity>& world_point, c
         }
 
         // Convert output world point to pixel point
-        output_csys.directionCoordinate().toPixel(pixel_point, world_direction);
+        output_csys->directionCoordinate().toPixel(pixel_point, world_direction);
         success = true;
-    } else if (_coord_sys->hasLinearCoordinate() && output_csys.hasLinearCoordinate()) {
+    } else if (_coord_sys->hasLinearCoordinate() && output_csys->hasLinearCoordinate()) {
         // Get linear axes indices
-        auto indices = output_csys.linearAxesNumbers();
+        auto indices = output_csys->linearAxesNumbers();
         if (indices.size() != 2) {
             return false;
         }
         // Input and output linear frames
-        casacore::Vector<casacore::String> output_units = output_csys.worldAxisUnits();
-        casacore::Vector<casacore::Double> world_point_value(output_csys.nWorldAxes(), 0);
+        casacore::Vector<casacore::String> output_units = output_csys->worldAxisUnits();
+        casacore::Vector<casacore::Double> world_point_value(output_csys->nWorldAxes(), 0);
         world_point_value(indices(0)) = world_point[0].get(output_units(indices(0))).getValue();
         world_point_value(indices(1)) = world_point[1].get(output_units(indices(1))).getValue();
 
         // Convert world point to output pixel point
         casacore::Vector<casacore::Double> tmp_pixel_point;
-        output_csys.toPixel(tmp_pixel_point, world_point_value);
+        output_csys->toPixel(tmp_pixel_point, world_point_value);
 
         // Only fill the pixel coordinate results
         pixel_point.resize(2);

--- a/src/Region/Region.h
+++ b/src/Region/Region.h
@@ -85,8 +85,7 @@ struct RegionState {
 
 class Region {
 public:
-    Region(const RegionState& state, casacore::CoordinateSystem* csys);
-    ~Region();
+    Region(const RegionState& state, std::shared_ptr<casacore::CoordinateSystem> csys);
 
     inline bool IsValid() { // control points validated
         return _valid;
@@ -117,7 +116,7 @@ public:
         return ((type == CARTA::RegionType::LINE) || (type == CARTA::RegionType::POLYLINE));
     }
 
-    inline casacore::CoordinateSystem* CoordinateSystem() {
+    inline std::shared_ptr<casacore::CoordinateSystem> CoordinateSystem() {
         return _coord_sys;
     }
 
@@ -126,13 +125,13 @@ public:
     void WaitForTaskCancellation();
 
     // Converted region as approximate LCPolygon and its mask
-    casacore::LCRegion* GetImageRegion(
-        int file_id, const casacore::CoordinateSystem& image_csys, const casacore::IPosition& image_shape, bool report_error = true);
+    std::shared_ptr<casacore::LCRegion> GetImageRegion(int file_id, std::shared_ptr<casacore::CoordinateSystem> image_csys,
+        const casacore::IPosition& image_shape, bool report_error = true);
     casacore::ArrayLattice<casacore::Bool> GetImageRegionMask(int file_id);
 
     // Converted region in Record for export
     casacore::TableRecord GetImageRegionRecord(
-        int file_id, const casacore::CoordinateSystem& output_csys, const casacore::IPosition& output_shape);
+        int file_id, std::shared_ptr<casacore::CoordinateSystem> output_csys, const casacore::IPosition& output_shape);
 
     std::shared_mutex& GetActiveTaskMutex();
 
@@ -157,48 +156,48 @@ private:
     bool EllipsePointsToWorld(std::vector<CARTA::Point>& pixel_points, std::vector<casacore::Quantity>& wcs_points, float& rotation);
 
     // Reference region as approximate polygon converted to image coordinates; used for data streams
-    bool UseApproximatePolygon(const casacore::CoordinateSystem& output_csys);
+    bool UseApproximatePolygon(std::shared_ptr<casacore::CoordinateSystem> output_csys);
     std::vector<CARTA::Point> GetRectangleMidpoints();
-    casacore::LCRegion* GetCachedPolygonRegion(int file_id);
-    casacore::LCRegion* GetAppliedPolygonRegion(
-        int file_id, const casacore::CoordinateSystem& output_csys, const casacore::IPosition& output_shape);
+    std::shared_ptr<casacore::LCRegion> GetCachedPolygonRegion(int file_id);
+    std::shared_ptr<casacore::LCRegion> GetAppliedPolygonRegion(
+        int file_id, std::shared_ptr<casacore::CoordinateSystem> output_csys, const casacore::IPosition& output_shape);
     std::vector<CARTA::Point> GetReferencePolygonPoints(int num_vertices);
     std::vector<CARTA::Point> GetApproximatePolygonPoints(int num_vertices);
     std::vector<CARTA::Point> GetApproximateEllipsePoints(int num_vertices);
     double GetTotalSegmentLength(std::vector<CARTA::Point>& points);
-    bool ConvertPointsToImagePixels(const std::vector<CARTA::Point>& points, const casacore::CoordinateSystem& output_csys,
+    bool ConvertPointsToImagePixels(const std::vector<CARTA::Point>& points, std::shared_ptr<casacore::CoordinateSystem> output_csys,
         casacore::Vector<casacore::Double>& x, casacore::Vector<casacore::Double>& y);
 
     // Region applied to any image; used for export
-    casacore::LCRegion* GetCachedLCRegion(int file_id);
-    casacore::LCRegion* GetConvertedLCRegion(
-        int file_id, const casacore::CoordinateSystem& output_csys, const casacore::IPosition& output_shape, bool report_error = true);
+    std::shared_ptr<casacore::LCRegion> GetCachedLCRegion(int file_id);
+    std::shared_ptr<casacore::LCRegion> GetConvertedLCRegion(int file_id, std::shared_ptr<casacore::CoordinateSystem> output_csys,
+        const casacore::IPosition& output_shape, bool report_error = true);
 
     // Control points converted to pixel coords in output image, returned in LCRegion Record format for export
     casacore::TableRecord GetRegionPointsRecord(
-        int file_id, const casacore::CoordinateSystem& output_csys, const casacore::IPosition& output_shape);
+        int file_id, std::shared_ptr<casacore::CoordinateSystem> output_csys, const casacore::IPosition& output_shape);
     casacore::TableRecord GetControlPointsRecord(const casacore::IPosition& shape);
     void CompleteLCRegionRecord(casacore::TableRecord& record, const casacore::IPosition& shape);
-    casacore::TableRecord GetPointRecord(const casacore::CoordinateSystem& output_csys, const casacore::IPosition& output_shape);
-    casacore::TableRecord GetPolygonRecord(const casacore::CoordinateSystem& output_csys);
-    casacore::TableRecord GetRotboxRecord(const casacore::CoordinateSystem& output_csys);
-    casacore::TableRecord GetEllipseRecord(const casacore::CoordinateSystem& output_csys);
+    casacore::TableRecord GetPointRecord(std::shared_ptr<casacore::CoordinateSystem> output_csys, const casacore::IPosition& output_shape);
+    casacore::TableRecord GetPolygonRecord(std::shared_ptr<casacore::CoordinateSystem> output_csys);
+    casacore::TableRecord GetRotboxRecord(std::shared_ptr<casacore::CoordinateSystem> output_csys);
+    casacore::TableRecord GetEllipseRecord(std::shared_ptr<casacore::CoordinateSystem> output_csys);
     casacore::TableRecord GetAnnotationRegionRecord(
-        int file_id, const casacore::CoordinateSystem& image_csys, const casacore::IPosition& image_shape);
+        int file_id, std::shared_ptr<casacore::CoordinateSystem> image_csys, const casacore::IPosition& image_shape);
     void CompleteRegionRecord(casacore::TableRecord& record, const casacore::IPosition& image_shape);
 
     // Utilities to convert control points
     // Input: CARTA::Point. Returns: point (x, y) in reference world coords
     bool ConvertCartaPointToWorld(const CARTA::Point& point, std::vector<casacore::Quantity>& world_point);
     // Input: point (x,y) in reference world coords. Returns: point (x,y) in output pixel coords
-    bool ConvertWorldToPixel(std::vector<casacore::Quantity>& world_point, const casacore::CoordinateSystem& output_csys,
+    bool ConvertWorldToPixel(std::vector<casacore::Quantity>& world_point, std::shared_ptr<casacore::CoordinateSystem> output_csys,
         casacore::Vector<casacore::Double>& pixel_point);
 
     // region parameters struct
     RegionState _region_state;
 
     // coord sys and shape of reference image
-    casacore::CoordinateSystem* _coord_sys;
+    std::shared_ptr<casacore::CoordinateSystem> _coord_sys;
 
     // Reference region cache
     std::mutex _region_mutex; // creation of casacore regions is not threadsafe

--- a/src/Region/RegionHandler.cc
+++ b/src/Region/RegionHandler.cc
@@ -44,7 +44,7 @@ int RegionHandler::GetNextRegionId() {
     return max_id + 1;
 }
 
-bool RegionHandler::SetRegion(int& region_id, RegionState& region_state, casacore::CoordinateSystem* csys) {
+bool RegionHandler::SetRegion(int& region_id, RegionState& region_state, std::shared_ptr<casacore::CoordinateSystem> csys) {
     // Set region params for region id; if id < 0, create new id
     // CoordinateSystem will be owned by Region
     bool valid_region(false);
@@ -112,9 +112,7 @@ bool RegionHandler::RegionSet(int region_id) {
 void RegionHandler::ImportRegion(int file_id, std::shared_ptr<Frame> frame, CARTA::FileType region_file_type,
     const std::string& region_file, bool file_is_filename, CARTA::ImportRegionAck& import_ack) {
     // Set regions from region file
-
-    // Importer must delete csys pointer
-    casacore::CoordinateSystem* csys = frame->CoordinateSystem();
+    auto csys = frame->CoordinateSystem();
     const casacore::IPosition shape = frame->ImageShape();
     std::unique_ptr<RegionImportExport> importer;
     switch (region_file_type) {
@@ -205,13 +203,10 @@ void RegionHandler::ExportRegion(int file_id, std::shared_ptr<Frame> frame, CART
     }
 
     bool pixel_coord(coord_type == CARTA::CoordinateType::PIXEL);
-
-    // Exporter must delete csys pointer
-    casacore::CoordinateSystem* output_csys = frame->CoordinateSystem();
+    auto output_csys = frame->CoordinateSystem();
 
     if (!pixel_coord && !output_csys->hasDirectionCoordinate()) {
         // Export fails, cannot convert to world coordinates
-        delete output_csys;
         export_ack.set_success(false);
         export_ack.set_message("Cannot export regions in world coordinates for linear coordinate system.");
         return;
@@ -251,7 +246,7 @@ void RegionHandler::ExportRegion(int file_id, std::shared_ptr<Frame> frame, CART
             } else {
                 try {
                     // Use Record containing pixel coords of region converted to output image
-                    casacore::TableRecord region_record = _regions.at(region_id)->GetImageRegionRecord(file_id, *output_csys, output_shape);
+                    casacore::TableRecord region_record = _regions.at(region_id)->GetImageRegionRecord(file_id, output_csys, output_shape);
                     if (!region_record.empty()) {
                         region_added = exporter->AddExportRegion(region_state, region_style, region_record, pixel_coord);
                     }
@@ -668,7 +663,7 @@ bool RegionHandler::RegionFileIdsValid(int region_id, int file_id) {
     return true;
 }
 
-casacore::LCRegion* RegionHandler::ApplyRegionToFile(int region_id, int file_id, bool report_error) {
+std::shared_ptr<casacore::LCRegion> RegionHandler::ApplyRegionToFile(int region_id, int file_id, bool report_error) {
     // Returns 2D region with no extension; nullptr if outside image or not closed region
     // Go through Frame for image mutex
     if (!RegionFileIdsValid(region_id, file_id)) {
@@ -682,15 +677,15 @@ casacore::LCRegion* RegionHandler::ApplyRegionToFile(int region_id, int file_id,
     return _frames.at(file_id)->GetImageRegion(file_id, _regions.at(region_id), report_error);
 }
 
-bool RegionHandler::ApplyRegionToFile(
-    int region_id, int file_id, const AxisRange& z_range, int stokes, casacore::ImageRegion& region, casacore::LCRegion* region_2D) {
+bool RegionHandler::ApplyRegionToFile(int region_id, int file_id, const AxisRange& z_range, int stokes, casacore::ImageRegion& region,
+    std::shared_ptr<casacore::LCRegion> region_2D) {
     // Returns 3D image region for region applied to image and extended by z-range and stokes index
     if (!RegionFileIdsValid(region_id, file_id)) {
         return false;
     }
 
     try {
-        casacore::LCRegion* applied_region = region_2D;
+        auto applied_region = region_2D;
         if (!applied_region) {
             applied_region = ApplyRegionToFile(region_id, file_id);
         }
@@ -737,11 +732,12 @@ bool RegionHandler::CalculateMoments(int file_id, int region_id, const std::shar
     GeneratorProgressCallback progress_callback, const CARTA::MomentRequest& moment_request, CARTA::MomentResponse& moment_response,
     std::vector<GeneratedImage>& collapse_results) {
     casacore::ImageRegion image_region;
+    std::shared_ptr<casacore::LCRegion> lc_region;
     int z_min(moment_request.spectral_range().min());
     int z_max(moment_request.spectral_range().max());
 
     // Do calculations
-    if (ApplyRegionToFile(region_id, file_id, AxisRange(z_min, z_max), frame->CurrentStokes(), image_region)) {
+    if (ApplyRegionToFile(region_id, file_id, AxisRange(z_min, z_max), frame->CurrentStokes(), image_region, lc_region)) {
         frame->CalculateMoments(file_id, progress_callback, image_region, moment_request, moment_response, collapse_results);
     }
     return !collapse_results.empty();
@@ -923,7 +919,8 @@ bool RegionHandler::GetRegionHistogramData(
     bool have_basic_stats(false);
 
     // Reuse the image region for each histogram
-    casacore::ImageRegion region;
+    casacore::ImageRegion image_region;
+    std::shared_ptr<casacore::LCRegion> lc_region;
 
     // Reuse data with respect to stokes and stats for each histogram; results depend on num_bins
     std::unordered_map<int, std::vector<float>> data;
@@ -949,7 +946,7 @@ bool RegionHandler::GetRegionHistogramData(
         histogram_message.set_stokes(stokes);
 
         // Get image region
-        if (!ApplyRegionToFile(region_id, file_id, z_range, stokes, region)) {
+        if (!ApplyRegionToFile(region_id, file_id, z_range, stokes, image_region, lc_region)) {
             // region outside image, send default histogram
             auto* default_histogram = histogram_message.mutable_histograms();
             std::vector<int> histogram_bins(1, 0);
@@ -960,7 +957,7 @@ bool RegionHandler::GetRegionHistogramData(
         // number of bins may be set or calculated
         int num_bins(hist_config.num_bins);
         if (num_bins == AUTO_BIN_SIZE) {
-            casacore::IPosition region_shape = _frames.at(file_id)->GetRegionShape(region);
+            casacore::IPosition region_shape = _frames.at(file_id)->GetRegionShape(image_region);
             num_bins = int(std::max(sqrt(region_shape(0) * region_shape(1)), 2.0));
         }
 
@@ -986,7 +983,7 @@ bool RegionHandler::GetRegionHistogramData(
         // Calculate stats and/or histograms, not in cache
         // Get data in region
         if (!data.count(stokes)) {
-            if (!_frames.at(file_id)->GetRegionData(region, data[stokes])) {
+            if (!_frames.at(file_id)->GetRegionData(image_region, data[stokes])) {
                 spdlog::error("Failed to get data in the region!");
                 return false;
             }
@@ -1144,8 +1141,8 @@ bool RegionHandler::GetRegionSpectralData(int region_id, int file_id, std::strin
     }
 
     // Get 2D region to check if inside image
-    casacore::LCRegion* lcregion = ApplyRegionToFile(region_id, file_id, report_error);
-    if (!lcregion) {
+    auto lc_region = ApplyRegionToFile(region_id, file_id, report_error);
+    if (!lc_region) {
         progress = 1.0;
         partial_results_callback(results, progress); // region outside image, send NaNs
         return true;
@@ -1155,10 +1152,10 @@ bool RegionHandler::GetRegionSpectralData(int region_id, int file_id, std::strin
     RegionState initial_region_state = _regions.at(region_id)->GetRegionState();
 
     // Use loader swizzled data for efficiency
-    if (_frames.at(file_id)->UseLoaderSpectralData(lcregion->shape())) {
+    if (_frames.at(file_id)->UseLoaderSpectralData(lc_region->shape())) {
         // Use cursor spectral profile for point region
         if (initial_region_state.type == CARTA::RegionType::POINT) {
-            casacore::IPosition origin = lcregion->boundingBox().start();
+            casacore::IPosition origin = lc_region->boundingBox().start();
             CARTA::Point point;
             point.set_x(origin(0));
             point.set_y(origin(1));
@@ -1175,7 +1172,7 @@ bool RegionHandler::GetRegionSpectralData(int region_id, int file_id, std::strin
         }
 
         // Get 2D origin and 2D mask for Hdf5Loader
-        casacore::IPosition origin = lcregion->boundingBox().start();
+        casacore::IPosition origin = lc_region->boundingBox().start();
         casacore::IPosition xy_origin = origin.keepAxes(casacore::IPosition(2, 0, 1)); // keep first two axes only
 
         // Get mask; LCRegion for file id is cached
@@ -1261,7 +1258,7 @@ bool RegionHandler::GetRegionSpectralData(int region_id, int file_id, std::strin
         // Get 3D region for z range and stokes_index
         AxisRange z_range(start_z, end_z);
         casacore::ImageRegion image_region;
-        if (!ApplyRegionToFile(region_id, file_id, z_range, stokes_index, image_region, lcregion)) {
+        if (!ApplyRegionToFile(region_id, file_id, z_range, stokes_index, image_region, lc_region)) {
             return false;
         }
 
@@ -1433,8 +1430,9 @@ bool RegionHandler::GetRegionStatsData(
 
     // Get region
     AxisRange z_range(z);
-    casacore::ImageRegion region;
-    if (!ApplyRegionToFile(region_id, file_id, z_range, stokes, region)) {
+    casacore::ImageRegion image_region;
+    std::shared_ptr<casacore::LCRegion> lc_region;
+    if (!ApplyRegionToFile(region_id, file_id, z_range, stokes, image_region, lc_region)) {
         // region outside image: NaN results
         std::map<CARTA::StatsType, double> stats_results;
         for (const auto& carta_stat : required_stats) {
@@ -1453,7 +1451,7 @@ bool RegionHandler::GetRegionStatsData(
     // calculate stats
     bool per_z(false);
     std::map<CARTA::StatsType, std::vector<double>> stats_map;
-    if (_frames.at(file_id)->GetRegionStats(region, required_stats, per_z, stats_map)) {
+    if (_frames.at(file_id)->GetRegionStats(image_region, required_stats, per_z, stats_map)) {
         // convert vector to single value in map
         std::map<CARTA::StatsType, double> stats_results;
         for (auto& value : stats_map) {
@@ -1514,12 +1512,12 @@ bool RegionHandler::FillSpatialProfileData(int file_id, int region_id, std::vect
     }
 
     // Map a point region (region_id) to an image (file_id)
-    casacore::LCRegion* lcregion = ApplyRegionToFile(region_id, file_id);
-    if (!lcregion) {
+    auto lc_region = ApplyRegionToFile(region_id, file_id);
+    if (!lc_region) {
         return false;
     }
 
-    casacore::IPosition origin = lcregion->boundingBox().start();
+    casacore::IPosition origin = lc_region->boundingBox().start();
     PointXy point(origin(0), origin(1));
 
     return _frames.at(file_id)->FillSpatialProfileData(point, _spatial_req.at(config_id), spatial_data_vec);
@@ -1609,8 +1607,8 @@ void RegionHandler::SetLineRotation(RegionState& region_state) {
 }
 
 bool RegionHandler::GetFixedPixelRegionProfiles(int file_id, int width, bool per_z, RegionState& region_state,
-    casacore::CoordinateSystem* reference_csys, std::function<void(float)>& progress_callback, casacore::Matrix<float>& profiles,
-    double& increment, bool& cancelled) {
+    std::shared_ptr<casacore::CoordinateSystem> reference_csys, std::function<void(float)>& progress_callback,
+    casacore::Matrix<float>& profiles, double& increment, bool& cancelled) {
     // Calculate mean spectral profiles for box regions along line with fixed pixel spacing, with progress updates after each profile.
     // Return parameters include the profiles, the increment between the box centers in arcsec, and whether profiles were cancelled.
     // Returns false if profiles cancelled or linear pixel centers are tabular in world coordinates.
@@ -1729,7 +1727,8 @@ bool RegionHandler::GetFixedPixelRegionProfiles(int file_id, int width, bool per
     return (progress == 1.0) && !allEQ(profiles, NAN);
 }
 
-bool RegionHandler::CheckLinearOffsets(const std::vector<CARTA::Point>& box_centers, casacore::CoordinateSystem* csys, double& increment) {
+bool RegionHandler::CheckLinearOffsets(
+    const std::vector<CARTA::Point>& box_centers, std::shared_ptr<casacore::CoordinateSystem> csys, double& increment) {
     // Check whether separation between box centers is linear.
     auto direction_coord = csys->directionCoordinate();
 
@@ -1787,7 +1786,7 @@ bool RegionHandler::CheckLinearOffsets(const std::vector<CARTA::Point>& box_cent
     return true;
 }
 
-double RegionHandler::GetSeparationTolerance(casacore::CoordinateSystem* csys) {
+double RegionHandler::GetSeparationTolerance(std::shared_ptr<casacore::CoordinateSystem> csys) {
     // Return 1% of CDELT2 in arcsec
     auto cdelt = csys->increment();
     auto cunit = csys->worldAxisUnits();
@@ -1796,8 +1795,8 @@ double RegionHandler::GetSeparationTolerance(casacore::CoordinateSystem* csys) {
 }
 
 bool RegionHandler::GetFixedAngularRegionProfiles(int file_id, int width, bool per_z, RegionState& region_state,
-    casacore::CoordinateSystem* reference_csys, std::function<void(float)>& progress_callback, casacore::Matrix<float>& profiles,
-    double& increment, bool& cancelled, std::string& message) {
+    std::shared_ptr<casacore::CoordinateSystem> reference_csys, std::function<void(float)>& progress_callback,
+    casacore::Matrix<float>& profiles, double& increment, bool& cancelled, std::string& message) {
     // Calculate mean spectral profiles for polygon regions along line with fixed angular spacing, with progress updates after each profile.
     // Return parameters include the profiles, the increment between the regions in arcsec, and whether profiles were cancelled.
     // Returns false if profiles cancelled or failed, with an error message.
@@ -2074,7 +2073,7 @@ RegionState RegionHandler::GetTemporaryRegionState(casacore::DirectionCoordinate
 }
 
 casacore::Vector<float> RegionHandler::GetTemporaryRegionProfile(
-    int file_id, RegionState& region_state, casacore::CoordinateSystem* reference_csys, bool per_z, double& num_pixels) {
+    int file_id, RegionState& region_state, std::shared_ptr<casacore::CoordinateSystem> reference_csys, bool per_z, double& num_pixels) {
     // Create temporary region with RegionState and CoordinateSystem
     // Return stats/spectral profile (depending on per_z) for given file_id image, and number of pixels in the region.
     auto depth = _frames.at(file_id)->Depth();
@@ -2095,8 +2094,7 @@ casacore::Vector<float> RegionHandler::GetTemporaryRegionProfile(
     }
 
     int region_id(TEMP_REGION_ID);
-    casacore::CoordinateSystem* region_csys = static_cast<casacore::CoordinateSystem*>(reference_csys->clone());
-    SetRegion(region_id, region_state, region_csys);
+    SetRegion(region_id, region_state, reference_csys);
 
     if (!RegionSet(region_id)) {
         return profile;

--- a/src/Region/RegionHandler.cc
+++ b/src/Region/RegionHandler.cc
@@ -117,11 +117,10 @@ void RegionHandler::ImportRegion(int file_id, std::shared_ptr<Frame> frame, CART
     std::unique_ptr<RegionImportExport> importer;
     switch (region_file_type) {
         case CARTA::FileType::CRTF:
-            importer = std::unique_ptr<RegionImportExport>(
-                new CrtfImportExport(csys, shape, frame->StokesAxis(), file_id, region_file, file_is_filename));
+            importer.reset(new CrtfImportExport(csys, shape, frame->StokesAxis(), file_id, region_file, file_is_filename));
             break;
         case CARTA::FileType::DS9_REG:
-            importer = std::unique_ptr<RegionImportExport>(new Ds9ImportExport(csys, shape, file_id, region_file, file_is_filename));
+            importer.reset(new Ds9ImportExport(csys, shape, file_id, region_file, file_is_filename));
             break;
         default:
             break;

--- a/src/Region/RegionHandler.h
+++ b/src/Region/RegionHandler.h
@@ -46,7 +46,7 @@ public:
     RegionHandler() = default;
 
     // Regions
-    bool SetRegion(int& region_id, RegionState& region_state, casacore::CoordinateSystem* csys);
+    bool SetRegion(int& region_id, RegionState& region_state, std::shared_ptr<casacore::CoordinateSystem> csys);
     bool RegionChanged(int region_id);
     void RemoveRegion(int region_id);
     std::shared_ptr<Region> GetRegion(int region_id);
@@ -113,9 +113,9 @@ private:
 
     // Apply region to image
     bool RegionFileIdsValid(int region_id, int file_id);
-    casacore::LCRegion* ApplyRegionToFile(int region_id, int file_id, bool report_error = true);
+    std::shared_ptr<casacore::LCRegion> ApplyRegionToFile(int region_id, int file_id, bool report_error = true);
     bool ApplyRegionToFile(int region_id, int file_id, const AxisRange& z_range, int stokes, casacore::ImageRegion& region,
-        casacore::LCRegion* region_2D = nullptr);
+        std::shared_ptr<casacore::LCRegion> region_2D);
 
     // Fill data stream messages
     bool GetRegionHistogramData(int region_id, int file_id, const std::vector<HistogramConfig>& configs,
@@ -132,13 +132,14 @@ private:
         double& increment, casacore::Matrix<float>& profiles, bool& cancelled, std::string& message);
     void SetLineRotation(RegionState& region_state);
     bool GetFixedPixelRegionProfiles(int file_id, int width, bool per_z, RegionState& region_state,
-        casacore::CoordinateSystem* reference_csys, std::function<void(float)>& progress_callback, casacore::Matrix<float>& profiles,
-        double& increment, bool& cancelled);
-    bool CheckLinearOffsets(const std::vector<CARTA::Point>& box_centers, casacore::CoordinateSystem* csys, double& increment);
-    double GetSeparationTolerance(casacore::CoordinateSystem* csys);
+        std::shared_ptr<casacore::CoordinateSystem> reference_csys, std::function<void(float)>& progress_callback,
+        casacore::Matrix<float>& profiles, double& increment, bool& cancelled);
+    bool CheckLinearOffsets(
+        const std::vector<CARTA::Point>& box_centers, std::shared_ptr<casacore::CoordinateSystem> csys, double& increment);
+    double GetSeparationTolerance(std::shared_ptr<casacore::CoordinateSystem> csys);
     bool GetFixedAngularRegionProfiles(int file_id, int width, bool per_z, RegionState& region_state,
-        casacore::CoordinateSystem* reference_csys, std::function<void(float)>& progress_callback, casacore::Matrix<float>& profiles,
-        double& increment, bool& cancelled, std::string& message);
+        std::shared_ptr<casacore::CoordinateSystem> reference_csys, std::function<void(float)>& progress_callback,
+        casacore::Matrix<float>& profiles, double& increment, bool& cancelled, std::string& message);
     bool SetPointInRange(float max_point, float& point);
     casacore::Vector<double> FindPointAtTargetSeparation(const casacore::DirectionCoordinate& direction_coord,
         const casacore::Vector<double>& endpoint0, const casacore::Vector<double>& endpoint1, double target_separation, double tolerance);
@@ -146,7 +147,7 @@ private:
         const casacore::Vector<double>& box_start, const casacore::Vector<double>& box_end, int pixel_width, double angular_width,
         float height_angle, double tolerance);
     casacore::Vector<float> GetTemporaryRegionProfile(
-        int file_id, RegionState& region_state, casacore::CoordinateSystem* csys, bool per_z, double& num_pixels);
+        int file_id, RegionState& region_state, std::shared_ptr<casacore::CoordinateSystem> csys, bool per_z, double& num_pixels);
 
     // Regions: key is region_id
     std::unordered_map<int, std::shared_ptr<Region>> _regions;

--- a/src/Region/RegionImportExport.cc
+++ b/src/Region/RegionImportExport.cc
@@ -16,12 +16,13 @@
 
 using namespace carta;
 
-RegionImportExport::RegionImportExport(casacore::CoordinateSystem* image_coord_sys, const casacore::IPosition& image_shape, int file_id)
+RegionImportExport::RegionImportExport(
+    std::shared_ptr<casacore::CoordinateSystem> image_coord_sys, const casacore::IPosition& image_shape, int file_id)
     : _coord_sys(image_coord_sys), _image_shape(image_shape), _file_id(file_id) {
     // Constructor for import. Use GetImportedRegions to retrieve regions.
 }
 
-RegionImportExport::RegionImportExport(casacore::CoordinateSystem* image_coord_sys, const casacore::IPosition& image_shape)
+RegionImportExport::RegionImportExport(std::shared_ptr<casacore::CoordinateSystem> image_coord_sys, const casacore::IPosition& image_shape)
     : _coord_sys(image_coord_sys), _image_shape(image_shape) {
     // Constructor for export. Use AddExportRegion to add regions, then ExportRegions to finalize
 }

--- a/src/Region/RegionImportExport.h
+++ b/src/Region/RegionImportExport.h
@@ -29,6 +29,8 @@ public:
     // Export constructor
     RegionImportExport(std::shared_ptr<casacore::CoordinateSystem> image_coord_sys, const casacore::IPosition& image_shape);
 
+    virtual ~RegionImportExport() = default;
+
     // Retrieve imported regions as RegionState vector
     std::vector<RegionProperties> GetImportedRegions(std::string& error);
 

--- a/src/Region/RegionImportExport.h
+++ b/src/Region/RegionImportExport.h
@@ -24,13 +24,10 @@ namespace carta {
 
 class RegionImportExport {
 public:
-    RegionImportExport() {}
-    virtual ~RegionImportExport() {}
-
     // Import constructor: file_id to add to RegionState
-    RegionImportExport(casacore::CoordinateSystem* image_coord_sys, const casacore::IPosition& image_shape, int file_id);
+    RegionImportExport(std::shared_ptr<casacore::CoordinateSystem> image_coord_sys, const casacore::IPosition& image_shape, int file_id);
     // Export constructor
-    RegionImportExport(casacore::CoordinateSystem* image_coord_sys, const casacore::IPosition& image_shape);
+    RegionImportExport(std::shared_ptr<casacore::CoordinateSystem> image_coord_sys, const casacore::IPosition& image_shape);
 
     // Retrieve imported regions as RegionState vector
     std::vector<RegionProperties> GetImportedRegions(std::string& error);
@@ -71,7 +68,7 @@ protected:
     std::string FormatColor(const std::string& color);
 
     // Image info to which region is applied
-    casacore::CoordinateSystem* _coord_sys;
+    std::shared_ptr<casacore::CoordinateSystem> _coord_sys;
     casacore::IPosition _image_shape;
 
     // For import

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -787,14 +787,14 @@ bool Session::OnSetRegion(const CARTA::SetRegion& message, uint32_t request_id, 
     bool success(false);
 
     if (_frames.count(file_id)) { // reference Frame for Region exists
-        casacore::CoordinateSystem* csys = _frames.at(file_id)->CoordinateSystem();
-
-        if (!_region_handler) { // created on demand only
+        if (!_region_handler) {
+            // created on demand only
             _region_handler = std::unique_ptr<RegionHandler>(new RegionHandler());
         }
 
         std::vector<CARTA::Point> points = {region_info.control_points().begin(), region_info.control_points().end()};
         RegionState region_state(file_id, region_info.region_type(), points, region_info.rotation());
+        auto csys = _frames.at(file_id)->CoordinateSystem();
 
         success = _region_handler->SetRegion(region_id, region_state, csys);
 

--- a/test/TestExprImage.cc
+++ b/test/TestExprImage.cc
@@ -24,8 +24,7 @@ public:
         // Image on disk
         std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(file_path));
         loader->OpenFile(hdu);
-        casacore::IPosition image_shape;
-        loader->GetShape(image_shape);
+        casacore::IPosition image_shape(loader->GetShape());
 
         std::shared_ptr<DataReader> reader = nullptr;
         if (file_type == CARTA::FileType::HDF5) {
@@ -51,8 +50,7 @@ public:
 
         std::shared_ptr<carta::FileLoader> expr_loader(carta::FileLoader::GetLoader(expr, directory));
         expr_loader->OpenFile(hdu);
-        casacore::IPosition expr_shape;
-        expr_loader->GetShape(expr_shape);
+        casacore::IPosition expr_shape(expr_loader->GetShape());
 
         // Slicer for x spatial profile at y=0
         casacore::IPosition start(expr_shape.size(), 0);
@@ -97,8 +95,7 @@ public:
 
         std::shared_ptr<carta::FileLoader> expr_loader(carta::FileLoader::GetLoader(expr, directory));
         expr_loader->OpenFile(hdu);
-        casacore::IPosition expr_shape;
-        expr_loader->GetShape(expr_shape);
+        casacore::IPosition expr_shape(expr_loader->GetShape());
 
         // Save LEL image, CASA format only allowed from loader (saves as LEL image)
         std::string save_path = (fs_path.parent_path() / "test_save_expr.im").string();
@@ -111,8 +108,7 @@ public:
         ASSERT_TRUE(expr_loader->GetImage().get() != nullptr);
         ASSERT_EQ(expr_loader->GetImage()->imageType(), "ImageExpr");
 
-        casacore::IPosition saved_expr_shape;
-        saved_expr_loader->GetShape(saved_expr_shape);
+        casacore::IPosition saved_expr_shape(saved_expr_loader->GetShape());
         ASSERT_EQ(expr_shape, saved_expr_shape);
     }
 };
@@ -141,13 +137,11 @@ TEST_F(ImageExprTest, ImageExprTwoDirs) {
 
     std::shared_ptr<carta::FileLoader> expr_loader(carta::FileLoader::GetLoader(expr, directory));
     expr_loader->OpenFile("");
-    casacore::IPosition expr_shape;
-    expr_loader->GetShape(expr_shape);
+    casacore::IPosition expr_shape(expr_loader->GetShape());
 
     auto fits_path = FileFinder::FitsImagePath("noise_10px_10px.fits");
     std::shared_ptr<carta::FileLoader> fits_loader(carta::FileLoader::GetLoader(fits_path));
     fits_loader->OpenFile("");
-    casacore::IPosition fits_shape;
-    fits_loader->GetShape(fits_shape);
+    casacore::IPosition fits_shape(fits_loader->GetShape());
     ASSERT_EQ(fits_shape, expr_shape);
 }

--- a/test/TestPvGenerator.cc
+++ b/test/TestPvGenerator.cc
@@ -21,7 +21,7 @@ using ::testing::Pointwise;
 class PvGeneratorTest : public ::testing::Test, public ImageGenerator {
 public:
     static void SetPvCut(carta::RegionHandler& region_handler, int file_id, int& region_id, std::vector<float>& endpoints,
-        casacore::CoordinateSystem* csys) {
+        std::shared_ptr<casacore::CoordinateSystem> csys) {
         // Define RegionState for line region
         std::vector<CARTA::Point> control_points;
         CARTA::Point point;
@@ -49,7 +49,7 @@ TEST_F(PvGeneratorTest, FitsPvImage) {
     carta::RegionHandler region_handler;
 
     // Image coordinate system
-    casacore::CoordinateSystem* csys = frame->CoordinateSystem();
+    auto csys = frame->CoordinateSystem();
     int image_spectral_axis = csys->spectralAxisNumber();
     auto image_spectral_name = csys->worldAxisNames()(image_spectral_axis);
     auto image_axis_increment = csys->increment();
@@ -118,7 +118,7 @@ TEST_F(PvGeneratorTest, FitsPvImageHorizontalCut) {
     carta::RegionHandler region_handler;
 
     // Image coordinate system
-    casacore::CoordinateSystem* csys = frame->CoordinateSystem();
+    auto csys = frame->CoordinateSystem();
     int image_spectral_axis = csys->spectralAxisNumber();
     auto image_spectral_name = csys->worldAxisNames()(image_spectral_axis);
     auto image_axis_increment = csys->increment();
@@ -194,7 +194,7 @@ TEST_F(PvGeneratorTest, FitsPvImageVerticalCut) {
     carta::RegionHandler region_handler;
 
     // Image coordinate system
-    casacore::CoordinateSystem* csys = frame->CoordinateSystem();
+    auto csys = frame->CoordinateSystem();
     int image_spectral_axis = csys->spectralAxisNumber();
     auto image_spectral_name = csys->worldAxisNames()(image_spectral_axis);
     auto image_axis_increment = csys->increment();
@@ -273,7 +273,7 @@ TEST_F(PvGeneratorTest, TestNoSpectralAxis) {
     // Set line region [0, 0] to [9, 9]
     int file_id(0), region_id(-1);
     std::vector<float> endpoints = {0.0, 0.0, 9.0, 9.0};
-    casacore::CoordinateSystem* csys = frame->CoordinateSystem();
+    auto csys = frame->CoordinateSystem();
     SetPvCut(region_handler, file_id, region_id, endpoints, csys);
 
     // Request PV image


### PR DESCRIPTION
Closes #1058 
Closes #1059

PR #1062  was reverted due to failing ICD tests for region import.  I reverted the reversion and added a RegionImportExport destructor for its unique_ptr in RegionHandler.

Reproduced crash and tested fix on macOS 10.15: manual region import and CASA_REGION_IMPORT_EXPORT and DS9_REGION_IMPORT_EXPORT ICD tests.