### PR TITLE
Fix abort when open FITS with cfitsio 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed error in regions when resuming session. ([#1210](https://github.com/CARTAvis/carta-backend/issues/1210)).
 * Fixed crash when exporting matched region ([#1205](https://github.com/CARTAvis/carta-backend/issues/1205), [#1208](https://github.com/CARTAvis/carta-backend/issues/1208)).
 * Fixed region import with space in region name ([#1188](https://github.com/CARTAvis/carta-backend/issues/1188));
+* Fixed cfitsio 4.2.0 fits_read_key abort ([#1231](https://github.com/CARTAvis/carta-backend/issues/1231));
 
 ## [3.0.0]
 

--- a/src/FileList/FitsHduList.cc
+++ b/src/FileList/FitsHduList.cc
@@ -12,7 +12,7 @@
 
 #include <casacore/casa/Exceptions/Error.h>
 
-#include "../Logger/Logger.h"
+#include "Logger/Logger.h"
 #include "Util/File.h"
 
 using namespace carta;
@@ -62,7 +62,7 @@ void FitsHduList::CheckFitsHeaders(fitsfile* fptr, std::vector<std::string>& hdu
 
         // Common arguments for fits_read_key
         std::string key;
-        char comment[70];
+        char* comment(nullptr); // unused
 
         bool is_image(false), is_fz(false);
 
@@ -112,7 +112,7 @@ void FitsHduList::CheckFitsHeaders(fitsfile* fptr, std::vector<std::string>& hdu
                 } else {
                     // Get extension name
                     key = "EXTNAME";
-                    char extname[70];
+                    char extname[FLEN_VALUE]; // cfitsio constant: max value length
                     status = 0;
                     fits_read_key(fptr, TSTRING, key.c_str(), extname, comment, &status);
 

--- a/src/ImageData/CartaFitsImage.cc
+++ b/src/ImageData/CartaFitsImage.cc
@@ -390,7 +390,7 @@ void CartaFitsImage::GetFitsHeaderString(int& nheaders, std::string& hdrstr) {
     if (bitpix > 0) {
         std::string key("BLANK");
         int blank_value;
-        char* comment(nullptr);
+        char* comment(nullptr); // ignore
         status = 0;
         fits_read_key(fptr, TLONG, key.c_str(), &blank_value, comment, &status);
         _has_blanks = !status;
@@ -1296,8 +1296,7 @@ void CartaFitsImage::ReadBeamsTable(casacore::ImageInfo& image_info) {
     }
 
     // Check nchan and npol
-    char* comment(nullptr);
-
+    char* comment(nullptr); // ignore
     std::string key("NCHAN");
     status = 0;
     fits_read_key(fptr, TINT, key.c_str(), &nchan, comment, &status);
@@ -1320,7 +1319,7 @@ void CartaFitsImage::ReadBeamsTable(casacore::ImageInfo& image_info) {
 
     std::unordered_map<string, string> beam_units;
     for (int i = 0; i < tfields; ++i) {
-        char name[10], unit[10];
+        char name[FLEN_VALUE], unit[FLEN_VALUE]; // cfitsio constant: max value length
         std::string index_str = std::to_string(i + 1);
 
         key = "TTYPE" + index_str;


### PR DESCRIPTION
Closes #1231

* What is implemented or fixed? Mention the linked issue(s), if any.
Fixes #1231
* How does this PR solve the issue? Give a brief summary.
Uses cfitsio constants for char array size used for input to fits_read_key, or a char* nullptr when the return value is not needed.  In 4.2.0, cfitsio uses strncpy with n set to length constant in cfitsio instead of length of char array.
* Are there any companion PRs (frontend, protobuf)?
No
* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
Build carta-backend with cfitsio 4.2.0 and open FITS file (file list info or open image).

**Checklist**

- [x] changelog updated / ~~no changelog update needed~~
- [x] e2e test passing / ~added corresponding fix~
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] added reviewers and assignee
- [x] added ZenHub estimate, milestone, and release
