### PR TITLE
ajm/jenkins slack notifications

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent none
     environment {
-        COMMIT_ID = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
+        COMMIT_ID=''
     }
     options {
         preserveStashes() 
@@ -15,6 +15,9 @@ pipeline {
                     }
                     steps {
                         catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            script {
+                                COMMIT_ID = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
+                            }
                             sh "uname -a"
                             sh "lsb_release -a"
                             sh "git submodule update --init --recursive"
@@ -127,7 +130,7 @@ pipeline {
             slackSend color: 'good', message: "Success - ${env.BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
         }
         failure {
-             slackSend color: 'danger', message: "Failed - ${env.BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+             slackSend color: 'danger', message: "Failed - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,8 @@
 pipeline {
     agent none
+    environment {
+        COMMIT_ID = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
+    }
     options {
         preserveStashes() 
     }
@@ -121,10 +124,10 @@ pipeline {
     }
     post {
         success {
-            slackSend color: 'good', message: "Success - ${env.BRANCH_NAME} ${env.GIT_REVISION:0:7} (<${env.RUN_DISPLAY_URL}|open>)";
+            slackSend color: 'good', message: "Success - ${env.BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
         }
         failure {
-             slackSend color: 'danger', message: "Failed - ${env.BRANCH_NAME} ${env.GIT_REVISION:0:7} (<${env.RUN_DISPLAY_URL}|open>)";
+             slackSend color: 'danger', message: "Failed - ${env.BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,12 +1,3 @@
-void setBuildStatus(String message, String state) {
-  step([
-      $class: "GitHubCommitStatusSetter",
-      reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/CARTAvis/carta-backend"],
-      contextSource: [$class: "ManuallyEnteredCommitContextSource", context: "ci/jenkins/build-status"],
-      errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
-      statusResultSource: [ $class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: message, state: state]] ]
-  ]);
-}
 pipeline {
     agent none
     options {
@@ -34,10 +25,10 @@ pipeline {
                     }
                     post {
                         success {
-                            setBuildStatus("build succeeded", "SUCCESS");
+                            slackSend color: 'good', message: 'Ubuntu backend build success';
                         }
                         failure {
-                            setBuildStatus("build failed", "FAILURE");
+                            slackSend color: 'danger', message: 'Ubuntu backend build failed';
                         }
                     }
                 }
@@ -61,10 +52,10 @@ pipeline {
                     }
                     post {
                         success {
-                            setBuildStatus("build succeeded", "SUCCESS");
+                            slackSend color: 'good', message: 'macOS backend build success';
                         }
                         failure {
-                            setBuildStatus("build failed", "FAILURE");
+                            slackSend color: 'danger', message: 'macOS backend build failed';
                         }
                     }
                 }
@@ -87,10 +78,10 @@ pipeline {
                     }
                     post {
                         success {
-                            setBuildStatus("build succeeded", "SUCCESS");
+                            slackSend color: 'good', message: 'RedHat backend build success';
                         }
                         failure {
-                            setBuildStatus("build failed", "FAILURE");
+                            slackSend color: 'danger', message: 'RedHat backend build success';
                         }
                     }
                 }
@@ -114,10 +105,10 @@ pipeline {
                             junit 'build/test/ubuntu_test_detail.xml'
                         }
                         success {
-                            setBuildStatus("build succeeded", "SUCCESS");
+                            slackSend color: 'good', message: 'Ubuntu Unit Tests success';
                         }
                         failure {
-                            setBuildStatus("build failed", "FAILURE");
+                            slackSend color: 'danger', message: 'Ubuntu Unit Tests failure';
                         }
                     }   
                 }
@@ -137,10 +128,10 @@ pipeline {
                             junit 'build/test/macos_test_detail.xml'
                         }
                         success {
-                            setBuildStatus("build succeeded", "SUCCESS");
+                            slackSend color: 'good', message: 'macOS Unit Tests success';
                         }
                         failure {
-                            setBuildStatus("build failed", "FAILURE");
+                            slackSend color: 'danger', message: 'macOS Unit Tests failure';
                         }   
                     }
                 }
@@ -160,14 +151,22 @@ pipeline {
                             junit 'build/test/almalinux_test_detail.xml'
                         }
                         success {
-                            setBuildStatus("build succeeded", "SUCCESS");
+                            slackSend color: 'good', message: 'macOS Unit Tests success';
                         }
                         failure {
-                            setBuildStatus("build failed", "FAILURE");
+                            slackSend color: 'danger', message: 'macOS Unit Tests failure';
                         }
                     }
                 }
             }
+        }
+    }
+    post {
+        success {
+            slackSend color: 'good', message: "Success - ${env.JOB_NAME} ${env.BUILD_NUMBER} ${env.BRANCH_NAME} ${env.GIT_BRANCH} (<${env.RUN_DISPLAY_URL}|open>)";
+        }
+        failure {
+             slackSend color: 'danger', message: "Failed - ${env.JOB_NAME} ${env.BUILD_NUMBER} ${env.BRANCH_NAME} ${env.GIT_BRANCH} (<${env.RUN_DISPLAY_URL}|open>)";
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -127,10 +127,10 @@ pipeline {
     }
     post {
         success {
-            slackSend color: 'good', message: "Success - ${env.BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+            slackSend color: 'good', message: "carta-backend - Success - ${env.BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
         }
         failure {
-             slackSend color: 'danger', message: "Failed - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+             slackSend color: 'danger', message: "carta-backend - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -127,10 +127,10 @@ pipeline {
     }
     post {
         success {
-            slackSend color: 'good', message: "carta-backend - Success - ${env.BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+            slackSend color: 'good', message: "carta-backend - Success - ${env.BRANCH_NAME} (<${env.RUN_DISPLAY_URL}|${COMMIT_ID}>)";
         }
         failure {
-             slackSend color: 'danger', message: "carta-backend - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+             slackSend color: 'danger', message: "carta-backend - Fail - ${env.BRANCH_NAME} (<${env.RUN_DISPLAY_URL}|${COMMIT_ID}>)";
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,14 +23,6 @@ pipeline {
                             }
                         }
                     }
-                    post {
-                        success {
-                            slackSend color: 'good', message: 'Ubuntu backend build success';
-                        }
-                        failure {
-                            slackSend color: 'danger', message: 'Ubuntu backend build failed';
-                        }
-                    }
                 }
                 stage('macOS 12') {
                     agent {
@@ -50,14 +42,6 @@ pipeline {
                             }
                         }
                     }
-                    post {
-                        success {
-                            slackSend color: 'good', message: 'macOS backend build success';
-                        }
-                        failure {
-                            slackSend color: 'danger', message: 'macOS backend build failed';
-                        }
-                    }
                 }
                 stage('AlmaLinux 8.5') {
                     agent {
@@ -74,14 +58,6 @@ pipeline {
                                 sh "make -j 32"
                                 sh "./carta_backend --version"
                             }
-                        }
-                    }
-                    post {
-                        success {
-                            slackSend color: 'good', message: 'RedHat backend build success';
-                        }
-                        failure {
-                            slackSend color: 'danger', message: 'RedHat backend build success';
                         }
                     }
                 }
@@ -104,12 +80,6 @@ pipeline {
                         always {
                             junit 'build/test/ubuntu_test_detail.xml'
                         }
-                        success {
-                            slackSend color: 'good', message: 'Ubuntu Unit Tests success';
-                        }
-                        failure {
-                            slackSend color: 'danger', message: 'Ubuntu Unit Tests failure';
-                        }
                     }   
                 }
                 stage('macOS 12') {
@@ -127,12 +97,6 @@ pipeline {
                         always {
                             junit 'build/test/macos_test_detail.xml'
                         }
-                        success {
-                            slackSend color: 'good', message: 'macOS Unit Tests success';
-                        }
-                        failure {
-                            slackSend color: 'danger', message: 'macOS Unit Tests failure';
-                        }   
                     }
                 }
                 stage('AlmaLinux 8.5') {
@@ -150,12 +114,6 @@ pipeline {
                         always {
                             junit 'build/test/almalinux_test_detail.xml'
                         }
-                        success {
-                            slackSend color: 'good', message: 'macOS Unit Tests success';
-                        }
-                        failure {
-                            slackSend color: 'danger', message: 'macOS Unit Tests failure';
-                        }
                     }
                 }
             }
@@ -163,10 +121,10 @@ pipeline {
     }
     post {
         success {
-            slackSend color: 'good', message: "Success - ${env.JOB_NAME} ${env.BUILD_NUMBER} ${env.BRANCH_NAME} ${env.GIT_BRANCH} (<${env.RUN_DISPLAY_URL}|open>)";
+            slackSend color: 'good', message: "Success - ${env.BRANCH_NAME} ${env.GIT_REVISION:0:7} (<${env.RUN_DISPLAY_URL}|open>)";
         }
         failure {
-             slackSend color: 'danger', message: "Failed - ${env.JOB_NAME} ${env.BUILD_NUMBER} ${env.BRANCH_NAME} ${env.GIT_BRANCH} (<${env.RUN_DISPLAY_URL}|open>)";
+             slackSend color: 'danger', message: "Failed - ${env.BRANCH_NAME} ${env.GIT_REVISION:0:7} (<${env.RUN_DISPLAY_URL}|open>)";
         }
     }
 }

--- a/Jenkinsfile-full
+++ b/Jenkinsfile-full
@@ -564,17 +564,15 @@ pipeline {
                         }
                     }
                 }
-                post {
-                    unstable {
-                        slackSend color: 'warning', message: "Full ICD test suite - Unstable - ${PLATFORM} ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
-                    }
-                }
             }
         }
     }
     post {
         success {
             slackSend color: 'good', message: "Full ICD test suite - Success - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+        }
+        unstable {
+            slackSend color: 'warning', message: "Full ICD test suite - Unstable - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
         }
     }
 }

--- a/Jenkinsfile-full
+++ b/Jenkinsfile-full
@@ -400,7 +400,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'FAILURE', stageResult: "FAILURE", message: "ICD test session and file_browser failure") {
+                            warnError(catchInterruptions: true, message: "ICD test session and file_browser failure") {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -409,8 +409,8 @@ pipeline {
                             }
                         }
                         post {
-                            failure {
-                                slackSend color: 'danger', message: "ICD test session and file_browser ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            unstable {
+                                slackSend color: 'warning', message: "ICD test session and file_browser ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -419,7 +419,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'ICD test animator failure') {
+                             warnError(catchInterruptions: true, message: 'ICD test animator failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -428,8 +428,8 @@ pipeline {
                             }
                         }
                         post {
-                            failure {
-                                slackSend color: 'danger', message: "ICD test animator ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            unstable {
+                                slackSend color: 'warning', message: "ICD test animator ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -438,7 +438,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'ICD test region_statistics failure') {
+                            warnError(catchInterruptions: true, message: 'ICD test region_statistics failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -447,8 +447,8 @@ pipeline {
                             }
                         }
                         post {
-                            failure {
-                                slackSend color: 'danger', message: "ICD test region_statistics ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            unstable {
+                                slackSend color: 'warning', message: "ICD test region_statistics ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -457,7 +457,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'ICD test region_manipulation failure') {
+                            warnError(catchInterruptions: true, message: 'ICD test region_manipulation failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -466,8 +466,8 @@ pipeline {
                             }
                         }
                         post {
-                            failure {
-                                slackSend color: 'danger', message: "ICD test region_manipulation ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            unstable {
+                                slackSend color: 'warning', message: "ICD test region_manipulation ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -476,7 +476,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'ICD test cube_histogram failure') {
+                            warnError(catchInterruptions: true, message: 'ICD test cube_histogram failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -485,8 +485,8 @@ pipeline {
                             }
                         }
                         post {
-                            failure {
-                                slackSend color: 'danger', message: "ICD test cube_histogram ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            unstable {
+                                slackSend color: 'warning', message: "ICD test cube_histogram ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -495,7 +495,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'ICD test pv_generator failure') {
+                            warnError(catchInterruptions: true, message: 'ICD test pv_generator failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -504,8 +504,8 @@ pipeline {
                             }
                         }
                         post {
-                            failure {
-                                slackSend color: 'danger', message: "ICD test pv_generator ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            unstable {
+                                slackSend color: 'warning', message: "ICD test pv_generator ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -514,7 +514,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'ICD test raster_tiles failure') {
+                            warnError(catchInterruptions: true, message: 'ICD test raster_tiles failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -523,8 +523,8 @@ pipeline {
                             }
                         }
                         post {
-                            failure {
-                                slackSend color: 'danger', message: "ICD test raster_tiles ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            unstable {
+                                slackSend color: 'warning', message: "ICD test raster_tiles ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -533,7 +533,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'ICD test catalog failure') {
+                            warnError(catchInterruptions: true, message: 'ICD test catalog failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -542,8 +542,8 @@ pipeline {
                             }
                         }
                         post {
-                            failure {
-                                slackSend color: 'danger', message: "ICD test catalog ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            unstable {
+                                slackSend color: 'warning', message: "ICD test catalog ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -552,7 +552,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'ICD test moment failure') {
+                            warnError(catchInterruptions: true, message: 'ICD test moment failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -561,8 +561,8 @@ pipeline {
                             }
                         }
                         post {
-                            failure {
-                                slackSend color: 'danger', message: "ICD test moment ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            unstable {
+                                slackSend color: 'warning', message: "ICD test moment ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -571,7 +571,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'ICD test resume failure') {
+                            warnError(catchInterruptions: true, message: 'ICD test resume failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -580,8 +580,8 @@ pipeline {
                             }
                         }
                         post {
-                            failure {
-                                slackSend color: 'danger', message: "ICD test resume ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            unstable {
+                                slackSend color: 'warning', message: "ICD test resume ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -590,7 +590,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'ICD test match failure') {
+                            warnError(catchInterruptions: true, message: 'ICD test match failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -599,8 +599,8 @@ pipeline {
                             }
                         }
                         post {
-                            failure {
-                                slackSend color: 'danger', message: "ICD test match ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            unstable {
+                                slackSend color: 'warning', message: "ICD test match ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -609,7 +609,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'ICD test close_file failure') {
+                            warnError(catchInterruptions: true, message: 'ICD test close_file failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -618,8 +618,8 @@ pipeline {
                             }
                         }
                         post {
-                            failure {
-                                slackSend color: 'danger', message: "ICD test close_file ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            unstable {
+                                slackSend color: 'warning', message: "ICD test close_file ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }

--- a/Jenkinsfile-full
+++ b/Jenkinsfile-full
@@ -29,7 +29,7 @@ pipeline {
                     }
                     post {
                         failure {
-                            slackSend color: 'danger', message: "Ubuntu 18.04 - carta-backend build - Fail - ${BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            slackSend color: 'danger', message: "Ubuntu 18.04 - carta-backend build - Fail - ${BRANCH_NAME} (<${env.RUN_DISPLAY_URL}|${COMMIT_ID_SHORT}>)";
                         }
                     }
                 }
@@ -52,7 +52,7 @@ pipeline {
                     }
                     post {
                         failure {
-                            slackSend color: 'danger', message: "Ubuntu 20.04 - carta-backend build - Fail - ${BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            slackSend color: 'danger', message: "Ubuntu 20.04 - carta-backend build - Fail - ${BRANCH_NAME} (<${env.RUN_DISPLAY_URL}|${COMMIT_ID_SHORT}>)";
                         }
                     }
                 }
@@ -75,7 +75,7 @@ pipeline {
                     }
                     post {
                         failure {
-                            slackSend color: 'danger', message: "Ubuntu 22.04 - carta-backend build - Fail - ${BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            slackSend color: 'danger', message: "Ubuntu 22.04 - carta-backend build - Fail - ${BRANCH_NAME} (<${env.RUN_DISPLAY_URL}|${COMMIT_ID_SHORT}>)";
                         }
                     }
                 }
@@ -97,7 +97,7 @@ pipeline {
                     }
                     post {
                         failure {
-                            slackSend color: 'danger', message: "macOS 11 - carta-backend build - Fail - ${BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            slackSend color: 'danger', message: "macOS 11 - carta-backend build - Fail - ${BRANCH_NAME} (<${env.RUN_DISPLAY_URL}|${COMMIT_ID_SHORT}>)";
                         }
                     }
                 }
@@ -110,7 +110,8 @@ pipeline {
                             sh "export PATH=/usr/local/bin:$PATH"
                             sh "git submodule update --init --recursive"
                             script {
-                                COMMIT_ID = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
+                                COMMIT_ID_SHORT = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
+                                COMMIT_ID_LONG = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
                                 BRANCH_NAME = sh(returnStdout: true, script: 'git rev-parse --abbrev-ref HEAD').trim()
                             }
                             dir ('build') {
@@ -123,7 +124,7 @@ pipeline {
                     }
                     post {
                         failure {
-                            slackSend color: 'danger', message: "macOS 12 - carta-backend build - Fail - ${BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            slackSend color: 'danger', message: "macOS 12 - carta-backend build - Fail - ${BRANCH_NAME} (<${env.RUN_DISPLAY_URL}|${COMMIT_ID_SHORT}>)";
                         }
                     }
                 }
@@ -146,7 +147,7 @@ pipeline {
                     }
                     post {
                         failure {
-                            slackSend color: 'danger', message: "RedHat 7 - carta-backend build - Fail - ${BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            slackSend color: 'danger', message: "RedHat 7 - carta-backend build - Fail - ${BRANCH_NAME} (<${env.RUN_DISPLAY_URL}|${COMMIT_ID_SHORT}>)";
                         }
                     }
                 }
@@ -169,7 +170,7 @@ pipeline {
                     }
                     post {
                         failure {
-                            slackSend color: 'danger', message: "RedHat 8 - carta-backend build - Fail - ${BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            slackSend color: 'danger', message: "RedHat 8 - carta-backend build - Fail - ${BRANCH_NAME} (<${env.RUN_DISPLAY_URL}|${COMMIT_ID_SHORT}>)";
                         }
                     }
                 }
@@ -194,7 +195,7 @@ pipeline {
                             junit 'test/ubuntu_bionic_test_detail.xml'
                         }
                         failure {
-                            slackSend color: 'danger', message: "Ubuntu 18.04 - Unit Tests - Fail - ${BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            slackSend color: 'danger', message: "Ubuntu 18.04 - Unit Tests - Fail - ${BRANCH_NAME} (<${env.RUN_DISPLAY_URL}|${COMMIT_ID_SHORT}>)";
                         }
                     }
                 }
@@ -215,7 +216,7 @@ pipeline {
                             junit 'test/ubuntu_focal_test_detail.xml'
                         }
                         failure {
-                            slackSend color: 'danger', message: "Ubuntu 20.04 - Unit Tests - Fail - ${BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            slackSend color: 'danger', message: "Ubuntu 20.04 - Unit Tests - Fail - ${BRANCH_NAME} (<${env.RUN_DISPLAY_URL}|${COMMIT_ID_SHORT}>)";
                         }   
                     }   
                 }
@@ -236,7 +237,7 @@ pipeline {
                             junit 'test/ubuntu_jammy_test_detail.xml'
                         }
                         failure {
-                            slackSend color: 'danger', message: "Ubuntu 22.04 - Unit Tests - Fail - ${BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            slackSend color: 'danger', message: "Ubuntu 22.04 - Unit Tests - Fail - ${BRANCH_NAME} (<${env.RUN_DISPLAY_URL}|${COMMIT_ID_SHORT}>)";
                         }
                     }   
                 }
@@ -256,7 +257,7 @@ pipeline {
                             junit 'build/test/macos11_test_detail.xml'
                         }
                         failure {
-                            slackSend color: 'danger', message: "macOS 11 - Unit Tests - Fail - ${BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            slackSend color: 'danger', message: "macOS 11 - Unit Tests - Fail - ${BRANCH_NAME} (<${env.RUN_DISPLAY_URL}|${COMMIT_ID_SHORT}>)";
                         }
                     }
                 }
@@ -276,7 +277,7 @@ pipeline {
                             junit 'build/test/macos12_test_detail.xml'
                         }
                         failure {
-                            slackSend color: 'danger', message: "macOS 12 - Unit Tests - Fail - ${BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            slackSend color: 'danger', message: "macOS 12 - Unit Tests - Fail - ${BRANCH_NAME} (<${env.RUN_DISPLAY_URL}|${COMMIT_ID_SHORT}>)";
                         }
                     }
                 }
@@ -297,7 +298,7 @@ pipeline {
                             junit 'test/rhel7_test_detail.xml'
                         }
                         failure {
-                            slackSend color: 'danger', message: "RedHat 7 - Unit Tests - Fail - ${BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            slackSend color: 'danger', message: "RedHat 7 - Unit Tests - Fail - ${BRANCH_NAME} (<${env.RUN_DISPLAY_URL}|${COMMIT_ID_SHORT}>)";
                         }
                     }
                 }
@@ -318,7 +319,7 @@ pipeline {
                             junit 'test/rhel8_test_detail.xml'
                         }
                         failure {
-                            slackSend color: 'danger', message: "RedHat 8 - Unit Tests - Fail - ${BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            slackSend color: 'danger', message: "RedHat 8 - Unit Tests - Fail - ${BRANCH_NAME} (<${env.RUN_DISPLAY_URL}|${COMMIT_ID_SHORT}>)";
                         }
                     }
                 }
@@ -567,7 +568,7 @@ pipeline {
     }
     post {
         success {
-            slackSend color: 'good', message: "Full ICD test suite - Success - ${BRANCH_NAME} (<${env.RUN_DISPLAY_URL}|${COMMIT_ID}>)";
+            slackSend color: 'good', message: "Full ICD test suite - Success - ${BRANCH_NAME} (<${env.RUN_DISPLAY_URL}|${COMMIT_ID_SHORT}>)";
             withCredentials([string(credentialsId: 'acdc-jenkins-token', variable: 'TOKEN')]) {
             sh("""curl -X POST -H "Accept: application/vnd.github+json" \
             -H "Authorization: token $TOKEN" https://api.github.com/repos/CARTAvis/carta-backend/statuses/${COMMIT_ID_LONG} \
@@ -576,7 +577,7 @@ pipeline {
 
         }
         unstable {
-            slackSend color: 'warning', message: "Full ICD test suite - Unstable - ${BRANCH_NAME} (<${env.RUN_DISPLAY_URL}|${COMMIT_ID}>)";
+            slackSend color: 'warning', message: "Full ICD test suite - Unstable - ${BRANCH_NAME} (<${env.RUN_DISPLAY_URL}|${COMMIT_ID_SHORT}>)";
             withCredentials([string(credentialsId: 'acdc-jenkins-token', variable: 'TOKEN')]) {
             sh("""curl -X POST -H "Accept: application/vnd.github+json" \
             -H "Authorization: token $TOKEN" https://api.github.com/repos/CARTAvis/carta-backend/statuses/${COMMIT_ID_LONG} \
@@ -586,7 +587,9 @@ pipeline {
     }
 }
 
-def COMMIT_ID
+def COMMIT_ID_SHORT
+
+def COMMIT_ID_LONG
 
 def BRANCH_NAME
 

--- a/Jenkinsfile-full
+++ b/Jenkinsfile-full
@@ -400,17 +400,12 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: "ICD test session and file_browser failure") {
+                            warnError(catchInterruptions: true, message: "ICD test session and file_browser failure") {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
                                 unstash "${PLATFORM}-ICD"
                                 file_browser()
-                            }
-                        }
-                        post {
-                            failure {
-                                slackSend color: 'danger', message: "ICD test session and file_browser ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -419,17 +414,12 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'ICD test animator failure') {
+                             warnError(catchInterruptions: true, message: 'ICD test animator failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
                                 unstash "${PLATFORM}-ICD"
                                 animator()
-                            }
-                        }
-                        post {
-                            failure {
-                                slackSend color: 'danger', message: "ICD test animator ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -438,17 +428,12 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'ICD test region_statistics failure') {
+                            warnError(catchInterruptions: true, message: 'ICD test region_statistics failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
                                 unstash "${PLATFORM}-ICD"
                                 region_statistics()
-                            }
-                        }
-                        post {
-                            failure {
-                                slackSend color: 'danger', message: "ICD test region_statistics ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -457,17 +442,12 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'ICD test region_manipulation failure') {
+                            warnError(catchInterruptions: true, message: 'ICD test region_manipulation failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
                                 unstash "${PLATFORM}-ICD"
                                 region_manipulation()
-                            }
-                        }
-                        post {
-                            failure {
-                                slackSend color: 'danger', message: "ICD test region_manipulation ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -476,17 +456,12 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'ICD test cube_histogram failure') {
+                            warnError(catchInterruptions: true, message: 'ICD test cube_histogram failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
                                 unstash "${PLATFORM}-ICD"
                                 cube_histogram()
-                            }
-                        }
-                        post {
-                            failure {
-                                slackSend color: 'danger', message: "ICD test cube_histogram ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -495,17 +470,12 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'ICD test pv_generator failure') {
+                            warnError(catchInterruptions: true, message: 'ICD test pv_generator failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
                                 unstash "${PLATFORM}-ICD"
                                 pv_generator()
-                            }
-                        }
-                        post {
-                            failure {
-                                slackSend color: 'danger', message: "ICD test pv_generator ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -514,17 +484,12 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'ICD test raster_tiles failure') {
+                            warnError(catchInterruptions: true, message: 'ICD test raster_tiles failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
                                 unstash "${PLATFORM}-ICD"
                                 raster_tiles()
-                            }
-                        }
-                        post {
-                            failure {
-                                slackSend color: 'danger', message: "ICD test raster_tiles ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -533,17 +498,12 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'ICD test catalog failure') {
+                            warnError(catchInterruptions: true, message: 'ICD test catalog failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
                                 unstash "${PLATFORM}-ICD"
                                 catalog()
-                            }
-                        }
-                        post {
-                            failure {
-                                slackSend color: 'danger', message: "ICD test catalog ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -552,17 +512,12 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'ICD test moment failure') {
+                            warnError(catchInterruptions: true, message: 'ICD test moment failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
                                 unstash "${PLATFORM}-ICD"
                                 moment()
-                            }
-                        }
-                        post {
-                            failure {
-                                slackSend color: 'danger', message: "ICD test moment ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -571,17 +526,12 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'ICD test resume failure') {
+                            warnError(catchInterruptions: true, message: 'ICD test resume failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
                                 unstash "${PLATFORM}-ICD"
                                 resume()
-                            }
-                        }
-                        post {
-                            failure {
-                                slackSend color: 'danger', message: "ICD test resume ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -590,17 +540,12 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'ICD test match failure') {
+                            warnError(catchInterruptions: true, message: 'ICD test match failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
                                 unstash "${PLATFORM}-ICD"
                                 match()
-                            }
-                        }
-                        post {
-                            failure {
-                                slackSend color: 'danger', message: "ICD test match ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -609,7 +554,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'ICD test close_file failure') {
+                            warnError(catchInterruptions: true, message: 'ICD test close_file failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -617,25 +562,20 @@ pipeline {
                                 close_file()
                             }
                         }
-                        post {
-                            failure {
-                                slackSend color: 'danger', message: "ICD test close_file ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
-                            }
-                        }
+                    }
+                }
+                post {
+                    success {
+                        slackSend color: 'good', message: "Full ICD test suite - Success - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                    }
+                    unstable {
+                        slackSend color: 'warning', message: "Full ICD test suite - Unstable - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                    }
+                    failure {
+                        slackSend color: 'danger', message: "Full ICD test suite - Unstable - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                     }
                 }
             }
-        }
-    }
-    post {
-        success {
-            slackSend color: 'good', message: "Full ICD test suite - Success - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
-        }
-        unstable {
-            slackSend color: 'warning', message: "Full ICD test suite - Unstable - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
-        }
-        failure {
-            slackSend color: 'danger', message: "Full ICD test suite - Unstable - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
         }
     }
 }

--- a/Jenkinsfile-full
+++ b/Jenkinsfile-full
@@ -567,10 +567,21 @@ pipeline {
     }
     post {
         success {
-            slackSend color: 'good', message: "Full ICD test suite - Success - ${BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+            slackSend color: 'good', message: "Full ICD test suite - Success - ${BRANCH_NAME} (<${env.RUN_DISPLAY_URL}|${COMMIT_ID}>)";
+            withCredentials([string(credentialsId: 'acdc-jenkins-token', variable: 'TOKEN')]) {
+            sh("""curl -X POST -H "Accept: application/vnd.github+json" \
+            -H "Authorization: token $TOKEN" https://api.github.com/repos/CARTAvis/carta-backend/statuses/${COMMIT_ID_LONG} \
+            -d "{\\"state\\":\\"success\\",\\"target_url\\":\\"${env.RUN_DISPLAY_URL}\\",\\"description\\":\\"Success\\",\\"context\\":\\"ICD test suite\\"}" """)
+            }
+
         }
         unstable {
-            slackSend color: 'warning', message: "Full ICD test suite - Unstable - ${BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+            slackSend color: 'warning', message: "Full ICD test suite - Unstable - ${BRANCH_NAME} (<${env.RUN_DISPLAY_URL}|${COMMIT_ID}>)";
+            withCredentials([string(credentialsId: 'acdc-jenkins-token', variable: 'TOKEN')]) {
+            sh("""curl -X POST -H "Accept: application/vnd.github+json" \
+            -H "Authorization: token $TOKEN" https://api.github.com/repos/CARTAvis/carta-backend/statuses/${COMMIT_ID_LONG} \
+            -d "{\\"state\\":\\"success\\",\\"target_url\\":\\"${env.RUN_DISPLAY_URL}\\",\\"description\\":\\"Unstable\\",\\"context\\":\\"ICD test suite\\"}" """)
+            }
         }
     }
 }

--- a/Jenkinsfile-full
+++ b/Jenkinsfile-full
@@ -1,14 +1,8 @@
-void setBuildStatus(String message, String state) {
-  step([
-      $class: "GitHubCommitStatusSetter",
-      reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/CARTAvis/carta-backend"],
-      contextSource: [$class: "ManuallyEnteredCommitContextSource", context: "ci/jenkins/build-status"],
-      errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
-      statusResultSource: [ $class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: message, state: state]] ]
-  ]);
-}
 pipeline {
     agent none
+    environment {
+        COMMIT_ID=''
+    }
     options {
         preserveStashes()
         timeout(time: 2, unit: 'HOURS') 
@@ -37,11 +31,8 @@ pipeline {
                         }
                     }
                     post {
-                        success {
-                            setBuildStatus("build succeeded", "SUCCESS");
-                        }
                         failure {
-                            setBuildStatus("build failed", "FAILURE");
+                            slackSend color: 'danger', message: "Ubuntu 18.04 - carta-backend build - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                         }
                     }
                 }
@@ -63,11 +54,8 @@ pipeline {
                         }
                     }
                     post {
-                        success {
-                            setBuildStatus("build succeeded", "SUCCESS");
-                        }
                         failure {
-                            setBuildStatus("build failed", "FAILURE");
+                            slackSend color: 'danger', message: "Ubuntu 20.04 - carta-backend build - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                         }
                     }
                 }
@@ -89,11 +77,8 @@ pipeline {
                         }
                     }
                     post {
-                        success {
-                            setBuildStatus("build succeeded", "SUCCESS");
-                        }
                         failure {
-                            setBuildStatus("build failed", "FAILURE");
+                            slackSend color: 'danger', message: "Ubuntu 22.04 - carta-backend build - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                         }
                     }
                 }
@@ -114,11 +99,8 @@ pipeline {
                         }
                     }
                     post {
-                        success {
-                            setBuildStatus("build succeeded", "SUCCESS");
-                        }
                         failure {
-                            setBuildStatus("build failed", "FAILURE");
+                            slackSend color: 'danger', message: "macOS 11 - carta-backend build - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                         }
                     }
                 }
@@ -128,6 +110,9 @@ pipeline {
                     }
                     steps {
                         catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            script {
+                                COMMIT_ID = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
+                            }
                             sh "export PATH=/usr/local/bin:$PATH"
                             sh "git submodule update --init --recursive"
                             dir ('build') {
@@ -139,11 +124,8 @@ pipeline {
                         }
                     }
                     post {
-                        success {
-                            setBuildStatus("build succeeded", "SUCCESS");
-                        }
                         failure {
-                            setBuildStatus("build failed", "FAILURE");
+                            slackSend color: 'danger', message: "macOS 12 - carta-backend build - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                         }
                     }
                 }
@@ -165,11 +147,8 @@ pipeline {
                         }
                     }
                     post {
-                        success {
-                            setBuildStatus("build succeeded", "SUCCESS");
-                        }
                         failure {
-                            setBuildStatus("build failed", "FAILURE");
+                            slackSend color: 'danger', message: "RedHat 7 - carta-backend build - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                         }
                     }
                 }
@@ -191,11 +170,8 @@ pipeline {
                         }
                     }
                     post {
-                        success {
-                            setBuildStatus("build succeeded", "SUCCESS");
-                        }
                         failure {
-                            setBuildStatus("build failed", "FAILURE");
+                            slackSend color: 'danger', message: "RedHat 8 - carta-backend build - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                         }
                     }
                 }
@@ -219,6 +195,9 @@ pipeline {
                         always {
                             junit 'test/ubuntu_bionic_test_detail.xml'
                         }
+                        failure {
+                            slackSend color: 'danger', message: "Ubuntu 18.04 - Unit Tests - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                        }
                     }
                 }
                 stage('2 Ubuntu 20.04') {
@@ -236,6 +215,9 @@ pipeline {
                     post {
                         always {
                             junit 'test/ubuntu_focal_test_detail.xml'
+                        }
+                        failure {
+                            slackSend color: 'danger', message: "Ubuntu 20.04 - Unit Tests - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                         }   
                     }   
                 }
@@ -255,6 +237,9 @@ pipeline {
                         always {
                             junit 'test/ubuntu_jammy_test_detail.xml'
                         }
+                        failure {
+                            slackSend color: 'danger', message: "Ubuntu 22.04 - Unit Tests - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                        }
                     }   
                 }
                 stage('4 macOS 11') {
@@ -272,12 +257,9 @@ pipeline {
                         always {
                             junit 'build/test/macos11_test_detail.xml'
                         }
-                        success {
-                            setBuildStatus("build succeeded", "SUCCESS");
-                        }
                         failure {
-                            setBuildStatus("build failed", "FAILURE");
-                        }   
+                            slackSend color: 'danger', message: "macOS 11 - Unit Tests - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                        }
                     }
                 }
                 stage('5 macOS 12') {
@@ -295,12 +277,9 @@ pipeline {
                         always {
                             junit 'build/test/macos12_test_detail.xml'
                         }
-                        success {
-                            setBuildStatus("build succeeded", "SUCCESS");
-                        }
                         failure {
-                            setBuildStatus("build failed", "FAILURE");
-                        }   
+                            slackSend color: 'danger', message: "macOS 12 - Unit Tests - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                        }
                     }
                 }
                 stage('6 RHEL7') {
@@ -319,6 +298,9 @@ pipeline {
                         always {
                             junit 'test/rhel7_test_detail.xml'
                         }
+                        failure {
+                            slackSend color: 'danger', message: "RedHat 7 - Unit Tests - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                        }
                     }
                 }
                 stage('7 RHEL8') {
@@ -336,6 +318,9 @@ pipeline {
                     post {
                         always {
                             junit 'test/rhel8_test_detail.xml'
+                        }
+                        failure {
+                            slackSend color: 'danger', message: "RedHat 8 - Unit Tests - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                         }
                     }
                 }
@@ -423,6 +408,11 @@ pipeline {
                                 file_browser()
                             }
                         }
+                        post {
+                            failure {
+                                slackSend color: 'danger', message: "ICD test session and file_browser - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            }
+                        }
                     }
                     stage('animator') {
                         agent {
@@ -435,6 +425,11 @@ pipeline {
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
                                 unstash "${PLATFORM}-ICD"
                                 animator()
+                            }
+                        }
+                        post {
+                            failure {
+                                slackSend color: 'danger', message: "ICD test animator - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -451,6 +446,11 @@ pipeline {
                                 region_statistics()
                             }
                         }
+                        post {
+                            failure {
+                                slackSend color: 'danger', message: "ICD test region_statistics - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            }
+                        }
                     }
                     stage('region_manipulation') {
                         agent {
@@ -463,6 +463,11 @@ pipeline {
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
                                 unstash "${PLATFORM}-ICD"
                                 region_manipulation()
+                            }
+                        }
+                        post {
+                            failure {
+                                slackSend color: 'danger', message: "ICD test region_manipulation - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -479,6 +484,11 @@ pipeline {
                                 cube_histogram()
                             }
                         }
+                        post {
+                            failure {
+                                slackSend color: 'danger', message: "ICD test cube_histogram - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            }
+                        }
                     }
                     stage('pv_generator') {
                         agent {
@@ -491,6 +501,11 @@ pipeline {
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
                                 unstash "${PLATFORM}-ICD"
                                 pv_generator()
+                            }
+                        }
+                        post {
+                            failure {
+                                slackSend color: 'danger', message: "ICD test pv_generator - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -507,6 +522,11 @@ pipeline {
                                 raster_tiles()
                             }
                         }
+                        post {
+                            failure {
+                                slackSend color: 'danger', message: "ICD test raster_tiles - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            }
+                        }
                     }
                     stage('catalog') {
                         agent {
@@ -519,6 +539,11 @@ pipeline {
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
                                 unstash "${PLATFORM}-ICD"
                                 catalog()
+                            }
+                        }
+                        post {
+                            failure {
+                                slackSend color: 'danger', message: "ICD test catalog - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -535,6 +560,11 @@ pipeline {
                                 moment()
                             }
                         }
+                        post {
+                            failure {
+                                slackSend color: 'danger', message: "ICD test moment - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            }
+                        }
                     }
                     stage('resume') {
                         agent {
@@ -547,6 +577,11 @@ pipeline {
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
                                 unstash "${PLATFORM}-ICD"
                                 resume()
+                            }
+                        }
+                        post {
+                            failure {
+                                slackSend color: 'danger', message: "ICD test resume - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -563,6 +598,11 @@ pipeline {
                                 match()
                             }
                         }
+                        post {
+                            failure {
+                                slackSend color: 'danger', message: "ICD test match - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            }
+                        }
                     }
                     stage('close_file') {
                         agent {
@@ -577,12 +617,23 @@ pipeline {
                                 close_file()
                             }
                         }
+                        post {
+                            failure {
+                                slackSend color: 'danger', message: "ICD test close_file - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            }
+                        }
                     }
                 }
             }
         }
     }
+    post {
+        success {
+            slackSend color: 'good', message: "Full ICD test suite - Success - ${env.BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+        }
+    }
 }
+
 def prepare_focal_ICD() {
     catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
         sh "git clone --depth 1 https://github.com/CARTAvis/carta-backend-ICD-test.git"

--- a/Jenkinsfile-full
+++ b/Jenkinsfile-full
@@ -1,5 +1,5 @@
 pipeline {
-    agent none
+    agent any
     options {
         preserveStashes()
         timeout(time: 2, unit: 'HOURS') 

--- a/Jenkinsfile-full
+++ b/Jenkinsfile-full
@@ -1,6 +1,3 @@
-def COMMIT_ID
-def BRANCH_NAME
-
 pipeline {
     agent none
     options {
@@ -32,7 +29,7 @@ pipeline {
                     }
                     post {
                         failure {
-                            slackSend color: 'danger', message: "Ubuntu 18.04 - carta-backend build - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            slackSend color: 'danger', message: "Ubuntu 18.04 - carta-backend build - Fail - ${BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                         }
                     }
                 }
@@ -55,7 +52,7 @@ pipeline {
                     }
                     post {
                         failure {
-                            slackSend color: 'danger', message: "Ubuntu 20.04 - carta-backend build - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            slackSend color: 'danger', message: "Ubuntu 20.04 - carta-backend build - Fail - ${BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                         }
                     }
                 }
@@ -78,7 +75,7 @@ pipeline {
                     }
                     post {
                         failure {
-                            slackSend color: 'danger', message: "Ubuntu 22.04 - carta-backend build - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            slackSend color: 'danger', message: "Ubuntu 22.04 - carta-backend build - Fail - ${BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                         }
                     }
                 }
@@ -100,7 +97,7 @@ pipeline {
                     }
                     post {
                         failure {
-                            slackSend color: 'danger', message: "macOS 11 - carta-backend build - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            slackSend color: 'danger', message: "macOS 11 - carta-backend build - Fail - ${BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                         }
                     }
                 }
@@ -126,7 +123,7 @@ pipeline {
                     }
                     post {
                         failure {
-                            slackSend color: 'danger', message: "macOS 12 - carta-backend build - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            slackSend color: 'danger', message: "macOS 12 - carta-backend build - Fail - ${BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                         }
                     }
                 }
@@ -149,7 +146,7 @@ pipeline {
                     }
                     post {
                         failure {
-                            slackSend color: 'danger', message: "RedHat 7 - carta-backend build - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            slackSend color: 'danger', message: "RedHat 7 - carta-backend build - Fail - ${BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                         }
                     }
                 }
@@ -172,7 +169,7 @@ pipeline {
                     }
                     post {
                         failure {
-                            slackSend color: 'danger', message: "RedHat 8 - carta-backend build - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            slackSend color: 'danger', message: "RedHat 8 - carta-backend build - Fail - ${BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                         }
                     }
                 }
@@ -197,7 +194,7 @@ pipeline {
                             junit 'test/ubuntu_bionic_test_detail.xml'
                         }
                         failure {
-                            slackSend color: 'danger', message: "Ubuntu 18.04 - Unit Tests - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            slackSend color: 'danger', message: "Ubuntu 18.04 - Unit Tests - Fail - ${BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                         }
                     }
                 }
@@ -218,7 +215,7 @@ pipeline {
                             junit 'test/ubuntu_focal_test_detail.xml'
                         }
                         failure {
-                            slackSend color: 'danger', message: "Ubuntu 20.04 - Unit Tests - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            slackSend color: 'danger', message: "Ubuntu 20.04 - Unit Tests - Fail - ${BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                         }   
                     }   
                 }
@@ -239,7 +236,7 @@ pipeline {
                             junit 'test/ubuntu_jammy_test_detail.xml'
                         }
                         failure {
-                            slackSend color: 'danger', message: "Ubuntu 22.04 - Unit Tests - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            slackSend color: 'danger', message: "Ubuntu 22.04 - Unit Tests - Fail - ${BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                         }
                     }   
                 }
@@ -259,7 +256,7 @@ pipeline {
                             junit 'build/test/macos11_test_detail.xml'
                         }
                         failure {
-                            slackSend color: 'danger', message: "macOS 11 - Unit Tests - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            slackSend color: 'danger', message: "macOS 11 - Unit Tests - Fail - ${BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                         }
                     }
                 }
@@ -279,7 +276,7 @@ pipeline {
                             junit 'build/test/macos12_test_detail.xml'
                         }
                         failure {
-                            slackSend color: 'danger', message: "macOS 12 - Unit Tests - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            slackSend color: 'danger', message: "macOS 12 - Unit Tests - Fail - ${BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                         }
                     }
                 }
@@ -300,7 +297,7 @@ pipeline {
                             junit 'test/rhel7_test_detail.xml'
                         }
                         failure {
-                            slackSend color: 'danger', message: "RedHat 7 - Unit Tests - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            slackSend color: 'danger', message: "RedHat 7 - Unit Tests - Fail - ${BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                         }
                     }
                 }
@@ -321,7 +318,7 @@ pipeline {
                             junit 'test/rhel8_test_detail.xml'
                         }
                         failure {
-                            slackSend color: 'danger', message: "RedHat 8 - Unit Tests - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            slackSend color: 'danger', message: "RedHat 8 - Unit Tests - Fail - ${BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                         }
                     }
                 }
@@ -577,6 +574,10 @@ pipeline {
         }
     }
 }
+
+def COMMIT_ID
+
+def BRANCH_NAME
 
 def prepare_focal_ICD() {
     catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {

--- a/Jenkinsfile-full
+++ b/Jenkinsfile-full
@@ -400,7 +400,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'ICD test session and file_browser failure') {
+                            catchError(buildResult: 'FAILURE', stageResult: "FAILURE", message: "ICD test session and file_browser failure") {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -410,7 +410,7 @@ pipeline {
                         }
                         post {
                             failure {
-                                slackSend color: 'danger', message: "ICD test session and file_browser - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                                slackSend color: 'danger', message: "ICD test session and file_browser ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -429,7 +429,7 @@ pipeline {
                         }
                         post {
                             failure {
-                                slackSend color: 'danger', message: "ICD test animator - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                                slackSend color: 'danger', message: "ICD test animator ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -448,7 +448,7 @@ pipeline {
                         }
                         post {
                             failure {
-                                slackSend color: 'danger', message: "ICD test region_statistics - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                                slackSend color: 'danger', message: "ICD test region_statistics ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -467,7 +467,7 @@ pipeline {
                         }
                         post {
                             failure {
-                                slackSend color: 'danger', message: "ICD test region_manipulation - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                                slackSend color: 'danger', message: "ICD test region_manipulation ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -486,7 +486,7 @@ pipeline {
                         }
                         post {
                             failure {
-                                slackSend color: 'danger', message: "ICD test cube_histogram - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                                slackSend color: 'danger', message: "ICD test cube_histogram ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -505,7 +505,7 @@ pipeline {
                         }
                         post {
                             failure {
-                                slackSend color: 'danger', message: "ICD test pv_generator - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                                slackSend color: 'danger', message: "ICD test pv_generator ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -524,7 +524,7 @@ pipeline {
                         }
                         post {
                             failure {
-                                slackSend color: 'danger', message: "ICD test raster_tiles - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                                slackSend color: 'danger', message: "ICD test raster_tiles ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -543,7 +543,7 @@ pipeline {
                         }
                         post {
                             failure {
-                                slackSend color: 'danger', message: "ICD test catalog - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                                slackSend color: 'danger', message: "ICD test catalog ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -562,7 +562,7 @@ pipeline {
                         }
                         post {
                             failure {
-                                slackSend color: 'danger', message: "ICD test moment - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                                slackSend color: 'danger', message: "ICD test moment ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -581,7 +581,7 @@ pipeline {
                         }
                         post {
                             failure {
-                                slackSend color: 'danger', message: "ICD test resume - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                                slackSend color: 'danger', message: "ICD test resume ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -600,7 +600,7 @@ pipeline {
                         }
                         post {
                             failure {
-                                slackSend color: 'danger', message: "ICD test match - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                                slackSend color: 'danger', message: "ICD test match ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -619,7 +619,7 @@ pipeline {
                         }
                         post {
                             failure {
-                                slackSend color: 'danger', message: "ICD test close_file - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                                slackSend color: 'danger', message: "ICD test close_file ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -629,7 +629,7 @@ pipeline {
     }
     post {
         success {
-            slackSend color: 'good', message: "Full ICD test suite - Success - ${env.BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+            slackSend color: 'good', message: "Full ICD test suite - Success - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
         }
     }
 }

--- a/Jenkinsfile-full
+++ b/Jenkinsfile-full
@@ -400,7 +400,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'ICD test session and file_browser failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -419,7 +419,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'ICD test animator failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -438,7 +438,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'ICD test region_statistics failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -457,7 +457,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'ICD test region_manipulation failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -476,7 +476,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'ICD test cube_histogram failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -495,7 +495,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'ICD test pv_generator failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -514,7 +514,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'ICD test raster_tiles failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -533,7 +533,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'ICD test catalog failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -552,7 +552,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'ICD test moment failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -571,7 +571,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'ICD test resume failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -590,7 +590,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'ICD test match failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -609,7 +609,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'ICD test close_file failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"

--- a/Jenkinsfile-full
+++ b/Jenkinsfile-full
@@ -580,7 +580,7 @@ pipeline {
             withCredentials([string(credentialsId: 'acdc-jenkins-token', variable: 'TOKEN')]) {
             sh("""curl -X POST -H "Accept: application/vnd.github+json" \
             -H "Authorization: token $TOKEN" https://api.github.com/repos/CARTAvis/carta-backend/statuses/${COMMIT_ID_LONG} \
-            -d "{\\"state\\":\\"success\\",\\"target_url\\":\\"${env.RUN_DISPLAY_URL}\\",\\"description\\":\\"Unstable\\",\\"context\\":\\"ICD test suite\\"}" """)
+            -d "{\\"state\\":\\"unstable\\",\\"target_url\\":\\"${env.RUN_DISPLAY_URL}\\",\\"description\\":\\"Unstable\\",\\"context\\":\\"ICD test suite\\"}" """)
             }
         }
     }

--- a/Jenkinsfile-full
+++ b/Jenkinsfile-full
@@ -42,6 +42,9 @@ pipeline {
                     }
                     steps {
                         catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            script {
+                                COMMIT_ID = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
+                            }
                             sh "uname -a"
                             sh "lsb_release -a"
                             sh "git submodule update --init --recursive"
@@ -110,9 +113,6 @@ pipeline {
                     }
                     steps {
                         catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                            script {
-                                COMMIT_ID = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
-                            }
                             sh "export PATH=/usr/local/bin:$PATH"
                             sh "git submodule update --init --recursive"
                             dir ('build') {
@@ -565,17 +565,16 @@ pipeline {
                     }
                 }
                 post {
-                    success {
-                        slackSend color: 'good', message: "Full ICD test suite - Success - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
-                    }
                     unstable {
-                        slackSend color: 'warning', message: "Full ICD test suite - Unstable - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
-                    }
-                    failure {
-                        slackSend color: 'danger', message: "Full ICD test suite - Unstable - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                        slackSend color: 'warning', message: "Full ICD test suite - Unstable - ${PLATFORM} ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                     }
                 }
             }
+        }
+    }
+    post {
+        success {
+            slackSend color: 'good', message: "Full ICD test suite - Success - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
         }
     }
 }

--- a/Jenkinsfile-full
+++ b/Jenkinsfile-full
@@ -1,8 +1,8 @@
+def COMMIT_ID
+def BRANCH_NAME
+
 pipeline {
     agent none
-    environment {
-        COMMIT_ID=''
-    }
     options {
         preserveStashes()
         timeout(time: 2, unit: 'HOURS') 
@@ -42,9 +42,6 @@ pipeline {
                     }
                     steps {
                         catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                            script {
-                                COMMIT_ID = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
-                            }
                             sh "uname -a"
                             sh "lsb_release -a"
                             sh "git submodule update --init --recursive"
@@ -115,6 +112,10 @@ pipeline {
                         catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                             sh "export PATH=/usr/local/bin:$PATH"
                             sh "git submodule update --init --recursive"
+                            script {
+                                COMMIT_ID = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
+                                BRANCH_NAME = sh(returnStdout: true, script: 'git rev-parse --abbrev-ref HEAD').trim()
+                            }
                             dir ('build') {
                                 sh "rm -rf *"
                                 sh "cmake .. -Dtest=on -DDevSuppressExternalWarnings=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS='-O0 -g -fsanitize=address -fno-omit-frame-pointer' -DCMAKE_EXE_LINKER_FLAGS='-fsanitize=address' "
@@ -569,10 +570,10 @@ pipeline {
     }
     post {
         success {
-            slackSend color: 'good', message: "Full ICD test suite - Success - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+            slackSend color: 'good', message: "Full ICD test suite - Success - ${BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
         }
         unstable {
-            slackSend color: 'warning', message: "Full ICD test suite - Unstable - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+            slackSend color: 'warning', message: "Full ICD test suite - Unstable - ${BRANCH_NAME} ${COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
         }
     }
 }

--- a/Jenkinsfile-full
+++ b/Jenkinsfile-full
@@ -400,7 +400,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            warnError(catchInterruptions: true, message: "ICD test session and file_browser failure") {
+                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: "ICD test session and file_browser failure") {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -409,8 +409,8 @@ pipeline {
                             }
                         }
                         post {
-                            unstable {
-                                slackSend color: 'warning', message: "ICD test session and file_browser ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            failure {
+                                slackSend color: 'danger', message: "ICD test session and file_browser ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -419,7 +419,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                             warnError(catchInterruptions: true, message: 'ICD test animator failure') {
+                             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'ICD test animator failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -428,8 +428,8 @@ pipeline {
                             }
                         }
                         post {
-                            unstable {
-                                slackSend color: 'warning', message: "ICD test animator ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            failure {
+                                slackSend color: 'danger', message: "ICD test animator ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -438,7 +438,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            warnError(catchInterruptions: true, message: 'ICD test region_statistics failure') {
+                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'ICD test region_statistics failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -447,8 +447,8 @@ pipeline {
                             }
                         }
                         post {
-                            unstable {
-                                slackSend color: 'warning', message: "ICD test region_statistics ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            failure {
+                                slackSend color: 'danger', message: "ICD test region_statistics ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -457,7 +457,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            warnError(catchInterruptions: true, message: 'ICD test region_manipulation failure') {
+                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'ICD test region_manipulation failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -466,8 +466,8 @@ pipeline {
                             }
                         }
                         post {
-                            unstable {
-                                slackSend color: 'warning', message: "ICD test region_manipulation ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            failure {
+                                slackSend color: 'danger', message: "ICD test region_manipulation ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -476,7 +476,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            warnError(catchInterruptions: true, message: 'ICD test cube_histogram failure') {
+                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'ICD test cube_histogram failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -485,8 +485,8 @@ pipeline {
                             }
                         }
                         post {
-                            unstable {
-                                slackSend color: 'warning', message: "ICD test cube_histogram ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            failure {
+                                slackSend color: 'danger', message: "ICD test cube_histogram ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -495,7 +495,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            warnError(catchInterruptions: true, message: 'ICD test pv_generator failure') {
+                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'ICD test pv_generator failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -504,8 +504,8 @@ pipeline {
                             }
                         }
                         post {
-                            unstable {
-                                slackSend color: 'warning', message: "ICD test pv_generator ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            failure {
+                                slackSend color: 'danger', message: "ICD test pv_generator ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -514,7 +514,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            warnError(catchInterruptions: true, message: 'ICD test raster_tiles failure') {
+                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'ICD test raster_tiles failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -523,8 +523,8 @@ pipeline {
                             }
                         }
                         post {
-                            unstable {
-                                slackSend color: 'warning', message: "ICD test raster_tiles ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            failure {
+                                slackSend color: 'danger', message: "ICD test raster_tiles ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -533,7 +533,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            warnError(catchInterruptions: true, message: 'ICD test catalog failure') {
+                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'ICD test catalog failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -542,8 +542,8 @@ pipeline {
                             }
                         }
                         post {
-                            unstable {
-                                slackSend color: 'warning', message: "ICD test catalog ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            failure {
+                                slackSend color: 'danger', message: "ICD test catalog ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -552,7 +552,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            warnError(catchInterruptions: true, message: 'ICD test moment failure') {
+                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'ICD test moment failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -561,8 +561,8 @@ pipeline {
                             }
                         }
                         post {
-                            unstable {
-                                slackSend color: 'warning', message: "ICD test moment ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            failure {
+                                slackSend color: 'danger', message: "ICD test moment ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -571,7 +571,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            warnError(catchInterruptions: true, message: 'ICD test resume failure') {
+                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'ICD test resume failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -580,8 +580,8 @@ pipeline {
                             }
                         }
                         post {
-                            unstable {
-                                slackSend color: 'warning', message: "ICD test resume ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            failure {
+                                slackSend color: 'danger', message: "ICD test resume ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -590,7 +590,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            warnError(catchInterruptions: true, message: 'ICD test match failure') {
+                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'ICD test match failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -599,8 +599,8 @@ pipeline {
                             }
                         }
                         post {
-                            unstable {
-                                slackSend color: 'warning', message: "ICD test match ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            failure {
+                                slackSend color: 'danger', message: "ICD test match ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -609,7 +609,7 @@ pipeline {
                             label "${PLATFORM}-agent"
                         }
                         steps {
-                            warnError(catchInterruptions: true, message: 'ICD test close_file failure') {
+                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'ICD test close_file failure') {
                                 unstash "${PLATFORM}-backend"
                                 sh "rm -f /root/.carta/log/carta.log"
                                 sh "ASAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan.supp LSAN_OPTIONS=suppressions=${WORKSPACE}/debug/asan/myasan-leaks.supp ASAN_SYMBOLIZER_PATH=llvm-symbolizer ./carta_backend /images --top_level_folder /images --port 3112 --omp_threads 8 --debug_no_auth --no_frontend --no_database --verbosity=5 &"
@@ -618,8 +618,8 @@ pipeline {
                             }
                         }
                         post {
-                            unstable {
-                                slackSend color: 'warning', message: "ICD test close_file ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+                            failure {
+                                slackSend color: 'danger', message: "ICD test close_file ${PLATFORM} - Fail - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
                             }
                         }
                     }
@@ -630,6 +630,12 @@ pipeline {
     post {
         success {
             slackSend color: 'good', message: "Full ICD test suite - Success - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+        }
+        unstable {
+            slackSend color: 'warning', message: "Full ICD test suite - Unstable - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
+        }
+        failure {
+            slackSend color: 'danger', message: "Full ICD test suite - Unstable - ${env.BRANCH_NAME} ${env.COMMIT_ID} (<${env.RUN_DISPLAY_URL}|open>)";
         }
     }
 }


### PR DESCRIPTION
An ongoing issue has been with `Jenkinsfile-full`. The Jenkinsfile-full builds the carta-backend, runs the unit tests, and runs the full-ICD test suite, on all 7 supported platforms. It takes ~45 minutes and uses a lot of local computational resources. It is not practical to run on every commit. Therefore we had decided to only run it once a day on the 'dev' branch. The issue has been that, even though the Jenkins job finishes, the build status remains 'pending' on Github indefinitely. I just can't figure out why. The Jenkins log says it sends out the final status message, but Github seemingly fails to receive it for some unknown reason.

This PR is an attempt to overcome the issue.

I propose to use the [Jenkins Slack Notification plugin](https://plugins.jenkins.io/slack/). Instead of reporting the build status of Jenkinsfile-full to Github, it reports the build status to Slack. We can join the `#jenkins-build-status` Slack channel (and mute it if it is annoying). If something changes in the carta-backend that breaks the build or unit tests on the platforms that we don't cover with the basic `Jenkinsfile`, or breaks the ICD tests, we will notice immediately.

Here are some notes:

- To reduce the number of messages posted, it will only post a message if any of the 7x carta-backend builds or 7x Unit Test runs fail. It will not post a success for each one, but we will still get one global 'success' message at the very end.
- At first, I wanted it to report the platform of the ICD test that failed. That didn't work out. It seems when using a matrix configuration (which we need to use otherwise the Jenkinsfile becomes too long to parse) then if one stage fails, all consecutive stages are marked as failures, even if they pass. This seems to be a [known issue](https://issues.jenkins.io/browse/JENKINS-61405). The easiest solution is to put the post command outside the matrix loop. It will report one global 'success' or one global 'unstable'. We can simply click the URL to see which stage failed and check the detailed log output, something that we would need to do anyway.
- If a backend build or unit test fails, it will be reported as a failure. If an ICD test does not pass, I decided to mark it 'unstable' because most times, that's what it is. The ICD tests usually pass after running a second time, or they need to be updated due to legitimate backend changes. I know this is not ideal. Either way, we always check, and if there is a serious issue introduced, we will report it. Also, @acdo2002's upcoming RxJS re-write of the ICD tests may help the ICD tests to pass more reliably. Not to mention, the ongoing work to migrate some ICD tests to Unit Tests. So over time, this may become less of an issue. Another advantage is we can also conveniently identify the issue from the colour of the Slack message; red will mean the backend or unit tests failed, yellow will mean an ICD test failed.
- The job on Jenkins to run the Jenkinsfile-full needs to be a Pipeline, and not a Multi-branch pipeline. For a Pipeline job, we can stop it from reporting the build status to Github, but I can't for a Multi-branch pipeline. In order to get the Branch ID from a Pipeline job, I needed to set it as a global variable in the Groovy context. Otherwise, we could have simply used the ${env.BRANCH_ID} variable that is available by default for a Multi-branch pipeline. Also, we need to apply the `Check out to specific local branch` setting in the Pipeline job, otherwise `BRANCH_ID` will only report `HEAD` and not the branch name. (Note: The main `Jenkinsfile` runs through a Multi-branch pipeline job).
- I have also updated the main `Jenkinsfile` to use slackSend. It still reports the build status of every commit to Github, but now also reports to Slack. I plan to use slackSend in the carta-frontend Jenkinsfile too. Similarly, to reduce the number of messages sent to Slack, `Jenkinsfile` only reports one global success or one global failure. 
- On the `#jenkins-build-status` Slack channel, for the main Jenkinsfile, we can see the identifier 'carta-backend' followed by the status (Success or Failure), the branch name, the commit ID, and a URL direct to the build in the Jenkins Blue Ocean interface. For the daily Jenkinsfile-full build, I have given it the name `Full ICD test suite`. You can see an example in the attached image below:
![Screen Shot 2022-07-19 at 2 17 42 PM](https://user-images.githubusercontent.com/20802551/179679060-e0f66ef1-02d0-4f5f-b9ff-029d34c44aa9.png)

