### PR TITLE
Yuhsuan/918 save restfreq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+* Added ability to set a custom rest frequency for saving subimages. ([#918](https://github.com/CARTAvis/carta-backend/issues/918)).
+
 ## [3.0.0-beta.2]
 
 ### Changed

--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -1832,6 +1832,19 @@ void Frame::SaveFile(const std::string& root_folder, const CARTA::SaveFile& save
         return;
     }
 
+    double rest_freq(save_file_msg.rest_freq());
+    if (!std::isnan(rest_freq)) {
+        casacore::CoordinateSystem coord_sys = image->coordinates();
+        casacore::String errorMsg("");
+        bool success = coord_sys.setRestFrequency(errorMsg, casacore::Quantity(rest_freq, casacore::Unit("Hz")));
+        if (success) {
+            success = image->setCoordinateInfo(coord_sys);
+        }
+        if (!success) {
+            spdlog::warn("Failed to set new rest freq; use header rest freq instead: {}", errorMsg);
+        }
+    }
+    
     // Export image data to file
     try {
         std::unique_lock<std::mutex> ulock(_image_mutex); // Lock the image while saving the file

--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -1779,10 +1779,15 @@ void Frame::SaveFile(const std::string& root_folder, const CARTA::SaveFile& save
         return;
     }
 
+    double rest_freq(save_file_msg.rest_freq());
+    bool change_rest_freq = !std::isnan(rest_freq);
+
     // Try to save file from loader (for entire LEL image in CASA format only)
-    if (!region && _loader->SaveFile(output_file_type, output_filename.string(), message)) {
-        save_file_ack.set_success(true);
-        return;
+    if (!region && !change_rest_freq) {
+        if (_loader->SaveFile(output_file_type, output_filename.string(), message)) {
+            save_file_ack.set_success(true);
+            return;
+        }
     }
 
     // Begin with entire image
@@ -1832,8 +1837,7 @@ void Frame::SaveFile(const std::string& root_folder, const CARTA::SaveFile& save
         return;
     }
 
-    double rest_freq(save_file_msg.rest_freq());
-    if (!std::isnan(rest_freq)) {
+    if (change_rest_freq) {
         casacore::CoordinateSystem coord_sys = image->coordinates();
         casacore::String errorMsg("");
         bool success = coord_sys.setRestFrequency(errorMsg, casacore::Quantity(rest_freq, casacore::Unit("Hz")));

--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -1844,7 +1844,7 @@ void Frame::SaveFile(const std::string& root_folder, const CARTA::SaveFile& save
             spdlog::warn("Failed to set new rest freq; use header rest freq instead: {}", errorMsg);
         }
     }
-    
+
     // Export image data to file
     try {
         std::unique_lock<std::mutex> ulock(_image_mutex); // Lock the image while saving the file

--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -1839,13 +1839,13 @@ void Frame::SaveFile(const std::string& root_folder, const CARTA::SaveFile& save
 
     if (change_rest_freq) {
         casacore::CoordinateSystem coord_sys = image->coordinates();
-        casacore::String errorMsg("");
-        bool success = coord_sys.setRestFrequency(errorMsg, casacore::Quantity(rest_freq, casacore::Unit("Hz")));
+        casacore::String error_msg("");
+        bool success = coord_sys.setRestFrequency(error_msg, casacore::Quantity(rest_freq, casacore::Unit("Hz")));
         if (success) {
             success = image->setCoordinateInfo(coord_sys);
         }
         if (!success) {
-            spdlog::warn("Failed to set new rest freq; use header rest freq instead: {}", errorMsg);
+            spdlog::warn("Failed to set new rest freq; use header rest freq instead: {}", error_msg);
         }
     }
 


### PR DESCRIPTION
Closes #918:
Set custom rest freq when saving files. The image is saved as `casacore::PagedImage` when changing rest freq is required.

Companion PRs:
https://github.com/CARTAvis/carta-frontend/pull/1830
https://github.com/CARTAvis/carta-protobuf/pull/69