### PR TITLE
Fix CASA image load failure due to FITS header error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed crash when exporting matched region ([#1205](https://github.com/CARTAvis/carta-backend/issues/1205), [#1208](https://github.com/CARTAvis/carta-backend/issues/1208)).
 * Fixed region import with space in region name ([#1188](https://github.com/CARTAvis/carta-backend/issues/1188));
 * Fixed cfitsio 4.2.0 fits_read_key abort ([#1231](https://github.com/CARTAvis/carta-backend/issues/1231));
+* Fixed failure when CASA image properties truncated for FITS headers ([#1239](https://github.com/CARTAvis/carta-backend/issues/1239));
 
 ## [3.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed crash when exporting matched region ([#1205](https://github.com/CARTAvis/carta-backend/issues/1205), [#1208](https://github.com/CARTAvis/carta-backend/issues/1208)).
 * Fixed region import with space in region name ([#1188](https://github.com/CARTAvis/carta-backend/issues/1188));
 * Fixed cfitsio 4.2.0 fits_read_key abort ([#1231](https://github.com/CARTAvis/carta-backend/issues/1231));
-* Fixed failure when CASA image properties truncated for FITS headers ([#1239](https://github.com/CARTAvis/carta-backend/issues/1239));
+* Fixed failure loading CASA image due to FITS headers error ([#1239](https://github.com/CARTAvis/carta-backend/issues/1239));
 
 ## [3.0.0]
 

--- a/src/FileList/FileExtInfoLoader.cc
+++ b/src/FileList/FileExtInfoLoader.cc
@@ -1503,14 +1503,18 @@ bool FileExtInfoLoader::GetFITSHeader(std::shared_ptr<casacore::ImageInterface<f
     GetSpectralCoordPreferences(image.get(), prefer_velocity, optical_velocity, prefer_wavelength, air_wavelength);
 
     casacore::String origin_string;
-    bool stokes_last(false), degenerate_last(false), verbose(false), allow_append(false), history(true);
+    bool stokes_last(false), degenerate_last(false), verbose(true), allow_append(false), history(true);
     bool prim_head(hdu == "0");
     int bit_pix(-32);
     float min_pix(1.0), max_pix(-1.0);
 
-    if (!casacore::ImageFITSConverter::ImageHeaderToFITS(error_string, fhi, *(image.get()), prefer_velocity, optical_velocity, bit_pix,
-            min_pix, max_pix, degenerate_last, verbose, stokes_last, prefer_wavelength, air_wavelength, prim_head, allow_append,
-            origin_string, history)) {
+    bool ok = casacore::ImageFITSConverter::ImageHeaderToFITS(error_string, fhi, *(image.get()), prefer_velocity, optical_velocity, bit_pix,
+        min_pix, max_pix, degenerate_last, verbose, stokes_last, prefer_wavelength, air_wavelength, prim_head, allow_append, origin_string,
+        history);
+
+    // ok can be false when unrecognized keyword or have to shorten keyword/value, but keyword list is still set.
+    // Return false only if no keyword list set.
+    if (!ok && fhi.kw.isempty()) {
         return false;
     }
 


### PR DESCRIPTION
Check if FITS headers were set before showing extended file info failure.  1-line fix with comment to explain.

**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
Fixes #1239.
* How does this PR solve the issue? Give a brief summary.
casacore::ImageFITSConverter::ImageHeaderToFITS returns false even when FITS headers are set, in this case when any keyword/value was shortened to the FITS format limit.  Check if the headers were set before failing to set extended file info.
* Are there any companion PRs (frontend, protobuf)?
No
* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
Example of failing image attached to issue.  It should load now.

**Checklist**

- [x] changelog updated / ~no changelog update needed~
- [ ] e2e test passing / added corresponding fix
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] added reviewers and assignee
- [x] added ZenHub estimate, milestone, and release
