### PR TITLE
Use existing region ids when resuming session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * Fixed issues with AIPS velocity axis by restoring previous casacore headers ([#1771](https://github.com/CARTAvis/carta-frontend/issues/1771)).
+* Fixed error in regions when resuming session.
 
 ## [3.0.0]
 

--- a/src/Region/RegionHandler.cc
+++ b/src/Region/RegionHandler.cc
@@ -66,8 +66,7 @@ bool RegionHandler::SetRegion(int& region_id, RegionState& region_state, std::sh
             ClearRegionCache(region_id);
         }
     } else {
-        if (region_id > TEMP_REGION_ID && region_id < CURSOR_REGION_ID) {
-            // new region, assign id
+        if (region_id == NEW_REGION_ID) {
             region_id = GetNextRegionId();
         }
 

--- a/src/Region/RegionHandler.cc
+++ b/src/Region/RegionHandler.cc
@@ -66,7 +66,7 @@ bool RegionHandler::SetRegion(int& region_id, RegionState& region_state, std::sh
             ClearRegionCache(region_id);
         }
     } else {
-        if (region_id > TEMP_REGION_ID) {
+        if (region_id > TEMP_REGION_ID && region_id < CURSOR_REGION_ID) {
             // new region, assign id
             region_id = GetNextRegionId();
         }

--- a/src/Util/Image.h
+++ b/src/Util/Image.h
@@ -21,6 +21,7 @@
 #define CUBE_REGION_ID -2
 #define IMAGE_REGION_ID -1
 #define CURSOR_REGION_ID 0
+#define NEW_REGION_ID -1 // SetRegion only
 #define ALL_REGIONS -10
 #define TEMP_REGION_ID -100
 #define TEMP_FOV_REGION_ID -1000


### PR DESCRIPTION
Fix setting new region ids on resume.

* How does this PR solve the issue? Give a brief summary.
Added check that region id is NEW_REGION_ID (-1, sent from frontend) before assigning new id.

* Are there any companion PRs (frontend, protobuf)?
No

* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
Create then delete regions, then create again (so that region ids do not start at 1).  Restart backend, resume session, and check that profiles/stats work where expected for region id and type.  Export regions and check that all were exported to file.

**Checklist**

- [x] changelog updated
- [x] e2e test passing / ~added corresponding fix~
- [x] no protobuf update needed
- [x] added reviewers and assignee
- [x] added ZenHub estimate, milestone, and release
