### PR TITLE
Fix DS9 world region import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.0.0-beta.3]
+## [Unreleased]
 
 ### Added
 * Added computed stokes images and supported the analysis (profiles, contours, statistics, etc.) of them ([#433](https://github.com/CARTAvis/carta-backend/issues/433)).
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * Fixed CRTF export bug for labelpos ([#1012](https://github.com/CARTAvis/carta-backend/issues/1012)).
+* Fixed DS9 import bug for region parameter with no unit ([#1101](https://github.com/CARTAvis/carta-backend/issues/1101)).
 
 ## [3.0.0-beta.2]
 

--- a/src/Region/Ds9ImportExport.cc
+++ b/src/Region/Ds9ImportExport.cc
@@ -473,7 +473,6 @@ RegionState Ds9ImportExport::ImportEllipseRegion(std::vector<std::string>& param
         bool is_circle = (parameters[3] == parameters[4]);
         // convert strings to Quantities
         std::vector<casacore::Quantity> param_quantities;
-        std::vector<casacore::String> units = {"", "deg", "deg", "arcsec", "arcsec", "deg"};
         for (size_t i = 1; i < nparam; ++i) {
             std::string param(parameters[i]);
             // Convert DS9 unit to Quantity unit for readQuantity
@@ -484,10 +483,10 @@ RegionState Ds9ImportExport::ImportEllipseRegion(std::vector<std::string>& param
                 casacore::Quantity param_quantity;
                 if (readQuantity(param_quantity, param)) {
                     if (param_quantity.getUnit().empty()) {
-                        if ((i == nparam - 1) || !_pixel_coord) {
-                            param_quantity.setUnit(units[i]);
-                        } else {
+                        if (_pixel_coord) {
                             param_quantity.setUnit("pixel");
+                        } else {
+                            param_quantity.setUnit("deg");
                         }
                     }
                     param_quantities.push_back(param_quantity);
@@ -566,7 +565,6 @@ RegionState Ds9ImportExport::ImportRectangleRegion(std::vector<std::string>& par
         // convert strings to Quantities
         std::vector<casacore::Quantity> param_quantities;
         // DS9 wcs default units
-        std::vector<casacore::String> ds9_units = {"", "deg", "deg", "arcsec", "arcsec", "deg"};
         for (size_t i = 1; i < nparam; ++i) {
             std::string param(parameters[i]);
             // Convert DS9 unit to Quantity unit for readQuantity
@@ -577,10 +575,10 @@ RegionState Ds9ImportExport::ImportRectangleRegion(std::vector<std::string>& par
                 casacore::Quantity param_quantity;
                 if (readQuantity(param_quantity, param)) {
                     if (param_quantity.getUnit().empty()) {
-                        if ((i == nparam - 1) || !_pixel_coord) {
-                            param_quantity.setUnit(ds9_units[i]);
-                        } else {
+                        if (_pixel_coord) {
                             param_quantity.setUnit("pixel");
+                        } else {
+                            param_quantity.setUnit("deg");
                         }
                     }
                     param_quantities.push_back(param_quantity);


### PR DESCRIPTION
Closes #1101 

For region definitions with wcs defined, import pure numbers (no unit) as degrees.

Specifically, box width/height and ellipse radii are deg (was arcsec, not sure why).  Still export these as explicit arcsec.