### PR TITLE
changing code coverage badge endpoint to a Github gist URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CARTA Image Viewer (Backend)
 
-![code coverage](https://img.shields.io/endpoint?style=plastic&url=https%3A%2F%2Fcarta.asiaa.sinica.edu.tw%2Fcoverage%2Fpercentage.json)
+![code coverage](https://img.shields.io/endpoint?style=plastic&url=https%3A%2F%2Fgist.githubusercontent.com%2Fajm-asiaa%2Fecad490776d42844903aeebf5e6d2173%2Fraw)
 
 Backend process for simple web-based interface for viewing radio astronomy images in CASA, FITS, MIRIAD, and HDF5 formats (using the IDIA custom schema for HDF5). Unlike the conventional approach of rendering an image on the backend and sending a rendered image to the frontend client, the backend sends a compressed subset of the data, and the frontend renders the image efficiently on the GPU using WebGL and GLSL shaders. While the data is compressed using the lossy ZFP algorithm, the compression artefacts are generally much less noticeable than those cropping up from full-colour JPEG compression. While data sizes depend on compression quality used, sizes are [comparable](https://docs.google.com/spreadsheets/d/1lp1687TL0bYmbM3jGyjuPd9dYZnrAYGnLIQXWVpnmS0/edit?usp=sharing) with sizes of compressed JPEG images with a 95% quality setting, depending on the colour map used to generate the JPEG image. PNG compression is generally a factor of 2 larger than the ZFP compressed data.
 


### PR DESCRIPTION
**Description**

This is a very minor change (1 line modification to the README.md) so I don't think it warrants creating a new issue and linking this PR to it.

The problem is the code coverage badge on the carta-backend's README.md has not been working for quite some time. It displays the following:
![Screenshot 2023-03-15 at 9 50 45 AM](https://user-images.githubusercontent.com/20802551/225183950-5a0da3d2-e475-4bd4-879f-1340282277d6.png)
I'm not sure why it doesn't work. As far as I can see, the endpoint URL json file is fully accessible outside the ASIAA firewall: https://carta.asiaa.sinica.edu.tw/coverage/percentage.json
My only guess is that the ASIAA firewall may be somehow blocking the https://shields.io/ website's access to it.

As a workaround, I have modified our CI system to upload the contents of the percentage.json file to a Github gist (It is using the `gist` command with the -u flag set to the gist URL so it should correctly re-write the same gist each time CI on the 'dev' branch runs). In this PR I change the shields.io badge's JSON endpoint to the gist URL instead. It seems to be working and badge displays the percentage again:
![Screenshot 2023-03-15 at 10 14 45 AM](https://user-images.githubusercontent.com/20802551/225187269-121625ba-dcbf-4c1b-ae53-dcc382e0f902.png)

Alternatively, if you think the badge is not necessary, I'm fine with removing it completely.

**Checklist**

- [x] no changelog update needed
- [x] e2e test passing / added corresponding fix
- [x] no protobuf update needed
- [x] added reviewers and assignee
- [ ] added ZenHub estimate, milestone, and release
