### PR TITLE
Add a check of averaging width for line/polyline spatial profiles or PV images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+* Added a check of averaging width when calculating line/polyline spatial profiles or PV images ([#1174](https://github.com/CARTAvis/carta-backend/issues/1174)).
+
 ## [3.0.0]
 
 ### Added

--- a/src/Region/RegionHandler.cc
+++ b/src/Region/RegionHandler.cc
@@ -1887,6 +1887,12 @@ bool RegionHandler::GetLineProfiles(int file_id, int region_id, int width, bool 
     // Calls progress_callback after each profile.
     // Return parameters: increment (angular spacing of boxes, in arcsec), per-region profiles, cancelled, message.
     // Returns whether profiles completed.
+    if (width < 1 || width > 20) {
+        message = fmt::format("Invalid averaging width: {}.", width);
+        spdlog::error(message);
+        return false;
+    }
+
     if (!RegionSet(region_id)) {
         return false;
     }

--- a/test/TestLineSpatialProfiles.cc
+++ b/test/TestLineSpatialProfiles.cc
@@ -65,6 +65,22 @@ public:
     void SetUp() {
         setenv("HDF5_USE_FILE_LOCKING", "FALSE", 0);
     }
+
+    static void TestAveragingWidthRange(int width, bool expected_width_range) {
+        std::string image_path = FileFinder::FitsImagePath("noise_3d.fits");
+        std::vector<float> endpoints = {0.0, 0.0, 9.0, 9.0};
+        int start(0), end(0), mip(0);
+        std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {Message::SpatialConfig("x", start, end, mip, width)};
+        CARTA::SpatialProfileData spatial_profile;
+
+        if (expected_width_range) {
+            ASSERT_TRUE(GetLineProfiles(image_path, endpoints, spatial_reqs, spatial_profile));
+            ASSERT_EQ(spatial_profile.profiles_size(), 1);
+        } else {
+            ASSERT_FALSE(GetLineProfiles(image_path, endpoints, spatial_reqs, spatial_profile));
+            ASSERT_EQ(spatial_profile.profiles_size(), 0);
+        }
+    }
 };
 
 TEST_F(LineSpatialProfileTest, FitsLineProfile) {
@@ -172,4 +188,11 @@ TEST_F(LineSpatialProfileTest, FitsPolylineProfile) {
 
     // Profile data width=1 of polyline is same as slices
     CmpVectors(profile_data, image_data);
+}
+
+TEST_F(LineSpatialProfileTest, AveragingWidthRange) {
+    TestAveragingWidthRange(0, false);
+    TestAveragingWidthRange(1, true);
+    TestAveragingWidthRange(20, true);
+    TestAveragingWidthRange(21, false);
 }


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
  As discussed in #1174, added a check of averaging width to prevent setting an unreasonable value in scripting.

* How does this PR solve the issue? Give a brief summary.
  Modified the `RegionHandler` method `GetLineProfiles` and added a width check.

* Are there any companion PRs (frontend, protobuf)?
  No.

* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
  New unit tests are added to show it works.

**Checklist**

- [x] changelog updated ~/ no changelog update needed~
- [x] e2e test passing / ~~added corresponding fix~~
- [x] ~protobuf updated to the latest dev commit /~ no protobuf update needed
- [ ] added reviewers and assignee
- [ ] added ZenHub estimate, milestone, and release
