### PR TITLE
Fix CartaFitsImage mask for floating point data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed CRTF export bug for labelpos ([#1012](https://github.com/CARTAvis/carta-backend/issues/1012)).
 * Fixed DS9 import bug for region parameter with no unit ([#1101](https://github.com/CARTAvis/carta-backend/issues/1101)).
 * Fixed offset in center of offset axis of generated PV image ([#1038](https://github.com/CARTAvis/carta-backend/issues/1038)).
+* Fixed CARTA FITS image pixel mask for floating-point images.
 * Fixed various memory leaks, and several memory errors uncovered by address sanitization.
 
 ## [3.0.0-beta.2]

--- a/src/ImageData/CartaFitsImage.cc
+++ b/src/ImageData/CartaFitsImage.cc
@@ -198,6 +198,7 @@ const casacore::Lattice<bool>& CartaFitsImage::pixelMask() const {
 }
 
 casacore::Lattice<bool>& CartaFitsImage::pixelMask() {
+    spdlog::debug("CartaFitsImage::pixelMask");
     if (!_has_blanks) {
         throw(casacore::AipsError("CartaFitsImage::pixelMask - no pixel mask used"));
     }
@@ -218,7 +219,11 @@ casacore::Bool CartaFitsImage::doGetMaskSlice(casacore::Array<bool>& buffer, con
     }
 
     if (!_pixel_mask) {
-        SetPixelMask();
+        if (_datatype > 0) {
+            SetPixelMask();
+        } else {
+            return doGetNanMaskSlice(buffer, section);
+        }
     }
 
     if (_pixel_mask) {
@@ -390,6 +395,9 @@ void CartaFitsImage::GetFitsHeaderString(int& nheaders, std::string& hdrstr) {
         status = 0;
         fits_read_key(fptr, TLONG, key.c_str(), &blank_value, comment, &status);
         _has_blanks = !status;
+    } else {
+        // For float (-32) and double (-64) mask is represented by NaN
+        _has_blanks = true;
     }
 
     // Get headers to set up image:
@@ -1414,11 +1422,15 @@ void CartaFitsImage::SetPixelMask() {
             break;
         }
         case -32: {
-            ok = GetPixelMask<float>(fptr, _datatype, _shape, mask_lattice);
+            ok = GetNanPixelMask<float>(mask_lattice);
             break;
         }
         case -64: {
-            ok = GetPixelMask<double>(fptr, _datatype, _shape, mask_lattice);
+            ok = GetNanPixelMask<double>(mask_lattice);
+            break;
+        }
+        default: {
+            ok = false;
             break;
         }
     }
@@ -1431,4 +1443,15 @@ void CartaFitsImage::SetPixelMask() {
     }
 
     CloseFile();
+}
+
+bool CartaFitsImage::doGetNanMaskSlice(casacore::Array<bool>& buffer, const casacore::Slicer& section) {
+    // Create mask from finite (not NaN or infinite) values in slice
+    casacore::Array<float> data;
+    if (doGetSlice(data, section)) {
+        buffer = isFinite(data);
+        return true;
+    }
+
+    return false;
 }

--- a/src/ImageData/CartaFitsImage.cc
+++ b/src/ImageData/CartaFitsImage.cc
@@ -198,7 +198,6 @@ const casacore::Lattice<bool>& CartaFitsImage::pixelMask() const {
 }
 
 casacore::Lattice<bool>& CartaFitsImage::pixelMask() {
-    spdlog::debug("CartaFitsImage::pixelMask");
     if (!_has_blanks) {
         throw(casacore::AipsError("CartaFitsImage::pixelMask - no pixel mask used"));
     }

--- a/src/ImageData/CartaFitsImage.h
+++ b/src/ImageData/CartaFitsImage.h
@@ -82,11 +82,14 @@ private:
 
     // Pixel mask
     void SetPixelMask();
+    bool doGetNanMaskSlice(casacore::Array<bool>& buffer, const casacore::Slicer& section);
 
     template <typename T>
     bool GetDataSubset(fitsfile* fptr, int datatype, const casacore::Slicer& section, casacore::Array<float>& buffer);
     template <typename T>
     bool GetPixelMask(fitsfile* fptr, int datatype, const casacore::IPosition& shape, casacore::ArrayLattice<bool>& mask);
+    template <typename T>
+    bool GetNanPixelMask(casacore::ArrayLattice<bool>& mask);
 
     std::string _filename;
     unsigned int _hdu;

--- a/src/ImageData/CartaFitsImage.tcc
+++ b/src/ImageData/CartaFitsImage.tcc
@@ -132,7 +132,7 @@ bool CartaFitsImage::GetNanPixelMask(casacore::ArrayLattice<bool>& mask) {
 
     for (lattice_iter.reset(); !lattice_iter.atEnd(); ++lattice_iter) {
         casacore::Array<T> cursor_data = lattice_iter.cursor();
-        casacore::Array<bool> cursor_mask = isNaN(cursor_data);
+        casacore::Array<bool> cursor_mask = isFinite(cursor_data);
 
         casacore::Slicer cursor_slicer(lattice_iter.position(), lattice_iter.cursorShape());
         mask_array(cursor_slicer) = cursor_mask;


### PR DESCRIPTION
Bug found with e2e testing failure after merge of PR to fix long history headers by using CartaFitsImage.  The image stats were incorrect, with the wrong number of pixels and all other stats set to NaN.

All values were being used for the calculations since there was no mask from the BLANK header.  Only integer FITS images have a BLANK header with a value representing undefined pixels, but float and double images use NaN values. CartaFitsImage now creates the pixel mask from float/double data values which are finite (not NaN or infinite).