### PR TITLE
Fix AIPS velocity ctype headers for correct rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+* Fixed issues with AIPS velocity axis by restoring previous casacore headers ([#1771](https://github.com/CARTAvis/carta-frontend/issues/1771)).
+
 ## [3.0.0]
 
 ### Added

--- a/src/FileList/FileExtInfoLoader.cc
+++ b/src/FileList/FileExtInfoLoader.cc
@@ -150,12 +150,29 @@ bool FileExtInfoLoader::FillFileInfoFromImage(CARTA::FileInfoExtended& extended_
                 bool use_image_for_entries(false);
                 auto data_type = _loader->GetDataType();
                 casacore::String image_type(image->imageType());
+                std::cerr << "************* FileExtInfoLoader using image type " << image_type << std::endl;
 
                 if (image_type == "FITSImage") {
                     // casacore FitsKeywordList has incomplete header names (no n on CRVALn, CDELTn, CROTA, etc.) so read with fitsio
                     casacore::String filename(image->name());
                     casacore::Vector<casacore::String> headers = FitsHeaderStrings(filename, FileInfo::GetFitsHdu(hdu));
-                    AddEntriesFromHeaderStrings(headers, hdu, extended_info);
+
+                    if (headers.empty()) {
+                        // Found unsupported headers
+                        // Get image headers in FITS format using casacore ImageHeaderToFITS
+                        casacore::ImageFITSHeaderInfo fhi;
+                        casacore::String error_string;
+                        if (GetFITSHeader(image, hdu, fhi, error_string)) {
+                            // Set header entries from ImageFITSHeaderInfo
+                            FitsHeaderInfoToHeaderEntries(fhi, extended_info);
+                            use_image_for_entries = true;
+                        } else {
+                            message = error_string;
+                            return false;
+                        }
+                    } else {
+                        AddEntriesFromHeaderStrings(headers, hdu, extended_info);
+                    }
                 } else if (image_type == "CartaFitsImage") {
                     CartaFitsImage* fits_image = dynamic_cast<CartaFitsImage*>(image.get());
                     casacore::Vector<casacore::String> headers = fits_image->FitsHeaderStrings();
@@ -166,25 +183,16 @@ bool FileExtInfoLoader::FillFileInfoFromImage(CARTA::FileInfoExtended& extended_
                     AddEntriesFromHeaderStrings(headers, hdu, extended_info);
                 } else {
                     // Get image headers in FITS format using casacore ImageHeaderToFITS
-                    bool prefer_velocity, optical_velocity, prefer_wavelength, air_wavelength;
-                    GetSpectralCoordPreferences(image.get(), prefer_velocity, optical_velocity, prefer_wavelength, air_wavelength);
                     casacore::ImageFITSHeaderInfo fhi;
-                    casacore::String error_string, origin_string;
-                    bool stokes_last(false), degenerate_last(false), verbose(false), allow_append(false), history(true);
-                    bool prim_head(hdu == "0");
-                    int bit_pix(-32);
-                    float min_pix(1.0), max_pix(-1.0);
-
-                    if (!casacore::ImageFITSConverter::ImageHeaderToFITS(error_string, fhi, *(image.get()), prefer_velocity,
-                            optical_velocity, bit_pix, min_pix, max_pix, degenerate_last, verbose, stokes_last, prefer_wavelength,
-                            air_wavelength, prim_head, allow_append, origin_string, history)) {
+                    casacore::String error_string;
+                    if (GetFITSHeader(image, hdu, fhi, error_string)) {
+                        // Set header entries from ImageFITSHeaderInfo
+                        FitsHeaderInfoToHeaderEntries(fhi, extended_info);
+                        use_image_for_entries = true;
+                    } else {
                         message = error_string;
-                        return info_ok;
+                        return false;
                     }
-
-                    // Set header entries from ImageFITSHeaderInfo
-                    FitsHeaderInfoToHeaderEntries(fhi, extended_info);
-                    use_image_for_entries = true;
                 }
 
                 AddDataTypeEntry(extended_info, data_type);
@@ -1478,8 +1486,34 @@ casacore::Vector<casacore::String> FileExtInfoLoader::FitsHeaderStrings(casacore
 
     for (int i = 0; i < nkeys; ++i) {
         header_strings[i] = header_str.substr(pos, 80);
+
+        if (header_strings[i].contains("FELO-HEL") || header_strings[i].contains("VELO-LSR")) {
+            header_strings.resize();
+            return header_strings;
+        }
+
         pos += 80;
     }
 
     return header_strings;
+}
+
+bool FileExtInfoLoader::GetFITSHeader(std::shared_ptr<casacore::ImageInterface<float>> image, const std::string& hdu,
+    casacore::ImageFITSHeaderInfo& fhi, casacore::String& error_string) {
+    bool prefer_velocity, optical_velocity, prefer_wavelength, air_wavelength;
+    GetSpectralCoordPreferences(image.get(), prefer_velocity, optical_velocity, prefer_wavelength, air_wavelength);
+
+    casacore::String origin_string;
+    bool stokes_last(false), degenerate_last(false), verbose(false), allow_append(false), history(true);
+    bool prim_head(hdu == "0");
+    int bit_pix(-32);
+    float min_pix(1.0), max_pix(-1.0);
+
+    if (!casacore::ImageFITSConverter::ImageHeaderToFITS(error_string, fhi, *(image.get()), prefer_velocity, optical_velocity, bit_pix,
+            min_pix, max_pix, degenerate_last, verbose, stokes_last, prefer_wavelength, air_wavelength, prim_head, allow_append,
+            origin_string, history)) {
+        return false;
+    }
+
+    return true;
 }

--- a/src/FileList/FileExtInfoLoader.cc
+++ b/src/FileList/FileExtInfoLoader.cc
@@ -150,7 +150,6 @@ bool FileExtInfoLoader::FillFileInfoFromImage(CARTA::FileInfoExtended& extended_
                 bool use_image_for_entries(false);
                 auto data_type = _loader->GetDataType();
                 casacore::String image_type(image->imageType());
-                std::cerr << "************* FileExtInfoLoader using image type " << image_type << std::endl;
 
                 if (image_type == "FITSImage") {
                     // casacore FitsKeywordList has incomplete header names (no n on CRVALn, CDELTn, CROTA, etc.) so read with fitsio

--- a/src/FileList/FileExtInfoLoader.h
+++ b/src/FileList/FileExtInfoLoader.h
@@ -43,7 +43,6 @@ private:
     casacore::Vector<casacore::String> FitsHeaderStrings(casacore::String& name, unsigned int hdu);
     bool GetFITSHeader(std::shared_ptr<casacore::ImageInterface<float>> image, const std::string& hdu, casacore::ImageFITSHeaderInfo& fhi,
         casacore::String& error_string);
-    casacore::ImageFITSHeaderInfo GetFITSHeader(std::shared_ptr<casacore::ImageInterface<float>> image);
     void AddEntriesFromHeaderStrings(
         const casacore::Vector<casacore::String>& headers, const std::string& hdu, CARTA::FileInfoExtended& extended_info);
     void ConvertHeaderValueToNumeric(const casacore::String& name, casacore::String& value, CARTA::HeaderEntry* entry);

--- a/src/FileList/FileExtInfoLoader.h
+++ b/src/FileList/FileExtInfoLoader.h
@@ -41,6 +41,9 @@ private:
 
     // Header entries
     casacore::Vector<casacore::String> FitsHeaderStrings(casacore::String& name, unsigned int hdu);
+    bool GetFITSHeader(std::shared_ptr<casacore::ImageInterface<float>> image, const std::string& hdu, casacore::ImageFITSHeaderInfo& fhi,
+        casacore::String& error_string);
+    casacore::ImageFITSHeaderInfo GetFITSHeader(std::shared_ptr<casacore::ImageInterface<float>> image);
     void AddEntriesFromHeaderStrings(
         const casacore::Vector<casacore::String>& headers, const std::string& hdu, CARTA::FileInfoExtended& extended_info);
     void ConvertHeaderValueToNumeric(const casacore::String& name, casacore::String& value, CARTA::HeaderEntry* entry);


### PR DESCRIPTION
Reverts to previous behavior using casacore::ImageHeaderToFITS for extended file info when the AIPS velocity headers are encountered.

* What is fixed?
Frontend issue [#1771](https://github.com/CARTAvis/carta-frontend/issues/1771)

* How does this PR solve the issue? Give a brief summary.
CFITSIO is used to read the headers as usual.  If CTYPE header value FELO-HEL or VELO-LSR is detected, the previous behavior using casacore to generate headers from the FITSImage is used so that image is rendered correctly in the frontend.

* Are there any companion PRs (frontend, protobuf)?
No

* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
FITS images and screenshots are attached in frontend issue.  The expected behavior described in the issue is now restored.

**Checklist**

- [x] changelog updated
- [x] e2e test passing / ~~added corresponding fix~~
- [x] no protobuf update needed
- [x] added reviewers and assignee
- [x] added ZenHub estimate, milestone, and release
