### PR TITLE
ajm/coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # CARTA Image Viewer (Backend)
 
-![code coverage](https://img.shields.io/badge/dynamic/json?color=brightgreen&style=plastic&label=code%20coverage&query=percentage&suffix=%25&url=https%3A%2F%2Fcarta.asiaa.sinica.edu.tw%2Fcoverage%2Fdev-percentage.json)
+![code coverage](https://img.shields.io/endpoint?style=plastic&url=https%3A%2F%2Fcarta.asiaa.sinica.edu.tw%2Fcoverage%2Fpercentage.json)
 
 Backend process for simple web-based interface for viewing radio astronomy images in CASA, FITS, MIRIAD, and HDF5 formats (using the IDIA custom schema for HDF5). Unlike the conventional approach of rendering an image on the backend and sending a rendered image to the frontend client, the backend sends a compressed subset of the data, and the frontend renders the image efficiently on the GPU using WebGL and GLSL shaders. While the data is compressed using the lossy ZFP algorithm, the compression artefacts are generally much less noticeable than those cropping up from full-colour JPEG compression. While data sizes depend on compression quality used, sizes are [comparable](https://docs.google.com/spreadsheets/d/1lp1687TL0bYmbM3jGyjuPd9dYZnrAYGnLIQXWVpnmS0/edit?usp=sharing) with sizes of compressed JPEG images with a 95% quality setting, depending on the colour map used to generate the JPEG image. PNG compression is generally a factor of 2 larger than the ZFP compressed data.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
+
 # CARTA Image Viewer (Backend)
+
+![code coverage](https://img.shields.io/badge/dynamic/json?color=brightgreen&style=plastic&label=code%20coverage&query=percentage&suffix=%25&url=https%3A%2F%2Fcarta.asiaa.sinica.edu.tw%2Fcoverage%2Fdev-percentage.json)
+
 Backend process for simple web-based interface for viewing radio astronomy images in CASA, FITS, MIRIAD, and HDF5 formats (using the IDIA custom schema for HDF5). Unlike the conventional approach of rendering an image on the backend and sending a rendered image to the frontend client, the backend sends a compressed subset of the data, and the frontend renders the image efficiently on the GPU using WebGL and GLSL shaders. While the data is compressed using the lossy ZFP algorithm, the compression artefacts are generally much less noticeable than those cropping up from full-colour JPEG compression. While data sizes depend on compression quality used, sizes are [comparable](https://docs.google.com/spreadsheets/d/1lp1687TL0bYmbM3jGyjuPd9dYZnrAYGnLIQXWVpnmS0/edit?usp=sharing) with sizes of compressed JPEG images with a 95% quality setting, depending on the colour map used to generate the JPEG image. PNG compression is generally a factor of 2 larger than the ZFP compressed data.
 
 ## Ubuntu packages
@@ -66,11 +70,5 @@ For more detailed example commands for installing the dependencies and performin
 ## Running the backend process
 
 Command-line arguments are in the format `--arg=value` or `--arg value`. Run `carta_backend --help` for a list of options. By default, the backend will attempt to host frontend files from `../share/carta/frontend` (relative to the executable path). This can be changed with the `--frontend_folder` argument. Hosting of the frontend can be disabled with the `--no_http` argument. Token-based authentication can be disabled for debugging or development purposes with the `--debug_no_auth` argument.
-
-[![Build Status](http://acdc0.asiaa.sinica.edu.tw:47565/job/carta-backend/badge/icon)](http://acdc0.asiaa.sinica.edu.tw:47565/job/carta-backend) 
-
-[![Build Status](https://travis-ci.org/CARTAvis/carta-backend.svg?branch=master)](https://travis-ci.org/CARTAvis/carta-backend)
-
-[![CircleCI](https://circleci.com/gh/CARTAvis/carta-backend.svg?style=svg)](https://circleci.com/gh/CARTAvis/carta-backend)
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3377984.svg)](https://doi.org/10.5281/zenodo.3377984)


### PR DESCRIPTION
This adds a code coverage badge to the top of the README.md. It will close issue [#134 in the carta repo](https://github.com/CARTAvis/carta/issues/134). 

It uses the [sheilds.io/endpoint](https://shields.io/endpoint) style of badge.

Our Jenkins CI already generates full code coverage reports using `gcovr` for every carta-backend commit. I have modified the Jenkins job to output a new json file in the format that sheilds.io can read. Here is an example of the json file: 
```
{
    "schemaVersion": 1,
    "label": "code coverage",
    "message": "39.1%",
    "color": "yellow"
}
```
It only re-writes the json file when there is a 'dev' branch commit. 
It also figures out the appropriate colour of the badge; <39% red, 39%-60% yellow, >60% green. 

I have also removed the three now defunct CI badges from the bottom of the README.md.
The Zenodo DOI badge remains at the bottom of the README.md (Would it be more appropriate at the top?)

Is this OK for now, or are there any other additional badges you would like added?
For example, the ones on the [carta-controller](https://github.com/CARTAvis/carta-controller) repo look good.