### PR TITLE
Do not calculate per-cube histogram when stokes is changed

### DIFF
--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -1850,7 +1850,6 @@ void Session::UpdateImageData(int file_id, bool send_image_histogram, bool z_cha
     // Do not send image histogram if already sent with raster data.
     if (_frames.count(file_id)) {
         if (stokes_changed) {
-            SendRegionHistogramData(file_id, CUBE_REGION_ID);
             SendSpectralProfileData(file_id, CURSOR_REGION_ID, stokes_changed);
         }
 


### PR DESCRIPTION
It is to solve #1013. The cube histogram should not be automatically calculated when stokes is changed.