### PR TITLE
Set float null values to NAN when reading CartaFitsImage data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed response when importing region file fails by catching exception ([#1160](https://github.com/CARTAvis/carta-backend/issues/1160)).
 * Fixed the crash when trying to load an unsupported image file ([#1161](https://github.com/CARTAvis/carta-backend/issues/1161)).
 * Fixed including directories in region file list ([#1159](https://github.com/CARTAvis/carta-backend/issues/1159)).
+* Fixed issue where NaN data was read incorrectly from a compressed FITS .fz image ([#1143](https://github.com/CARTAvis/carta-backend/issues/1143)).
 
 ## [3.0.0-beta.3]
 

--- a/src/ImageData/CartaFitsImage.tcc
+++ b/src/ImageData/CartaFitsImage.tcc
@@ -41,27 +41,34 @@ bool CartaFitsImage::GetDataSubset(fitsfile* fptr, int datatype, const casacore:
     int dtype(TFLOAT);
 
     switch (datatype) {
-        case 8:
-            dtype = TBYTE;
+        case 8: {
+            fits_read_subset(fptr, TBYTE, start.data(), end.data(), inc.data(), &null_val, tmp_buffer.data(), &anynul, &status);
             break;
-        case 16:
-            dtype = TSHORT;
+        }
+        case 16: {
+            fits_read_subset(fptr, TSHORT, start.data(), end.data(), inc.data(), &null_val, tmp_buffer.data(), &anynul, &status);
             break;
-        case 32:
-            dtype = TINT;
+        }
+        case 32: {
+            fits_read_subset(fptr, TINT, start.data(), end.data(), inc.data(), &null_val, tmp_buffer.data(), &anynul, &status);
             break;
-        case 64:
-            dtype = TLONGLONG;
+        }
+        case 64: {
+            fits_read_subset(fptr, TLONGLONG, start.data(), end.data(), inc.data(), &null_val, tmp_buffer.data(), &anynul, &status);
             break;
-        case -32:
-            dtype = TFLOAT;
+        }
+        case -32: {
+            float fnull_val(NAN);
+            fits_read_subset(fptr, TFLOAT, start.data(), end.data(), inc.data(), &fnull_val, tmp_buffer.data(), &anynul, &status);
             break;
-        case -64:
-            dtype = TDOUBLE;
+        }
+        case -64: {
+            double dnull_val(NAN);
+            fits_read_subset(fptr, TDOUBLE, start.data(), end.data(), inc.data(), &dnull_val, tmp_buffer.data(), &anynul, &status);
             break;
+        }
     }
 
-    fits_read_subset(fptr, dtype, start.data(), end.data(), inc.data(), &null_val, tmp_buffer.data(), &anynul, &status);
     if (status > 0) {
         spdlog::debug("fits_read_subset exited with status {}", status);
         return false;


### PR DESCRIPTION
Closes #1143 

* Fixes issue where NaN data was read incorrectly from a compressed FITS .fz image.
* Null values in the returned data array are set to NaN by the cfitsio read subset function.
* No companion PRs (frontend, protobuf), backend issue only
* See images attached to the issue to reproduce the bug

**Checklist**

- [x] changelog updated - waiting until v3 code freeze and new Unreleased section for v4
- [x] e2e test passing / ~~added corresponding fix~~
- [x] no protobuf update needed
- [x] added reviewers and assignee
- [x] added ZenHub estimate, milestone, and release
