### PR TITLE
Recognize the FITS gzip file from ALMA archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Stopped calculating per-cube histogram unnecessarily when switching to a new Stokes value ([#1013](https://github.com/CARTAvis/carta-backend/issues/1013)).
 * Ensured that HTTP server returns error codes correctly ([#1011](https://github.com/CARTAvis/carta-backend/issues/1011)).
 * Fixed crash problems for compressed FITS files ([#999](https://github.com/CARTAvis/carta-backend/issues/999) and [#1014](https://github.com/CARTAvis/carta-backend/issues/1014)).
+* Fixed the problem of recognizing FITS gzip files from ALMA Science Archive ([#1130](https://github.com/CARTAvis/carta-backend/issues/1130)).
 
 ## [3.0.0-beta.3]
 

--- a/src/Util/File.cc
+++ b/src/Util/File.cc
@@ -25,7 +25,7 @@ uint32_t GetMagicNumber(const std::string& filename) {
 
 bool IsCompressedFits(const std::string& filename) {
     // Check if gzip file, then check .fits extension
-    if (IsGzFile(GetMagicNumber(filename))) {
+    if (IsGzMagicNumber(GetMagicNumber(filename))) {
         fs::path gz_path(filename);
         std::string extension = gz_path.stem().extension().string();
         return HasSuffix(extension, ".fits");
@@ -34,7 +34,7 @@ bool IsCompressedFits(const std::string& filename) {
     return false;
 }
 
-bool IsGzFile(uint32_t magic_number) {
+bool IsGzMagicNumber(uint32_t magic_number) {
     std::string hex_string = fmt::format("{:#x}", magic_number);
     return (hex_string.length() > 4) && (hex_string.substr(hex_string.length() - 4) == "8b1f");
 }
@@ -81,7 +81,7 @@ CARTA::FileType GuessImageType(const std::string& path_string, bool check_conten
             return CARTA::FITS;
         } else if (magic_number == HDF5_MAGIC_NUMBER) {
             return CARTA::HDF5;
-        } else if (IsGzFile(magic_number)) {
+        } else if (IsGzMagicNumber(magic_number)) {
             fs::path gz_path(path_string);
             std::string extension = gz_path.stem().extension().string();
             return HasSuffix(extension, ".fits") ? CARTA::FITS : CARTA::UNKNOWN;

--- a/src/Util/File.cc
+++ b/src/Util/File.cc
@@ -25,7 +25,7 @@ uint32_t GetMagicNumber(const std::string& filename) {
 bool IsCompressedFits(const std::string& filename) {
     // Check if gzip file, then check .fits extension
     auto magic_number = GetMagicNumber(filename);
-    if (magic_number == GZ_MAGIC_NUMBER) {
+    if ((magic_number == GZ_MAGIC_NUMBER) || (magic_number == ALMA_GZ_MAGIC_NUMBER)) {
         fs::path gz_path(filename);
         std::string extension = gz_path.stem().extension().string();
         return HasSuffix(extension, ".fits");
@@ -77,6 +77,7 @@ CARTA::FileType GuessImageType(const std::string& path_string, bool check_conten
                 return CARTA::FITS;
             case HDF5_MAGIC_NUMBER:
                 return CARTA::HDF5;
+            case ALMA_GZ_MAGIC_NUMBER:
             case GZ_MAGIC_NUMBER:
                 fs::path gz_path(path_string);
                 std::string extension = gz_path.stem().extension().string();

--- a/src/Util/File.cc
+++ b/src/Util/File.cc
@@ -36,10 +36,7 @@ bool IsCompressedFits(const std::string& filename) {
 
 bool IsGzFile(uint32_t magic_number) {
     std::string hex_string = fmt::format("{:#x}", magic_number);
-    if ((hex_string.length() > 4) && (hex_string.substr(hex_string.length() - 4) == "8b1f")) {
-        return true;
-    }
-    return false;
+    return (hex_string.length() > 4) && (hex_string.substr(hex_string.length() - 4) == "8b1f");
 }
 
 int GetNumItems(const std::string& path) {

--- a/src/Util/File.cc
+++ b/src/Util/File.cc
@@ -6,6 +6,7 @@
 
 #include "File.h"
 
+#include <spdlog/fmt/fmt.h>
 #include <fstream>
 
 #include "String.h"
@@ -24,13 +25,20 @@ uint32_t GetMagicNumber(const std::string& filename) {
 
 bool IsCompressedFits(const std::string& filename) {
     // Check if gzip file, then check .fits extension
-    auto magic_number = GetMagicNumber(filename);
-    if ((magic_number == GZ_MAGIC_NUMBER) || (magic_number == ALMA_GZ_MAGIC_NUMBER)) {
+    if (IsGzFile(GetMagicNumber(filename))) {
         fs::path gz_path(filename);
         std::string extension = gz_path.stem().extension().string();
         return HasSuffix(extension, ".fits");
     }
 
+    return false;
+}
+
+bool IsGzFile(uint32_t magic_number) {
+    std::string hex_string = fmt::format("{:#x}", magic_number);
+    if ((hex_string.length() > 4) && (hex_string.substr(hex_string.length() - 4) == "8b1f")) {
+        return true;
+    }
     return false;
 }
 
@@ -72,16 +80,14 @@ CARTA::FileType GuessImageType(const std::string& path_string, bool check_conten
     if (check_content) {
         // Guess file type by magic number
         auto magic_number = GetMagicNumber(path_string);
-        switch (magic_number) {
-            case FITS_MAGIC_NUMBER:
-                return CARTA::FITS;
-            case HDF5_MAGIC_NUMBER:
-                return CARTA::HDF5;
-            case ALMA_GZ_MAGIC_NUMBER:
-            case GZ_MAGIC_NUMBER:
-                fs::path gz_path(path_string);
-                std::string extension = gz_path.stem().extension().string();
-                return HasSuffix(extension, ".fits") ? CARTA::FITS : CARTA::UNKNOWN;
+        if (magic_number == FITS_MAGIC_NUMBER) {
+            return CARTA::FITS;
+        } else if (magic_number == HDF5_MAGIC_NUMBER) {
+            return CARTA::HDF5;
+        } else if (IsGzFile(magic_number)) {
+            fs::path gz_path(path_string);
+            std::string extension = gz_path.stem().extension().string();
+            return HasSuffix(extension, ".fits") ? CARTA::FITS : CARTA::UNKNOWN;
         }
     } else {
         // Guess file type by extension

--- a/src/Util/File.h
+++ b/src/Util/File.h
@@ -29,7 +29,7 @@ CARTA::CatalogFileType GuessTableType(const std::string& path_string, bool check
 
 uint32_t GetMagicNumber(const std::string& filename);
 bool IsCompressedFits(const std::string& filename);
-bool IsGzFile(uint32_t magic_number);
+bool IsGzMagicNumber(uint32_t magic_number);
 
 // directory functions
 int GetNumItems(const std::string& path);

--- a/src/Util/File.h
+++ b/src/Util/File.h
@@ -12,9 +12,7 @@
 #include "FileSystem.h"
 
 // Valid for little-endian only
-#define ALMA_GZ_MAGIC_NUMBER 0x88B1F
 #define FITS_MAGIC_NUMBER 0x504D4953
-#define GZ_MAGIC_NUMBER 0x08088B1F
 #define HDF5_MAGIC_NUMBER 0x46444889
 #define XML_MAGIC_NUMBER 0x6D783F3C
 
@@ -31,6 +29,7 @@ CARTA::CatalogFileType GuessTableType(const std::string& path_string, bool check
 
 uint32_t GetMagicNumber(const std::string& filename);
 bool IsCompressedFits(const std::string& filename);
+bool IsGzFile(uint32_t magic_number);
 
 // directory functions
 int GetNumItems(const std::string& path);

--- a/src/Util/File.h
+++ b/src/Util/File.h
@@ -12,6 +12,7 @@
 #include "FileSystem.h"
 
 // Valid for little-endian only
+#define ALMA_GZ_MAGIC_NUMBER 0x88B1F
 #define FITS_MAGIC_NUMBER 0x504D4953
 #define GZ_MAGIC_NUMBER 0x08088B1F
 #define HDF5_MAGIC_NUMBER 0x46444889


### PR DESCRIPTION
Closes #1130. It seems the magic number of fits.gz from ALMA archive is different from that of ordinary FITS gzip files. Although they are the same file type. @kswang1029 could you please check does it can also recognize the other fits.gz files from ALMA archive? Thank you!