### PR TITLE
Fix errors on loading images via LEL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed slow loading of FITS image with large number of HISTORY headers ([#1063](https://github.com/CARTAvis/carta-backend/issues/1063)).
 * Fixed the DS9 import bug with region properties ([#1129](https://github.com/CARTAvis/carta-backend/issues/1129)).
 * Fixed incorrect pixel number when fitting image with nan pixels ([#1128](https://github.com/CARTAvis/carta-backend/pull/1128)).
+* Fixed errors on loading images via LEL ([#1144](https://github.com/CARTAvis/carta-backend/issues/1144)).
 
 ## [3.0.0-beta.3]
 

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -46,16 +46,16 @@ LoaderCache::LoaderCache(int capacity) : _capacity(capacity){};
 
 std::shared_ptr<FileLoader> LoaderCache::Get(const std::string& filename, const std::string& directory) {
     std::unique_lock<std::mutex> guard(_loader_cache_mutex);
-    std::string fullname = directory.empty() ? filename : fmt::format("{}/{}", directory, filename);
+    auto key = GetKey(filename, directory);
 
     // We have a cached loader, but the file has changed
-    if (_map.find(fullname) != _map.end() && _map[fullname]->ImageUpdated()) {
-        _map.erase(fullname);
-        _queue.remove(fullname);
+    if (_map.find(key) != _map.end() && _map[key]->ImageUpdated()) {
+        _map.erase(key);
+        _queue.remove(key);
     }
 
     // We don't have a cached loader
-    if (_map.find(fullname) == _map.end()) {
+    if (_map.find(key) == _map.end()) {
         // Create the loader -- don't block while doing this
         std::shared_ptr<FileLoader> loader_ptr;
         guard.unlock();
@@ -63,7 +63,7 @@ std::shared_ptr<FileLoader> LoaderCache::Get(const std::string& filename, const 
         guard.lock();
 
         // Check if the loader was added in the meantime
-        if (_map.find(fullname) == _map.end()) {
+        if (_map.find(key) == _map.end()) {
             // Evict oldest loader if necessary
             if (_map.size() == _capacity) {
                 _map.erase(_queue.back());
@@ -71,22 +71,27 @@ std::shared_ptr<FileLoader> LoaderCache::Get(const std::string& filename, const 
             }
 
             // Insert the new loader
-            _map[fullname] = loader_ptr;
-            _queue.push_front(fullname);
+            _map[key] = loader_ptr;
+            _queue.push_front(key);
         }
     } else {
         // Touch the cache entry
-        _queue.remove(fullname);
-        _queue.push_front(fullname);
+        _queue.remove(key);
+        _queue.push_front(key);
     }
 
-    return _map[fullname];
+    return _map[key];
 }
 
-void LoaderCache::Remove(const std::string& fullname) {
+void LoaderCache::Remove(const std::string& filename, const std::string& directory) {
     std::unique_lock<std::mutex> guard(_loader_cache_mutex);
-    _map.erase(fullname);
-    _queue.remove(fullname);
+    auto key = GetKey(filename, directory);
+    _map.erase(key);
+    _queue.remove(key);
+}
+
+std::string LoaderCache::GetKey(const std::string& filename, const std::string& directory) {
+    return (directory.empty() ? filename : fmt::format("{}/{}", directory, filename));
 }
 
 volatile int Session::_num_sessions = 0;
@@ -480,8 +485,7 @@ bool Session::OnOpenFile(const CARTA::OpenFile& message, uint32_t request_id, bo
             auto image = loader->GetImage();
             success = OnOpenFile(file_id, filename, image, &ack);
         } catch (const casacore::AipsError& err) {
-            std::string fullname = dir_path.empty() ? filename : fmt::format("{}/{}", dir_path, filename);
-            _loaders.Remove(fullname);
+            _loaders.Remove(filename, dir_path);
             success = false;
             err_message = err.getMesg();
         }

--- a/src/Session/Session.h
+++ b/src/Session/Session.h
@@ -54,7 +54,7 @@ class LoaderCache {
 public:
     LoaderCache(int capacity);
     std::shared_ptr<FileLoader> Get(const std::string& filename, const std::string& directory = "");
-    void Remove(const std::string& filename);
+    void Remove(const std::string& fullname);
 
 private:
     int _capacity;

--- a/src/Session/Session.h
+++ b/src/Session/Session.h
@@ -54,9 +54,10 @@ class LoaderCache {
 public:
     LoaderCache(int capacity);
     std::shared_ptr<FileLoader> Get(const std::string& filename, const std::string& directory = "");
-    void Remove(const std::string& fullname);
+    void Remove(const std::string& filename, const std::string& directory = "");
 
 private:
+    std::string GetKey(const std::string& filename, const std::string& directory);
     int _capacity;
     std::unordered_map<std::string, std::shared_ptr<FileLoader>> _map;
     std::list<std::string> _queue;


### PR DESCRIPTION
Closes #1144. This issue is due to the incorrect cache of the image loader for LEL expression. I included the file directory name in the search key to avoid ambiguity when getting loaders for LEL expression.