### PR TITLE
Fix matched polygon pixel count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed incorrect spectral profiles for computed stokes ([#1122](https://github.com/CARTAvis/carta-backend/issues/1122)). 
 * Fixed the problem of recognizing FITS gzip files from ALMA Science Archive ([#1130](https://github.com/CARTAvis/carta-backend/issues/1130)).
 * Fixed slow loading of FITS image with large number of HISTORY headers ([#1063](https://github.com/CARTAvis/carta-backend/issues/1063)).
+* Fixed matched polygon statistics ([#1108](https://github.com/CARTAvis/carta-backend/issues/1108)).
 
 ## [3.0.0-beta.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed slow loading of FITS image with large number of HISTORY headers ([#1063](https://github.com/CARTAvis/carta-backend/issues/1063)).
 * Fixed the DS9 import bug with region properties ([#1129](https://github.com/CARTAvis/carta-backend/issues/1129)).
 * Fixed incorrect pixel number when fitting image with nan pixels ([#1128](https://github.com/CARTAvis/carta-backend/pull/1128)).
-* Fixed matched polygon statistics caused by masking ([#1108](https://github.com/CARTAvis/carta-backend/issues/1108)).
+* Fixed incorrect matched polygon statistics caused by masking ([#1108](https://github.com/CARTAvis/carta-backend/issues/1108)).
 
 ## [3.0.0-beta.3]
 

--- a/src/Region/Region.cc
+++ b/src/Region/Region.cc
@@ -507,12 +507,17 @@ std::shared_ptr<casacore::LCRegion> Region::GetAppliedPolygonRegion(
     casacore::Vector<casacore::Double> x, y;
 
     if (polygon_points.size() == 1) {
-        // Point, Rectangle, and Ellipse have one "segment"
+        // Point and ellipse have one vector for all points
         if (!ConvertPointsToImagePixels(polygon_points[0], output_csys, x, y)) {
             spdlog::error("Error approximating {} as polygon in matched image.", RegionName(region_state.type));
             return lc_region;
         }
+
+        if (!is_point) {
+            RemoveHorizontalPolygonPoints(x, y);
+        }
     } else {
+        // Rectangle and polygon have one vector for each side of rectangle or segment of original polygon
         for (auto& segment : polygon_points) {
             casacore::Vector<casacore::Double> segment_x, segment_y;
             if (!ConvertPointsToImagePixels(segment, output_csys, segment_x, segment_y)) {

--- a/src/Region/Region.h
+++ b/src/Region/Region.h
@@ -164,12 +164,14 @@ private:
     std::shared_ptr<casacore::LCRegion> GetCachedPolygonRegion(int file_id);
     std::shared_ptr<casacore::LCRegion> GetAppliedPolygonRegion(
         int file_id, std::shared_ptr<casacore::CoordinateSystem> output_csys, const casacore::IPosition& output_shape);
-    std::vector<CARTA::Point> GetReferencePolygonPoints(int num_vertices);
-    std::vector<CARTA::Point> GetApproximatePolygonPoints(int num_vertices);
+    std::vector<std::vector<CARTA::Point>> GetReferencePolygonPoints(int num_vertices);
+    std::vector<std::vector<CARTA::Point>> GetApproximatePolygonPoints(int num_vertices);
     std::vector<CARTA::Point> GetApproximateEllipsePoints(int num_vertices);
     double GetTotalSegmentLength(std::vector<CARTA::Point>& points);
     bool ConvertPointsToImagePixels(const std::vector<CARTA::Point>& points, std::shared_ptr<casacore::CoordinateSystem> output_csys,
         casacore::Vector<casacore::Double>& x, casacore::Vector<casacore::Double>& y);
+    void RemoveHorizontalPolygonPoints(casacore::Vector<casacore::Double>& x, casacore::Vector<casacore::Double>& y);
+    bool ValuesNear(float val1, float val2);
 
     // Region applied to any image; used for export
     std::shared_ptr<casacore::LCRegion> GetCachedLCRegion(int file_id);


### PR DESCRIPTION
Closes #1108 

casacore LCPolygon sets the mask for each y in the region's bounding box to the x value of the intercept of the line segment if not horizontal or the x value of the next point if horizontal.  Setting many points along the line resulted in many horizontal line segments which added pixels not included in reference image.

In this fix, for a matched polygon with an approximately horizontal line segment, only the points nearest an even y-pixel are selected in that segment.  