### PR TITLE
Angus/1213 no runtime config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Added a check of averaging width when calculating line/polyline spatial profiles or PV images ([#1174](https://github.com/CARTAvis/carta-backend/issues/1174)).
 * Added support for image fitting with fixed parameters ([#150](https://github.com/CARTAvis/carta-backend/issues/150)).
+* Added a debug config flag for disabling runtime config ([#1213](https://github.com/CARTAvis/carta-backend/issues/1213))
 
 ### Fixed
 * Fixed issues with AIPS velocity axis by restoring previous casacore headers ([#1771](https://github.com/CARTAvis/carta-frontend/issues/1771)).

--- a/src/HttpServer/HttpServer.cc
+++ b/src/HttpServer/HttpServer.cc
@@ -24,7 +24,8 @@ const std::string success_string = json({{"success", true}}).dump();
 uint32_t HttpServer::_scripting_request_id = 0;
 
 HttpServer::HttpServer(std::shared_ptr<SessionManager> session_manager, fs::path root_folder, fs::path user_directory,
-    std::string auth_token, bool read_only_mode, bool enable_frontend, bool enable_database, bool enable_scripting)
+    std::string auth_token, bool read_only_mode, bool enable_frontend, bool enable_database, bool enable_scripting,
+    bool enable_runtime_config)
     : _session_manager(session_manager),
       _http_root_folder(root_folder),
       _auth_token(auth_token),
@@ -32,7 +33,8 @@ HttpServer::HttpServer(std::shared_ptr<SessionManager> session_manager, fs::path
       _config_folder(user_directory / "config"),
       _enable_frontend(enable_frontend),
       _enable_database(enable_database),
-      _enable_scripting(enable_scripting) {
+      _enable_scripting(enable_scripting),
+      _enable_runtime_config(enable_runtime_config) {
     if (_enable_frontend && !root_folder.empty()) {
         _frontend_found = IsValidFrontendFolder(root_folder);
 
@@ -80,10 +82,14 @@ void HttpServer::RegisterRoutes() {
 }
 
 void HttpServer::HandleGetConfig(Res* res, Req* req) {
-    json runtime_config = {{"apiAddress", "/api"}};
-    res->writeStatus(HTTP_200);
-    res->writeHeader("Content-Type", "application/json");
-    res->end(runtime_config.dump());
+    if (_enable_runtime_config) {
+        json runtime_config = {{"apiAddress", "/api"}};
+        res->writeStatus(HTTP_200);
+        res->writeHeader("Content-Type", "application/json");
+        res->end(runtime_config.dump());
+    } else {
+        res->writeStatus(HTTP_200)->end();
+    }
 }
 
 void HttpServer::HandleStaticRequest(Res* res, Req* req) {

--- a/src/HttpServer/HttpServer.cc
+++ b/src/HttpServer/HttpServer.cc
@@ -73,7 +73,11 @@ void HttpServer::RegisterRoutes() {
     }
 
     if (_enable_frontend) {
-        app.get("/config", [&](auto res, auto req) { HandleGetConfig(res, req); });
+        if (_enable_runtime_config) {
+            app.get("/config", [&](auto res, auto req) { HandleGetConfig(res, req); });
+        } else {
+            app.get("/config", [&](auto res, auto req) { DefaultSuccess(res, req); });
+        }
         // Static routes for all other files
         app.get("/*", [&](Res* res, Req* req) { HandleStaticRequest(res, req); });
     } else {
@@ -82,14 +86,10 @@ void HttpServer::RegisterRoutes() {
 }
 
 void HttpServer::HandleGetConfig(Res* res, Req* req) {
-    if (_enable_runtime_config) {
-        json runtime_config = {{"apiAddress", "/api"}};
-        res->writeStatus(HTTP_200);
-        res->writeHeader("Content-Type", "application/json");
-        res->end(runtime_config.dump());
-    } else {
-        res->writeStatus(HTTP_200)->end();
-    }
+    json runtime_config = {{"apiAddress", "/api"}};
+    res->writeStatus(HTTP_200);
+    res->writeHeader("Content-Type", "application/json");
+    res->end(runtime_config.dump());
 }
 
 void HttpServer::HandleStaticRequest(Res* res, Req* req) {
@@ -669,6 +669,11 @@ void HttpServer::OnScriptingAbort(int session_id, uint32_t scripting_request_id)
 
 void HttpServer::NotImplemented(Res* res, Req* req) {
     res->writeStatus(HTTP_501)->end();
+    return;
+}
+
+void HttpServer::DefaultSuccess(Res* res, Req* req) {
+    res->writeStatus(HTTP_200)->end();
     return;
 }
 

--- a/src/HttpServer/HttpServer.h
+++ b/src/HttpServer/HttpServer.h
@@ -79,6 +79,7 @@ private:
     void HandleClearObject(const std::string& object_type, Res* res, Req* req);
     void HandleScriptingAction(Res* res, Req* req);
     void NotImplemented(Res* res, Req* req);
+    void DefaultSuccess(Res* res, Req* req);
 
     fs::path _http_root_folder;
     fs::path _config_folder;

--- a/src/HttpServer/HttpServer.h
+++ b/src/HttpServer/HttpServer.h
@@ -38,7 +38,8 @@ typedef std::function<bool(int&, uint32_t&, std::string&, std::string&, std::str
 class HttpServer {
 public:
     HttpServer(std::shared_ptr<SessionManager> session_manager, fs::path root_folder, fs::path user_directory, std::string auth_token,
-        bool read_only_mode = false, bool enable_frontend = true, bool enable_database = true, bool enable_scripting = false);
+        bool read_only_mode = false, bool enable_frontend = true, bool enable_database = true, bool enable_scripting = false,
+        bool enable_runtime_config = true);
     bool CanServeFrontend() {
         return _frontend_found;
     }
@@ -87,6 +88,7 @@ private:
     bool _enable_frontend;
     bool _enable_database;
     bool _enable_scripting;
+    bool _enable_runtime_config;
     std::shared_ptr<SessionManager> _session_manager;
     static uint32_t _scripting_request_id;
 };

--- a/src/Main/Main.cc
+++ b/src/Main/Main.cc
@@ -113,8 +113,9 @@ int main(int argc, char* argv[]) {
                 }
             }
 
-            http_server = std::make_unique<HttpServer>(session_manager, frontend_path, settings.user_directory, auth_token,
-                settings.read_only_mode, !settings.no_frontend, !settings.no_database, settings.enable_scripting);
+            http_server =
+                std::make_unique<HttpServer>(session_manager, frontend_path, settings.user_directory, auth_token, settings.read_only_mode,
+                    !settings.no_frontend, !settings.no_database, settings.enable_scripting, !settings.no_runtime_config);
             http_server->RegisterRoutes();
 
             if (!settings.no_frontend && !http_server->CanServeFrontend()) {

--- a/src/Main/ProgramSettings.cc
+++ b/src/Main/ProgramSettings.cc
@@ -196,6 +196,7 @@ void ProgramSettings::ApplyCommandLineSettings(int argc, char** argv) {
 
     options.add_options("Deprecated and debug")
         ("debug_no_auth", "accept all incoming WebSocket connections on the specified port(s) (not secure; use with caution!)", cxxopts::value<bool>())
+        ("no_runtime_config", "do not send a runtime config object to frontend clients", cxxopts::value<bool>())
         ("threads", "[deprecated] manually set number of event processing threads (no longer supported)", cxxopts::value<int>(), "<threads>")
         ("base", "[deprecated] set starting folder for data files (use the positional parameter instead)", cxxopts::value<string>(), "<dir>")
         ("root", "[deprecated] use 'top_level_folder' instead", cxxopts::value<string>(), "<dir>")
@@ -295,6 +296,7 @@ global configuration files, respectively.
     no_database = result["no_database"].as<bool>();
     no_frontend = result["no_frontend"].as<bool>();
     debug_no_auth = result["debug_no_auth"].as<bool>();
+    no_runtime_config = result["no_runtime_config"].as<bool>();
     no_browser = result["no_browser"].as<bool>();
     read_only_mode = result["read_only_mode"].as<bool>();
     enable_scripting = result["enable_scripting"].as<bool>();

--- a/src/Main/ProgramSettings.h
+++ b/src/Main/ProgramSettings.h
@@ -45,6 +45,7 @@ struct ProgramSettings {
     bool no_http = false; // Deprecated
     bool no_frontend = false;
     bool no_database = false;
+    bool no_runtime_config = false;
     bool debug_no_auth = false;
     bool no_browser = false;
     bool no_log = false;
@@ -87,7 +88,8 @@ struct ProgramSettings {
         {"read_only_mode", &read_only_mode},
         {"enable_scripting", &enable_scripting},
         {"no_frontend", &no_frontend},
-        {"no_database", &no_database}
+        {"no_database", &no_database},
+        {"no_runtime_config", &no_runtime_config}
     };
 
     std::unordered_map<std::string, std::string*> strings_keys_map{


### PR DESCRIPTION
**Description**

Closes #1213 by adding the `no_runtime_config` commandline argument. Workaround for the NRAO archive.

**Checklist**

- [x] changelog updated / ~~no changelog update needed~~
- [x] e2e test passing / ~~added corresponding fix~~
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] added reviewers and assignee
- [x] added ZenHub estimate, milestone, and release
