### PR TITLE
Fix region export message when overwrite fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed the DS9 import bug with no header line ([#1064](https://github.com/CARTAvis/carta-backend/issues/1064)).
 * Fixed the getstat error on generated image ([#1148](https://github.com/CARTAvis/carta-backend/issues/1148)).
 * Fixed file info hang when a CASA image is locked ([#578](https://github.com/CARTAvis/carta-backend/pull/578)).
+* Fixed region export failure when no write permission ([#1133](https://github.com/CARTAvis/carta-backend/pull/1133)).
 
 ## [3.0.0-beta.3]
 

--- a/src/Region/RegionHandler.cc
+++ b/src/Region/RegionHandler.cc
@@ -213,7 +213,14 @@ void RegionHandler::ExportRegion(int file_id, std::shared_ptr<Frame> frame, CART
     // Check ability to create export file if filename given
     if (!filename.empty()) {
         casacore::File export_file(filename);
-        if (!export_file.canCreate()) {
+        if (export_file.exists()) {
+            if (!export_file.isWritable()) {
+                export_ack.set_success(false);
+                export_ack.set_message("Export region failed: cannot overwrite file.");
+                export_ack.add_contents();
+                return;
+            }
+        } else if (!export_file.canCreate()) {
             export_ack.set_success(false);
             export_ack.set_message("Export region failed: cannot create file.");
             export_ack.add_contents();


### PR DESCRIPTION
Closes #1133 

Uses casacore::File to determine if file exists and is writable, else export fails with error message.