### PR TITLE
PV generator features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 * Added a check of averaging width when calculating line/polyline spatial profiles or PV images ([#1174](https://github.com/CARTAvis/carta-backend/issues/1174)).
+* Added PV generator features for spectral range, reversed axes, and keeping previous image ([#1175](https://github.com/CARTAvis/carta-backend/issues/1175), [#1176](https://github.com/CARTAvis/carta-backend/issues/1176), [#1177](https://github.com/CARTAvis/carta-backend/issues/1177)).
 
 ### Fixed
 * Fixed issues with AIPS velocity axis by restoring previous casacore headers ([#1771](https://github.com/CARTAvis/carta-frontend/issues/1771)).

--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -1714,10 +1714,10 @@ bool Frame::GetLoaderPointSpectralData(std::vector<float>& profile, int stokes, 
     return _loader->GetCursorSpectralData(profile, stokes, point.x(), 1, point.y(), 1, _image_mutex);
 }
 
-bool Frame::GetLoaderSpectralData(int region_id, int stokes, const casacore::ArrayLattice<casacore::Bool>& mask,
+bool Frame::GetLoaderSpectralData(int region_id, const AxisRange& z_range, int stokes, const casacore::ArrayLattice<casacore::Bool>& mask,
     const casacore::IPosition& origin, std::map<CARTA::StatsType, std::vector<double>>& results, float& progress) {
     // Get spectral data from loader (add image mutex for swizzled data)
-    return _loader->GetRegionSpectralData(region_id, stokes, mask, origin, _image_mutex, results, progress);
+    return _loader->GetRegionSpectralData(region_id, z_range, stokes, mask, origin, _image_mutex, results, progress);
 }
 
 bool Frame::CalculateMoments(int file_id, GeneratorProgressCallback progress_callback, const StokesRegion& stokes_region,

--- a/src/Frame/Frame.h
+++ b/src/Frame/Frame.h
@@ -179,7 +179,7 @@ public:
     // Spectral profiles from loader
     bool UseLoaderSpectralData(const casacore::IPosition& region_shape);
     bool GetLoaderPointSpectralData(std::vector<float>& profile, int stokes, CARTA::Point& point);
-    bool GetLoaderSpectralData(int region_id, int stokes, const casacore::ArrayLattice<casacore::Bool>& mask,
+    bool GetLoaderSpectralData(int region_id, const AxisRange& z_range, int stokes, const casacore::ArrayLattice<casacore::Bool>& mask,
         const casacore::IPosition& origin, std::map<CARTA::StatsType, std::vector<double>>& results, float& progress);
 
     // Moments calculation

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -294,13 +294,17 @@ std::vector<int> FileLoader::GetRenderAxes() {
             axes[0] = dir_axes[0];
             axes[1] = dir_axes[1];
         } else if (_coord_sys->hasLinearCoordinate()) {
-            // Check for PV image: [Linear, Spectral] axes
+            // Check for PV image: usually [Linear, Spectral] axes but could be reversed
             // Returns -1 if no spectral axis
             int spectral_axis = _coord_sys->spectralAxisNumber();
 
             if (spectral_axis >= 0) {
                 // Find valid (not -1) linear axes
                 std::vector<int> valid_axes;
+                if (spectral_axis == 0) { // reversed
+                    valid_axes.push_back(spectral_axis);
+                }
+
                 casacore::Vector<casacore::Int> lin_axes = _coord_sys->linearAxesNumbers();
                 for (auto axis : lin_axes) {
                     if (axis >= 0) {
@@ -308,9 +312,12 @@ std::vector<int> FileLoader::GetRenderAxes() {
                     }
                 }
 
-                // One linear + spectral axis = pV image
-                if (valid_axes.size() == 1) {
+                if (spectral_axis > 0) { // not reversed
                     valid_axes.push_back(spectral_axis);
+                }
+
+                // One linear + spectral axis = pV image
+                if (valid_axes.size() == 2) {
                     axes = valid_axes;
                 }
             }

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -837,8 +837,9 @@ bool FileLoader::UseRegionSpectralData(const casacore::IPosition& region_shape, 
     return false;
 }
 
-bool FileLoader::GetRegionSpectralData(int region_id, int stokes, const casacore::ArrayLattice<casacore::Bool>& mask,
-    const casacore::IPosition& origin, std::mutex& image_mutex, std::map<CARTA::StatsType, std::vector<double>>& results, float& progress) {
+bool FileLoader::GetRegionSpectralData(int region_id, const AxisRange& z_range, int stokes,
+    const casacore::ArrayLattice<casacore::Bool>& mask, const casacore::IPosition& origin, std::mutex& image_mutex,
+    std::map<CARTA::StatsType, std::vector<double>>& results, float& progress) {
     // Must be implemented in subclasses
     return false;
 }

--- a/src/ImageData/FileLoader.h
+++ b/src/ImageData/FileLoader.h
@@ -100,9 +100,9 @@ public:
         std::vector<float>& data, int stokes, int cursor_x, int count_x, int cursor_y, int count_y, std::mutex& image_mutex);
     // Check if one can apply swizzled data under such image format and region condition
     virtual bool UseRegionSpectralData(const casacore::IPosition& region_shape, std::mutex& image_mutex);
-    virtual bool GetRegionSpectralData(int region_id, int stokes, const casacore::ArrayLattice<casacore::Bool>& mask,
-        const casacore::IPosition& origin, std::mutex& image_mutex, std::map<CARTA::StatsType, std::vector<double>>& results,
-        float& progress);
+    virtual bool GetRegionSpectralData(int region_id, const AxisRange& z_range, int stokes,
+        const casacore::ArrayLattice<casacore::Bool>& mask, const casacore::IPosition& origin, std::mutex& image_mutex,
+        std::map<CARTA::StatsType, std::vector<double>>& results, float& progress);
     virtual bool GetDownsampledRasterData(
         std::vector<float>& data, int z, int stokes, CARTA::ImageBounds& bounds, int mip, std::mutex& image_mutex);
     virtual bool GetChunk(

--- a/src/ImageData/Hdf5Loader.h
+++ b/src/ImageData/Hdf5Loader.h
@@ -33,7 +33,7 @@ public:
         std::vector<float>& data, int stokes, int cursor_x, int count_x, int cursor_y, int count_y, std::mutex& image_mutex) override;
 
     bool UseRegionSpectralData(const casacore::IPosition& region_shape, std::mutex& image_mutex) override;
-    bool GetRegionSpectralData(int region_id, int stokes, const casacore::ArrayLattice<casacore::Bool>& mask,
+    bool GetRegionSpectralData(int region_id, const AxisRange& z_range, int stokes, const casacore::ArrayLattice<casacore::Bool>& mask,
         const casacore::IPosition& origin, std::mutex& image_mutex, std::map<CARTA::StatsType, std::vector<double>>& results,
         float& progress) override;
     bool GetDownsampledRasterData(

--- a/src/ImageData/Hdf5Loader.h
+++ b/src/ImageData/Hdf5Loader.h
@@ -33,9 +33,9 @@ public:
         std::vector<float>& data, int stokes, int cursor_x, int count_x, int cursor_y, int count_y, std::mutex& image_mutex) override;
 
     bool UseRegionSpectralData(const casacore::IPosition& region_shape, std::mutex& image_mutex) override;
-    bool GetRegionSpectralData(int region_id, const AxisRange& z_range, int stokes, const casacore::ArrayLattice<casacore::Bool>& mask,
-        const casacore::IPosition& origin, std::mutex& image_mutex, std::map<CARTA::StatsType, std::vector<double>>& results,
-        float& progress) override;
+    bool GetRegionSpectralData(int region_id, const AxisRange& spectral_range, int stokes,
+        const casacore::ArrayLattice<casacore::Bool>& mask, const casacore::IPosition& origin, std::mutex& image_mutex,
+        std::map<CARTA::StatsType, std::vector<double>>& results, float& progress) override;
     bool GetDownsampledRasterData(
         std::vector<float>& data, int z, int stokes, CARTA::ImageBounds& bounds, int mip, std::mutex& image_mutex) override;
     bool GetChunk(std::vector<float>& data, int& data_width, int& data_height, int min_x, int min_y, int z, int stokes,

--- a/src/ImageGenerators/ImageGenerator.h
+++ b/src/ImageGenerators/ImageGenerator.h
@@ -12,7 +12,7 @@
 #include <functional>
 
 #define MOMENT_ID_MULTIPLIER 1000
-#define PV_ID_MULTIPLIER 2000
+#define PV_ID_MULTIPLIER -1000
 
 using GeneratorProgressCallback = std::function<void(float)>;
 

--- a/src/ImageGenerators/ImageGenerator.h
+++ b/src/ImageGenerators/ImageGenerator.h
@@ -12,7 +12,7 @@
 #include <functional>
 
 #define MOMENT_ID_MULTIPLIER 1000
-#define PV_ID_MULTIPLIER 1000
+#define PV_ID_MULTIPLIER 2000
 
 using GeneratorProgressCallback = std::function<void(float)>;
 

--- a/src/ImageGenerators/ImageGenerator.h
+++ b/src/ImageGenerators/ImageGenerator.h
@@ -11,7 +11,8 @@
 
 #include <functional>
 
-#define ID_MULTIPLIER 1000
+#define MOMENT_ID_MULTIPLIER 1000
+#define PV_ID_MULTIPLIER 1000
 
 using GeneratorProgressCallback = std::function<void(float)>;
 

--- a/src/ImageGenerators/MomentGenerator.cc
+++ b/src/ImageGenerators/MomentGenerator.cc
@@ -71,7 +71,7 @@ bool MomentGenerator::CalculateMoments(int file_id, const casacore::ImageRegion&
 
                         // Set a temp moment file Id. Todo: find another better way to assign the temp file Id
                         int moment_type = _moments[i];
-                        int moment_file_id = (file_id + 1) * ID_MULTIPLIER + moment_type + 1;
+                        int moment_file_id = (file_id + 1) * MOMENT_ID_MULTIPLIER + moment_type + 1;
 
                         // Fill results
                         std::shared_ptr<casacore::ImageInterface<casacore::Float>> moment_image =

--- a/src/ImageGenerators/PvGenerator.cc
+++ b/src/ImageGenerators/PvGenerator.cc
@@ -25,9 +25,9 @@
 
 using namespace carta;
 
-PvGenerator::PvGenerator(int file_id, const std::string& filename, int suffix = 0) {
-    _file_id = (file_id + 1) * ID_MULTIPLIER;
-    _name = GetPvFilename(filename, suffix);
+PvGenerator::PvGenerator(int file_id, const std::string& filename, int index = 0) {
+    _file_id = ((file_id + 1) * PV_ID_MULTIPLIER) + index;
+    _name = GetPvFilename(filename, index);
 }
 
 bool PvGenerator::GetPvImage(std::shared_ptr<casacore::ImageInterface<float>> input_image, const casacore::Matrix<float>& pv_data,
@@ -47,15 +47,17 @@ bool PvGenerator::GetPvImage(std::shared_ptr<casacore::ImageInterface<float>> in
     return true;
 }
 
-std::string PvGenerator::GetPvFilename(const std::string& filename, int suffix) {
-    // image.ext -> image_pv.ext
+std::string PvGenerator::GetPvFilename(const std::string& filename, int index) {
+    // Index appended when multiple PV images shown for one input image
+    // image.ext -> image_pv[index].ext
     fs::path input_filepath(filename);
 
     // Assemble new filename
     auto pv_path = input_filepath.stem();
     pv_path += "_pv";
-    if (suffix > 0) {
-        pv_path += std::to_string(suffix);
+
+    if (index > 0) {
+        pv_path += std::to_string(index);
     }
 
     pv_path += input_filepath.extension();

--- a/src/ImageGenerators/PvGenerator.cc
+++ b/src/ImageGenerators/PvGenerator.cc
@@ -113,8 +113,10 @@ casacore::CoordinateSystem PvGenerator::GetPvCoordinateSystem(const casacore::Co
 
     // Set spectral reference value (changes if spectral range)
     casacore::Vector<casacore::Double> refval(1, spectral_refval);
+    casacore::Vector<casacore::Double> refpix(1, 0.0);
     auto spectral_coord = input_csys.spectralCoordinate();
     spectral_coord.setReferenceValue(refval);
+    spectral_coord.setReferencePixel(refpix);
 
     // Add offset and spectral coordinates
     if (reverse) {

--- a/src/ImageGenerators/PvGenerator.cc
+++ b/src/ImageGenerators/PvGenerator.cc
@@ -26,7 +26,7 @@
 using namespace carta;
 
 PvGenerator::PvGenerator(int file_id, const std::string& filename, int index = 0) {
-    _file_id = ((file_id + 1) * PV_ID_MULTIPLIER) + index;
+    _file_id = ((file_id + 1) * PV_ID_MULTIPLIER) - index;
     _name = GetPvFilename(filename, index);
 }
 

--- a/src/ImageGenerators/PvGenerator.cc
+++ b/src/ImageGenerators/PvGenerator.cc
@@ -25,9 +25,9 @@
 
 using namespace carta;
 
-PvGenerator::PvGenerator(int file_id, const std::string& filename) {
+PvGenerator::PvGenerator(int file_id, const std::string& filename, int suffix = 0) {
     _file_id = (file_id + 1) * ID_MULTIPLIER;
-    _name = GetPvFilename(filename);
+    _name = GetPvFilename(filename, suffix);
 }
 
 bool PvGenerator::GetPvImage(std::shared_ptr<casacore::ImageInterface<float>> input_image, const casacore::Matrix<float>& pv_data,
@@ -47,13 +47,17 @@ bool PvGenerator::GetPvImage(std::shared_ptr<casacore::ImageInterface<float>> in
     return true;
 }
 
-std::string PvGenerator::GetPvFilename(const std::string& filename) {
+std::string PvGenerator::GetPvFilename(const std::string& filename, int suffix) {
     // image.ext -> image_pv.ext
     fs::path input_filepath(filename);
 
     // Assemble new filename
     auto pv_path = input_filepath.stem();
     pv_path += "_pv";
+    if (suffix > 0) {
+        pv_path += std::to_string(suffix);
+    }
+
     pv_path += input_filepath.extension();
 
     return pv_path.string();

--- a/src/ImageGenerators/PvGenerator.h
+++ b/src/ImageGenerators/PvGenerator.h
@@ -19,7 +19,7 @@ namespace carta {
 
 class PvGenerator {
 public:
-    PvGenerator(int file_id, const std::string& filename, int suffix);
+    PvGenerator(int file_id, const std::string& filename, int index);
 
     // Normally set up as x=offset, y=spectral.  If reverse=true, set up x=spectral, y=offset.
     // Returns generated pv_image or message if failure.
@@ -27,7 +27,7 @@ public:
         const casacore::Quantity& offset_increment, int stokes, bool reverse, GeneratedImage& pv_image, std::string& message);
 
 private:
-    std::string GetPvFilename(const std::string& filename, int suffix);
+    std::string GetPvFilename(const std::string& filename, int index);
 
     bool SetupPvImage(std::shared_ptr<casacore::ImageInterface<float>> input_image, casacore::IPosition& pv_shape, int stokes,
         const casacore::Quantity& offset_increment, bool reverse, std::string& message);

--- a/src/ImageGenerators/PvGenerator.h
+++ b/src/ImageGenerators/PvGenerator.h
@@ -23,16 +23,17 @@ public:
 
     // Normally set up as x=offset, y=spectral.  If reverse=true, set up x=spectral, y=offset.
     // Returns generated pv_image or message if failure.
-    bool GetPvImage(std::shared_ptr<casacore::ImageInterface<float>> input_image, const casacore::Matrix<float>& pv_data,
-        const casacore::Quantity& offset_increment, double spectral_refval, int stokes, bool reverse, GeneratedImage& pv_image,
-        std::string& message);
+    bool GetPvImage(std::shared_ptr<casacore::ImageInterface<float>> input_image, std::shared_ptr<casacore::CoordinateSystem> input_csys,
+        const casacore::Matrix<float>& pv_data, const casacore::Quantity& offset_increment, double spectral_refval, int stokes,
+        bool reverse, GeneratedImage& pv_image, std::string& message);
 
 private:
     std::string GetPvFilename(const std::string& filename, int index);
 
-    bool SetupPvImage(std::shared_ptr<casacore::ImageInterface<float>> input_image, casacore::IPosition& pv_shape, int stokes,
-        const casacore::Quantity& offset_increment, double spectral_refval, bool reverse, std::string& message);
-    casacore::CoordinateSystem GetPvCoordinateSystem(const casacore::CoordinateSystem& input_csys, casacore::IPosition& pv_shape,
+    bool SetupPvImage(std::shared_ptr<casacore::ImageInterface<float>> input_image, std::shared_ptr<casacore::CoordinateSystem> input_csys,
+        casacore::IPosition& pv_shape, int stokes, const casacore::Quantity& offset_increment, double spectral_refval, bool reverse,
+        std::string& message);
+    casacore::CoordinateSystem GetPvCoordinateSystem(std::shared_ptr<casacore::CoordinateSystem> input_csys, casacore::IPosition& pv_shape,
         int stokes, const casacore::Quantity& offset_increment, double spectral_refval, bool reverse);
     GeneratedImage GetGeneratedImage();
 

--- a/src/ImageGenerators/PvGenerator.h
+++ b/src/ImageGenerators/PvGenerator.h
@@ -24,15 +24,16 @@ public:
     // Normally set up as x=offset, y=spectral.  If reverse=true, set up x=spectral, y=offset.
     // Returns generated pv_image or message if failure.
     bool GetPvImage(std::shared_ptr<casacore::ImageInterface<float>> input_image, const casacore::Matrix<float>& pv_data,
-        const casacore::Quantity& offset_increment, int stokes, bool reverse, GeneratedImage& pv_image, std::string& message);
+        const casacore::Quantity& offset_increment, double spectral_refval, int stokes, bool reverse, GeneratedImage& pv_image,
+        std::string& message);
 
 private:
     std::string GetPvFilename(const std::string& filename, int index);
 
     bool SetupPvImage(std::shared_ptr<casacore::ImageInterface<float>> input_image, casacore::IPosition& pv_shape, int stokes,
-        const casacore::Quantity& offset_increment, bool reverse, std::string& message);
+        const casacore::Quantity& offset_increment, double spectral_refval, bool reverse, std::string& message);
     casacore::CoordinateSystem GetPvCoordinateSystem(const casacore::CoordinateSystem& input_csys, casacore::IPosition& pv_shape,
-        int stokes, const casacore::Quantity& offset_increment, bool reverse);
+        int stokes, const casacore::Quantity& offset_increment, double spectral_refval, bool reverse);
     GeneratedImage GetGeneratedImage();
 
     // GeneratedImage parameters

--- a/src/ImageGenerators/PvGenerator.h
+++ b/src/ImageGenerators/PvGenerator.h
@@ -21,16 +21,18 @@ class PvGenerator {
 public:
     PvGenerator(int file_id, const std::string& filename);
 
+    // Normally set up as x=offset, y=spectral.  If reverse=true, set up x=spectral, y=offset.
+    // Returns generated pv_image or message if failure.
     bool GetPvImage(std::shared_ptr<casacore::ImageInterface<float>> input_image, const casacore::Matrix<float>& pv_data,
-        const casacore::Quantity& offset_increment, int stokes, GeneratedImage& pv_image, std::string& message);
+        const casacore::Quantity& offset_increment, int stokes, bool reverse, GeneratedImage& pv_image, std::string& message);
 
 private:
     std::string GetPvFilename(const std::string& filename);
 
     bool SetupPvImage(std::shared_ptr<casacore::ImageInterface<float>> input_image, casacore::IPosition& pv_shape, int stokes,
-        const casacore::Quantity& offset_increment, std::string& message);
+        const casacore::Quantity& offset_increment, bool reverse, std::string& message);
     casacore::CoordinateSystem GetPvCoordinateSystem(const casacore::CoordinateSystem& input_csys, casacore::IPosition& pv_shape,
-        int stokes, const casacore::Quantity& offset_increment);
+        int stokes, const casacore::Quantity& offset_increment, bool reverse);
     GeneratedImage GetGeneratedImage();
 
     // GeneratedImage parameters

--- a/src/ImageGenerators/PvGenerator.h
+++ b/src/ImageGenerators/PvGenerator.h
@@ -19,7 +19,7 @@ namespace carta {
 
 class PvGenerator {
 public:
-    PvGenerator(int file_id, const std::string& filename);
+    PvGenerator(int file_id, const std::string& filename, int suffix);
 
     // Normally set up as x=offset, y=spectral.  If reverse=true, set up x=spectral, y=offset.
     // Returns generated pv_image or message if failure.
@@ -27,7 +27,7 @@ public:
         const casacore::Quantity& offset_increment, int stokes, bool reverse, GeneratedImage& pv_image, std::string& message);
 
 private:
-    std::string GetPvFilename(const std::string& filename);
+    std::string GetPvFilename(const std::string& filename, int suffix);
 
     bool SetupPvImage(std::shared_ptr<casacore::ImageInterface<float>> input_image, casacore::IPosition& pv_shape, int stokes,
         const casacore::Quantity& offset_increment, bool reverse, std::string& message);

--- a/src/Region/RegionHandler.cc
+++ b/src/Region/RegionHandler.cc
@@ -972,8 +972,8 @@ bool RegionHandler::CalculatePvImage(const CARTA::PvRequest& pv_request, std::sh
             casacore::Quantity pv_increment = AdjustIncrementUnit(increment, pv_data.shape()(offset_axis));
             double spectral_worldval, spectral_pixval(z_range.from); // reference value in PV image
             input_image->coordinates().spectralCoordinate().toWorld(spectral_worldval, spectral_pixval);
-            pv_success =
-                pv_generator.GetPvImage(input_image, pv_data, pv_increment, spectral_worldval, stokes_index, reverse, pv_image, message);
+            pv_success = pv_generator.GetPvImage(
+                input_image, frame->CoordinateSystem(), pv_data, pv_increment, spectral_worldval, stokes_index, reverse, pv_image, message);
 
             frame->CloseCachedImage(input_filename);
         }

--- a/src/Region/RegionHandler.cc
+++ b/src/Region/RegionHandler.cc
@@ -970,7 +970,10 @@ bool RegionHandler::CalculatePvImage(const CARTA::PvRequest& pv_request, std::sh
             auto input_image = frame->GetImage();
             int offset_axis = reverse ? 1 : 0;
             casacore::Quantity pv_increment = AdjustIncrementUnit(increment, pv_data.shape()(offset_axis));
-            pv_success = pv_generator.GetPvImage(input_image, pv_data, pv_increment, stokes_index, reverse, pv_image, message);
+            double spectral_worldval, spectral_pixval(z_range.from); // reference value in PV image
+            input_image->coordinates().spectralCoordinate().toWorld(spectral_worldval, spectral_pixval);
+            pv_success =
+                pv_generator.GetPvImage(input_image, pv_data, pv_increment, spectral_worldval, stokes_index, reverse, pv_image, message);
 
             frame->CloseCachedImage(input_filename);
         }

--- a/src/Region/RegionHandler.cc
+++ b/src/Region/RegionHandler.cc
@@ -905,7 +905,7 @@ bool RegionHandler::CalculatePvImage(const CARTA::PvRequest& pv_request, std::sh
     int file_id(pv_request.file_id());
     int width(pv_request.width());
     bool reverse(pv_request.reverse());
-    bool overwrite(pv_request.overwrite());
+    bool keep(pv_request.keep());
 
     AxisRange z_range;
     if (pv_request.has_spectral_range()) {
@@ -959,7 +959,7 @@ bool RegionHandler::CalculatePvImage(const CARTA::PvRequest& pv_request, std::sh
             auto input_filename = frame->GetFileName();
 
             int name_suffix(0);
-            if (!overwrite) {
+            if (keep) {
                 if (_pv_name_suffix.find(file_id) != _pv_name_suffix.end()) {
                     name_suffix = ++_pv_name_suffix[file_id];
                 }

--- a/src/Region/RegionHandler.cc
+++ b/src/Region/RegionHandler.cc
@@ -1297,7 +1297,7 @@ bool RegionHandler::FillSpectralProfileData(
 
                 // Return spectral profile for this requirement
                 bool report_error(true);
-                AxisRange z_range(0, _frames.at(file_id)->Depth() - 1); // all channels
+                AxisRange z_range(0, _frames.at(config_file_id)->Depth() - 1); // all channels
                 profile_ok = GetRegionSpectralData(config_region_id, config_file_id, z_range, coordinate, stokes_index, required_stats,
                     report_error, [&](std::map<CARTA::StatsType, std::vector<double>> results, float progress) {
                         auto profile_message = Message::SpectralProfileData(
@@ -1360,7 +1360,6 @@ bool RegionHandler::GetRegionSpectralData(int region_id, int file_id, const Axis
 
     // Get 2D region with original image coordinate to check if inside image and whether to use loader
     auto lc_region = ApplyRegionToFile(region_id, file_id, StokesSource(), report_error);
-
     if (!lc_region) {
         // region outside image, send NaNs
         progress = 1.0;

--- a/src/Region/RegionHandler.h
+++ b/src/Region/RegionHandler.h
@@ -135,9 +135,9 @@ private:
 
     // Generate box regions to approximate a line with a width, and get mean of each box for z-range.
     // Used for pv generator and spatial profiles.
-    bool GetLineProfiles(int file_id, int region_id, int width, const AxisRange& z_range, int stokes_index, const std::string& coordinate,
-        std::function<void(float)>& progress_callback, double& increment, casacore::Matrix<float>& profiles, bool& cancelled,
-        std::string& message, bool reverse = false);
+    bool GetLineProfiles(int file_id, int region_id, int width, const AxisRange& z_range, bool per_z, int stokes_index,
+        const std::string& coordinate, std::function<void(float)>& progress_callback, double& increment, casacore::Matrix<float>& profiles,
+        bool& cancelled, std::string& message, bool reverse = false);
     bool CancelLineProfiles(int region_id, int file_id, RegionState& region_state);
     float GetLineRotation(const std::vector<double>& line_start, const std::vector<double>& line_end);
     bool GetFixedPixelRegionProfiles(int file_id, int region_id, int width, bool per_z, const AxisRange& z_range, int stokes_index,

--- a/src/Region/RegionHandler.h
+++ b/src/Region/RegionHandler.h
@@ -137,12 +137,12 @@ private:
     // Used for pv generator and spatial profiles.
     bool GetLineProfiles(int file_id, int region_id, int width, const AxisRange& z_range, int stokes_index, const std::string& coordinate,
         std::function<void(float)>& progress_callback, double& increment, casacore::Matrix<float>& profiles, bool& cancelled,
-        std::string& message);
+        std::string& message, bool reverse = false);
     bool CancelLineProfiles(int region_id, int file_id, RegionState& region_state);
     float GetLineRotation(const std::vector<double>& line_start, const std::vector<double>& line_end);
     bool GetFixedPixelRegionProfiles(int file_id, int region_id, int width, bool per_z, const AxisRange& z_range, int stokes_index,
         const std::string& coordinate, RegionState& region_state, std::shared_ptr<casacore::CoordinateSystem> reference_csys,
-        std::function<void(float)>& progress_callback, casacore::Matrix<float>& profiles, double& increment, bool& cancelled);
+        std::function<void(float)>& progress_callback, casacore::Matrix<float>& profiles, double& increment, bool& cancelled, bool reverse);
     bool CheckLinearOffsets(
         const std::vector<std::vector<double>>& box_centers, std::shared_ptr<casacore::CoordinateSystem> csys, double& increment);
     double GetPointSeparation(
@@ -151,7 +151,7 @@ private:
     bool GetFixedAngularRegionProfiles(int file_id, int region_id, int width, bool per_z, const AxisRange& z_range, int stokes_index,
         const std::string& coordinate, RegionState& region_state, std::shared_ptr<casacore::CoordinateSystem> reference_csys,
         std::function<void(float)>& progress_callback, casacore::Matrix<float>& profiles, double& increment, bool& cancelled,
-        std::string& message);
+        std::string& message, bool reverse);
     std::vector<double> FindPointAtTargetSeparation(std::shared_ptr<casacore::CoordinateSystem> coord_sys,
         const std::vector<double>& start_point, const std::vector<double>& end_point, double target_separation, double tolerance);
     RegionState GetTemporaryRegionState(std::shared_ptr<casacore::CoordinateSystem> coord_sys, int file_id,

--- a/src/Region/RegionHandler.h
+++ b/src/Region/RegionHandler.h
@@ -206,7 +206,7 @@ private:
 
     // PV generator: key is file_id
     std::unordered_map<int, bool> _stop_pv;
-    std::unordered_map<int, int> _pv_name_suffix;
+    std::unordered_map<int, int> _pv_name_index;
 
     // For pixel-MVDirection conversion; static variable used in casacore::DirectionCoordinate
     std::mutex _pix_mvdir_mutex;

--- a/src/Region/RegionHandler.h
+++ b/src/Region/RegionHandler.h
@@ -204,8 +204,9 @@ private:
         CARTA::StatsType::RMS, CARTA::StatsType::Sigma, CARTA::StatsType::SumSq, CARTA::StatsType::Min, CARTA::StatsType::Max,
         CARTA::StatsType::Extrema, CARTA::StatsType::NumPixels};
 
-    // PV cancellation: key is file_id
+    // PV generator: key is file_id
     std::unordered_map<int, bool> _stop_pv;
+    std::unordered_map<int, int> _pv_name_suffix;
 
     // For pixel-MVDirection conversion; static variable used in casacore::DirectionCoordinate
     std::mutex _pix_mvdir_mutex;

--- a/src/Region/RegionHandler.h
+++ b/src/Region/RegionHandler.h
@@ -88,7 +88,7 @@ public:
     std::vector<int> GetSpatialReqFilesForRegion(int region_id);
 
     // Generate PV image
-    bool CalculatePvImage(int file_id, int region_id, int width, std::shared_ptr<Frame>& frame, GeneratorProgressCallback progress_callback,
+    bool CalculatePvImage(const CARTA::PvRequest& pv_request, std::shared_ptr<Frame>& frame, GeneratorProgressCallback progress_callback,
         CARTA::PvResponse& pv_response, GeneratedImage& pv_image);
     void StopPvCalc(int file_id);
 
@@ -125,7 +125,7 @@ private:
     // Data stream helpers
     bool GetRegionHistogramData(int region_id, int file_id, const std::vector<HistogramConfig>& configs,
         std::vector<CARTA::RegionHistogramData>& histogram_messages);
-    bool GetRegionSpectralData(int region_id, int file_id, std::string& coordinate, int stokes_index,
+    bool GetRegionSpectralData(int region_id, int file_id, const AxisRange& z_range, std::string& coordinate, int stokes_index,
         std::vector<CARTA::StatsType>& required_stats, bool report_error,
         const std::function<void(std::map<CARTA::StatsType, std::vector<double>>, float)>& partial_results_callback);
     bool GetRegionStatsData(
@@ -133,23 +133,23 @@ private:
     bool GetLineSpatialData(int file_id, int region_id, const std::string& coordinate, int stokes_index, int width,
         const std::function<void(std::vector<float>, double)>& spatial_profile_callback);
 
-    // Generate box regions to approximate a line with a width, and get mean of each box (per z else current z).
+    // Generate box regions to approximate a line with a width, and get mean of each box for z-range.
     // Used for pv generator and spatial profiles.
-    bool GetLineProfiles(int file_id, int region_id, int width, bool per_z, int stokes_index, const std::string& coordinate,
+    bool GetLineProfiles(int file_id, int region_id, int width, const AxisRange& z_range, int stokes_index, const std::string& coordinate,
         std::function<void(float)>& progress_callback, double& increment, casacore::Matrix<float>& profiles, bool& cancelled,
         std::string& message);
     bool CancelLineProfiles(int region_id, int file_id, RegionState& region_state);
     float GetLineRotation(const std::vector<double>& line_start, const std::vector<double>& line_end);
-    bool GetFixedPixelRegionProfiles(int file_id, int region_id, int width, bool per_z, int stokes_index, const std::string& coordinate,
-        RegionState& region_state, std::shared_ptr<casacore::CoordinateSystem> reference_csys,
+    bool GetFixedPixelRegionProfiles(int file_id, int region_id, int width, bool per_z, const AxisRange& z_range, int stokes_index,
+        const std::string& coordinate, RegionState& region_state, std::shared_ptr<casacore::CoordinateSystem> reference_csys,
         std::function<void(float)>& progress_callback, casacore::Matrix<float>& profiles, double& increment, bool& cancelled);
     bool CheckLinearOffsets(
         const std::vector<std::vector<double>>& box_centers, std::shared_ptr<casacore::CoordinateSystem> csys, double& increment);
     double GetPointSeparation(
         std::shared_ptr<CoordinateSystem> coord_sys, const std::vector<double>& point1, const std::vector<double>& point2);
     double GetSeparationTolerance(std::shared_ptr<casacore::CoordinateSystem> csys);
-    bool GetFixedAngularRegionProfiles(int file_id, int region_id, int width, bool per_z, int stokes_index, const std::string& coordinate,
-        RegionState& region_state, std::shared_ptr<casacore::CoordinateSystem> reference_csys,
+    bool GetFixedAngularRegionProfiles(int file_id, int region_id, int width, bool per_z, const AxisRange& z_range, int stokes_index,
+        const std::string& coordinate, RegionState& region_state, std::shared_ptr<casacore::CoordinateSystem> reference_csys,
         std::function<void(float)>& progress_callback, casacore::Matrix<float>& profiles, double& increment, bool& cancelled,
         std::string& message);
     std::vector<double> FindPointAtTargetSeparation(std::shared_ptr<casacore::CoordinateSystem> coord_sys,
@@ -158,7 +158,7 @@ private:
         const std::vector<double>& box_start, const std::vector<double>& box_end, int pixel_width, double angular_width,
         float line_rotation, double tolerance);
     casacore::Vector<float> GetTemporaryRegionProfile(int region_idx, int file_id, RegionState& region_state,
-        std::shared_ptr<casacore::CoordinateSystem> csys, bool per_z, int stokes_index, double& num_pixels);
+        std::shared_ptr<casacore::CoordinateSystem> csys, bool per_z, const AxisRange& z_range, int stokes_index, double& num_pixels);
     casacore::Quantity AdjustIncrementUnit(double offset_increment, size_t num_offsets);
 
     // Get computed stokes profiles for a region

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -1310,7 +1310,6 @@ bool Session::OnConcatStokesFiles(const CARTA::ConcatStokesFiles& message, uint3
 void Session::OnPvRequest(const CARTA::PvRequest& pv_request, uint32_t request_id) {
     int file_id(pv_request.file_id());
     int region_id(pv_request.region_id());
-    int width(pv_request.width());
     CARTA::PvResponse pv_response;
 
     if (_frames.count(file_id)) {
@@ -1328,7 +1327,7 @@ void Session::OnPvRequest(const CARTA::PvRequest& pv_request, uint32_t request_i
             auto& frame = _frames.at(file_id);
             GeneratedImage pv_image;
 
-            if (_region_handler->CalculatePvImage(file_id, region_id, width, frame, progress_callback, pv_response, pv_image)) {
+            if (_region_handler->CalculatePvImage(pv_request, frame, progress_callback, pv_response, pv_image)) {
                 auto* open_file_ack = pv_response.mutable_open_file_ack();
                 OnOpenFile(pv_image.file_id, pv_image.name, pv_image.image, open_file_ack);
             }

--- a/src/Util/Message.cc
+++ b/src/Util/Message.cc
@@ -536,8 +536,7 @@ CARTA::MomentProgress Message::MomentProgress(int32_t file_id, float progress) {
     return message;
 }
 
-CARTA::PvRequest Message::PvRequest(
-    int32_t file_id, int32_t region_id, int32_t width, int z_min, int32_t z_max, bool reverse, bool keep) {
+CARTA::PvRequest Message::PvRequest(int32_t file_id, int32_t region_id, int32_t width, int z_min, int32_t z_max, bool reverse, bool keep) {
     CARTA::PvRequest message;
     message.set_file_id(file_id);
     message.set_region_id(region_id);

--- a/src/Util/Message.cc
+++ b/src/Util/Message.cc
@@ -536,6 +536,24 @@ CARTA::MomentProgress Message::MomentProgress(int32_t file_id, float progress) {
     return message;
 }
 
+CARTA::PvRequest Message::PvRequest(
+    int32_t file_id, int32_t region_id, int32_t width, int z_min, int32_t z_max, bool reverse, bool overwrite) {
+    CARTA::PvRequest message;
+    message.set_file_id(file_id);
+    message.set_region_id(region_id);
+    message.set_width(width);
+
+    if (z_min >= 0 && z_max >= 0) {
+        auto spectral_range = message.mutable_spectral_range();
+        spectral_range->set_min(z_min);
+        spectral_range->set_max(z_max);
+    }
+
+    message.set_reverse(reverse);
+    message.set_overwrite(overwrite);
+    return message;
+}
+
 CARTA::PvProgress Message::PvProgress(int32_t file_id, float progress) {
     CARTA::PvProgress message;
     message.set_file_id(file_id);

--- a/src/Util/Message.cc
+++ b/src/Util/Message.cc
@@ -537,7 +537,7 @@ CARTA::MomentProgress Message::MomentProgress(int32_t file_id, float progress) {
 }
 
 CARTA::PvRequest Message::PvRequest(
-    int32_t file_id, int32_t region_id, int32_t width, int z_min, int32_t z_max, bool reverse, bool overwrite) {
+    int32_t file_id, int32_t region_id, int32_t width, int z_min, int32_t z_max, bool reverse, bool keep) {
     CARTA::PvRequest message;
     message.set_file_id(file_id);
     message.set_region_id(region_id);
@@ -550,7 +550,7 @@ CARTA::PvRequest Message::PvRequest(
     }
 
     message.set_reverse(reverse);
-    message.set_overwrite(overwrite);
+    message.set_keep(keep);
     return message;
 }
 

--- a/src/Util/Message.h
+++ b/src/Util/Message.h
@@ -128,7 +128,7 @@ public:
         uint32_t session_id, bool success, const std::string& status, const CARTA::SessionType& type);
     static CARTA::MomentProgress MomentProgress(int32_t file_id, float progress);
     static CARTA::PvRequest PvRequest(
-        int32_t file_id, int32_t region_id, int32_t width, int z_min = -1, int32_t z_max = -1, bool reverse = false, bool overwrite = true);
+        int32_t file_id, int32_t region_id, int32_t width, int z_min = -1, int32_t z_max = -1, bool reverse = false, bool keep = false);
     static CARTA::PvProgress PvProgress(int32_t file_id, float progress);
     static CARTA::RegionHistogramData RegionHistogramData(
         int32_t file_id, int32_t region_id, int32_t channel, int32_t stokes, float progress);

--- a/src/Util/Message.h
+++ b/src/Util/Message.h
@@ -127,6 +127,8 @@ public:
     static CARTA::RegisterViewerAck RegisterViewerAck(
         uint32_t session_id, bool success, const std::string& status, const CARTA::SessionType& type);
     static CARTA::MomentProgress MomentProgress(int32_t file_id, float progress);
+    static CARTA::PvRequest PvRequest(
+        int32_t file_id, int32_t region_id, int32_t width, int z_min = -1, int32_t z_max = -1, bool reverse = false, bool overwrite = true);
     static CARTA::PvProgress PvProgress(int32_t file_id, float progress);
     static CARTA::RegionHistogramData RegionHistogramData(
         int32_t file_id, int32_t region_id, int32_t channel, int32_t stokes, float progress);

--- a/test/TestPvGenerator.cc
+++ b/test/TestPvGenerator.cc
@@ -418,7 +418,7 @@ TEST_F(PvGeneratorTest, PvImageKeep) {
     // Check PV image file_id and name
     int index(0);
     EXPECT_EQ(pv_response.success(), true);
-    EXPECT_EQ(pv_image.file_id, PV_ID_MULTIPLIER + index);
+    EXPECT_EQ(pv_image.file_id, PV_ID_MULTIPLIER - index);
     EXPECT_TRUE(pv_image.name.find("pv.fits") != std::string::npos);
 
     // Request PV image, keeping the first
@@ -430,7 +430,7 @@ TEST_F(PvGeneratorTest, PvImageKeep) {
     // Check PV image file_id and name
     index++;
     EXPECT_EQ(pv_response2.success(), true);
-    EXPECT_EQ(pv_image2.file_id, PV_ID_MULTIPLIER + index);
+    EXPECT_EQ(pv_image2.file_id, PV_ID_MULTIPLIER - index);
     EXPECT_TRUE(pv_image2.name.find("pv1.fits") != std::string::npos);
 
     // Request PV image, replace all and reset index
@@ -442,6 +442,6 @@ TEST_F(PvGeneratorTest, PvImageKeep) {
     // Check PV image file_id and name
     index = 0;
     EXPECT_EQ(pv_response3.success(), true);
-    EXPECT_EQ(pv_image3.file_id, PV_ID_MULTIPLIER + index);
+    EXPECT_EQ(pv_image3.file_id, PV_ID_MULTIPLIER - index);
     EXPECT_TRUE(pv_image3.name.find("pv.fits") != std::string::npos);
 }

--- a/test/TestPvGenerator.cc
+++ b/test/TestPvGenerator.cc
@@ -59,10 +59,11 @@ TEST_F(PvGeneratorTest, FitsPvImage) {
 
     // Request PV image
     int width(3);
+    auto pv_request = Message::PvRequest(file_id, region_id, width);
     auto progress_callback = [&](float progress) {};
     CARTA::PvResponse pv_response;
     carta::GeneratedImage pv_image;
-    region_handler.CalculatePvImage(file_id, region_id, width, frame, progress_callback, pv_response, pv_image);
+    region_handler.CalculatePvImage(pv_request, frame, progress_callback, pv_response, pv_image);
 
     EXPECT_EQ(pv_response.success(), true);
     EXPECT_EQ(pv_response.cancel(), false);
@@ -128,10 +129,11 @@ TEST_F(PvGeneratorTest, FitsPvImageHorizontalCut) {
 
     // Request PV image
     int width(1);
+    auto pv_request = Message::PvRequest(file_id, region_id, width);
     auto progress_callback = [&](float progress) {};
     CARTA::PvResponse pv_response;
     carta::GeneratedImage pv_image;
-    region_handler.CalculatePvImage(file_id, region_id, width, frame, progress_callback, pv_response, pv_image);
+    region_handler.CalculatePvImage(pv_request, frame, progress_callback, pv_response, pv_image);
 
     EXPECT_EQ(pv_response.success(), true);
     EXPECT_EQ(pv_response.cancel(), false);
@@ -204,10 +206,11 @@ TEST_F(PvGeneratorTest, FitsPvImageVerticalCut) {
 
     // Request PV image
     int width(1);
+    auto pv_request = Message::PvRequest(file_id, region_id, width);
     auto progress_callback = [&](float progress) {};
     CARTA::PvResponse pv_response;
     carta::GeneratedImage pv_image;
-    region_handler.CalculatePvImage(file_id, region_id, width, frame, progress_callback, pv_response, pv_image);
+    region_handler.CalculatePvImage(pv_request, frame, progress_callback, pv_response, pv_image);
 
     EXPECT_EQ(pv_response.success(), true);
     EXPECT_EQ(pv_response.cancel(), false);
@@ -273,10 +276,11 @@ TEST_F(PvGeneratorTest, TestNoSpectralAxis) {
 
     // Request PV image
     int width(3);
+    auto pv_request = Message::PvRequest(file_id, region_id, width);
     auto progress_callback = [&](float progress) {};
     CARTA::PvResponse pv_response;
     carta::GeneratedImage pv_image;
-    region_handler.CalculatePvImage(file_id, region_id, width, frame, progress_callback, pv_response, pv_image);
+    region_handler.CalculatePvImage(pv_request, frame, progress_callback, pv_response, pv_image);
 
     EXPECT_EQ(pv_response.success(), false);
     EXPECT_EQ(pv_response.cancel(), false);

--- a/test/TestPvGenerator.cc
+++ b/test/TestPvGenerator.cc
@@ -46,10 +46,11 @@ public:
         SetPvCut(region_handler, file_id, region_id, endpoints, frame->CoordinateSystem());
 
         // Request PV image
+        auto pv_request = Message::PvRequest(file_id, region_id, width);
         auto progress_callback = [&](float progress) {};
         CARTA::PvResponse pv_response;
         carta::GeneratedImage pv_image;
-        region_handler.CalculatePvImage(file_id, region_id, width, frame, progress_callback, pv_response, pv_image);
+        region_handler.CalculatePvImage(pv_request, frame, progress_callback, pv_response, pv_image);
 
         if (expected_width_range) {
             EXPECT_TRUE(pv_response.success());

--- a/test/TestPvGenerator.cc
+++ b/test/TestPvGenerator.cc
@@ -9,6 +9,7 @@
 
 #include "CommonTestUtilities.h"
 #include "ImageData/FileLoader.h"
+#include "ImageGenerators/ImageGenerator.h"
 #include "Region/Region.h"
 #include "Region/RegionHandler.h"
 #include "src/Frame/Frame.h"
@@ -70,7 +71,6 @@ TEST_F(PvGeneratorTest, FitsPvImage) {
     auto image_path = TestRoot() / "data/images/fits/noise_3d.fits"; // 10x10x10 image
     std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
     std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
-    carta::RegionHandler region_handler;
 
     // Image coordinate system
     auto csys = frame->CoordinateSystem();
@@ -82,6 +82,7 @@ TEST_F(PvGeneratorTest, FitsPvImage) {
     auto image_cdelt2_arcmin = image_cdelt2.get("arcmin").getValue();
 
     // Set line region [0, 0] to [9, 9]
+    carta::RegionHandler region_handler;
     int file_id(0), region_id(-1);
     std::vector<float> endpoints = {0.0, 0.0, 9.0, 9.0};
     SetPvCut(region_handler, file_id, region_id, endpoints, csys);
@@ -140,7 +141,6 @@ TEST_F(PvGeneratorTest, FitsPvImageHorizontalCut) {
     auto image_path = TestRoot() / "data/images/fits/noise_3d.fits"; // 10x10x10 image
     std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
     std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
-    carta::RegionHandler region_handler;
 
     // Image coordinate system
     auto csys = frame->CoordinateSystem();
@@ -152,6 +152,7 @@ TEST_F(PvGeneratorTest, FitsPvImageHorizontalCut) {
     auto image_cdelt2_arcsec = image_cdelt2.get("arcsec").getValue();
 
     // Set line region at y=5
+    carta::RegionHandler region_handler;
     int file_id(0), region_id(-1);
     std::vector<float> endpoints = {9.0, 5.0, 1.0, 5.0};
     SetPvCut(region_handler, file_id, region_id, endpoints, csys);
@@ -217,7 +218,6 @@ TEST_F(PvGeneratorTest, FitsPvImageVerticalCut) {
     auto image_path = TestRoot() / "data/images/fits/noise_3d.fits"; // 10x10x10 image
     std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
     std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
-    carta::RegionHandler region_handler;
 
     // Image coordinate system
     auto csys = frame->CoordinateSystem();
@@ -229,6 +229,7 @@ TEST_F(PvGeneratorTest, FitsPvImageVerticalCut) {
     auto image_cdelt2_arcsec = image_cdelt2.get("arcsec").getValue();
 
     // Set line region at y=5
+    carta::RegionHandler region_handler;
     int file_id(0), region_id(-1);
     std::vector<float> endpoints = {5.0, 9.0, 5.0, 1.0};
     SetPvCut(region_handler, file_id, region_id, endpoints, csys);
@@ -295,9 +296,9 @@ TEST_F(PvGeneratorTest, TestNoSpectralAxis) {
     auto path_string = GeneratedHdf5ImagePath("10 10 10");
     std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(path_string));
     std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
-    carta::RegionHandler region_handler;
 
     // Set line region [0, 0] to [9, 9]
+    carta::RegionHandler region_handler;
     int file_id(0), region_id(-1);
     std::vector<float> endpoints = {0.0, 0.0, 9.0, 9.0};
     auto csys = frame->CoordinateSystem();
@@ -321,4 +322,126 @@ TEST_F(PvGeneratorTest, AveragingWidthRange) {
     TestAveragingWidthRange(1, true);
     TestAveragingWidthRange(20, true);
     TestAveragingWidthRange(21, false);
+}
+
+TEST_F(PvGeneratorTest, PvImageSpectralRange) {
+    // FITS
+    auto image_path = TestRoot() / "data/images/fits/noise_3d.fits"; // 10x10x10 image
+    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
+    std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
+    auto csys = frame->CoordinateSystem();
+
+    // Set line region [0, 0] to [9, 9]
+    carta::RegionHandler region_handler;
+    int file_id(0), region_id(-1);
+    std::vector<float> endpoints = {0.0, 0.0, 9.0, 9.0};
+    SetPvCut(region_handler, file_id, region_id, endpoints, csys);
+
+    // Request PV image
+    int width(3), z_min(0), z_max(5); // first 6 channels
+    auto pv_request = Message::PvRequest(file_id, region_id, width, z_min, z_max);
+    auto progress_callback = [&](float progress) {};
+    CARTA::PvResponse pv_response;
+    carta::GeneratedImage pv_image;
+    region_handler.CalculatePvImage(pv_request, frame, progress_callback, pv_response, pv_image);
+
+    EXPECT_EQ(pv_response.success(), true);
+    EXPECT_EQ(pv_response.cancel(), false);
+    EXPECT_NE(pv_image.image.get(), nullptr);
+
+    // Check shape
+    auto pv_image_shape = pv_image.image->shape();
+    EXPECT_EQ(pv_image_shape.size(), 2);
+    EXPECT_EQ(pv_image_shape(1), 6); // spectral axis is 6 channels
+}
+
+TEST_F(PvGeneratorTest, PvImageReversedAxes) {
+    auto image_path = TestRoot() / "data/images/fits/noise_3d.fits"; // 10x10x10 image
+    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
+    std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
+    auto csys = frame->CoordinateSystem();
+
+    // Set line region [0, 0] to [9, 9]
+    carta::RegionHandler region_handler;
+    int file_id(0), region_id(-1);
+    std::vector<float> endpoints = {0.0, 0.0, 9.0, 9.0};
+    SetPvCut(region_handler, file_id, region_id, endpoints, csys);
+
+    // Request PV image
+    int width(3), z_min(0), z_max(9); // all channels
+    bool reverse(false);
+    auto pv_request = Message::PvRequest(file_id, region_id, width, z_min, z_max, reverse);
+    auto progress_callback = [&](float progress) {};
+    CARTA::PvResponse pv_response;
+    carta::GeneratedImage pv_image;
+    region_handler.CalculatePvImage(pv_request, frame, progress_callback, pv_response, pv_image);
+    EXPECT_EQ(pv_response.success(), true);
+    EXPECT_NE(pv_image.image.get(), nullptr);
+    auto pv_image_shape = pv_image.image->shape();
+
+    // Request reverse PV image with same cut
+    reverse = true;
+    pv_request = Message::PvRequest(file_id, region_id, width, z_min, z_max, reverse);
+    CARTA::PvResponse rev_pv_response;
+    carta::GeneratedImage rev_pv_image;
+    region_handler.CalculatePvImage(pv_request, frame, progress_callback, rev_pv_response, rev_pv_image);
+    EXPECT_EQ(rev_pv_response.success(), true);
+    EXPECT_NE(rev_pv_image.image.get(), nullptr);
+    auto rev_pv_image_shape = rev_pv_image.image->shape();
+
+    // Check reversed shape
+    EXPECT_EQ(rev_pv_image_shape.size(), pv_image_shape.size());
+    EXPECT_EQ(rev_pv_image_shape(0), pv_image_shape(1));
+    EXPECT_EQ(rev_pv_image_shape(1), pv_image_shape(0));
+}
+
+TEST_F(PvGeneratorTest, PvImageKeep) {
+    auto image_path = TestRoot() / "data/images/fits/noise_3d.fits"; // 10x10x10 image
+    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
+    std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
+    auto csys = frame->CoordinateSystem();
+
+    // Set line region [0, 0] to [9, 9]
+    carta::RegionHandler region_handler;
+    int file_id(0), region_id(-1);
+    std::vector<float> endpoints = {0.0, 0.0, 9.0, 9.0};
+    SetPvCut(region_handler, file_id, region_id, endpoints, csys);
+
+    // Request PV image
+    int width(3), z_min(0), z_max(9); // all channels
+    bool reverse(false), keep(false);
+    auto pv_request = Message::PvRequest(file_id, region_id, width, z_min, z_max, reverse, keep);
+    auto progress_callback = [&](float progress) {};
+    CARTA::PvResponse pv_response;
+    carta::GeneratedImage pv_image;
+    region_handler.CalculatePvImage(pv_request, frame, progress_callback, pv_response, pv_image);
+    // Check PV image file_id and name
+    int index(0);
+    EXPECT_EQ(pv_response.success(), true);
+    EXPECT_EQ(pv_image.file_id, PV_ID_MULTIPLIER + index);
+    EXPECT_TRUE(pv_image.name.find("pv.fits") != std::string::npos);
+
+    // Request PV image, keeping the first
+    keep = true;
+    pv_request = Message::PvRequest(file_id, region_id, width, z_min, z_max, reverse, keep);
+    CARTA::PvResponse pv_response2;
+    carta::GeneratedImage pv_image2;
+    region_handler.CalculatePvImage(pv_request, frame, progress_callback, pv_response2, pv_image2);
+    // Check PV image file_id and name
+    index++;
+    EXPECT_EQ(pv_response2.success(), true);
+    EXPECT_EQ(pv_image2.file_id, PV_ID_MULTIPLIER + index);
+    EXPECT_TRUE(pv_image2.name.find("pv1.fits") != std::string::npos);
+
+    // Request PV image, replace all and reset index
+    keep = false;
+    pv_request = Message::PvRequest(file_id, region_id, width, z_min, z_max, reverse, keep);
+    CARTA::PvResponse pv_response3;
+    carta::GeneratedImage pv_image3;
+    region_handler.CalculatePvImage(pv_request, frame, progress_callback, pv_response3, pv_image3);
+    // Check PV image file_id and name
+    index = 0;
+    EXPECT_EQ(pv_response3.success(), true);
+    EXPECT_EQ(pv_image3.file_id, PV_ID_MULTIPLIER + index);
+    EXPECT_TRUE(pv_image3.name.find("pv.fits") != std::string::npos);
 }


### PR DESCRIPTION
Enhancements to the PV generator

* What is implemented or fixed? Mention the linked issue(s), if any.
Implements #1175 , #1176 , and #1177 .

* How does this PR solve the issue? Give a brief summary.
For reversed axes, the profiles are added as columns instead of rows and the coordinate system coordinates are reversed.  To keep a PV image, an index is incremented and added as a suffix to the new PV image name, as well as used to create a new file_id.  For the spectral range, only the channels requested are used for the spectral profiles.

* Are there any companion PRs (frontend, protobuf)?
Frontend PR [#2007](https://github.com/CARTAvis/carta-frontend/pull/2007), protobuf PR [#75](https://github.com/CARTAvis/carta-protobuf/pull/75)

* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
Frontend PV generator dialog box (in branch `carli/1950_pv_x_y_axis_setting`) now shows the spectral range and reversed-axes options.  After clicking "Generate", a popup asks whether to overwrite a previous image.

**Checklist**

- [x] changelog updated
- [x] ~e2e test passing~ / added corresponding fix
- [x] protobuf updated to add PvRequest fields
- [x] added reviewers and assignee
- [x] added ZenHub estimate, milestone, and release
- [x] added backend unit tests
