### PR TITLE
Fix the crash when trying to load an unsupported image file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed region export failure when no write permission ([#1133](https://github.com/CARTAvis/carta-backend/pull/1133)).
 * Fixed HTTP response codes when returning response to PUT requests ([#1157](https://github.com/CARTAvis/carta-backend/issues/1157)).
 * Fixed the problem of one-pixel position offset for DS9 regions projections ([#1138](https://github.com/CARTAvis/carta-backend/issues/1138)).
+* Fixed the crash when trying to load an unsupported image file ([#1161](https://github.com/CARTAvis/carta-backend/issues/1161)).
 
 ## [3.0.0-beta.3]
 

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -49,7 +49,7 @@ std::shared_ptr<FileLoader> LoaderCache::Get(const std::string& filename, const 
     auto key = GetKey(filename, directory);
 
     // We have a cached loader, but the file has changed
-    if (_map.find(key) != _map.end() && _map[key]->ImageUpdated()) {
+    if ((_map.find(key) != _map.end()) && _map[key] && _map[key]->ImageUpdated()) {
         _map.erase(key);
         _queue.remove(key);
     }


### PR DESCRIPTION
Closes #1161. The backend will cache a file loader as a null pointer if the file format is unsupported. I added a check whether a file loader is a null pointer before checking its updated time.