### PR TITLE
Add directory in region list if listing all files or not image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed region export failure when no write permission ([#1133](https://github.com/CARTAvis/carta-backend/pull/1133)).
 * Fixed HTTP response codes when returning response to PUT requests ([#1157](https://github.com/CARTAvis/carta-backend/issues/1157)).
 * Fixed the problem of one-pixel position offset for DS9 regions projections ([#1138](https://github.com/CARTAvis/carta-backend/issues/1138)).
+* Fixed including directories in region file list ([#1159](https://github.com/CARTAvis/carta-backend/issues/1159)).
 
 ## [3.0.0-beta.3]
 


### PR DESCRIPTION
Closes #1159 

List directories in region file list if

- listing all files (could be CASA/MIRIAD image but listed as directory)
- checking contents/extension and image type of directory is unknown.