### PR TITLE
1063 fix info/load time for FITS with long history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Stopped calculating per-cube histogram unnecessarily when switching to a new Stokes value ([#1013](https://github.com/CARTAvis/carta-backend/issues/1013)).
 * Ensured that HTTP server returns error codes correctly ([#1011](https://github.com/CARTAvis/carta-backend/issues/1011)).
+* Fixed slow loading of FITS image with large number of HISTORY headers ([#1063](https://github.com/CARTAvis/carta-backend/issues/1063)).
 
 ## [3.0.0-beta.3]
 

--- a/src/ImageData/CartaFitsImage.h
+++ b/src/ImageData/CartaFitsImage.h
@@ -62,8 +62,8 @@ private:
     void CloseFileIfError(const int& status, const std::string& error);
 
     void SetUpImage();
-    void GetFitsHeaders(int& nheaders, std::string& hdrstr);
-    casacore::Vector<casacore::String> FitsHeaderStrings(int nheaders, const std::string& header);
+    void GetFitsHeaderString(int& nheaders, std::string& hdrstr);
+    void SetFitsHeaderStrings(int nheaders, const std::string& header);
 
     // casacore ImageFITSConverter workaround
     casacore::CoordinateSystem SetCoordinateSystem(
@@ -99,7 +99,8 @@ private:
     casacore::IPosition _shape;
     int _datatype; // bitpix value
     bool _has_blanks;
-    casacore::Vector<casacore::String> _fits_header_strings;
+    casacore::Vector<casacore::String> _all_header_strings;
+    casacore::Vector<casacore::String> _image_header_strings;
 
     casacore::Lattice<bool>* _pixel_mask;
     casacore::TiledShape _tiled_shape;

--- a/src/ImageData/FitsLoader.h
+++ b/src/ImageData/FitsLoader.h
@@ -7,7 +7,7 @@
 #ifndef CARTA_BACKEND_IMAGEDATA_FITSLOADER_H_
 #define CARTA_BACKEND_IMAGEDATA_FITSLOADER_H_
 
-#include <chrono>
+#include <fitsio.h>
 
 #include <casacore/casa/OS/HostInfo.h>
 #include <casacore/images/Images/FITSImage.h>
@@ -30,6 +30,7 @@ private:
     std::string _unzip_file;
     casacore::uInt _hdu_num;
 
+    int GetNumHeaders(const std::string& filename, int hdu);
     void RemoveHistoryBeam(unsigned int hdu_num);
 };
 
@@ -76,6 +77,14 @@ void FitsLoader::OpenFile(const std::string& hdu) {
 
         // Default is casacore::FITSImage; if fails, try CartaFitsImage
         bool use_casacore_fits(true);
+        auto num_headers = GetNumHeaders(_filename, hdu_num);
+        if (num_headers == 0) {
+            throw(casacore::AipsError("Error reading FITS file."));
+        }
+        if (num_headers > 10000) {
+            // casacore::FITSImage parses HISTORY for beam
+            use_casacore_fits = false;
+        }
 
         try {
             if (_is_gz) {
@@ -88,9 +97,11 @@ void FitsLoader::OpenFile(const std::string& hdu) {
                     // use casacore for unzipped FITS file
                     _image.reset(new casacore::FITSImage(_unzip_file, 0, hdu_num));
                 }
-            } else {
+            } else if (use_casacore_fits) {
                 _image.reset(new casacore::FITSImage(_filename, 0, hdu_num));
                 RemoveHistoryBeam(hdu_num);
+            } else {
+                _image.reset(new CartaFitsImage(_filename, hdu_num));
             }
         } catch (const casacore::AipsError& err) {
             if (use_casacore_fits) {
@@ -126,6 +137,31 @@ void FitsLoader::OpenFile(const std::string& hdu) {
             _data_type = fits_image->internalDataType();
         }
     }
+}
+
+int FitsLoader::GetNumHeaders(const std::string& filename, int hdu) {
+    // Return number of FITS headers, 0 if error.
+    int num_headers(0);
+
+    // Open file read-only
+    fitsfile* fptr(nullptr);
+    int status(0);
+    fits_open_file(&fptr, filename.c_str(), 0, &status);
+    if (status) {
+        return num_headers;
+    }
+
+    // Advance to hdu (FITS hdu is 1-based)
+    int* hdutype(nullptr);
+    fits_movabs_hdu(fptr, hdu + 1, hdutype, &status);
+    if (status) {
+        return num_headers;
+    }
+
+    fits_get_hdrspace(fptr, &num_headers, nullptr, &status);
+    fits_close_file(fptr, &status);
+
+    return num_headers;
 }
 
 void FitsLoader::RemoveHistoryBeam(unsigned int hdu_num) {

--- a/src/ImageData/FitsLoader.h
+++ b/src/ImageData/FitsLoader.h
@@ -78,11 +78,13 @@ void FitsLoader::OpenFile(const std::string& hdu) {
         // Default is casacore::FITSImage; if fails, try CartaFitsImage
         bool use_casacore_fits(true);
         auto num_headers = GetNumHeaders(_filename, hdu_num);
+
         if (num_headers == 0) {
             throw(casacore::AipsError("Error reading FITS file."));
         }
-        if (num_headers > 10000) {
-            // casacore::FITSImage parses HISTORY for beam
+
+        if (num_headers > 2000) {
+            // casacore::FITSImage parses HISTORY
             use_casacore_fits = false;
         }
 


### PR DESCRIPTION
Closes #1063 

Find number of headers using cfitsio; if > 10,000 use CartaFitsImage which will read all headers into one list `_all_header_strings` and non-HISTORY headers into another list `_image_header_strings`.  Using the image headers list to set up CartaFitsImage (particularly the coordinate system) speeds this up considerably.  This has no effect for an image with a large number of headers which are not HISTORY.  All headers, including history, are shown in the file browser.

NOTE the image does not use beam information in the HISTORY headers - see #935 and #1083 (same as previous behavior, which removes the history beam when casacore::FITSImage is used).