### PR TITLE
Catch exception in region importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed region export failure when no write permission ([#1133](https://github.com/CARTAvis/carta-backend/pull/1133)).
 * Fixed HTTP response codes when returning response to PUT requests ([#1157](https://github.com/CARTAvis/carta-backend/issues/1157)).
 * Fixed the problem of one-pixel position offset for DS9 regions projections ([#1138](https://github.com/CARTAvis/carta-backend/issues/1138)).
-* Fixed response when DS9 region parsing fails by catching exception ([#1160](https://github.com/CARTAvis/carta-backend/issues/1160)).
+* Fixed response when importing region file fails by catching exception ([#1160](https://github.com/CARTAvis/carta-backend/issues/1160)).
 
 ## [3.0.0-beta.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed region export failure when no write permission ([#1133](https://github.com/CARTAvis/carta-backend/pull/1133)).
 * Fixed HTTP response codes when returning response to PUT requests ([#1157](https://github.com/CARTAvis/carta-backend/issues/1157)).
 * Fixed the problem of one-pixel position offset for DS9 regions projections ([#1138](https://github.com/CARTAvis/carta-backend/issues/1138)).
+* Fixed response when DS9 region parsing fails by catching exception ([#1160](https://github.com/CARTAvis/carta-backend/issues/1160)).
 
 ## [3.0.0-beta.3]
 

--- a/src/Region/RegionHandler.cc
+++ b/src/Region/RegionHandler.cc
@@ -133,15 +133,22 @@ void RegionHandler::ImportRegion(int file_id, std::shared_ptr<Frame> frame, CART
     auto csys = frame->CoordinateSystem();
     const casacore::IPosition shape = frame->ImageShape();
     std::unique_ptr<RegionImportExport> importer;
-    switch (region_file_type) {
-        case CARTA::FileType::CRTF:
-            importer.reset(new CrtfImportExport(csys, shape, frame->StokesAxis(), file_id, region_file, file_is_filename));
-            break;
-        case CARTA::FileType::DS9_REG:
-            importer.reset(new Ds9ImportExport(csys, shape, file_id, region_file, file_is_filename));
-            break;
-        default:
-            break;
+
+    try {
+        switch (region_file_type) {
+            case CARTA::FileType::CRTF:
+                importer.reset(new CrtfImportExport(csys, shape, frame->StokesAxis(), file_id, region_file, file_is_filename));
+                break;
+            case CARTA::FileType::DS9_REG:
+                importer.reset(new Ds9ImportExport(csys, shape, file_id, region_file, file_is_filename));
+                break;
+            default:
+                break;
+        }
+    } catch (const casacore::AipsError& err) {
+        import_ack.set_success(false);
+        import_ack.set_message("Region import failed: " + err.getMesg());
+        return;
     }
 
     if (!importer) {


### PR DESCRIPTION
Closes #1160 

The backend did not crash, it was an uncaught exception so the backend was done while the frontend was waiting for a response.  Instead of only checking for a null importer, RegionHandler now catches the exception to report the failure.

The message is now: "Region import failed:" + the error message from the exception (in the test case, "Not a valid DS9 region file").  If the importer constructor fails without an exception, the existing message "Region importer failed" is sent.  The ICD test may need to be updated for this change in error message but I think adding the exception text is helpful.