### PR TITLE
Fix reversed PV generation when getting with fixed angular region profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed region import with space in region name ([#1188](https://github.com/CARTAvis/carta-backend/issues/1188));
 * Fixed cfitsio 4.2.0 fits_read_key abort ([#1231](https://github.com/CARTAvis/carta-backend/issues/1231));
 * Fixed failure loading CASA image due to FITS headers error ([#1239](https://github.com/CARTAvis/carta-backend/issues/1239));
+* Fixed incorrect PV image orientation if the cube has projection distortion ([#1244](https://github.com/CARTAvis/carta-backend/issues/1244)).
 
 ## [3.0.0]
 


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
Fixed #1244.
 
* How does this PR solve the issue? Give a brief summary.
Added a handler of reversed option in the `RegionHandler` method `GetFixedAngularRegionProfiles`.

* Are there any companion PRs (frontend, protobuf)?
No.

* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
This will not affect the ICD tests.

**Checklist**

- [x] changelog updated ~/ no changelog update needed~
- [x] e2e test passing / ~added corresponding fix~
- [x] ~protobuf updated to the latest dev commit /~ no protobuf update needed
- [ ] added reviewers and assignee
- [ ] added ZenHub estimate, milestone, and release
