### PR TITLE
Fix c&p error in tile cache key hash function

### DIFF
--- a/src/Cache/TileCacheKey.h
+++ b/src/Cache/TileCacheKey.h
@@ -24,7 +24,7 @@ namespace std {
 template <>
 struct hash<carta::TileCacheKey> {
     std::size_t operator()(const carta::TileCacheKey& k) const {
-        return std::hash<int32_t>()(k.x) ^ (std::hash<int32_t>()(k.x) << 1);
+        return std::hash<int32_t>()(k.x) ^ (std::hash<int32_t>()(k.y) << 1);
     }
 };
 } // namespace std


### PR DESCRIPTION
This is a one-character fix for a logic error that I found while writing demo documentation. This tile cache key hash function should be combining the hashes for its x and y coordinates, but it's actually using the x coordinate twice. This means that all keys with the same x coordinate will have colliding hashes.

This may be having a detrimental effect on the performance of Y profiles (for HDF5 files, which use the tile cache), but the total number of tiles / keys in use at once may be too low for the impact to be significant. If there is a noticeable difference, it may be worthwhile to mention this in the changelog, otherwise it's probably too minor a change (we could add an aggregate bugfix item before release).

- [x] ~changelog updated~ / no changelog update needed
- [x] e2e test passing / ~added corresponding fix~
- [X] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [X] added reviewers and assignee
- [X] added ZenHub estimate, milestone, and release
