### PR TITLE
Fix region import when name has spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * Fixed issues with AIPS velocity axis by restoring previous casacore headers ([#1771](https://github.com/CARTAvis/carta-frontend/issues/1771)).
-* Fixed error in regions when resuming session. ([#1210](https://github.com/CARTAvis/carta-frontend/issues/1210)).
-* Fixed crash when exporting matched region ([#1205](https://github.com/CARTAvis/carta-frontend/issues/1205), [#1208](https://github.com/CARTAvis/carta-frontend/issues/1208)).
+* Fixed error in regions when resuming session. ([#1210](https://github.com/CARTAvis/carta-backend/issues/1210)).
+* Fixed crash when exporting matched region ([#1205](https://github.com/CARTAvis/carta-backend/issues/1205), [#1208](https://github.com/CARTAvis/carta-backend/issues/1208)).
+* Fixed region import with space in region name ([#1188](https://github.com/CARTAvis/carta-backend/issues/1188));
 
 ## [3.0.0]
 


### PR DESCRIPTION
Fixes region import failure when region name has spaces.

* What is implemented or fixed?
Closes #1188 .
* How does this PR solve the issue? Give a brief summary.
Fixed RegionImportExport parser to correctly find the closing quote for CRTF `label` property, which holds the region name (or any property enclosed in quotes).  Also fixed the links in the changelog, copy/paste error was using `carta-frontend` path.
* Are there any companion PRs (frontend, protobuf)?
No, backend bug only.
* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
Import CRTF region with one or more spaces in name.

**Checklist**

- [x] changelog updated
- [x] e2e test passing / ~added corresponding fix~
- [x] no protobuf update needed
- [x] added reviewers and assignee
- [x] added ZenHub estimate, milestone, and release
