### PR TITLE
add pugixml as third-party library with PUGIXML_COMPACT enabled

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "test/image-generator"]
 	path = third-party/image-generator
 	url = https://github.com/idia-astro/image-generator
+[submodule "third-party/pugixml"]
+	path = third-party/pugixml
+	url = https://github.com/zeux/pugixml.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added PV generator features for spectral range, reversed axes, and keeping previous image ([#1175](https://github.com/CARTAvis/carta-backend/issues/1175), [#1176](https://github.com/CARTAvis/carta-backend/issues/1176), [#1177](https://github.com/CARTAvis/carta-backend/issues/1177)).
 * Added a debug config flag for disabling runtime config ([#1213](https://github.com/CARTAvis/carta-backend/issues/1213)).
 * Added support to keep previously generated moment images ([#1202](https://github.com/CARTAvis/carta-backend/issues/1202)).
+* Added pugixml as a third-party library with the option PUGIXML_COMPACT enabled ([#1217](https://github.com/CARTAvis/carta-backend/issues/1217)).
 
 ### Changed
 * Removed CASA CRTF parser for performance and annotation region support ([#1219](https://github.com/CARTAvis/carta-backend/issues/1219)).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,18 +63,6 @@ endif()
 FIND_PACKAGE(ZFP CONFIG REQUIRED)
 FIND_PACKAGE(PkgConfig REQUIRED)
 
-FIND_PACKAGE(PUGIXML QUIET)
-if (PUGIXML_FOUND)
-    message(STATUS "Found pugixml using find_package")
-else ()
-        PKG_SEARCH_MODULE(PUGIXML REQUIRED pugixml)
-        if (PUGIXML_FOUND)
-        message(STATUS "Found pugixml using pkg-config")
-    else ()
-        message(FATAL_ERROR "Could not find pugixml")
-    endif ()
-endif()
-
 FIND_PACKAGE(CFITSIO QUIET)
 if (CFITSIO_FOUND)
     message(STATUS "Found cfitsio using find_package")
@@ -165,6 +153,13 @@ endif ()
 # Include uWebSockets headers and build the uSockets lib
 include_directories(${CMAKE_SOURCE_DIR}/third-party/include)
 install_uWebSockets()
+
+#pugixml
+SET(PUGIXML_COMPACT ON CACHE BOOL "" FORCE)
+add_subdirectory(third-party/pugixml)
+include_directories(${CMAKE_SOURCE_DIR}/third-party/pugixml/src)
+
+#spdlog
 add_subdirectory(third-party/spdlog)
 
 set(LINK_LIBS

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ The backend build depends on the following libraries:
 * [protobuf](https://developers.google.com/protocol-buffers) for client-side communication using specific message formats. Debian package `libprotobuf-dev` (> 3.0 required. Can use [PPA](https://launchpad.net/~maarten-fonville/+archive/ubuntu/protobuf) for earlier versions of Ubuntu). The Debian package `protobuf-compiler` may also be required.
 * [HDF5](https://support.hdfgroup.org/HDF5/) C++ library for HDF5 support. Debian packages `libhdf5-dev` and `libhdf5-cpp-100`. By default, the serial version of the HDF5 library is targeted.
 * [libuuid](https://linux.die.net/man/3/libuuid) for generating auth tokens (if not using external authentication). Debian package `uuid-dev`.
-* [pugixml](https://pugixml.org/) for parsing catalog data. Debian package: `libpugixml-dev`. On Ubuntu 16.04, build from source. On newer versions you can also build from source to save memory: use the `PUGIXML_COMPACT` and `PUGIXML_NO_XPATH` flags.
 * [cfitsio](https://heasarc.gsfc.nasa.gov/fitsio/) library for I/O with FITS format data files. Debian package: `libcfitsio-dev`.
 * [wcslib](https://www.gnu.org/software/gnuastro/manual/html_node/WCSLIB.html) library to handle world coordinate system. Debian package: `wcslib-dev`.
 


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any:
Closes #1217 
* How does this PR solve the issue? Give a brief summary:
Enabling PUGIXML_COMPACT in pugixml halves the memory usage when loading a votable catalog. It keeps the performance nearly the same.
* Are there any companion PRs (frontend, protobuf)?
No.
* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
Compare dev against this pr, load a votable while track memory and cpu usage.

**Checklist**

- [x] changelog updated / no changelog update needed
- [x] e2e test passing / ~added corresponding fix~
- [x] protobuf updated to the latest dev commit / no protobuf update needed
- [x] added reviewers and assignee
- [ ] added ZenHub estimate, milestone, and release
