### PR TITLE
ksw/enhance image fitting performance by switching the solver from qr to cholesky

### DIFF
--- a/src/ImageFitter/ImageFitter.cc
+++ b/src/ImageFitter/ImageFitter.cc
@@ -91,6 +91,7 @@ void ImageFitter::SetInitialValues(const std::vector<CARTA::GaussianComponent>& 
 int ImageFitter::SolveSystem() {
     gsl_multifit_nlinear_parameters fdf_params = gsl_multifit_nlinear_default_parameters();
     const gsl_multifit_nlinear_type* T = gsl_multifit_nlinear_trust;
+    fdf_params.solver = gsl_multifit_nlinear_solver_cholesky;
     const double xtol = 1.0e-8;
     const double gtol = 1.0e-8;
     const double ftol = 1.0e-8;


### PR DESCRIPTION
This is to address the performance concern from @Jordatious about the current 2D image fitting implementation by switching the default solver "qr" to "cholesky". You may refer to 
https://www.gnu.org/software/gsl/doc/html/nls.html#c.gsl_multilarge_nlinear_solver.gsl_multifit_nlinear_solver_qr
https://www.gnu.org/software/gsl/doc/html/nls.html#c.gsl_multilarge_nlinear_solver.gsl_multifit_nlinear_solver_cholesky
to see the differences as also mentioned in the comment chain of the PR #1055. 

With some tests, the performance boost in terms of elapsed time is reduced by ~66%. This is measured by testing single and triple gaussian fit with different image sizes. As for the fitting result accuracy, it appears to me that the two solvers give very similar solutions.

I also tried other methods to solve the trust region subproblem (https://www.gnu.org/software/gsl/doc/html/nls.html#solving-the-trust-region-subproblem-trs)
We use `gsl_multifit_nlinear_trs_lm` : Levenberg-Marquardt algorithm now:
`gsl_multifit_nlinear_trs_lmaccel` : Levenberg-Marquardt algorithm with geodesic acceleration --> slower. I don't provide the second directional derivative vector so it is using finite difference method for approximation
`gsl_multifit_nlinear_trs_dogleg`:  dogleg algorithm --> slower
`gsl_multifit_nlinear_trs_ddogleg`: double dogleg algorithm --> slower
`gsl_multifit_nlinear_trs_subspace2D`: 2D subspace algorithm --> super fast and converged with just 1 iteration but the result is not correct. Not sure if I miss something configurable here

This PR is considered as a quick-and-dirty improvement of the fitting performance for the final v3 release. Open for comments on whether or not merging this. 