### PR TITLE
Support DS9 file with no header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed slow loading of FITS image with large number of HISTORY headers ([#1063](https://github.com/CARTAvis/carta-backend/issues/1063)).
 * Fixed the DS9 import bug with region properties ([#1129](https://github.com/CARTAvis/carta-backend/issues/1129)).
 * Fixed incorrect pixel number when fitting image with nan pixels ([#1128](https://github.com/CARTAvis/carta-backend/pull/1128)).
+* Fixed the DS9 import bug with no header line ([#1064](https://github.com/CARTAvis/carta-backend/issues/1064)).
 
 ## [3.0.0-beta.3]
 

--- a/src/FileList/FileListHandler.h
+++ b/src/FileList/FileListHandler.h
@@ -50,6 +50,7 @@ private:
     void GetFileList(CARTA::FileListResponse& file_list, std::string folder, ResultMsg& result_msg, CARTA::FileListFilterMode filter_mode,
         bool region_list = false);
 
+    bool IsDs9FileNoHeader(const std::string& full_path);
     bool FillRegionFileInfo(CARTA::FileInfo& file_info, const std::string& filename, CARTA::FileType type = CARTA::FileType::UNKNOWN,
         bool determine_file_type = true);
     void GetRegionFileContents(std::string& full_name, std::vector<std::string>& file_contents);

--- a/src/FileList/FileListHandler.h
+++ b/src/FileList/FileListHandler.h
@@ -50,7 +50,6 @@ private:
     void GetFileList(CARTA::FileListResponse& file_list, std::string folder, ResultMsg& result_msg, CARTA::FileListFilterMode filter_mode,
         bool region_list = false);
 
-    bool IsDs9FileNoHeader(const std::string& full_path);
     bool FillRegionFileInfo(CARTA::FileInfo& file_info, const std::string& filename, CARTA::FileType type = CARTA::FileType::UNKNOWN,
         bool determine_file_type = true);
     void GetRegionFileContents(std::string& full_name, std::vector<std::string>& file_contents);

--- a/src/Region/Ds9ImportExport.cc
+++ b/src/Region/Ds9ImportExport.cc
@@ -336,6 +336,10 @@ void Ds9ImportExport::SetRegion(std::string& region_definition) {
     std::unordered_map<std::string, std::string> properties;
     ParseRegionParameters(region_definition, parameters, properties);
 
+    if (parameters.empty()) {
+        return;
+    }
+
     // Process region definition include/exclude and remove indicator
     std::string region_type(parameters[0]);
     bool exclude_region(false);

--- a/src/Region/RegionImportExport.cc
+++ b/src/Region/RegionImportExport.cc
@@ -123,6 +123,11 @@ std::vector<std::string> RegionImportExport::ReadRegionFile(const std::string& f
 void RegionImportExport::ParseRegionParameters(
     std::string& region_definition, std::vector<std::string>& parameters, std::unordered_map<std::string, std::string>& properties) {
     // Parse the input string by space, comma, parentheses to get region parameters and properties (keyword=value)
+
+    // Remove spaces around = to recognize properties
+    std::regex equals_spaces("[ ]+=[ ]+");
+    region_definition = std::regex_replace(region_definition, equals_spaces, "=");
+
     size_t next(0), current(0), end(region_definition.size());
 
     while (current < end) {
@@ -133,13 +138,16 @@ void RegionImportExport::ParseRegionParameters(
         }
 
         if ((next - current) > 0) {
-            std::string param = region_definition.substr(current, next - current);
+            // Section of region_definition between parser delimiters
+            std::string parse_string = region_definition.substr(current, next - current);
 
-            if (param.find("=") == std::string::npos) {
-                parameters.push_back(param);
+            if (parse_string.find("=") == std::string::npos) {
+                // Assume region parameter (region type)
+                parameters.push_back(parse_string);
             } else {
+                // Assume region property (kv pair)
                 std::vector<std::string> kvpair;
-                SplitString(param, '=', kvpair);
+                SplitString(parse_string, '=', kvpair);
                 std::string key = kvpair[0];
 
                 if (kvpair.size() == 1) {
@@ -204,10 +212,19 @@ void RegionImportExport::ParseRegionParameters(
                         value.erase(0, 1); // erase start delim
 
                         if (value.back() == end_delim) {
+                            // next parser delimiter is end delimiter
                             value.pop_back();
                             properties[key] = value;
+                        } else if ((start_delim == '\'') || (start_delim == '"')) {
+                            // quotes (not parser delimiter) used for string, find end
+                            auto end_string = value.find_first_of(end_delim);
+                            if (end_string == std::string::npos) {
+                                throw(casacore::AipsError("string syntax error in " + region_definition));
+                            }
+
+                            properties[key] = value.substr(0, end_string);
                         } else {
-                            // value has parser delim in it (e.g. sp); add it and advance
+                            // value has other parser delim inside outer delim
                             value.append(1, region_definition[next]);
                             current = next + 1;
 

--- a/src/Region/RegionImportExport.cc
+++ b/src/Region/RegionImportExport.cc
@@ -34,7 +34,7 @@ std::vector<RegionProperties> RegionImportExport::GetImportedRegions(std::string
     error = _import_errors;
 
     if ((_import_regions.size() == 0) && error.empty()) {
-        error = "Import error: zero regions set. Regions may lie far outside image and cannot be converted to pixel coordinates.";
+        error = "Import error: zero regions set. No regions defined or regions lie outside image coordinate system.";
     }
 
     return _import_regions;


### PR DESCRIPTION
Closes #1064 

For the region file list, carta reads the first line to look for the expected CRTF or DS9 header.  When the optional DS9 header line is missing, the carta file type is unknown; with this change, the extension is checked to determine the file type.  If the region file does not have the header or extension to indicate its type, it is not recognized by the file browser.