### PR TITLE
Fix getstat error on generated image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed incorrect pixel number when fitting image with nan pixels ([#1128](https://github.com/CARTAvis/carta-backend/pull/1128)).
 * Fixed errors on loading images via LEL ([#1144](https://github.com/CARTAvis/carta-backend/issues/1144)).
 * Fixed the DS9 import bug with no header line ([#1064](https://github.com/CARTAvis/carta-backend/issues/1064)).
+* Fixed the getstat error on generated image ([#1148](https://github.com/CARTAvis/carta-backend/issues/1148)).
 
 ## [3.0.0-beta.3]
 

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -72,10 +72,8 @@ FileLoader* FileLoader::GetLoader(std::shared_ptr<casacore::ImageInterface<float
 
 FileLoader::FileLoader(const std::string& filename, const std::string& directory, bool is_gz)
     : _filename(filename), _directory(directory), _is_gz(is_gz), _modify_time(0), _num_dims(0), _has_pixel_mask(false), _stokes_cdelt(0) {
-    // Set initial modify time if filename is not LEL expression for file in directory
-    if (directory.empty()) {
-        ImageUpdated();
-    }
+    // Set initial modify time
+    ImageUpdated();
 }
 
 bool FileLoader::CanOpenFile(std::string& /*error*/) {
@@ -109,8 +107,9 @@ void FileLoader::CloseImageIfUpdated() {
 bool FileLoader::ImageUpdated() {
     bool changed(false);
 
-    // Do not close compressed image or run getstat on LEL ImageExpr (sets directory)
-    if (_is_gz || !_directory.empty()) {
+    // Do not close compressed image, or run getstat on generated image (no filename, in memory only) or
+    // LEL ImageExpr (directory is set, filename is LEL expression)
+    if (_is_gz || _filename.empty() || !_directory.empty()) {
         return changed;
     }
 


### PR DESCRIPTION
Closes #1148  

Do not check modify time on generated image in memory (no filename).