### PR TITLE
Fix DS9 import region crash on Mac

### DIFF
--- a/src/Region/RegionImportExport.cc
+++ b/src/Region/RegionImportExport.cc
@@ -91,7 +91,7 @@ std::vector<std::string> RegionImportExport::ReadRegionFile(const std::string& f
             std::string single_line;
             getline(region_file, single_line);
 
-            if (single_line.back() == '\r') {
+            if (!single_line.empty() && (single_line.back() == '\r')) {
                 // Remove carriage return from DOS file
                 single_line.pop_back();
             }


### PR DESCRIPTION
Closes #1066 
Closes #1096 

Fixes crash on Mac when accessing last character of empty string.  Tested by @ajm-asiaa.