### PR TITLE
Use LCRegion clone rather than object ptr in shared_ptr

### DIFF
--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -1851,21 +1851,29 @@ void Frame::SaveFile(const std::string& root_folder, const CARTA::SaveFile& save
 
     if (region) {
         image_region = GetImageRegion(file_id, region);
+
+        if (!image_region) {
+            save_file_ack.set_success(false);
+            save_file_ack.set_message("The selected region is entirely outside the image.");
+            return;
+        }
+
         region_shape = image_region->shape();
     }
 
     //// Todo: support saving computed stokes images
     if (image_shape.size() == 2) {
         if (region) {
-            _loader->GetSubImage(StokesRegion(StokesSource(), ImageRegion(image_region.get())), sub_image);
+            _loader->GetSubImage(StokesRegion(StokesSource(), ImageRegion(image_region->cloneRegion())), sub_image);
             image = sub_image.cloneII();
             _loader->CloseImageIfUpdated();
         }
     } else if (image_shape.size() > 2 && image_shape.size() < 5) {
         try {
             if (region) {
-                auto latt_region_holder = LattRegionHolder(image_region.get());
-                auto slice_sub_image = GetExportRegionSlicer(save_file_msg, image_shape, region_shape, image_region, latt_region_holder);
+                auto latt_region_holder = LattRegionHolder(image_region->cloneRegion());
+                auto slice_sub_image = GetExportRegionSlicer(save_file_msg, image_shape, region_shape, latt_region_holder);
+
                 _loader->GetSubImage(slice_sub_image, latt_region_holder, sub_image);
             } else {
                 auto slice_sub_image = GetExportImageSlicer(save_file_msg, image_shape);
@@ -2113,11 +2121,11 @@ casacore::Slicer Frame::GetExportImageSlicer(const CARTA::SaveFile& save_file_ms
 // Input image_shape as casacore::IPosition of source image
 // Input region_shape as casacore::IPosition of target region
 // Input image_region as casacore::LCRegion of infomation of target region to chop
-// Output latt_region_holder as casacore::LattRegionHolder of target region
-//   If dimension of region does not match the source image, will modify latt_region_holder.
+// Input latt_region_holder as casacore::LattRegionHolder of target LCRegion (or will throw exception)
+// Output latt_region_holder modified if dimension of region does not match the source image
 // Return casacore::Slicer(start, end, stride) for apply subImage()
 casacore::Slicer Frame::GetExportRegionSlicer(const CARTA::SaveFile& save_file_msg, casacore::IPosition image_shape,
-    casacore::IPosition region_shape, std::shared_ptr<casacore::LCRegion> image_region, casacore::LattRegionHolder& latt_region_holder) {
+    casacore::IPosition region_shape, casacore::LattRegionHolder& latt_region_holder) {
     auto channels = std::vector<int>();
     auto stokes = std::vector<int>();
     ValidateChannelStokes(channels, stokes, save_file_msg);
@@ -2125,6 +2133,7 @@ casacore::Slicer Frame::GetExportRegionSlicer(const CARTA::SaveFile& save_file_m
     casacore::IPosition start;
     casacore::IPosition end;
     casacore::IPosition stride;
+
     switch (image_shape.size()) {
         // 3 dimensional cube image
         case 3:
@@ -2134,10 +2143,10 @@ casacore::Slicer Frame::GetExportRegionSlicer(const CARTA::SaveFile& save_file_m
                 end = casacore::IPosition(3, region_shape[0] - 1, region_shape[1] - 1, channels[1]);
                 stride = casacore::IPosition(3, 1, 1, channels[2]);
                 if (region_shape.size() < image_shape.size()) {
-                    auto region_ext = casacore::LCExtension(*image_region, casacore::IPosition(1, 2),
+                    auto region_ext = casacore::LCExtension(*latt_region_holder.asLCRegionPtr(), casacore::IPosition(1, 2),
                         casacore::LCBox(
                             casacore::IPosition(1, 0), casacore::IPosition(1, image_shape[2]), casacore::IPosition(1, image_shape[2])));
-                    latt_region_holder = LattRegionHolder(*(region_ext.cloneRegion()));
+                    latt_region_holder = LattRegionHolder(region_ext);
                 }
             } else {
                 // Stokes present
@@ -2145,10 +2154,10 @@ casacore::Slicer Frame::GetExportRegionSlicer(const CARTA::SaveFile& save_file_m
                 end = casacore::IPosition(3, region_shape[0] - 1, region_shape[1] - 1, stokes[1]);
                 stride = casacore::IPosition(3, 1, 1, stokes[2]);
                 if (region_shape.size() < image_shape.size()) {
-                    auto region_ext = casacore::LCExtension(*image_region, casacore::IPosition(1, 2),
+                    auto region_ext = casacore::LCExtension(*latt_region_holder.asLCRegionPtr(), casacore::IPosition(1, 2),
                         casacore::LCBox(
                             casacore::IPosition(1, 0), casacore::IPosition(1, image_shape[3]), casacore::IPosition(1, image_shape[3])));
-                    latt_region_holder = LattRegionHolder(*(region_ext.cloneRegion()));
+                    latt_region_holder = LattRegionHolder(region_ext);
                 }
             }
             break;
@@ -2160,10 +2169,10 @@ casacore::Slicer Frame::GetExportRegionSlicer(const CARTA::SaveFile& save_file_m
                 end = casacore::IPosition(4, region_shape[0] - 1, region_shape[1] - 1, channels[1], stokes[1]);
                 stride = casacore::IPosition(4, 1, 1, channels[2], stokes[2]);
                 if (region_shape.size() < image_shape.size()) {
-                    auto region_ext = casacore::LCExtension(*image_region, casacore::IPosition(2, 2, 3),
+                    auto region_ext = casacore::LCExtension(*latt_region_holder.asLCRegionPtr(), casacore::IPosition(2, 2, 3),
                         casacore::LCBox(casacore::IPosition(2, 0, 0), casacore::IPosition(2, image_shape[2], image_shape[3]),
                             casacore::IPosition(2, image_shape[2], image_shape[3])));
-                    latt_region_holder = LattRegionHolder(*(region_ext.cloneRegion()));
+                    latt_region_holder = LattRegionHolder(region_ext);
                 }
             } else {
                 // Channels present after stokes
@@ -2171,10 +2180,10 @@ casacore::Slicer Frame::GetExportRegionSlicer(const CARTA::SaveFile& save_file_m
                 end = casacore::IPosition(4, region_shape[0] - 1, region_shape[1] - 1, stokes[1], channels[1]);
                 stride = casacore::IPosition(4, 1, 1, stokes[2], channels[2]);
                 if (region_shape.size() < image_shape.size()) {
-                    auto region_ext = casacore::LCExtension(*image_region, casacore::IPosition(2, 2, 3),
+                    auto region_ext = casacore::LCExtension(*latt_region_holder.asLCRegionPtr(), casacore::IPosition(2, 2, 3),
                         casacore::LCBox(casacore::IPosition(2, 0, 0), casacore::IPosition(2, image_shape[3], image_shape[2]),
                             casacore::IPosition(2, image_shape[3], image_shape[2])));
-                    latt_region_holder = LattRegionHolder(*(region_ext.cloneRegion()));
+                    latt_region_holder = LattRegionHolder(region_ext);
                 }
             }
             break;

--- a/src/Frame/Frame.h
+++ b/src/Frame/Frame.h
@@ -245,7 +245,7 @@ protected:
     void ValidateChannelStokes(std::vector<int>& channels, std::vector<int>& stokes, const CARTA::SaveFile& save_file_msg);
     casacore::Slicer GetExportImageSlicer(const CARTA::SaveFile& save_file_msg, casacore::IPosition image_shape);
     casacore::Slicer GetExportRegionSlicer(const CARTA::SaveFile& save_file_msg, casacore::IPosition image_shape,
-        casacore::IPosition region_shape, std::shared_ptr<casacore::LCRegion> image_region, casacore::LattRegionHolder& latt_region_holder);
+        casacore::IPosition region_shape, casacore::LattRegionHolder& latt_region_holder);
 
     void InitImageHistogramConfigs();
 

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -1317,12 +1317,10 @@ void Session::OnSaveFile(const CARTA::SaveFile& save_file, uint32_t request_id) 
         } else if (region_id) {
             std::shared_ptr<Region> _region = _region_handler->GetRegion(region_id);
             if (_region) {
-                if (active_frame->GetImageRegion(file_id, _region)) {
-                    active_frame->SaveFile(_top_level_folder, save_file, save_file_ack, _region);
-                } else {
-                    save_file_ack.set_success(false);
-                    save_file_ack.set_message("The selected region is entirely outside the image.");
-                }
+                active_frame->SaveFile(_top_level_folder, save_file, save_file_ack, _region);
+            } else {
+                save_file_ack.set_success(false);
+                save_file_ack.set_message("No region with id {} found.", region_id);
             }
         } else {
             // Save full image


### PR DESCRIPTION
Closes #1092 

When saving an image from a region, the object pointer in `shared_ptr<LCRegion>` was given to ImageRegion which then owned and deleted the pointer, causing the crash in the shared_ptr destructor.  Fixed by passing a clone of the LCRegion instead, which can be safely deleted.

Also removed redundant use of `shared_ptr<LCRegion>` .