### PR TITLE
Fix crash problem in moments ICD tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed slow loading of FITS image with large number of HISTORY headers ([#1063](https://github.com/CARTAvis/carta-backend/issues/1063)).
 * Fixed the DS9 import bug with region properties ([#1129](https://github.com/CARTAvis/carta-backend/issues/1129)).
 * Fixed incorrect pixel number when fitting image with nan pixels ([#1128](https://github.com/CARTAvis/carta-backend/pull/1128)).
+* Fixed crash problems during moments ICD tests ([#1070](https://github.com/CARTAvis/carta-backend/issues/1070)).
 
 ## [3.0.0-beta.3]
 

--- a/Jenkinsfile-full
+++ b/Jenkinsfile-full
@@ -944,10 +944,6 @@ def moment() {
                 } else {
                     ret = true
                 }
-                echo "*** Temporarily skipping tests *** Related to carta-backend issue #1070"
-                sh "perl -p -i -e 's/describe/describe.skip/' src/test/MOMENTS_GENERATOR_CASA.test.ts"
-                sh "perl -p -i -e 's/describe/describe.skip/' src/test/MOMENTS_GENERATOR_FITS.test.ts"
-                sh "perl -p -i -e 's/describe/describe.skip/' src/test/MOMENTS_GENERATOR_HDF5.test.ts"
                 sh "pgrep carta_backend"
                 sh "CI=true npm test src/test/MOMENTS_GENERATOR_CASA.test.ts # test 1 of 6"
                 sh "sleep 3 && pgrep carta_backend"

--- a/src/Session/SessionManager.cc
+++ b/src/Session/SessionManager.cc
@@ -17,11 +17,11 @@ SessionManager::SessionManager(ProgramSettings& settings, std::string auth_token
     : _session_number(0), _app(uWS::App()), _settings(settings), _auth_token(auth_token), _file_list_handler(file_list_handler) {}
 
 void SessionManager::DeleteSession(uint32_t session_id) {
+    std::unique_lock<std::mutex> ulock(_sessions_mutex);
     if (!_sessions.count(session_id)) {
         return;
     }
 
-    std::unique_lock<std::mutex> ulock(_sessions_mutex);
     Session* session = _sessions[session_id];
     if (session) {
         spdlog::info(

--- a/src/Session/SessionManager.h
+++ b/src/Session/SessionManager.h
@@ -41,6 +41,7 @@ private:
     // Sessions map
     uint32_t _session_number;
     std::unordered_map<uint32_t, Session*> _sessions;
+    std::mutex _sessions_mutex;
     // uWebSockets app
     uWS::App _app;
     // Shared objects


### PR DESCRIPTION
Closes #1070. It seems the crash is not due to the moment images generation, but the destruction of Session which is called twice at the end of execution. The `DeleteSession` function is called twice and run in parallel under [SessionManager::OnDisconnect](https://github.com/CARTAvis/carta-backend/blob/dev/src/Session/SessionManager.cc#L109) and [~OnMessageTask()](https://github.com/CARTAvis/carta-backend/blob/dev/src/Session/OnMessageTask.h#L41). Now I add an unique lock for Sessions map's modification and check the existence of it before the deletion. @ajm-asiaa or @acdo2002 could you please check if the problem is solved if you have time? Thank you!