### PR TITLE
fix for the unintialised string

### DIFF
--- a/src/FileList/FileListHandler.cc
+++ b/src/FileList/FileListHandler.cc
@@ -65,7 +65,7 @@ void FileListHandler::GetRelativePath(std::string& folder) {
         folder.replace(0, 2, ""); // remove leading "./"
     } else if (folder.find(_top_level_folder) == 0) {
         folder.replace(0, _top_level_folder.length(), ""); // remove root folder path
-        if (folder.front() == '/') {
+        if (!folder.empty() && folder.front() == '/') {
             folder.replace(0, 1, "");
         } // remove leading '/'
     }


### PR DESCRIPTION
**Description**

@confluence and @jolopezl Thank you for the discussion on Slack regarding the `FileListTest.SetTopLevelFolder` Unit Test crash on AlmaLinux 9 / RedHat 9. I took the liberty to apply the simple fix you proposed and it appears to work fine. Unit Tests now pass on RedHat 9, and Unit Tests and CI continue to work on our other supported platforms.

**Checklist**

- [x] no changelog update needed - a very minor bug fix that only shows up in Red Hat 9 when using ASAN flags.
- [x] e2e test passing / added corresponding fix - should not affect e2e tests
- [x] no protobuf update needed
- [x] added reviewers and assignee
- [x] added ZenHub estimate, milestone, and release - not necessary, minor bug fix
