### PR TITLE
Use top_level_folder after it is completely set up

### DIFF
--- a/src/Main/ProgramSettings.cc
+++ b/src/Main/ProgramSettings.cc
@@ -58,6 +58,9 @@ ProgramSettings::ProgramSettings(int argc, char** argv) {
         SetSettingsFromJSON(settings);
     }
 
+    // Push files after all settings are applied
+    PushFilePathsToFiles();
+
     // Apply deprecated no_http flag
     if (no_http) {
         no_frontend = true;
@@ -342,7 +345,6 @@ global configuration files, respectively.
 
     // base will be overridden by the positional argument if it exists and is a folder
     applyOptionalArgument(starting_folder, "base", result);
-    std::vector<fs::path> file_paths;
 
     for (const auto& arg : positional_arguments) {
         fs::path p(arg);
@@ -372,14 +374,6 @@ global configuration files, respectively.
             file_paths.clear();
         }
     }
-    if (file_paths.size()) {
-        // Calculate paths relative to top level folder
-        auto top_level_path = fs::absolute(top_level_folder).lexically_normal();
-        for (const auto& p : file_paths) {
-            auto relative_path = fs::absolute(p).lexically_normal().lexically_relative(top_level_path);
-            files.push_back(relative_path.string());
-        }
-    }
 
     // produce JSON for overridding system and user configuration;
     // Options here need to match all options available for system and user settings
@@ -402,6 +396,17 @@ global configuration files, respectively.
     for (const auto& [key, elem] : vector_int_keys_map) {
         if (result.count(key)) {
             command_line_settings[key] = result[key].as<std::vector<int>>();
+        }
+    }
+}
+
+void ProgramSettings::PushFilePathsToFiles() {
+    if (file_paths.size()) {
+        // Calculate paths relative to top level folder
+        auto top_level_path = fs::absolute(top_level_folder).lexically_normal();
+        for (const auto& p : file_paths) {
+            auto relative_path = fs::absolute(p).lexically_normal().lexically_relative(top_level_path);
+            files.push_back(relative_path.string());
         }
     }
 }

--- a/src/Main/ProgramSettings.h
+++ b/src/Main/ProgramSettings.h
@@ -4,8 +4,8 @@
    SPDX-License-Identifier: GPL-3.0-or-later
 */
 
-#ifndef CARTA_BACKEND_SRC_SESSIONMANAGER_PROGRAMSETTINGS_H_
-#define CARTA_BACKEND_SRC_SESSIONMANAGER_PROGRAMSETTINGS_H_
+#ifndef CARTA_BACKEND_SRC_MAIN_PROGRAMSETTINGS_H_
+#define CARTA_BACKEND_SRC_MAIN_PROGRAMSETTINGS_H_
 
 #include <iostream>
 #include <string>
@@ -113,10 +113,11 @@ struct ProgramSettings {
     ProgramSettings() = default;
     ProgramSettings(int argc, char** argv);
     void ApplyCommandLineSettings(int argc, char** argv);
+    void ApplyJSONSettings();
     void AddDeprecationWarning(const std::string& option, std::string where);
     nlohmann::json JSONSettingsFromFile(const std::string& fsp);
     void SetSettingsFromJSON(const nlohmann::json& j);
-    void PushFilePathsToFiles();
+    void PushFilePaths();
 
     // TODO: this is outdated. It's used by the equality operator, which is used by a test.
     auto GetTuple() const {
@@ -137,4 +138,4 @@ struct ProgramSettings {
     }
 };
 } // namespace carta
-#endif // CARTA_BACKEND_SRC_SESSIONMANAGER_PROGRAMSETTINGS_H_
+#endif // CARTA_BACKEND_SRC_MAIN_PROGRAMSETTINGS_H_

--- a/src/Main/ProgramSettings.h
+++ b/src/Main/ProgramSettings.h
@@ -40,6 +40,7 @@ struct ProgramSettings {
     std::string starting_folder = ".";
     std::string host = "0.0.0.0";
     std::vector<std::string> files;
+    std::vector<fs::path> file_paths;
     std::string frontend_folder;
     bool no_http = false; // Deprecated
     bool no_frontend = false;
@@ -115,6 +116,7 @@ struct ProgramSettings {
     void AddDeprecationWarning(const std::string& option, std::string where);
     nlohmann::json JSONSettingsFromFile(const std::string& fsp);
     void SetSettingsFromJSON(const nlohmann::json& j);
+    void PushFilePathsToFiles();
 
     // TODO: this is outdated. It's used by the equality operator, which is used by a test.
     auto GetTuple() const {

--- a/test/TestProgramSettings.cc
+++ b/test/TestProgramSettings.cc
@@ -32,7 +32,7 @@ public:
 
         carta::ProgramSettings settings;
         settings.ApplyCommandLineSettings(argVector.size(), cstrings.data());
-        settings.PushFilePathsToFiles();
+        settings.PushFilePaths();
         return std::move(settings);
     }
 

--- a/test/TestProgramSettings.cc
+++ b/test/TestProgramSettings.cc
@@ -32,6 +32,7 @@ public:
 
         carta::ProgramSettings settings;
         settings.ApplyCommandLineSettings(argVector.size(), cstrings.data());
+        settings.PushFilePathsToFiles();
         return std::move(settings);
     }
 


### PR DESCRIPTION
Use top_level_folder only after it is completely set up from all settings sources. See https://github.com/CARTAvis/carta-backend/issues/1089.