### PR TITLE
updating all Dockerfiles plus CMakeLists.txt for carta-gsl on el7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,19 @@ endif ()
 # Needed by clang-tidy and other clang tools
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-FIND_PACKAGE(GSL REQUIRED)
+FIND_PACKAGE(GSL QUIET)
+if (GSL_FOUND)
+    message(STATUS "Found gsl using find_package")
+else ()
+    if(EXISTS /opt/carta-gsl)
+        message(STATUS "Found carta-gsl for el7")
+        INCLUDE_DIRECTORIES(/opt/carta-gsl/include)
+        LINK_DIRECTORIES(/opt/carta-gsl/lib)
+    else ()
+        message(FATAL_ERROR "Could not find gsl")
+    endif ()
+endif()
+
 FIND_PACKAGE(ZFP CONFIG REQUIRED)
 FIND_PACKAGE(PkgConfig REQUIRED)
 

--- a/Dockerfiles/Dockerfile-AlmaLinux8
+++ b/Dockerfiles/Dockerfile-AlmaLinux8
@@ -1,4 +1,4 @@
-FROM almalinux:latest
+FROM almalinux:8
 
 # Install the required packages
 RUN \
@@ -7,16 +7,17 @@ RUN \
   dnf -y config-manager --set-enabled powertools && \
   dnf -y update && \
   dnf -y install autoconf automake bison blas-devel bzip2 cfitsio-devel cmake curl-devel flex gcc \
-         gcc-c++ git git-lfs gsl-devel hdf5-devel lapack-devel \
+         gcc-c++ git git-lfs gsl-devel hdf5-devel lapack-devel libasan \
          libtool libxml2-devel libzstd-devel libuuid-devel make openssl-devel protobuf-devel \
          python36 python3-pip pugixml-devel readline-devel subversion \
          wcslib-devel wget zlib-devel libuuid-devel zfp-devel && \
   pip3 install numpy astropy
 
-# Get carta dependencies from the cartavis rpm repository
+# Install carta-casacore-devel and fits2idia from the Copr cartavis/carta repository
 RUN \
-  curl https://packages.cartavis.org/cartavis-el8.repo --output /etc/yum.repos.d/cartavis.repo && \
-  yum -y install carta-casacore-devel gtest-devel gmock-devel fits2idia measures-data
+  dnf -y install 'dnf-command(copr)' && \
+  dnf -y copr enable cartavis/carta && \
+  dnf -y install carta-casacore-devel fits2idia gmock-devel gtest-devel measures-data
 
 # Forward port so that the webapp can properly access it
 # from outside of the container

--- a/Dockerfiles/Dockerfile-AlmaLinux9
+++ b/Dockerfiles/Dockerfile-AlmaLinux9
@@ -1,0 +1,36 @@
+FROM almalinux:9
+
+# Install the required packages
+RUN \
+  dnf -y install epel-release && \
+  dnf -y install 'dnf-command(config-manager)' && \
+  dnf -y config-manager --set-enabled crb && \
+  dnf -y update && \
+  dnf -y install autoconf automake bison blas-devel bzip2 cfitsio-devel cmake curl-devel flex gcc \
+         gcc-c++ git git-lfs gmock-devel gsl-devel gtest-devel hdf5-devel lapack-devel libasan \
+         libtool libxml2-devel libzstd-devel libuuid-devel make openssl-devel protobuf-devel \
+         python3 python3-pip pugixml-devel readline-devel subversion \
+         wget zlib-devel libuuid-devel && \
+  pip3 install numpy astropy
+
+# Install carta-casacore-devel and fits2idia from the Copr cartavis/carta repository
+# (Also install wcslib-devel and zfp-devel as those packages are not yet available from official AlmaLinux 9 repositories)
+RUN \
+  dnf -y install 'dnf-command(copr)' && \
+  dnf -y copr enable cartavis/carta && \
+  dnf -y install carta-casacore-devel fits2idia measures-data wcslib-devel zfp-devel
+
+# To work on Jenkins
+RUN \
+  yum -y install nodejs npm
+
+# Forward port so that the webapp can properly access it
+# from outside of the container
+EXPOSE 3002
+
+ENV HOME /root
+WORKDIR /root
+
+# overwrite this with 'CMD []' in a dependent Dockerfile
+CMD ["bash"]
+

--- a/Dockerfiles/Dockerfile-CentOS7
+++ b/Dockerfiles/Dockerfile-CentOS7
@@ -3,24 +3,24 @@ FROM centos:7
 # The carta-backend will use GCC 8 functions, so install and activate devtoolset-8 
 RUN \
   yum -y install centos-release-scl && \
-  yum install -y centos-release-scl && yum install -y devtoolset-8-gcc devtoolset-8-gcc-c++ devtoolset-8-gcc-gfortran && \
+  yum install -y centos-release-scl && yum install -y devtoolset-8-gcc devtoolset-8-gcc-c++ devtoolset-8-gcc-gfortran devtoolset-8-libasan-devel && \
   echo "source scl_source enable devtoolset-8" >> /etc/bashrc
 
 # Install the required packages
 RUN \
-  yum -y install centos-release-openstack-train && \
   yum -y install epel-release && \
   yum install -y autoconf automake bison blas-devel bzip2 cfitsio-devel cmake3 curl-devel flex \
-    git git-lfs gsl-devel hdf5-devel lapack-devel libtool libxml2-devel libzstd-devel \
-    make openssl-devel protobuf-devel pugixml-devel python3 readline-devel subversion systemd-devel wcslib-devel wget \
+    git git-lfs hdf5-devel lapack-devel libtool libxml2-devel libzstd-devel \
+    make openssl-devel pugixml-devel python3 readline-devel subversion systemd-devel wcslib-devel wget \
     zlib-devel libuuid-devel zfp-devel && \
   pip3 install numpy astropy && \
   ln -s /usr/bin/cmake3 /usr/bin/cmake
 
-# Get carta dependencies from the cartavis rpm repository
-RUN \ 
-  curl https://packages.cartavis.org/cartavis-el7.repo --output /etc/yum.repos.d/cartavis.repo && \
-  yum -y install carta-casacore-devel gtest-devel gmock-devel fits2idia measures-data
+# Install carta-casacore-devel and fits2idia from the Copr cartavis/carta repository
+RUN \
+  yum -y install yum-plugin-copr && \
+  yum -y copr enable cartavis/carta && \
+  yum -y install carta-casacore-devel carta-gsl-devel fits2idia gmock-devel gtest-devel measures-data protobuf-devel
 
 # Forward port so that the webapp can properly access it
 # from outside of the container
@@ -34,4 +34,3 @@ WORKDIR /root
 
 # overwrite this with 'CMD []' in a dependent Dockerfile
 CMD ["bash"]
-

--- a/Dockerfiles/Dockerfile-ubuntu-22.04
+++ b/Dockerfiles/Dockerfile-ubuntu-22.04
@@ -1,0 +1,32 @@
+FROM ubuntu:22.04
+# Note: kern PPA has been temporarily disabled until kernsuite provide 'jammy' packages. 
+# Until then, the 'casacore-data' package may not be fully up-to-date.
+
+# Install the basic packages
+RUN \
+  apt-get update && \
+  apt-get -y upgrade && \
+  DEBIAN_FRONTEND=noninteractive \
+  apt-get install -y apt-utils autoconf bison build-essential cmake curl fftw3-dev flex gcc g++ \
+    gdb gfortran git git-lfs libgmock-dev googletest libblas-dev libcfitsio-dev \
+    libgsl-dev libgtest-dev libhdf5-dev liblapack-dev libncurses-dev \
+    libprotobuf-dev libpugixml-dev libreadline-dev libssl-dev libstarlink-ast-dev \
+    libtool libxml2-dev libxslt1-dev libzstd-dev pkg-config protobuf-compiler \
+    python3-numpy python3-astropy software-properties-common unzip wcslib-dev wget uuid-dev
+
+# Get carta dependencies carta-casacore, fits2idia, and zfp from cartavis-team PPA and casacore-data from KERN
+RUN \
+  #apt-add-repository -y -s ppa:kernsuite/kern-7 && \
+  add-apt-repository -y ppa:cartavis-team/carta-testing && \
+  apt-get update && \
+  apt-get -y install carta-casacore-dev fits2idia libzfp-dev
+
+# Forward port so that the webapp can properly access it from outside of the container
+EXPOSE 3002
+
+ENV HOME /root
+WORKDIR /root
+
+# Overwrite this with 'CMD []' in a dependent Dockerfile
+CMD ["bash"]
+

--- a/Dockerfiles/Dockerfile-ubuntu-22.04
+++ b/Dockerfiles/Dockerfile-ubuntu-22.04
@@ -16,7 +16,6 @@ RUN \
 
 # Get carta dependencies carta-casacore, fits2idia, and zfp from cartavis-team PPA and casacore-data from KERN
 RUN \
-  #apt-add-repository -y -s ppa:kernsuite/kern-7 && \
   add-apt-repository -y ppa:cartavis-team/carta-testing && \
   apt-get update && \
   apt-get -y install carta-casacore-dev fits2idia libzfp-dev

--- a/Dockerfiles/Dockerfile-ubuntu-22.04
+++ b/Dockerfiles/Dockerfile-ubuntu-22.04
@@ -14,7 +14,7 @@ RUN \
     libtool libxml2-dev libxslt1-dev libzstd-dev pkg-config protobuf-compiler \
     python3-numpy python3-astropy software-properties-common unzip wcslib-dev wget uuid-dev
 
-# Get carta dependencies carta-casacore, fits2idia, and zfp from cartavis-team PPA and casacore-data from KERN
+# Get carta dependencies carta-casacore, fits2idia, and zfp from the cartavis-team PPA
 RUN \
   add-apt-repository -y ppa:cartavis-team/carta-testing && \
   apt-get update && \


### PR DESCRIPTION
**Description**

The Dockerfiles have been updated. All Dockerfiles are capable of building the current carta-backend with ASAN flags and the Unit Tests. I have checked all six, and the carta-backend runs plus all Unit Tests run and pass in each one.

I have added `Dockerfile-ubuntu-22.04`. Currently the line to add the kern-7 PPA (for up-to-date casacore-data) is commented out because they currently do not produce 'jammy' packages. I know the carta-backend will still work fine, but casacore-data may not be up to date. I put a note saying as much at the top of the Dockerfile. Once the Kernsuite team produce 'jammy' packages, we can update the Dockerfile again.

I have split the old `Dockerfile-AlmaLinux` into two files. When we created it first, we were using `almalinux:latest` because there was only AlmaLinux 8 (Redhat 8). But now there is AlmaLinux 9.

I have converted the three RedHat-based Dockerfiles (CentOS7, AlmaLinux8, and AlmaLinux9) to use our new [CARTAvis Copr RPM repo](https://copr.fedorainfracloud.org/coprs/cartavis/carta) rather than our old https://packages.cartavis.org/. I have put all required packages on our Copr repo so that each one can build the carta-backend with ASAN flags and run the Unit Tests.

CentOS7 is slightly problematic because it now requires a newer GSL (gsl-2.5) rather than the default version (gsl-1.15). At the time, there was concern about simply creating a gsl-2.5 RPM and installing it in the normal location because it could potentially conflict with other packages such as Inkscape that were built against the older default gsl-1.15 version. So it was decided we should call our newer RPM `carta-gsl` and install it to a custom location, namely `/opt/carta-gsl`. Furthermore, to ensure it could not interfere with default gsl, we do not install pkgconfig information with it. 

This has been perfectly fine when creating the carta-backend el7 RPMs because we can simply add additional build flags to the SPEC file. e.g. `-DCMAKE_CXX_FLAGS="-I/opt/carta-gsl/include" DCMAKE_CXX_STANDARD_LIBRARIES="-L/opt/carta-gsl/lib"`

However, explaining this special requirement to potential el7 users would be a bit complicated. So in order to keep it as simple as `cmake ..`, I propose to modify the carta-backend `CMakeLists.txt` file as follows:

```
FIND_PACKAGE(GSL QUIET)
if (GSL_FOUND)
    message(STATUS "Found gsl using find_package")
else ()
    if(EXISTS /opt/carta-gsl)
        message(STATUS "Found carta-gsl for el7")
        INCLUDE_DIRECTORIES(/opt/carta-gsl/include)
        LINK_DIRECTORIES(/opt/carta-gsl/lib)
    else ()
        message(FATAL_ERROR "Could not find gsl")
    endif ()
endif()
```


This conveniently deals with the special case of carta-gsl on el7 and has no effect on any other platform. I have tested it, and it seems to work fine.

I think that is the easiest way. An alternative would be additional work to re-do the carta-gsl RPM in order to get it to install a special `carta-gsl.pc` alongside the normal `gsl.pc` in the default pkconfig search folder. However, the carta-backend CMakeLists.txt would still need to be modified in order to ignore GSL only on el7 and only pick up the special CARTA-GSL. That seems a bit more complicated.

I should mention the only caveat of using Copr, is that there is no support for el7 aarch64.

We should also merge @veggiesaurus' `angus/minimal_dockerfile` branch.

**Checklist**

- [x] no changelog update needed
- [x] e2e test should not be affected
- [x] no protobuf update needed
- [x] added reviewers and assignee
- [x] added ZenHub estimate, milestone, and release
