### PR TITLE
Add data type to file info

### DIFF
--- a/src/FileList/FileExtInfoLoader.cc
+++ b/src/FileList/FileExtInfoLoader.cc
@@ -1478,8 +1478,6 @@ casacore::TempImage<float>* FileExtInfoLoader::ConvertImageToFloat(casacore::Lat
     switch (image_in->dataType()) {
         case casacore::TpFloat: {
             casacore::ImageInterface<float>* basic_image = dynamic_cast<casacore::ImageInterface<float>*>(image_in);
-            std::cerr << "LatticeBase shape=" << image_in->shape() << " ImageInterface shape=" << basic_image->shape() << std::endl;
-            std::cerr << "CoordSys nPixelAxes=" << basic_image->coordinates().nPixelAxes() << std::endl;
             image_out = new casacore::TempImage<float>(tiled_shape, basic_image->coordinates());
             image_out->setUnits(basic_image->units());
             image_out->setMiscInfo(basic_image->miscInfo());

--- a/src/FileList/FileExtInfoLoader.h
+++ b/src/FileList/FileExtInfoLoader.h
@@ -20,12 +20,13 @@
 #include <carta-protobuf/file_info.pb.h>
 #include "ImageData/CompressedFits.h"
 #include "ImageData/FileLoader.h"
+#include "Util/Casacore.h"
 
 namespace carta {
 
 class FileExtInfoLoader {
 public:
-    FileExtInfoLoader(std::shared_ptr<FileLoader> loader);
+    FileExtInfoLoader() = default;
 
     // Fill extended file info for all FITS image hdus
     bool FillFitsFileInfoMap(
@@ -34,24 +35,27 @@ public:
     // Fill extended file info for specified hdu
     bool FillFileExtInfo(CARTA::FileInfoExtended& extended_info, const std::string& filename, const std::string& hdu, std::string& message);
 
+    // Fill extended file info for given image
+    bool FillFileExtInfo(
+        CARTA::FileInfoExtended& extended_info, casacore::LatticeBase* image, const std::string& hdu, std::string& message);
+
 private:
-    bool FillFileInfoFromImage(CARTA::FileInfoExtended& ext_info, const std::string& hdu, std::string& message);
     void StripHduName(std::string& hdu); // remove extension name
 
     // Header entries
-    casacore::Vector<casacore::String> FitsHeaderStrings(casacore::String& name, unsigned int hdu);
+    casacore::Vector<casacore::String> FitsHeaderStrings(casacore::String& name, unsigned int hdu); // cfitio for FITS
+    casacore::TempImage<float>* ConvertImageToFloat(casacore::LatticeBase* image);                  // for ImageHeaderToFITS
     void AddEntriesFromHeaderStrings(
         const casacore::Vector<casacore::String>& headers, const std::string& hdu, CARTA::FileInfoExtended& extended_info);
     void ConvertHeaderValueToNumeric(const casacore::String& name, casacore::String& value, CARTA::HeaderEntry* entry);
     void FitsHeaderInfoToHeaderEntries(casacore::ImageFITSHeaderInfo& fhi, CARTA::FileInfoExtended& extended_info);
 
     // Computed entries
-    void AddShapeEntries(CARTA::FileInfoExtended& extended_info, const casacore::IPosition& shape, int chan_axis, int depth_axis,
-        int stokes_axis, const std::vector<int>& render_axes);
+    void AddShapeEntries(CARTA::FileInfoExtended& extended_info, const CoordinateAxes& coord_axes);
     void AddInitialComputedEntries(const std::string& hdu, CARTA::FileInfoExtended& extended_info, const std::string& filename,
         const std::vector<int>& render_axes, CompressedFits* compressed_fits = nullptr);
-    void AddComputedEntries(CARTA::FileInfoExtended& extended_info, casacore::ImageInterface<float>* image,
-        const std::vector<int>& display_axes, bool use_image_for_entries);
+    void AddComputedEntriesFromImage(
+        CARTA::FileInfoExtended& extended_info, casacore::ImageInterface<float>* image, const std::vector<int>& display_axes);
     void AddComputedEntriesFromHeaders(
         CARTA::FileInfoExtended& extended_info, const std::vector<int>& display_axes, CompressedFits* compressed_fits = nullptr);
     void AddBeamEntry(CARTA::FileInfoExtended& extended_info, const casacore::ImageBeamSet& beam_set);
@@ -68,7 +72,6 @@ private:
     void GetCoordNames(std::string& ctype1, std::string& ctype2, std::string& radesys, std::string& coord_name1, std::string& coord_name2,
         std::string& projection);
 
-    std::shared_ptr<FileLoader> _loader;
     CARTA::FileType _type;
 };
 

--- a/src/Frame/Frame.h
+++ b/src/Frame/Frame.h
@@ -262,10 +262,8 @@ protected:
     std::shared_ptr<FileLoader> _loader;
 
     // Shape and axis info: X, Y, Z, Stokes
-    casacore::IPosition _image_shape;
-    int _x_axis, _y_axis, _z_axis, _spectral_axis, _stokes_axis;
+    CoordinateAxes _coord_axes;
     int _z_index, _stokes_index; // current index
-    size_t _width, _height, _depth, _num_stokes;
 
     // Image settings
     CARTA::AddRequiredTiles _required_animation_tiles;

--- a/src/ImageData/CartaFitsImage.cc
+++ b/src/ImageData/CartaFitsImage.cc
@@ -15,6 +15,7 @@
 #include <casacore/coordinates/Coordinates/FITSCoordinateUtil.h>
 #include <casacore/coordinates/Coordinates/SpectralCoordinate.h>
 #include <casacore/images/Images/ImageFITSConverter.h>
+#include <casacore/images/Images/ImageOpener.h>
 #include <casacore/measures/Measures/MDirection.h>
 #include <casacore/measures/Measures/Stokes.h>
 #include <casacore/tables/DataMan/TiledFileAccess.h>
@@ -63,6 +64,14 @@ CartaFitsImage::CartaFitsImage(const CartaFitsImage& other)
 CartaFitsImage::~CartaFitsImage() {
     CloseFile();
     delete _pixel_mask;
+}
+
+casacore::LatticeBase* CartaFitsImage::OpenCartaFitsImage(const casacore::String& name, const casacore::MaskSpecifier& spec) {
+    return new CartaFitsImage(name, 0);
+}
+
+void CartaFitsImage::RegisterOpenFunction() {
+    casacore::ImageOpener::registerOpenImageFunction(casacore::ImageOpener::FITS, &OpenCartaFitsImage);
 }
 
 // Image interface

--- a/src/ImageData/CartaFitsImage.h
+++ b/src/ImageData/CartaFitsImage.h
@@ -29,6 +29,12 @@ public:
     CartaFitsImage(const CartaFitsImage& other);
     ~CartaFitsImage() override;
 
+    // Function to open a CARTA FITS image
+    static casacore::LatticeBase* OpenCartaFitsImage(const casacore::String& name, const casacore::MaskSpecifier& spec);
+
+    // Register the open function in casacore::ImageOpener
+    static void RegisterOpenFunction();
+
     // implement casacore ImageInterface
     casacore::String imageType() const override;
     casacore::String name(bool stripPath = false) const override;

--- a/src/ImageData/CartaMiriadImage.cc
+++ b/src/ImageData/CartaMiriadImage.cc
@@ -9,6 +9,7 @@
 #include "CartaMiriadImage.h"
 
 #include <casacore/casa/OS/Path.h>
+#include <casacore/images/Images/ImageOpener.h>
 #include <casacore/mirlib/maxdimc.h>
 #include <casacore/mirlib/miriad.h>
 
@@ -37,6 +38,14 @@ CartaMiriadImage::~CartaMiriadImage() {
     if (_pixel_mask != nullptr) {
         delete _pixel_mask;
     }
+}
+
+casacore::LatticeBase* CartaMiriadImage::OpenCartaMiriadImage(const casacore::String& name, const casacore::MaskSpecifier& spec) {
+    return new CartaMiriadImage(name, spec);
+}
+
+void CartaMiriadImage::RegisterOpenFunction() {
+    casacore::ImageOpener::registerOpenImageFunction(casacore::ImageOpener::MIRIAD, &OpenCartaMiriadImage);
 }
 
 void CartaMiriadImage::SetUp() {

--- a/src/ImageData/CartaMiriadImage.h
+++ b/src/ImageData/CartaMiriadImage.h
@@ -23,6 +23,12 @@ public:
     CartaMiriadImage(const CartaMiriadImage& other);
     ~CartaMiriadImage();
 
+    // Function to open a CARTA MIRIAD image
+    static casacore::LatticeBase* OpenCartaMiriadImage(const casacore::String& name, const casacore::MaskSpecifier& spec);
+
+    // Register the open function in casacore::ImageOpener
+    static void RegisterOpenFunction();
+
     inline casacore::SpectralCoordinate::SpecType NativeType() {
         return _native_type;
     }

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -180,11 +180,15 @@ bool FileLoader::GetCoordinateAxes(CoordinateAxes& coord_axes, std::string& mess
     _coord_axes = image_axes; // save in loader
     _image_plane_size = image_axes.width * image_axes.height;
 
-    // TODO: not saved by FileExtInfoLoader!
     // save stokes types with respect to the stokes index
-    if (_stokes_cdelt != 0) {
+    auto stokes_axis = image_axes.stokes_axis;
+    if (stokes_axis >= 0) {
+        double stokes_cdelt = _coord_sys.increment()(stokes_axis);
+        double stokes_crval = _coord_sys.referenceValue()(stokes_axis);
+        double stokes_crpix = _coord_sys.referencePixel()(stokes_axis);
+
         for (int i = 0; i < image_axes.num_stokes; ++i) {
-            int stokes_fits_value = _stokes_crval + (i + 1 - _stokes_crpix) * _stokes_cdelt;
+            int stokes_fits_value = stokes_crval + (i + 1 - stokes_crpix) * stokes_cdelt;
             int stokes_value;
             if (FileInfo::ConvertFitsStokesValue(stokes_fits_value, stokes_value)) {
                 _stokes_indices[GetStokesType(stokes_value)] = i;
@@ -770,18 +774,6 @@ bool FileLoader::GetStokesTypeIndex(const CARTA::PolarizationType& stokes_type, 
         return true;
     }
     return false;
-}
-
-void FileLoader::SetStokesCrval(float stokes_crval) {
-    _stokes_crval = stokes_crval;
-}
-
-void FileLoader::SetStokesCrpix(float stokes_crpix) {
-    _stokes_crpix = stokes_crpix;
-}
-
-void FileLoader::SetStokesCdelt(int stokes_cdelt) {
-    _stokes_cdelt = stokes_cdelt;
 }
 
 bool FileLoader::SaveFile(const CARTA::FileType type, const std::string& output_filename, std::string& message) {

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -188,7 +188,7 @@ bool FileLoader::GetCoordinateAxes(CoordinateAxes& coord_axes, std::string& mess
         double stokes_crpix = _coord_sys.referencePixel()(stokes_axis);
 
         for (int i = 0; i < image_axes.num_stokes; ++i) {
-            int stokes_fits_value = stokes_crval + (i + 1 - stokes_crpix) * stokes_cdelt;
+            int stokes_fits_value = stokes_crval + (i - stokes_crpix) * stokes_cdelt;
             int stokes_value;
             if (FileInfo::ConvertFitsStokesValue(stokes_fits_value, stokes_value)) {
                 _stokes_indices[GetStokesType(stokes_value)] = i;

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -12,6 +12,7 @@
 #include <casacore/lattices/Lattices/MaskedLatticeIterator.h>
 
 #include "Logger/Logger.h"
+#include "Util/Casacore.h"
 #include "Util/File.h"
 
 #include "CasaLoader.h"
@@ -153,22 +154,16 @@ bool FileLoader::GetCoordinateSystem(casacore::CoordinateSystem& coord_sys) {
     return true;
 }
 
-bool FileLoader::FindCoordinateAxes(IPos& shape, int& spectral_axis, int& z_axis, int& stokes_axis, std::string& message) {
+bool FileLoader::GetCoordinateAxes(CoordinateAxes& coord_axes, std::string& message) {
     // Return image shape and axes for image. Spectral axis may or may not be z axis.
     // All parameters are return values.
-    spectral_axis = -1;
-    z_axis = -1;
-    stokes_axis = -1;
-
     if (!HasData(FileInfo::Data::Image)) {
         message = "Image has no data.";
         return false;
     }
 
-    shape = _image_shape;
-
     // Dimension check
-    _num_dims = shape.size();
+    _num_dims = _image_shape.size();
     if (_num_dims < 2 || _num_dims > 4) {
         message = "Image must be 2D, 3D, or 4D.";
         return false;
@@ -179,76 +174,16 @@ bool FileLoader::FindCoordinateAxes(IPos& shape, int& spectral_axis, int& z_axis
         return false;
     }
 
-    // Determine which axes will be rendered
-    std::vector<int> render_axes = GetRenderAxes();
-    _width = shape(render_axes[0]);
-    _height = shape(render_axes[1]);
-    _image_plane_size = _width * _height;
+    // Find coordinate axes
+    CoordinateAxes image_axes = FindCoordinateAxes(_coord_sys, _image_shape);
+    coord_axes = image_axes;  // return value
+    _coord_axes = image_axes; // save in loader
+    _image_plane_size = image_axes.width * image_axes.height;
 
-    // Spectral and stokes axis
-    spectral_axis = _coord_sys.spectralAxisNumber();
-    stokes_axis = _coord_sys.polarizationAxisNumber();
-
-    // 2D image
-    if (_num_dims == 2) {
-        // Save z values
-        _z_axis = -1;
-        _depth = 1;
-        // Save stokes values
-        _stokes_axis = -1;
-        _num_stokes = 1;
-        return true;
-    }
-
-    // Cope with incomplete/invalid headers for 3D, 4D images
-    bool no_spectral(spectral_axis < 0), no_stokes(stokes_axis < 0);
-    if ((no_spectral && no_stokes) && (_num_dims == 3)) {
-        // assume third is spectral with no stokes
-        spectral_axis = 2;
-    }
-
-    if ((no_spectral || no_stokes) && (_num_dims == 4)) {
-        if (no_spectral && !no_stokes) { // stokes is known
-            spectral_axis = (stokes_axis == 3 ? 2 : 3);
-        } else if (!no_spectral && no_stokes) { // spectral is known
-            stokes_axis = (spectral_axis == 3 ? 2 : 3);
-        } else { // neither is known
-            // guess by shape (max 4 stokes)
-            if (shape(2) > 4) {
-                spectral_axis = 2;
-                stokes_axis = 3;
-            } else if (shape(3) > 4) {
-                spectral_axis = 3;
-                stokes_axis = 2;
-            }
-
-            if ((spectral_axis < 0) && (stokes_axis < 0)) {
-                // could not guess, assume [spectral, stokes]
-                spectral_axis = 2;
-                stokes_axis = 3;
-            }
-        }
-    }
-
-    // Z axis is non-render axis that is not stokes (if any)
-    for (size_t i = 0; i < _num_dims; ++i) {
-        if ((i != render_axes[0]) && (i != render_axes[1]) && (i != stokes_axis)) {
-            z_axis = i;
-            break;
-        }
-    }
-
-    // Save z axis values
-    _z_axis = z_axis;
-    _depth = (z_axis >= 0 ? shape(z_axis) : 1);
-
-    // Save stokes axis values
-    _stokes_axis = stokes_axis;
-    _num_stokes = (stokes_axis >= 0 ? shape(stokes_axis) : 1);
-
+    // TODO: not saved by FileExtInfoLoader!
     // save stokes types with respect to the stokes index
     if (_stokes_cdelt != 0) {
-        for (int i = 0; i < _num_stokes; ++i) {
+        for (int i = 0; i < image_axes.num_stokes; ++i) {
             int stokes_fits_value = _stokes_crval + (i + 1 - _stokes_crpix) * _stokes_cdelt;
             int stokes_value;
             if (FileInfo::ConvertFitsStokesValue(stokes_fits_value, stokes_value)) {
@@ -258,52 +193,6 @@ bool FileLoader::FindCoordinateAxes(IPos& shape, int& spectral_axis, int& z_axis
     }
 
     return true;
-}
-
-std::vector<int> FileLoader::GetRenderAxes() {
-    // Determine which axes will be rendered
-    std::vector<int> axes;
-
-    if (!_render_axes.empty()) {
-        axes = _render_axes;
-        return axes;
-    }
-
-    // Default unless PV image
-    axes.assign({0, 1});
-
-    if (_image_shape.size() > 2) {
-        // Normally, use direction axes
-        if (_coord_sys.hasDirectionCoordinate()) {
-            casacore::Vector<casacore::Int> dir_axes = _coord_sys.directionAxesNumbers();
-            axes[0] = dir_axes[0];
-            axes[1] = dir_axes[1];
-        } else if (_coord_sys.hasLinearCoordinate()) {
-            // Check for PV image: [Linear, Spectral] axes
-            // Returns -1 if no spectral axis
-            int spectral_axis = _coord_sys.spectralAxisNumber();
-
-            if (spectral_axis >= 0) {
-                // Find valid (not -1) linear axes
-                std::vector<int> valid_axes;
-                casacore::Vector<casacore::Int> lin_axes = _coord_sys.linearAxesNumbers();
-                for (auto axis : lin_axes) {
-                    if (axis >= 0) {
-                        valid_axes.push_back(axis);
-                    }
-                }
-
-                // One linear + spectral axis = pV image
-                if (valid_axes.size() == 1) {
-                    valid_axes.push_back(spectral_axis);
-                    axes = valid_axes;
-                }
-            }
-        }
-    }
-
-    _render_axes = axes;
-    return axes;
 }
 
 bool FileLoader::GetSlice(casacore::Array<float>& data, const casacore::Slicer& slicer) {
@@ -466,17 +355,18 @@ casacore::ArrayBase* FileLoader::GetStatsData(FileInfo::Data ds) {
 void FileLoader::LoadStats2DBasic(FileInfo::Data ds) {
     if (HasData(ds)) {
         const IPos& stat_dims = GetStatsDataShape(ds);
+        size_t depth(_coord_axes.depth), num_stokes(_coord_axes.num_stokes);
 
         // We can handle 2D, 3D and 4D in the same way
-        if ((_num_dims == 2 && stat_dims.size() == 0) || (_num_dims == 3 && stat_dims.isEqual(IPos(1, _depth))) ||
-            (_num_dims == 4 && stat_dims.isEqual(IPos(2, _depth, _num_stokes)))) {
+        if ((_num_dims == 2 && stat_dims.size() == 0) || (_num_dims == 3 && stat_dims.isEqual(IPos(1, depth))) ||
+            (_num_dims == 4 && stat_dims.isEqual(IPos(2, depth, num_stokes)))) {
             auto data = GetStatsData(ds);
 
             switch (ds) {
                 case FileInfo::Data::STATS_2D_MAX: {
                     auto it = static_cast<casacore::Array<casacore::Float>*>(data)->begin();
-                    for (size_t s = 0; s < _num_stokes; s++) {
-                        for (size_t z = 0; z < _depth; z++) {
+                    for (size_t s = 0; s < num_stokes; s++) {
+                        for (size_t z = 0; z < depth; z++) {
                             _z_stats[s][z].basic_stats[CARTA::StatsType::Max] = *it++;
                         }
                     }
@@ -484,8 +374,8 @@ void FileLoader::LoadStats2DBasic(FileInfo::Data ds) {
                 }
                 case FileInfo::Data::STATS_2D_MIN: {
                     auto it = static_cast<casacore::Array<casacore::Float>*>(data)->begin();
-                    for (size_t s = 0; s < _num_stokes; s++) {
-                        for (size_t z = 0; z < _depth; z++) {
+                    for (size_t s = 0; s < num_stokes; s++) {
+                        for (size_t z = 0; z < depth; z++) {
                             _z_stats[s][z].basic_stats[CARTA::StatsType::Min] = *it++;
                         }
                     }
@@ -493,8 +383,8 @@ void FileLoader::LoadStats2DBasic(FileInfo::Data ds) {
                 }
                 case FileInfo::Data::STATS_2D_SUM: {
                     auto it = static_cast<casacore::Array<casacore::Float>*>(data)->begin();
-                    for (size_t s = 0; s < _num_stokes; s++) {
-                        for (size_t z = 0; z < _depth; z++) {
+                    for (size_t s = 0; s < num_stokes; s++) {
+                        for (size_t z = 0; z < depth; z++) {
                             _z_stats[s][z].basic_stats[CARTA::StatsType::Sum] = *it++;
                         }
                     }
@@ -502,8 +392,8 @@ void FileLoader::LoadStats2DBasic(FileInfo::Data ds) {
                 }
                 case FileInfo::Data::STATS_2D_SUMSQ: {
                     auto it = static_cast<casacore::Array<casacore::Float>*>(data)->begin();
-                    for (size_t s = 0; s < _num_stokes; s++) {
-                        for (size_t z = 0; z < _depth; z++) {
+                    for (size_t s = 0; s < num_stokes; s++) {
+                        for (size_t z = 0; z < depth; z++) {
                             _z_stats[s][z].basic_stats[CARTA::StatsType::SumSq] = *it++;
                         }
                     }
@@ -511,8 +401,8 @@ void FileLoader::LoadStats2DBasic(FileInfo::Data ds) {
                 }
                 case FileInfo::Data::STATS_2D_NANS: {
                     auto it = static_cast<casacore::Array<casacore::Int64>*>(data)->begin();
-                    for (size_t s = 0; s < _num_stokes; s++) {
-                        for (size_t z = 0; z < _depth; z++) {
+                    for (size_t s = 0; s < num_stokes; s++) {
+                        for (size_t z = 0; z < depth; z++) {
                             _z_stats[s][z].basic_stats[CARTA::StatsType::NanCount] = *it++;
                         }
                     }
@@ -532,16 +422,16 @@ void FileLoader::LoadStats2DHist() {
 
     if (HasData(ds)) {
         const IPos& stat_dims = GetStatsDataShape(ds);
-        size_t num_bins = stat_dims[0];
+        size_t num_bins(stat_dims[0]), depth(_coord_axes.depth), num_stokes(_coord_axes.num_stokes);
 
         // We can handle 2D, 3D and 4D in the same way
-        if ((_num_dims == 2 && stat_dims.isEqual(IPos(1, num_bins))) || (_num_dims == 3 && stat_dims.isEqual(IPos(2, num_bins, _depth))) ||
-            (_num_dims == 4 && stat_dims.isEqual(IPos(3, num_bins, _depth, _num_stokes)))) {
+        if ((_num_dims == 2 && stat_dims.isEqual(IPos(1, num_bins))) || (_num_dims == 3 && stat_dims.isEqual(IPos(2, num_bins, depth))) ||
+            (_num_dims == 4 && stat_dims.isEqual(IPos(3, num_bins, depth, num_stokes)))) {
             auto data = static_cast<casacore::Array<casacore::Int64>*>(GetStatsData(ds));
             auto it = data->begin();
 
-            for (size_t s = 0; s < _num_stokes; s++) {
-                for (size_t z = 0; z < _depth; z++) {
+            for (size_t s = 0; s < num_stokes; s++) {
+                for (size_t z = 0; z < depth; z++) {
                     _z_stats[s][z].histogram_bins.resize(num_bins);
                     for (size_t b = 0; b < num_bins; b++) {
                         _z_stats[s][z].histogram_bins[b] = *it++;
@@ -564,20 +454,19 @@ void FileLoader::LoadStats2DPercent() {
         const IPos& dims_vals = GetStatsDataShape(dsp);
         const IPos& dims_ranks = GetStatsDataShape(dsr);
 
-        size_t num_ranks = dims_ranks[0];
+        size_t num_ranks(dims_ranks[0]), depth(_coord_axes.depth), num_stokes(_coord_axes.num_stokes);
 
         // We can handle 2D, 3D and 4D in the same way
-        if ((_num_dims == 2 && dims_vals.isEqual(IPos(1, num_ranks))) ||
-            (_num_dims == 3 && dims_vals.isEqual(IPos(2, num_ranks, _depth))) ||
-            (_num_dims == 4 && dims_vals.isEqual(IPos(3, num_ranks, _depth, _num_stokes)))) {
+        if ((_num_dims == 2 && dims_vals.isEqual(IPos(1, num_ranks))) || (_num_dims == 3 && dims_vals.isEqual(IPos(2, num_ranks, depth))) ||
+            (_num_dims == 4 && dims_vals.isEqual(IPos(3, num_ranks, depth, num_stokes)))) {
             auto ranks = static_cast<casacore::Array<casacore::Float>*>(GetStatsData(dsr));
             auto data = static_cast<casacore::Array<casacore::Float>*>(GetStatsData(dsp));
 
             auto it = data->begin();
             auto itr = ranks->begin();
 
-            for (size_t s = 0; s < _num_stokes; s++) {
-                for (size_t z = 0; z < _depth; z++) {
+            for (size_t s = 0; s < num_stokes; s++) {
+                for (size_t z = 0; z < depth; z++) {
                     _z_stats[s][z].percentiles.resize(num_ranks);
                     _z_stats[s][z].percentile_ranks.resize(num_ranks);
                     for (size_t r = 0; r < num_ranks; r++) {
@@ -596,43 +485,44 @@ void FileLoader::LoadStats2DPercent() {
 void FileLoader::LoadStats3DBasic(FileInfo::Data ds) {
     if (HasData(ds)) {
         const IPos& stat_dims = GetStatsDataShape(ds);
+        size_t num_stokes(_coord_axes.num_stokes);
 
         // We can handle 3D and 4D in the same way
-        if ((_num_dims == 3 && stat_dims.size() == 0) || (_num_dims == 4 && stat_dims.isEqual(IPos(1, _num_stokes)))) {
+        if ((_num_dims == 3 && stat_dims.size() == 0) || (_num_dims == 4 && stat_dims.isEqual(IPos(1, num_stokes)))) {
             auto data = GetStatsData(ds);
 
             switch (ds) {
                 case FileInfo::Data::STATS_3D_MAX: {
                     auto it = static_cast<casacore::Array<casacore::Float>*>(data)->begin();
-                    for (size_t s = 0; s < _num_stokes; s++) {
+                    for (size_t s = 0; s < num_stokes; s++) {
                         _cube_stats[s].basic_stats[CARTA::StatsType::Max] = *it++;
                     }
                     break;
                 }
                 case FileInfo::Data::STATS_3D_MIN: {
                     auto it = static_cast<casacore::Array<casacore::Float>*>(data)->begin();
-                    for (size_t s = 0; s < _num_stokes; s++) {
+                    for (size_t s = 0; s < num_stokes; s++) {
                         _cube_stats[s].basic_stats[CARTA::StatsType::Min] = *it++;
                     }
                     break;
                 }
                 case FileInfo::Data::STATS_3D_SUM: {
                     auto it = static_cast<casacore::Array<casacore::Float>*>(data)->begin();
-                    for (size_t s = 0; s < _num_stokes; s++) {
+                    for (size_t s = 0; s < num_stokes; s++) {
                         _cube_stats[s].basic_stats[CARTA::StatsType::Sum] = *it++;
                     }
                     break;
                 }
                 case FileInfo::Data::STATS_3D_SUMSQ: {
                     auto it = static_cast<casacore::Array<casacore::Float>*>(data)->begin();
-                    for (size_t s = 0; s < _num_stokes; s++) {
+                    for (size_t s = 0; s < num_stokes; s++) {
                         _cube_stats[s].basic_stats[CARTA::StatsType::SumSq] = *it++;
                     }
                     break;
                 }
                 case FileInfo::Data::STATS_3D_NANS: {
                     auto it = static_cast<casacore::Array<casacore::Int64>*>(data)->begin();
-                    for (size_t s = 0; s < _num_stokes; s++) {
+                    for (size_t s = 0; s < num_stokes; s++) {
                         _cube_stats[s].basic_stats[CARTA::StatsType::NanCount] = *it++;
                     }
                     break;
@@ -651,15 +541,15 @@ void FileLoader::LoadStats3DHist() {
 
     if (HasData(ds)) {
         const IPos& stat_dims = GetStatsDataShape(ds);
-        size_t num_bins = stat_dims[0];
+        size_t num_bins(stat_dims[0]), num_stokes(_coord_axes.num_stokes);
 
         // We can handle 3D and 4D in the same way
         if ((_num_dims == 3 && stat_dims.isEqual(IPos(1, num_bins))) ||
-            (_num_dims == 4 && stat_dims.isEqual(IPos(2, num_bins, _num_stokes)))) {
+            (_num_dims == 4 && stat_dims.isEqual(IPos(2, num_bins, num_stokes)))) {
             auto data = static_cast<casacore::Array<casacore::Int64>*>(GetStatsData(ds));
             auto it = data->begin();
 
-            for (size_t s = 0; s < _num_stokes; s++) {
+            for (size_t s = 0; s < num_stokes; s++) {
                 _cube_stats[s].histogram_bins.resize(num_bins);
                 for (size_t b = 0; b < num_bins; b++) {
                     _cube_stats[s].histogram_bins[b] = *it++;
@@ -681,17 +571,17 @@ void FileLoader::LoadStats3DPercent() {
         const IPos& dims_vals = GetStatsDataShape(dsp);
         const IPos& dims_ranks = GetStatsDataShape(dsr);
 
-        size_t nranks = dims_ranks[0];
+        size_t nranks(dims_ranks[0]), num_stokes(_coord_axes.num_stokes);
 
         // We can handle 3D and 4D in the same way
-        if ((_num_dims == 3 && dims_vals.isEqual(IPos(1, nranks))) || (_num_dims == 4 && dims_vals.isEqual(IPos(2, nranks, _num_stokes)))) {
+        if ((_num_dims == 3 && dims_vals.isEqual(IPos(1, nranks))) || (_num_dims == 4 && dims_vals.isEqual(IPos(2, nranks, num_stokes)))) {
             auto ranks = static_cast<casacore::Array<casacore::Float>*>(GetStatsData(dsr));
             auto data = static_cast<casacore::Array<casacore::Float>*>(GetStatsData(dsp));
 
             auto it = data->begin();
             auto itr = ranks->begin();
 
-            for (size_t s = 0; s < _num_stokes; s++) {
+            for (size_t s = 0; s < num_stokes; s++) {
                 _cube_stats[s].percentiles.resize(nranks);
                 _cube_stats[s].percentile_ranks.resize(nranks);
                 for (size_t r = 0; r < nranks; r++) {
@@ -707,11 +597,13 @@ void FileLoader::LoadStats3DPercent() {
 }
 
 void FileLoader::LoadImageStats(bool load_percentiles) {
-    _z_stats.resize(_num_stokes);
-    for (size_t s = 0; s < _num_stokes; s++) {
-        _z_stats[s].resize(_depth);
+    size_t num_stokes(_coord_axes.num_stokes), depth(_coord_axes.depth);
+
+    _z_stats.resize(num_stokes);
+    for (size_t s = 0; s < num_stokes; s++) {
+        _z_stats[s].resize(depth);
     }
-    _cube_stats.resize(_num_stokes);
+    _cube_stats.resize(num_stokes);
 
     // Remove this check when we drop support for the old schema.
     // We assume that checking for only one of these datasets is sufficient.
@@ -739,8 +631,8 @@ void FileLoader::LoadImageStats(bool load_percentiles) {
             bool has_flux = !std::isnan(beam_area);
 
             // If we loaded all the 2D stats successfully, assume all channel stats are valid
-            for (size_t s = 0; s < _num_stokes; s++) {
-                for (size_t z = 0; z < _depth; z++) {
+            for (size_t s = 0; s < num_stokes; s++) {
+                for (size_t z = 0; z < depth; z++) {
                     auto& stats = _z_stats[s][z].basic_stats;
                     if (full) {
                         num_pixels = _image_plane_size - stats[CARTA::StatsType::NanCount];
@@ -784,10 +676,10 @@ void FileLoader::LoadImageStats(bool load_percentiles) {
             bool has_flux = !std::isnan(beam_area);
 
             // If we loaded all the 3D stats successfully, assume all cube stats are valid
-            for (size_t s = 0; s < _num_stokes; s++) {
+            for (size_t s = 0; s < _coord_axes.num_stokes; s++) {
                 auto& stats = _cube_stats[s].basic_stats;
                 if (full) {
-                    num_pixels = (_image_plane_size * _depth) - stats[CARTA::StatsType::NanCount];
+                    num_pixels = (_image_plane_size * _coord_axes.depth) - stats[CARTA::StatsType::NanCount];
                     sum = stats[CARTA::StatsType::Sum];
                     sum_sq = stats[CARTA::StatsType::SumSq];
                     min = stats[CARTA::StatsType::Min];

--- a/src/ImageData/FileLoader.h
+++ b/src/ImageData/FileLoader.h
@@ -91,9 +91,6 @@ public:
     std::string GetFileName();
 
     // Handle stokes type index
-    virtual void SetStokesCrval(float stokes_crval);
-    virtual void SetStokesCrpix(float stokes_crpix);
-    virtual void SetStokesCdelt(int stokes_cdelt);
     virtual bool GetStokesTypeIndex(const CARTA::PolarizationType& stokes_type, int& stokes_index);
     std::unordered_map<CARTA::PolarizationType, int> GetStokesIndices() {
         return _stokes_indices;
@@ -127,9 +124,6 @@ protected:
 
     // Storage for the stokes type vs. stokes index
     std::unordered_map<CARTA::PolarizationType, int> _stokes_indices;
-    float _stokes_crval;
-    float _stokes_crpix;
-    int _stokes_cdelt;
 
     // Return the shape of the specified stats dataset
     virtual const IPos GetStatsDataShape(FileInfo::Data ds);

--- a/src/ImageData/FileLoader.h
+++ b/src/ImageData/FileLoader.h
@@ -17,6 +17,7 @@
 #include <carta-protobuf/enums.pb.h>
 
 #include "ImageData/FileInfo.h"
+#include "Util/Casacore.h"
 
 namespace carta {
 
@@ -54,8 +55,7 @@ public:
     // Image shape and coordinate system axes
     bool GetShape(IPos& shape);
     bool GetCoordinateSystem(casacore::CoordinateSystem& coord_sys);
-    bool FindCoordinateAxes(IPos& shape, int& spectral_axis, int& z_axis, int& stokes_axis, std::string& message);
-    std::vector<int> GetRenderAxes(); // Determine axes used for image raster data
+    bool GetCoordinateAxes(CoordinateAxes& coord_axes, std::string& message);
 
     // Slice image data (with mask applied)
     bool GetSlice(casacore::Array<float>& data, const casacore::Slicer& slicer);
@@ -114,16 +114,11 @@ protected:
 
     std::shared_ptr<casacore::ImageInterface<casacore::Float>> _image;
 
-    // Save image properties; only reopen for data or beams
-    // Axes, dimension values
-    casacore::IPosition _image_shape;
-    size_t _num_dims, _image_plane_size;
-    size_t _width, _height, _depth, _num_stokes;
-    int _z_axis, _stokes_axis;
-    std::vector<int> _render_axes;
-    // Coordinate system
+    // Image properties; only reopen image for data or beams
     casacore::CoordinateSystem _coord_sys;
-    // Pixel mask
+    casacore::IPosition _image_shape;
+    CoordinateAxes _coord_axes;
+    size_t _num_dims, _image_plane_size;
     bool _has_pixel_mask;
 
     // Storage for z-plane and cube statistics

--- a/src/ImageData/Hdf5Loader.cc
+++ b/src/ImageData/Hdf5Loader.cc
@@ -220,14 +220,15 @@ bool Hdf5Loader::GetCursorSpectralData(
     bool has_swizzled = HasData(FileInfo::Data::SWIZZLED);
     ulock.unlock();
     if (has_swizzled) {
+        size_t depth(_coord_axes.depth);
         casacore::Slicer slicer;
         if (_num_dims == 4) {
-            slicer = casacore::Slicer(IPos(4, 0, cursor_y, cursor_x, stokes), IPos(4, _depth, count_y, count_x, 1));
+            slicer = casacore::Slicer(IPos(4, 0, cursor_y, cursor_x, stokes), IPos(4, depth, count_y, count_x, 1));
         } else if (_num_dims == 3) {
-            slicer = casacore::Slicer(IPos(3, 0, cursor_y, cursor_x), IPos(3, _depth, count_y, count_x));
+            slicer = casacore::Slicer(IPos(3, 0, cursor_y, cursor_x), IPos(3, depth, count_y, count_x));
         }
 
-        data.resize(_depth * count_y * count_x);
+        data.resize(depth * count_y * count_x);
         casacore::Array<float> tmp(slicer.length(), data.data(), casacore::StorageInitPolicy::SHARE);
         std::lock_guard<std::mutex> lguard(image_mutex);
         try {
@@ -250,7 +251,7 @@ bool Hdf5Loader::UseRegionSpectralData(const IPos& region_shape, std::mutex& ima
 
     int width = region_shape(0);
     int height = region_shape(1);
-    int depth = _depth;
+    int depth = _coord_axes.depth;
 
     // Using the normal dataset may be faster if the region is wider than it is deep.
     // This is an initial estimate; we need to examine casacore's algorithm in more detail.
@@ -287,7 +288,7 @@ bool Hdf5Loader::GetRegionSpectralData(int region_id, int stokes, const casacore
 
     int width = mask_shape(0);
     int height = mask_shape(1);
-    int depth = _depth;
+    int depth = _coord_axes.depth;
     double beam_area = CalculateBeamArea();
     bool has_flux = !std::isnan(beam_area);
 
@@ -471,8 +472,8 @@ bool Hdf5Loader::GetChunk(
     std::vector<float>& data, int& data_width, int& data_height, int min_x, int min_y, int z, int stokes, std::mutex& image_mutex) {
     bool data_ok(false);
 
-    data_width = std::min(CHUNK_SIZE, (int)_width - min_x);
-    data_height = std::min(CHUNK_SIZE, (int)_height - min_y);
+    data_width = std::min(CHUNK_SIZE, (int)_coord_axes.width - min_x);
+    data_height = std::min(CHUNK_SIZE, (int)_coord_axes.height - min_y);
 
     casacore::Slicer slicer;
     if (_num_dims == 4) {

--- a/src/ImageData/StokesFilesConnector.cc
+++ b/src/ImageData/StokesFilesConnector.cc
@@ -309,23 +309,17 @@ bool StokesFilesConnector::StokesFilesValid(std::string& err, int& stokes_axis) 
         return false;
     }
 
-    casacore::IPosition ref_shape(0);
-    int ref_spectral_axis = -1;
-    int ref_z_axis = -1;
-    int ref_stokes_axis = -1;
-    int ref_index = 0;
+    CoordinateAxes ref_coord_axes;
+    CoordinateAxes coord_axes;
+    int ref_index(0);
 
     for (auto& loader : _loaders) {
-        casacore::IPosition shape;
-        int spectral_axis;
-        int z_axis;
-
         if (ref_index == 0) {
-            loader.second->FindCoordinateAxes(ref_shape, ref_spectral_axis, ref_z_axis, ref_stokes_axis, err);
+            loader.second->GetCoordinateAxes(ref_coord_axes, err);
         } else {
-            loader.second->FindCoordinateAxes(shape, spectral_axis, z_axis, stokes_axis, err);
-            if ((ref_shape.nelements() != shape.nelements()) || (ref_shape != shape) || (ref_spectral_axis != spectral_axis) ||
-                (ref_stokes_axis != stokes_axis)) {
+            loader.second->GetCoordinateAxes(coord_axes, err);
+            if ((ref_coord_axes.image_shape != coord_axes.image_shape) || (ref_coord_axes.spectral_axis != coord_axes.spectral_axis) ||
+                (ref_coord_axes.stokes_axis != coord_axes.stokes_axis)) {
                 err = "Image shapes or axes are not consistent!";
                 return false;
             }

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -226,19 +226,13 @@ bool Session::FillExtendedFileInfo(std::map<std::string, CARTA::FileInfoExtended
         }
 
         // FileInfoExtended
-        auto loader = _loaders.Get(fullname);
-        if (!loader) {
-            message = "Unsupported format.";
-            return file_info_ok;
-        }
-        FileExtInfoLoader ext_info_loader(loader);
-
         std::string requested_hdu(hdu);
         if (requested_hdu.empty() && (file_info.hdu_list_size() > 0)) {
             // Use first hdu
             requested_hdu = file_info.hdu_list(0);
         }
 
+        FileExtInfoLoader ext_info_loader;
         if (!requested_hdu.empty() || (file_info.type() != CARTA::FileType::FITS)) {
             // Get extended file info for requested hdu or images without hdus
             CARTA::FileInfoExtended file_info_ext;
@@ -274,7 +268,6 @@ bool Session::FillExtendedFileInfo(CARTA::FileInfoExtended& extended_info, CARTA
             message = "Unsupported format.";
             return file_info_ok;
         }
-        FileExtInfoLoader ext_info_loader = FileExtInfoLoader(loader);
 
         // Discern hdu for extended file info
         if (hdu.empty()) {
@@ -305,6 +298,7 @@ bool Session::FillExtendedFileInfo(CARTA::FileInfoExtended& extended_info, CARTA
             }
         }
 
+        FileExtInfoLoader ext_info_loader;
         file_info_ok = ext_info_loader.FillFileExtInfo(extended_info, fullname, hdu, message);
     } catch (casacore::AipsError& err) {
         message = err.getMesg();
@@ -319,9 +313,9 @@ bool Session::FillExtendedFileInfo(CARTA::FileInfoExtended& extended_info, std::
     bool file_info_ok(false);
 
     try {
-        image_loader = std::shared_ptr<FileLoader>(FileLoader::GetLoader(image));
-        FileExtInfoLoader ext_info_loader(image_loader);
-        file_info_ok = ext_info_loader.FillFileExtInfo(extended_info, filename, "", message);
+        FileExtInfoLoader ext_info_loader;
+        std::string hdu;
+        file_info_ok = ext_info_loader.FillFileExtInfo(extended_info, image.get(), hdu, message);
     } catch (casacore::AipsError& err) {
         message = err.getMesg();
     }

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -579,7 +579,7 @@ bool Session::OnOpenFile(
 
     if (info_loaded) {
         // Create Frame for image
-        auto loader = _loaders.Get(name);
+        auto loader = std::shared_ptr<FileLoader>(FileLoader::GetLoader(image));
         auto frame = std::make_unique<Frame>(_id, loader, "");
 
         if (frame->IsValid()) {

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -308,7 +308,7 @@ bool Session::FillExtendedFileInfo(CARTA::FileInfoExtended& extended_info, CARTA
 }
 
 bool Session::FillExtendedFileInfo(CARTA::FileInfoExtended& extended_info, std::shared_ptr<casacore::ImageInterface<float>> image,
-    const std::string& filename, std::string& message, std::shared_ptr<FileLoader>& image_loader) {
+    const std::string& filename, std::string& message) {
     // Fill FileInfoExtended for given image; no hdu
     bool file_info_ok(false);
 
@@ -572,15 +572,15 @@ bool Session::OnOpenFile(
     // Response message for opening a file
     open_file_ack->set_file_id(file_id);
     string err_message;
-    std::shared_ptr<FileLoader> image_loader;
 
     CARTA::FileInfoExtended file_info_extended;
-    bool info_loaded = FillExtendedFileInfo(file_info_extended, image, name, err_message, image_loader);
+    bool info_loaded = FillExtendedFileInfo(file_info_extended, image, name, err_message);
     bool success(false);
 
     if (info_loaded) {
         // Create Frame for image
-        auto frame = std::make_unique<Frame>(_id, image_loader, "");
+        auto loader = _loaders.Get(name);
+        auto frame = std::make_unique<Frame>(_id, loader, "");
 
         if (frame->IsValid()) {
             if (_frames.count(file_id) > 0) {

--- a/src/Session/Session.h
+++ b/src/Session/Session.h
@@ -264,7 +264,7 @@ protected:
 
     // File info for open generated image (not disk image)
     bool FillExtendedFileInfo(CARTA::FileInfoExtended& extended_info, std::shared_ptr<casacore::ImageInterface<float>> image,
-        const std::string& filename, std::string& message, std::shared_ptr<FileLoader>& image_loader);
+        const std::string& filename, std::string& message);
 
     // Delete Frame(s)
     void DeleteFrame(int file_id);

--- a/src/Util/Casacore.cc
+++ b/src/Util/Casacore.cc
@@ -115,7 +115,7 @@ casacore::String GetResolvedFilename(const string& root_dir, const string& direc
     return resolved_filename;
 }
 
-void GetSpectralCoordPreferences(
+void GetSpectralCoordSettings(
     casacore::ImageInterface<float>* image, bool& prefer_velocity, bool& optical_velocity, bool& prefer_wavelength, bool& air_wavelength) {
     prefer_velocity = optical_velocity = prefer_wavelength = air_wavelength = false;
     casacore::CoordinateSystem coord_sys(image->coordinates());
@@ -169,4 +169,92 @@ std::string FormatBeam(const casacore::GaussianBeam& gaussian_beam) {
 
 std::string FormatQuantity(const casacore::Quantity& quantity) {
     return fmt::format("{:.6f} {}", quantity.getValue(), quantity.getUnit());
+}
+
+CoordinateAxes FindCoordinateAxes(const casacore::CoordinateSystem& coord_sys, const casacore::IPosition& image_shape) {
+    std::vector<int> xy_axes = GetRenderAxes(coord_sys, image_shape);
+    int spectral_axis(coord_sys.spectralAxisNumber());
+    int stokes_axis(coord_sys.polarizationAxisNumber());
+    int z_axis(-1);
+
+    bool no_spectral(spectral_axis < 0), no_stokes(stokes_axis < 0);
+    size_t num_axes(image_shape.size());
+
+    if (no_spectral && no_stokes && (num_axes > 2)) {
+        // Cope with incomplete/invalid headers for 3D, 4D images
+        if ((no_spectral && no_stokes) && (num_axes == 3)) {
+            // assume third is spectral with no stokes
+            spectral_axis = 2;
+        }
+
+        if ((no_spectral || no_stokes) && (num_axes == 4)) {
+            if (no_spectral && !no_stokes) { // stokes is known
+                spectral_axis = (stokes_axis == 3 ? 2 : 3);
+            } else if (!no_spectral && no_stokes) { // spectral is known
+                stokes_axis = (spectral_axis == 3 ? 2 : 3);
+            } else { // neither is known
+                // guess by shape (max 4 stokes)
+                if (image_shape(2) > 4) {
+                    spectral_axis = 2;
+                    stokes_axis = 3;
+                } else if (image_shape(3) > 4) {
+                    spectral_axis = 3;
+                    stokes_axis = 2;
+                }
+
+                if ((spectral_axis < 0) && (stokes_axis < 0)) {
+                    // could not guess, assume [spectral, stokes]
+                    spectral_axis = 2;
+                    stokes_axis = 3;
+                }
+            }
+        }
+    }
+
+    // Set z axis: depth axis that is not stokes
+    for (size_t i = 0; i < num_axes; ++i) {
+        if ((i != xy_axes[0]) && (i != xy_axes[1]) && (i != stokes_axis)) {
+            z_axis = i;
+            break;
+        }
+    }
+
+    return CoordinateAxes(image_shape, xy_axes, z_axis, spectral_axis, stokes_axis);
+}
+
+std::vector<int> GetRenderAxes(const casacore::CoordinateSystem& coord_sys, const casacore::IPosition& image_shape) {
+    // Determine which axes will be rendered
+    std::vector<int> axes = {0, 1};
+
+    if (image_shape.size() > 2) {
+        // Normally, use direction axes
+        if (coord_sys.hasDirectionCoordinate()) {
+            casacore::Vector<casacore::Int> dir_axes = coord_sys.directionAxesNumbers();
+            axes[0] = dir_axes[0];
+            axes[1] = dir_axes[1];
+        } else if (coord_sys.hasLinearCoordinate()) {
+            // Check for PV image: [Linear, Spectral] axes
+            // Returns -1 if no spectral axis
+            int spectral_axis = coord_sys.spectralAxisNumber();
+
+            if (spectral_axis >= 0) {
+                // Find valid (not -1) linear axes
+                std::vector<int> valid_axes;
+                casacore::Vector<casacore::Int> lin_axes = coord_sys.linearAxesNumbers();
+                for (auto axis : lin_axes) {
+                    if (axis >= 0) {
+                        valid_axes.push_back(axis);
+                    }
+                }
+
+                // One linear + spectral axis = pV image
+                if (valid_axes.size() == 1) {
+                    valid_axes.push_back(spectral_axis);
+                    axes = valid_axes;
+                }
+            }
+        }
+    }
+
+    return axes;
 }

--- a/src/Util/Casacore.h
+++ b/src/Util/Casacore.h
@@ -11,6 +11,38 @@
 #include <casacore/images/Images/ImageOpener.h>
 #include <casacore/scimath/Mathematics/GaussianBeam.h>
 
+struct CoordinateAxes {
+    casacore::IPosition image_shape;
+    std::vector<int> xy_axes;
+    int z_axis;
+    int spectral_axis;
+    int stokes_axis;
+    size_t width;
+    size_t height;
+    size_t depth;
+    size_t num_stokes;
+
+    CoordinateAxes() : xy_axes({0, 1}), z_axis(-1), spectral_axis(-1), stokes_axis(-1), width(0), height(0), depth(1), num_stokes(1) {}
+    CoordinateAxes(const casacore::IPosition& shape, const std::vector<int>& xy_axis, int z_axis, int sp_axis, int st_axis)
+        : image_shape(shape), xy_axes(xy_axis), spectral_axis(sp_axis), stokes_axis(st_axis), z_axis(z_axis) {
+        width = image_shape(xy_axes[0]);
+        height = image_shape(xy_axes[1]);
+        depth = z_axis >= 0 ? image_shape(z_axis) : 1;
+        num_stokes = stokes_axis >= 0 ? image_shape(stokes_axis) : 1;
+    }
+    void operator=(CoordinateAxes& other) {
+        image_shape = other.image_shape;
+        xy_axes = other.xy_axes;
+        z_axis = other.z_axis;
+        spectral_axis = other.spectral_axis;
+        stokes_axis = other.stokes_axis;
+        width = other.width;
+        height = other.height;
+        depth = other.depth;
+        num_stokes = other.num_stokes;
+    }
+};
+
 bool CheckFolderPaths(std::string& top_level_string, std::string& starting_string);
 bool IsSubdirectory(std::string folder, std::string top_folder);
 casacore::String GetResolvedFilename(const std::string& root_dir, const std::string& directory, const std::string& file);
@@ -20,10 +52,14 @@ inline casacore::ImageOpener::ImageTypes CasacoreImageType(const std::string& fi
     return casacore::ImageOpener::imageType(filename);
 }
 
-void GetSpectralCoordPreferences(
+void GetSpectralCoordSettings(
     casacore::ImageInterface<float>* image, bool& prefer_velocity, bool& optical_velocity, bool& prefer_wavelength, bool& air_wavelength);
 
 std::string FormatBeam(const casacore::GaussianBeam& gaussian_beam);
 std::string FormatQuantity(const casacore::Quantity& quantity);
+
+// Determine axes information
+CoordinateAxes FindCoordinateAxes(const casacore::CoordinateSystem& coord_sys, const casacore::IPosition& image_shape);
+std::vector<int> GetRenderAxes(const casacore::CoordinateSystem& coord_sys, const casacore::IPosition& image_shape);
 
 #endif // CARTA_BACKEND__UTIL_CASACORE_H_

--- a/test/TestFileInfo.cc
+++ b/test/TestFileInfo.cc
@@ -47,8 +47,7 @@ public:
     static void CheckFileExtInfoLoader(
         const std::string& request_filename, const CARTA::FileType& request_file_type, const std::string& request_hdu = "") {
         std::string fullname = SAMPLE_FILES_PATH + "/" + request_filename;
-        auto loader = std::shared_ptr<carta::FileLoader>(carta::FileLoader::GetLoader(fullname));
-        FileExtInfoLoader ext_info_loader(loader);
+        FileExtInfoLoader ext_info_loader;
         bool file_info_ok;
         std::string message;
         std::map<std::string, CARTA::FileInfoExtended> file_info_extended_map;


### PR DESCRIPTION
As a first step for complex image support #520 , include data type in the extended file information computed_entries so that the frontend can use an LEL expression to open the image.

FileLoader has been removed from FileExtInfoLoader so that the complex image does not have to be opened from the loader, which currently fails.  Instead, the image is opened with casacore::ImageOpener, which returns an untyped casacore::LatticeBase*.  For non-float CASA images, a generic `ImageInterface<float>` is created from the image metadata only (shape, CoordinateSystem, units, MiscInfo, ImageInfo) so that ImageHeaderToFITS can continue to be used (requires `<float>`).  The data is ignored since it is not used here.

Determining the image's coordinate axes (x/y/z axes, spectral axis, stokes axis) has been moved to Util/Casacore.h so that it can be accessed from FileExtInfoLoader and FileLoader.  These values are returned and stored in a new struct `CoordinateAxes`.  Since FileExtInfoLoader no longer sets the stokes header values in FileLoader, these values are obtained from the image CoordinateSystem in the FileLoader.