### PR TITLE
#1129 Fix DS9 region imports with region properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed the incorrect STD for images with large pixel values ([#1069](https://github.com/CARTAvis/carta-backend/issues/1069)).
 * Fixed incorrect spectral profiles for computed stokes ([#1122](https://github.com/CARTAvis/carta-backend/issues/1122)). 
 * Fixed the problem of recognizing FITS gzip files from ALMA Science Archive ([#1130](https://github.com/CARTAvis/carta-backend/issues/1130)).
-* Fixed the DS9 import bug with line arrow properties ([#1129](https://github.com/CARTAvis/carta-backend/issues/1129)).
+* Fixed the DS9 import bug with line arrow and point properties ([#1129](https://github.com/CARTAvis/carta-backend/issues/1129)).
 
 ## [3.0.0-beta.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed the incorrect STD for images with large pixel values ([#1069](https://github.com/CARTAvis/carta-backend/issues/1069)).
 * Fixed incorrect spectral profiles for computed stokes ([#1122](https://github.com/CARTAvis/carta-backend/issues/1122)). 
 * Fixed the problem of recognizing FITS gzip files from ALMA Science Archive ([#1130](https://github.com/CARTAvis/carta-backend/issues/1130)).
+* Fixed the DS9 import bug with line arrow properties ([#1129](https://github.com/CARTAvis/carta-backend/issues/1129)).
 
 ## [3.0.0-beta.3]
 

--- a/src/Region/Ds9ImportExport.cc
+++ b/src/Region/Ds9ImportExport.cc
@@ -643,7 +643,7 @@ RegionState Ds9ImportExport::ImportRectangleRegion(std::vector<std::string>& par
 
 RegionState Ds9ImportExport::ImportPolygonLineRegion(std::vector<std::string>& parameters) {
     // Import DS9 polygon into RegionState
-    // polygon x1 y1 x2 y2 x3 y3 ...
+    // polygon x1 y1 x2 y2 x3 y3 ... or line x1 y1 x2 y2
     RegionState region_state;
 
     size_t nparam(parameters.size());

--- a/src/Region/Ds9ImportExport.cc
+++ b/src/Region/Ds9ImportExport.cc
@@ -646,13 +646,13 @@ RegionState Ds9ImportExport::ImportPolygonLineRegion(std::vector<std::string>& p
     // polygon x1 y1 x2 y2 x3 y3 ... or line x1 y1 x2 y2
     RegionState region_state;
 
+    std::string region_name(parameters[0]);
+
     size_t nparam(parameters.size());
     if ((nparam % 2) != 1) { // parameters[0] is region name
-        _import_errors.append("polygon syntax error, odd number of arguments.\n");
+        _import_errors.append(region_name + " syntax error.\n");
         return region_state;
     }
-
-    std::string region_name(parameters[0]);
 
     // convert strings to Quantities
     std::vector<casacore::Quantity> param_quantities;
@@ -674,7 +674,7 @@ RegionState Ds9ImportExport::ImportPolygonLineRegion(std::vector<std::string>& p
                 }
                 param_quantities.push_back(param_quantity);
             } else {
-                std::string invalid_param("Invalid polygon parameter " + param + ".\n");
+                std::string invalid_param("Invalid " + region_name + " parameter " + param + ".\n");
                 _import_errors.append(invalid_param);
                 return region_state;
             }
@@ -702,7 +702,7 @@ RegionState Ds9ImportExport::ImportPolygonLineRegion(std::vector<std::string>& p
                 point.set_y(pixel_coords(1));
                 control_points.push_back(point);
             } else {
-                _import_errors.append("Failed to apply polygon to image.\n");
+                _import_errors.append("Failed to apply " + region_name + " to image.\n");
                 return region_state;
             }
         }

--- a/src/Region/RegionImportExport.cc
+++ b/src/Region/RegionImportExport.cc
@@ -146,6 +146,7 @@ void RegionImportExport::ParseRegionParameters(
                     } else { // e.g. color=#00ffff
                         next = region_definition.find_first_of(" ", current);
                     }
+
                     if ((next != std::string::npos) && (next - current > 0)) {
                         std::string value = region_definition.substr(current, next - current);
                         properties[key] = value;
@@ -153,8 +154,8 @@ void RegionImportExport::ParseRegionParameters(
                 } else if (kvpair.size() == 2) {
                     // check if value is delimited by ' ', " ", [ ], or { }
                     std::string value = kvpair[1];
-                    if (key == "dashlist") {
-                        // values separated by space e.g. "dashlist=8 3"; find next space
+                    if ((key == "dashlist") || (key == "line")) {
+                        // values separated by space e.g. "dashlist=8 3" or "line=0 0"; find next space
                         current = next + 1;
                         next = region_definition.find_first_of(" ", current);
                         string value_end = region_definition.substr(current, next - current);

--- a/src/Region/RegionImportExport.cc
+++ b/src/Region/RegionImportExport.cc
@@ -160,6 +160,21 @@ void RegionImportExport::ParseRegionParameters(
                         next = region_definition.find_first_of(" ", current);
                         string value_end = region_definition.substr(current, next - current);
                         properties[key] = value + " " + value_end;
+                    } else if (key == "point") {
+                        // size optional, get next string and try to convert to long int
+                        current = next + 1;
+                        auto possible_next = region_definition.find_first_of(" ", current);
+                        string possible_size = region_definition.substr(current, possible_next - current);
+
+                        char* endptr(nullptr);
+                        auto point_size = strtol(possible_size.c_str(), &endptr, 10);
+                        if ((point_size != 0) && (point_size != LONG_MAX) && (point_size != LONG_MIN)) {
+                            // conversion successful
+                            next = possible_next;
+                            properties[key] = value + " " + possible_size;
+                        } else {
+                            properties[key] = value;
+                        }
                     } else if (value.find_first_of("'\"[{(", 0) == 0) {
                         // value delimited by special chars; find end and strip delimiters
                         char start_delim = value.front();

--- a/src/Region/RegionImportExport.cc
+++ b/src/Region/RegionImportExport.cc
@@ -124,13 +124,17 @@ void RegionImportExport::ParseRegionParameters(
     std::string& region_definition, std::vector<std::string>& parameters, std::unordered_map<std::string, std::string>& properties) {
     // Parse the input string by space, comma, parentheses to get region parameters and properties (keyword=value)
     size_t next(0), current(0), end(region_definition.size());
+
     while (current < end) {
         next = region_definition.find_first_of(_parser_delim, current);
+
         if (next == std::string::npos) {
             next = end;
         }
+
         if ((next - current) > 0) {
             std::string param = region_definition.substr(current, next - current);
+
             if (param.find("=") == std::string::npos) {
                 parameters.push_back(param);
             } else {
@@ -141,6 +145,7 @@ void RegionImportExport::ParseRegionParameters(
                 if (kvpair.size() == 1) {
                     // value starts with delim
                     current = next + 1;
+
                     if (region_definition[next] == '[') { // e.g. corr=[I, Q]
                         next = region_definition.find_first_of("]", current);
                     } else { // e.g. color=#00ffff
@@ -154,25 +159,41 @@ void RegionImportExport::ParseRegionParameters(
                 } else if (kvpair.size() == 2) {
                     // check if value is delimited by ' ', " ", [ ], or { }
                     std::string value = kvpair[1];
+
                     if ((key == "dashlist") || (key == "line")) {
                         // values separated by space e.g. "dashlist=8 3" or "line=0 0"; find next space
                         current = next + 1;
-                        next = region_definition.find_first_of(" ", current);
-                        string value_end = region_definition.substr(current, next - current);
-                        properties[key] = value + " " + value_end;
-                    } else if (key == "point") {
-                        // size optional, get next string and try to convert to long int
-                        current = next + 1;
-                        auto possible_next = region_definition.find_first_of(" ", current);
-                        string possible_size = region_definition.substr(current, possible_next - current);
 
-                        char* endptr(nullptr);
-                        auto point_size = strtol(possible_size.c_str(), &endptr, 10);
-                        if ((point_size != 0) && (point_size != LONG_MAX) && (point_size != LONG_MIN)) {
-                            // conversion successful
-                            next = possible_next;
-                            properties[key] = value + " " + possible_size;
+                        if (current < end) {
+                            next = region_definition.find_first_of(" ", current);
+                            std::string second_arg = region_definition.substr(current, next - current);
+                            properties[key] = value + " " + second_arg;
+                        }
+                    } else if (key == "point") {
+                        // point=shape [size] e.g. "point=circle" or "point=diamond 10" - size optional
+                        current = next + 1;
+
+                        if (current < end) {
+                            // Get next string
+                            auto possible_next = region_definition.find_first_of(" ", current);
+                            string possible_size = region_definition.substr(current, possible_next - current);
+
+                            if (!possible_size.empty()) {
+                                // Try to convert to int
+                                char* endptr(nullptr);
+                                auto point_size = strtol(possible_size.c_str(), &endptr, 10);
+
+                                if ((point_size != 0) && (point_size != LONG_MAX) && (point_size != LONG_MIN)) {
+                                    // conversion successful - add size
+                                    next = possible_next;
+                                    properties[key] = value + " " + possible_size;
+                                } else {
+                                    // conversion failed - shape only
+                                    properties[key] = value;
+                                }
+                            }
                         } else {
+                            // end of line
                             properties[key] = value;
                         }
                     } else if (value.find_first_of("'\"[{(", 0) == 0) {
@@ -180,8 +201,8 @@ void RegionImportExport::ParseRegionParameters(
                         char start_delim = value.front();
                         std::unordered_map<char, char> delim_map = {{'\'', '\''}, {'"', '"'}, {'[', ']'}, {'{', '}'}, {'(', ')'}};
                         char end_delim = delim_map[start_delim];
-
                         value.erase(0, 1); // erase start delim
+
                         if (value.back() == end_delim) {
                             value.pop_back();
                             properties[key] = value;
@@ -202,6 +223,7 @@ void RegionImportExport::ParseRegionParameters(
                 }
             }
         }
+
         if (next < end) {
             current = next + 1;
         } else {


### PR DESCRIPTION
Closes #1129 

Fix parsing of DS9 region properties with two arguments: `line=0 0` indicating arrow heads and `point=circle 5` indicating the point shape and size (bug mentioned in #1064).  These properties are not currently supported in CARTA but the file is parsed successfully and the regions are imported.