### PR TITLE
Support complex data type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0-beta.3]
+
+### Added
+* Added data type to file info and open complex image with amplitude expression ([#520](https://github.com/CARTAvis/carta-backend/issues/520)).
+
 ## [3.0.0-beta.2]
 
 ### Changed
@@ -32,7 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fixed control points record for polygon / line / polyline ([#891](https://github.com/CARTAvis/carta-backend/issues/891)).
 * Fixed bug causing cube histogram to be generated even if it was available in an HDF5 file ([#899](https://github.com/CARTAvis/carta-backend/issues/899)).
-* Fixed bug of missing cursor values for matched images ([#900](https://github.com/CARTAvis/carta-backend/issues/900)).
+* Fixed bug of mis:wq
+sing cursor values for matched images ([#900](https://github.com/CARTAvis/carta-backend/issues/900)).
 
 ## [3.0.0-beta.1]
 

--- a/src/FileList/FileExtInfoLoader.h
+++ b/src/FileList/FileExtInfoLoader.h
@@ -13,6 +13,7 @@
 #include <string>
 
 #include <casacore/casa/Arrays/IPosition.h>
+#include <casacore/casa/Utilities/DataType.h>
 #include <casacore/fits/FITS/hdu.h>
 #include <casacore/images/Images/ImageFITSConverter.h>
 #include <casacore/images/Images/ImageInterface.h>
@@ -46,6 +47,7 @@ private:
     void FitsHeaderInfoToHeaderEntries(casacore::ImageFITSHeaderInfo& fhi, CARTA::FileInfoExtended& extended_info);
 
     // Computed entries
+    void AddDataTypeEntry(CARTA::FileInfoExtended& extended_info, casacore::DataType data_type);
     void AddShapeEntries(CARTA::FileInfoExtended& extended_info, const casacore::IPosition& shape, int chan_axis, int depth_axis,
         int stokes_axis, const std::vector<int>& render_axes);
     void AddInitialComputedEntries(const std::string& hdu, CARTA::FileInfoExtended& extended_info, const std::string& filename,

--- a/src/ImageData/CartaHdf5Image.cc
+++ b/src/ImageData/CartaHdf5Image.cc
@@ -254,6 +254,9 @@ casacore::Vector<casacore::String> CartaHdf5Image::FitsHeaderStrings() {
     return _fits_header_strings;
 }
 
+casacore::DataType CartaHdf5Image::internalDataType() {
+    return _lattice.dataType();
+}
 casacore::uInt CartaHdf5Image::advisedMaxPixels() const {
     return _lattice.advisedMaxPixels();
 }

--- a/src/ImageData/CartaHdf5Image.h
+++ b/src/ImageData/CartaHdf5Image.h
@@ -65,6 +65,8 @@ public:
 
     casacore::Vector<casacore::String> FitsHeaderStrings();
 
+    casacore::DataType internalDataType();
+
 private:
     // Function to return the internal HDF5File object to the RegionHandlerHDF5
     inline static const casacore::CountedPtr<casacore::HDF5File>& GetHdf5File(void* image) {

--- a/src/ImageData/CasaLoader.h
+++ b/src/ImageData/CasaLoader.h
@@ -62,13 +62,14 @@ void CasaLoader::OpenFile(const std::string& /*hdu*/) {
 casacore::TempImage<float>* CasaLoader::ConvertImageToFloat(casacore::LatticeBase* lattice) {
     // Create a TempImage with no data
     if (!lattice) {
+        // Not supported by ImageOpener
         throw(casacore::AipsError("Image data type not supported."));
     }
 
     casacore::TempImage<float>* float_image(nullptr);
 
     switch (lattice->dataType()) {
-        case casacore::TpBool: { // not supported by ImageOpener
+        case casacore::TpBool: { // Not supported by ImageOpener
             casacore::PagedImage<bool>* bool_image = dynamic_cast<casacore::PagedImage<bool>*>(lattice);
             float_image = new casacore::TempImage<float>(bool_image->shape(), bool_image->coordinates());
             float_image->setUnits(bool_image->units());
@@ -76,7 +77,7 @@ casacore::TempImage<float>* CasaLoader::ConvertImageToFloat(casacore::LatticeBas
             float_image->setImageInfo(bool_image->imageInfo());
             break;
         }
-        case casacore::TpInt: { // not supported by ImageOpener
+        case casacore::TpInt: { // Not supported by ImageOpener
             casacore::PagedImage<int>* int_image = dynamic_cast<casacore::PagedImage<int>*>(lattice);
             float_image = new casacore::TempImage<float>(int_image->shape(), int_image->coordinates());
             float_image->setUnits(int_image->units());

--- a/src/ImageData/CasaLoader.h
+++ b/src/ImageData/CasaLoader.h
@@ -7,7 +7,9 @@
 #ifndef CARTA_BACKEND_IMAGEDATA_CASALOADER_H_
 #define CARTA_BACKEND_IMAGEDATA_CASALOADER_H_
 
+#include <casacore/images/Images/ImageOpener.h>
 #include <casacore/images/Images/PagedImage.h>
+#include <casacore/images/Images/TempImage.h>
 
 #include "FileLoader.h"
 
@@ -18,13 +20,28 @@ public:
     CasaLoader(const std::string& filename);
 
     void OpenFile(const std::string& hdu) override;
+
+private:
+    casacore::TempImage<float>* ConvertImageToFloat(casacore::LatticeBase* lattice);
 };
 
 CasaLoader::CasaLoader(const std::string& filename) : FileLoader(filename) {}
 
 void CasaLoader::OpenFile(const std::string& /*hdu*/) {
     if (!_image) {
-        _image.reset(new casacore::PagedImage<float>(_filename));
+        bool converted(false);
+
+        try {
+            _image.reset(new casacore::PagedImage<float>(_filename));
+        } catch (const casacore::AipsError& err) {
+            if (err.getMesg().startsWith("Invalid Table data type")) {
+                // Temporary workaround (no data) to support complex images in file browser; must use LEL expression for data
+                auto lattice = casacore::ImageOpener::openImage(_filename);
+                _image.reset(ConvertImageToFloat(lattice));
+                _data_type = lattice->dataType();
+                converted = true;
+            }
+        }
 
         if (!_image) {
             throw(casacore::AipsError("Error opening image"));
@@ -34,7 +51,67 @@ void CasaLoader::OpenFile(const std::string& /*hdu*/) {
         _num_dims = _image_shape.size();
         _has_pixel_mask = _image->hasPixelMask();
         _coord_sys = std::shared_ptr<casacore::CoordinateSystem>(static_cast<casacore::CoordinateSystem*>(_image->coordinates().clone()));
+
+        if (!converted) {
+            _data_type = _image->dataType();
+        }
     }
+}
+
+casacore::TempImage<float>* CasaLoader::ConvertImageToFloat(casacore::LatticeBase* lattice) {
+    // Create a TempImage with no data
+    if (!lattice) {
+        throw(casacore::AipsError("Image data type not supported."));
+    }
+
+    casacore::TempImage<float>* float_image(nullptr);
+
+    switch (lattice->dataType()) {
+        case casacore::TpBool: { // not supported by ImageOpener
+            casacore::PagedImage<bool>* bool_image = dynamic_cast<casacore::PagedImage<bool>*>(lattice);
+            float_image = new casacore::TempImage<float>(bool_image->shape(), bool_image->coordinates());
+            float_image->setUnits(bool_image->units());
+            float_image->setMiscInfo(bool_image->miscInfo());
+            float_image->setImageInfo(bool_image->imageInfo());
+            break;
+        }
+        case casacore::TpInt: { // not supported by ImageOpener
+            casacore::PagedImage<int>* int_image = dynamic_cast<casacore::PagedImage<int>*>(lattice);
+            float_image = new casacore::TempImage<float>(int_image->shape(), int_image->coordinates());
+            float_image->setUnits(int_image->units());
+            float_image->setMiscInfo(int_image->miscInfo());
+            float_image->setImageInfo(int_image->imageInfo());
+            break;
+        }
+        case casacore::TpDouble: {
+            casacore::PagedImage<double>* double_image = dynamic_cast<casacore::PagedImage<double>*>(lattice);
+            float_image = new casacore::TempImage<float>(double_image->shape(), double_image->coordinates());
+            float_image->setUnits(double_image->units());
+            float_image->setMiscInfo(double_image->miscInfo());
+            float_image->setImageInfo(double_image->imageInfo());
+            break;
+        }
+        case casacore::TpComplex: {
+            casacore::PagedImage<casacore::Complex>* complex_image = dynamic_cast<casacore::PagedImage<casacore::Complex>*>(lattice);
+            float_image = new casacore::TempImage<float>(complex_image->shape(), complex_image->coordinates());
+            float_image->setUnits(complex_image->units());
+            float_image->setMiscInfo(complex_image->miscInfo());
+            float_image->setImageInfo(complex_image->imageInfo());
+            break;
+        }
+        case casacore::TpDComplex: {
+            casacore::PagedImage<casacore::DComplex>* complex_image = dynamic_cast<casacore::PagedImage<casacore::DComplex>*>(lattice);
+            float_image = new casacore::TempImage<float>(complex_image->shape(), complex_image->coordinates());
+            float_image->setUnits(complex_image->units());
+            float_image->setMiscInfo(complex_image->miscInfo());
+            float_image->setImageInfo(complex_image->imageInfo());
+            break;
+        }
+        default:
+            throw(casacore::AipsError("Image data type not supported."));
+    }
+
+    return float_image;
 }
 
 } // namespace carta

--- a/src/ImageData/CasaLoader.h
+++ b/src/ImageData/CasaLoader.h
@@ -39,6 +39,7 @@ void CasaLoader::OpenFile(const std::string& /*hdu*/) {
                 auto lattice = casacore::ImageOpener::openImage(_filename);
                 _image.reset(ConvertImageToFloat(lattice));
                 _data_type = lattice->dataType();
+                delete lattice;
                 converted = true;
             }
         }

--- a/src/ImageData/CompListLoader.h
+++ b/src/ImageData/CompListLoader.h
@@ -36,6 +36,7 @@ void CompListLoader::OpenFile(const std::string& /*hdu*/) {
         _num_dims = _image_shape.size();
         _has_pixel_mask = _image->hasPixelMask();
         _coord_sys = std::shared_ptr<casacore::CoordinateSystem>(static_cast<casacore::CoordinateSystem*>(_image->coordinates().clone()));
+        _data_type = _image->dataType();
     }
 }
 

--- a/src/ImageData/ConcatLoader.h
+++ b/src/ImageData/ConcatLoader.h
@@ -37,6 +37,7 @@ void ConcatLoader::OpenFile(const std::string& /*hdu*/) {
         _num_dims = _image_shape.size();
         _has_pixel_mask = _image->hasPixelMask();
         _coord_sys = std::shared_ptr<casacore::CoordinateSystem>(static_cast<casacore::CoordinateSystem*>(_image->coordinates().clone()));
+        _data_type = _image->dataType();
     }
 }
 

--- a/src/ImageData/ExprLoader.h
+++ b/src/ImageData/ExprLoader.h
@@ -61,6 +61,7 @@ void ExprLoader::OpenFile(const std::string& /*hdu*/) {
         _num_dims = _image_shape.size();
         _has_pixel_mask = _image->hasPixelMask();
         _coord_sys = std::shared_ptr<casacore::CoordinateSystem>(static_cast<casacore::CoordinateSystem*>(_image->coordinates().clone()));
+        _data_type = _image->dataType();
     }
 }
 

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -87,10 +87,10 @@ typename FileLoader::ImageRef FileLoader::GetImage(bool check_data_type) {
     }
 
     if (check_data_type && _image && (_image->imageType() == "TempImage")) {
-        if ((_data_type == casacore::TpComplex) || (_data_type == casacore::TpDComplex)) {
+        if (IsComplexDataType()) {
             throw(casacore::AipsError("Use LEL expression to open images with complex data."));
         } else {
-            throw(casacore::AipsError("Image data type not supported."));
+            throw(casacore::AipsError("Data type not supported."));
         }
     }
 
@@ -145,6 +145,10 @@ bool FileLoader::HasData(FileInfo::Data dl) const {
 
 casacore::DataType FileLoader::GetDataType() {
     return _data_type;
+}
+
+bool FileLoader::IsComplexDataType() {
+    return (_data_type == casacore::DataType::TpComplex) || (_data_type == casacore::DataType::TpDComplex);
 }
 
 casacore::IPosition FileLoader::GetShape() {

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -86,9 +86,10 @@ typename FileLoader::ImageRef FileLoader::GetImage(bool check_data_type) {
         OpenFile(_hdu);
     }
 
-    if (check_data_type && _image && (_image->imageType() == "TempImage")) {
+    if (_image && check_data_type && (_data_type != _image->dataType()) && (_image->imageType() == "TempImage")) {
+        // Check for CasaLoader workaround for non-float data; does not copy data into new image (for file list only)
         if (IsComplexDataType()) {
-            throw(casacore::AipsError("Use LEL expression to open images with complex data."));
+            throw(casacore::AipsError("Use image arithmetic to open images with complex data."));
         } else {
             throw(casacore::AipsError("Data type not supported."));
         }

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -81,9 +81,17 @@ bool FileLoader::CanOpenFile(std::string& /*error*/) {
     return true;
 }
 
-typename FileLoader::ImageRef FileLoader::GetImage() {
+typename FileLoader::ImageRef FileLoader::GetImage(bool check_data_type) {
     if (!_image) {
         OpenFile(_hdu);
+    }
+
+    if (check_data_type && _image && (_image->imageType() == "TempImage")) {
+        if ((_data_type == casacore::TpComplex) || (_data_type == casacore::TpDComplex)) {
+            throw(casacore::AipsError("Use LEL expression to open images with complex data."));
+        } else {
+            throw(casacore::AipsError("Image data type not supported."));
+        }
     }
 
     return _image;
@@ -133,6 +141,10 @@ bool FileLoader::HasData(FileInfo::Data dl) const {
     }
 
     return false;
+}
+
+casacore::DataType FileLoader::GetDataType() {
+    return _data_type;
 }
 
 casacore::IPosition FileLoader::GetShape() {

--- a/src/ImageData/FileLoader.h
+++ b/src/ImageData/FileLoader.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <string>
 
+#include <casacore/casa/Utilities/DataType.h>
 #include <casacore/images/Images/ImageInterface.h>
 #include <casacore/images/Images/SubImage.h>
 
@@ -45,7 +46,8 @@ public:
     void CloseImageIfUpdated();
 
     // Return the opened casacore image or its class name
-    ImageRef GetImage();
+    ImageRef GetImage(bool check_data_type = true);
+    casacore::DataType GetDataType();
 
     // read beam subtable
     bool GetBeams(std::vector<CARTA::Beam>& beams, std::string& error);
@@ -113,17 +115,15 @@ protected:
 
     std::shared_ptr<casacore::ImageInterface<casacore::Float>> _image;
 
-    // Save image properties; only reopen for data or beams
-    // Axes, dimension values
+    // Save image properties
     casacore::IPosition _image_shape;
     size_t _num_dims, _image_plane_size;
     size_t _width, _height, _depth, _num_stokes;
     int _z_axis, _stokes_axis;
     std::vector<int> _render_axes;
-    // Coordinate system
     std::shared_ptr<casacore::CoordinateSystem> _coord_sys;
-    // Pixel mask
     bool _has_pixel_mask;
+    casacore::DataType _data_type;
 
     // Storage for z-plane and cube statistics
     std::vector<std::vector<FileInfo::ImageStats>> _z_stats;

--- a/src/ImageData/FileLoader.h
+++ b/src/ImageData/FileLoader.h
@@ -48,6 +48,7 @@ public:
     // Return the opened casacore image or its class name
     ImageRef GetImage(bool check_data_type = true);
     casacore::DataType GetDataType();
+    bool IsComplexDataType();
 
     // read beam subtable
     bool GetBeams(std::vector<CARTA::Beam>& beams, std::string& error);

--- a/src/ImageData/FitsLoader.h
+++ b/src/ImageData/FitsLoader.h
@@ -96,6 +96,7 @@ void FitsLoader::OpenFile(const std::string& hdu) {
             if (use_casacore_fits) {
                 // casacore::FITSImage failed, try CartaFitsImage
                 try {
+                    use_casacore_fits = false;
                     _image.reset(new CartaFitsImage(_filename, hdu_num));
                 } catch (const casacore::AipsError& err) {
                     spdlog::error(err.getMesg());
@@ -116,6 +117,14 @@ void FitsLoader::OpenFile(const std::string& hdu) {
         _num_dims = _image_shape.size();
         _has_pixel_mask = _image->hasPixelMask();
         _coord_sys = std::shared_ptr<casacore::CoordinateSystem>(static_cast<casacore::CoordinateSystem*>(_image->coordinates().clone()));
+
+        if (use_casacore_fits) {
+            casacore::FITSImage* fits_image = dynamic_cast<casacore::FITSImage*>(_image.get());
+            _data_type = fits_image->internalDataType();
+        } else {
+            CartaFitsImage* fits_image = dynamic_cast<CartaFitsImage*>(_image.get());
+            _data_type = fits_image->internalDataType();
+        }
     }
 }
 

--- a/src/ImageData/Hdf5Loader.cc
+++ b/src/ImageData/Hdf5Loader.cc
@@ -30,6 +30,7 @@ void Hdf5Loader::OpenFile(const std::string& hdu) {
         _num_dims = _image_shape.size();
         _has_pixel_mask = _image->hasPixelMask();
         _coord_sys = std::shared_ptr<casacore::CoordinateSystem>(static_cast<casacore::CoordinateSystem*>(_image->coordinates().clone()));
+        _data_type = hdf5_image->internalDataType();
 
         // Load swizzled image lattice
         if (HasData(FileInfo::Data::SWIZZLED)) {

--- a/src/ImageData/ImagePtrLoader.h
+++ b/src/ImageData/ImagePtrLoader.h
@@ -25,6 +25,7 @@ ImagePtrLoader::ImagePtrLoader(std::shared_ptr<casacore::ImageInterface<float>> 
     _num_dims = _image_shape.size();
     _has_pixel_mask = _image->hasPixelMask();
     _coord_sys = std::shared_ptr<casacore::CoordinateSystem>(static_cast<casacore::CoordinateSystem*>(_image->coordinates().clone()));
+    _data_type = _image->dataType();
 }
 
 void ImagePtrLoader::OpenFile(const std::string& /*hdu*/) {}

--- a/src/ImageData/ImagePtrLoader.h
+++ b/src/ImageData/ImagePtrLoader.h
@@ -25,6 +25,8 @@ ImagePtrLoader::ImagePtrLoader(std::shared_ptr<casacore::ImageInterface<float>> 
     _num_dims = _image_shape.size();
     _has_pixel_mask = _image->hasPixelMask();
     _coord_sys = std::shared_ptr<casacore::CoordinateSystem>(static_cast<casacore::CoordinateSystem*>(_image->coordinates().clone()));
+    std::cerr << "ImagePtrLoader image shape=" << _image->shape() << std::endl;
+    std::cerr << "ImagePtrLoader image datatype=" << _image->dataType() << std::endl;
     _data_type = _image->dataType();
 }
 

--- a/src/ImageData/MiriadLoader.h
+++ b/src/ImageData/MiriadLoader.h
@@ -64,6 +64,7 @@ void MiriadLoader::OpenFile(const std::string& /*hdu*/) {
         _num_dims = _image_shape.size();
         _has_pixel_mask = _image->hasPixelMask();
         _coord_sys = std::shared_ptr<casacore::CoordinateSystem>(static_cast<casacore::CoordinateSystem*>(_image->coordinates().clone()));
+        _data_type = _image->dataType();
     }
 }
 

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -505,6 +505,16 @@ bool Session::OnOpenFile(const CARTA::OpenFile& message, uint32_t request_id, bo
             // Get or create loader for frame
             auto loader = _loaders.Get(fullname);
 
+            // Open complex image with LEL amplitude instead
+            if (loader->IsComplexDataType()) {
+                _loaders.Remove(filename);
+
+                std::string expression = "AMPLITUDE(" + filename + ")";
+                bool is_lel_expr(true);
+                auto open_file_message = Message::OpenFile(directory, expression, hdu, file_id, message.render_mode(), is_lel_expr);
+                return OnOpenFile(open_file_message, request_id, silent);
+            }
+
             // create Frame for image
             auto frame = std::shared_ptr<Frame>(new Frame(_id, loader, hdu));
 

--- a/src/Util/Message.cc
+++ b/src/Util/Message.cc
@@ -22,13 +22,14 @@ CARTA::CloseFile Message::CloseFile(int32_t file_id) {
 }
 
 CARTA::OpenFile Message::OpenFile(
-    std::string directory, std::string file, std::string hdu, int32_t file_id, CARTA::RenderMode render_mode) {
+    std::string directory, std::string file, std::string hdu, int32_t file_id, CARTA::RenderMode render_mode, bool lel_expr) {
     CARTA::OpenFile open_file;
     open_file.set_directory(directory);
     open_file.set_file(file);
     open_file.set_hdu(hdu);
     open_file.set_file_id(file_id);
     open_file.set_render_mode(render_mode);
+    open_file.set_lel_expr(lel_expr);
     return open_file;
 }
 

--- a/src/Util/Message.h
+++ b/src/Util/Message.h
@@ -47,7 +47,7 @@ public:
     static CARTA::RegisterViewer RegisterViewer(uint32_t session_id, std::string api_key, uint32_t client_feature_flags);
     static CARTA::CloseFile CloseFile(int32_t file_id);
     static CARTA::OpenFile OpenFile(
-        std::string directory, std::string file, std::string hdu, int32_t file_id, CARTA::RenderMode render_mode);
+        std::string directory, std::string file, std::string hdu, int32_t file_id, CARTA::RenderMode render_mode, bool lel_expr = false);
     static CARTA::SetImageChannels SetImageChannels(
         int32_t file_id, int32_t channel, int32_t stokes, CARTA::CompressionType compression_type, float compression_quality);
     static CARTA::SetCursor SetCursor(int32_t file_id, float x, float y);


### PR DESCRIPTION
A simpler code change than failed PR #1079 and #1082 - keeps the loaders in FileExtInfoLoader to handle the complexity of opening images, e.g. compressed FITS.

When opening an image in the loaders, the native image data type is stored so that it can be shown in the file info.  When opening a complex image by filename is requested (e.g. double-click or open from command line), this data type is checked and the OpenFile message is converted to an OpenFile message with an LEL expression using amplitude.

Non-float CASA images (PagedImage) are converted to `TempImage<float>` with no data for file info after storing the data type from the original image.  If FileLoader::GetImage is called, the image type is checked for TempImage and fails.