### PR TITLE
Fix unintentional insertion of null pointers into the sessions map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed issues with AIPS velocity axis by restoring previous casacore headers ([#1771](https://github.com/CARTAvis/carta-frontend/issues/1771)).
 * Fixed error in regions when resuming session. ([#1210](https://github.com/CARTAvis/carta-backend/issues/1210)).
 * Fixed crash when exporting matched region ([#1205](https://github.com/CARTAvis/carta-backend/issues/1205), [#1208](https://github.com/CARTAvis/carta-backend/issues/1208)).
-* Fixed region import with space in region name ([#1188](https://github.com/CARTAvis/carta-backend/issues/1188));
-* Fixed cfitsio 4.2.0 fits_read_key abort ([#1231](https://github.com/CARTAvis/carta-backend/issues/1231));
-* Fixed failure loading CASA image due to FITS headers error ([#1239](https://github.com/CARTAvis/carta-backend/issues/1239));
+* Fixed region import with space in region name ([#1188](https://github.com/CARTAvis/carta-backend/issues/1188)).
+* Fixed cfitsio 4.2.0 fits_read_key abort ([#1231](https://github.com/CARTAvis/carta-backend/issues/1231)).
+* Fixed failure loading CASA image due to FITS headers error ([#1239](https://github.com/CARTAvis/carta-backend/issues/1239)).
+* Fixed crash following use of an incorrect session ID ([#1248](https://github.com/CARTAvis/carta-backend/issues/1248)).
 
 ## [3.0.0]
 

--- a/src/Session/SessionManager.cc
+++ b/src/Session/SessionManager.cc
@@ -16,7 +16,7 @@ namespace carta {
 SessionManager::SessionManager(ProgramSettings& settings, std::string auth_token, std::shared_ptr<FileListHandler> file_list_handler)
     : _session_number(0), _app(uWS::App()), _settings(settings), _auth_token(auth_token), _file_list_handler(file_list_handler) {}
 
-Session* SessionManager::findSession(uint32_t session_id) {
+Session* SessionManager::FindSession(uint32_t session_id) {
     std::unique_lock<std::mutex> ulock(_sessions_mutex);
     if (_sessions.count(session_id)) {
         return _sessions[session_id];
@@ -118,7 +118,7 @@ void SessionManager::OnDisconnect(WSType* ws, int code, std::string_view message
     uint32_t session_id = static_cast<PerSocketData*>(ws->getUserData())->session_id;
 
     // Delete the Session
-    auto session = findSession(session_id);
+    auto session = FindSession(session_id);
     if (session) {
         session->DecreaseRefCount();
         DeleteSession(session_id);
@@ -130,7 +130,7 @@ void SessionManager::OnDisconnect(WSType* ws, int code, std::string_view message
 
 void SessionManager::OnDrain(WSType* ws) {
     uint32_t session_id = ws->getUserData()->session_id;
-    Session* session = findSession(session_id);
+    Session* session = FindSession(session_id);
     if (session) {
         spdlog::debug("Draining WebSocket backpressure: client {} [{}]. Remaining buffered amount: {} (bytes).", session->GetId(),
             session->GetAddress(), ws->getBufferedAmount());
@@ -141,7 +141,7 @@ void SessionManager::OnDrain(WSType* ws) {
 
 void SessionManager::OnMessage(WSType* ws, std::string_view sv_message, uWS::OpCode op_code) {
     uint32_t session_id = static_cast<PerSocketData*>(ws->getUserData())->session_id;
-    Session* session = findSession(session_id);
+    Session* session = FindSession(session_id);
     if (!session) {
         spdlog::error("Missing session!");
         return;
@@ -583,7 +583,7 @@ void SessionManager::RunApp() {
 bool SessionManager::SendScriptingRequest(int& session_id, uint32_t& scripting_request_id, std::string& target, std::string& action,
     std::string& parameters, bool& async, std::string& return_path, ScriptingResponseCallback callback,
     ScriptingSessionClosedCallback session_closed_callback) {
-    Session* session = findSession(session_id);
+    Session* session = FindSession(session_id);
     if (!session) {
         return false;
     }
@@ -594,7 +594,7 @@ bool SessionManager::SendScriptingRequest(int& session_id, uint32_t& scripting_r
 }
 
 void SessionManager::OnScriptingAbort(int session_id, uint32_t scripting_request_id) {
-    Session* session = findSession(session_id);
+    Session* session = FindSession(session_id);
     if (!session) {
         return; // Session is gone; nothing to do
     }

--- a/src/Session/SessionManager.cc
+++ b/src/Session/SessionManager.cc
@@ -16,6 +16,14 @@ namespace carta {
 SessionManager::SessionManager(ProgramSettings& settings, std::string auth_token, std::shared_ptr<FileListHandler> file_list_handler)
     : _session_number(0), _app(uWS::App()), _settings(settings), _auth_token(auth_token), _file_list_handler(file_list_handler) {}
 
+Session* SessionManager::findSession(uint32_t session_id) {
+    std::unique_lock<std::mutex> ulock(_sessions_mutex);
+    if (_sessions.count(session_id)) {
+        return _sessions[session_id];
+    }
+    return nullptr;
+}
+
 void SessionManager::DeleteSession(uint32_t session_id) {
     std::unique_lock<std::mutex> ulock(_sessions_mutex);
     if (!_sessions.count(session_id)) {
@@ -91,7 +99,6 @@ void SessionManager::OnConnect(WSType* ws) {
     std::unique_lock<std::mutex> ulock(_sessions_mutex);
     _sessions[session_id] = new Session(ws, loop, session_id, address, _settings.top_level_folder, _settings.starting_folder,
         _file_list_handler, _settings.read_only_mode, _settings.enable_scripting);
-    ulock.unlock();
 
     _sessions[session_id]->IncreaseRefCount();
 
@@ -111,8 +118,9 @@ void SessionManager::OnDisconnect(WSType* ws, int code, std::string_view message
     uint32_t session_id = static_cast<PerSocketData*>(ws->getUserData())->session_id;
 
     // Delete the Session
-    if (_sessions.count(session_id)) {
-        _sessions[session_id]->DecreaseRefCount();
+    auto session = findSession(session_id);
+    if (session) {
+        session->DecreaseRefCount();
         DeleteSession(session_id);
     }
 
@@ -122,7 +130,7 @@ void SessionManager::OnDisconnect(WSType* ws, int code, std::string_view message
 
 void SessionManager::OnDrain(WSType* ws) {
     uint32_t session_id = ws->getUserData()->session_id;
-    Session* session = _sessions[session_id];
+    Session* session = findSession(session_id);
     if (session) {
         spdlog::debug("Draining WebSocket backpressure: client {} [{}]. Remaining buffered amount: {} (bytes).", session->GetId(),
             session->GetAddress(), ws->getBufferedAmount());
@@ -133,7 +141,7 @@ void SessionManager::OnDrain(WSType* ws) {
 
 void SessionManager::OnMessage(WSType* ws, std::string_view sv_message, uWS::OpCode op_code) {
     uint32_t session_id = static_cast<PerSocketData*>(ws->getUserData())->session_id;
-    Session* session = _sessions[session_id];
+    Session* session = findSession(session_id);
     if (!session) {
         spdlog::error("Missing session!");
         return;
@@ -575,7 +583,7 @@ void SessionManager::RunApp() {
 bool SessionManager::SendScriptingRequest(int& session_id, uint32_t& scripting_request_id, std::string& target, std::string& action,
     std::string& parameters, bool& async, std::string& return_path, ScriptingResponseCallback callback,
     ScriptingSessionClosedCallback session_closed_callback) {
-    Session* session = _sessions[session_id];
+    Session* session = findSession(session_id);
     if (!session) {
         return false;
     }
@@ -586,7 +594,7 @@ bool SessionManager::SendScriptingRequest(int& session_id, uint32_t& scripting_r
 }
 
 void SessionManager::OnScriptingAbort(int session_id, uint32_t scripting_request_id) {
-    Session* session = _sessions[session_id];
+    Session* session = findSession(session_id);
     if (!session) {
         return; // Session is gone; nothing to do
     }

--- a/src/Session/SessionManager.h
+++ b/src/Session/SessionManager.h
@@ -42,6 +42,7 @@ private:
     uint32_t _session_number;
     std::unordered_map<uint32_t, Session*> _sessions;
     std::mutex _sessions_mutex;
+    Session* findSession(uint32_t session_id);
     // uWebSockets app
     uWS::App _app;
     // Shared objects

--- a/src/Session/SessionManager.h
+++ b/src/Session/SessionManager.h
@@ -42,7 +42,7 @@ private:
     uint32_t _session_number;
     std::unordered_map<uint32_t, Session*> _sessions;
     std::mutex _sessions_mutex;
-    Session* findSession(uint32_t session_id);
+    Session* FindSession(uint32_t session_id);
     // uWebSockets app
     uWS::App _app;
     // Shared objects

--- a/src/Session/SessionManager.h
+++ b/src/Session/SessionManager.h
@@ -42,7 +42,6 @@ private:
     uint32_t _session_number;
     std::unordered_map<uint32_t, Session*> _sessions;
     std::mutex _sessions_mutex;
-    Session* FindSession(uint32_t session_id);
     // uWebSockets app
     uWS::App _app;
     // Shared objects


### PR DESCRIPTION
**Description**

This fixes #1248.

If a scripting request was made with an invalid session ID,  a null pointer was unintentionally inserted into the session manager's sessions map when the `[]` operator was used to access the map with a key which did not exist. Subsequently when a file was opened, the session manager would attempt to close cached file loaders for that file by iterating over the sessions in the map, and crash when it tried to call a function on the null pointer.

There were a few other places in the session manager code which were using the same logic -- these may never have triggered the issue because they were never called with a key that did not exist, or perhaps because if they ever were (e.g. because the session had already been deleted) if was shortly before shutdown. Nevertheless, I have replaced all of those instances as well -- all remaining instances of `_sessions[session_id]` occur while the session mutex is locked after the key is found in the map.

While I think that this change guarantees that we will never insert a null pointer into the sessions map by mistake, I'm concerned that the code doesn't currently protect against a session pointer being invalidated by the session being deleted from another thread. Fixing this would require a more careful examination of the threading logic to determine where locks (or reference counting) need to be added. I suggest discussing this in a separate issue. This particular bug was not caused by this type of race condition.

There are no companion PRs.

**Checklist**

- [x] changelog updated / no changelog update needed
- [x] e2e test passing / added corresponding fix
- [x] protobuf updated to the latest dev commit / no protobuf update needed
- [x] added reviewers and assignee
- [x] added ZenHub estimate, milestone, and release
