### PR TITLE
Fix empty name variable on RHEL9

### DIFF
--- a/src/Region/CrtfImportExport.cc
+++ b/src/Region/CrtfImportExport.cc
@@ -808,7 +808,7 @@ CARTA::RegionStyle CrtfImportExport::ImportStyleParameters(
     // name
     if (properties.count("label")) {
         auto name = properties["label"];
-        if (name.front() == '"' && name.back() == '"') {
+        if (!name.empty() && name.front() == '"' && name.back() == '"') {
             name = name.substr(1, name.length() - 2);
         }
         region_style.set_name(name);

--- a/src/Region/Ds9ImportExport.cc
+++ b/src/Region/Ds9ImportExport.cc
@@ -893,7 +893,7 @@ CARTA::RegionStyle Ds9ImportExport::ImportStyleParameters(
     // name for most regions, or text for text region
     if (properties.find("text") != properties.end()) {
         auto name = properties["text"];
-        if (name.front() == '{' && name.back() == '}') {
+        if (!name.empty() && name.front() == '{' && name.back() == '}') {
             name = name.substr(1, name.length() - 2);
         }
 

--- a/src/Region/RegionImportExport.cc
+++ b/src/Region/RegionImportExport.cc
@@ -176,7 +176,7 @@ void RegionImportExport::ParseRegionParameters(
             // Item is region_definition between parser delimiters
             std::string item = region_definition.substr(current, next - current);
 
-            if ((item.front() == '"' || item.front() == '\'') && !(item.back() == '"' || item.back() == '\'')) {
+            if (!item.empty() && (item.front() == '"' || item.front() == '\'') && !(item.back() == '"' || item.back() == '\'')) {
                 // find closing quote
                 is_quoted_string = true;
                 current = next;
@@ -201,8 +201,8 @@ void RegionImportExport::ParseRegionParameters(
                 } else {
                     std::string value = kvpair[1];
 
-                    if (value.front() == '"' || value.front() == '\'') {
-                        if (value.back() == '"' || value.back() == '\'') {
+		    if (!value.empty() && (value.front() == '"' || value.front() == '\'')) {
+                        if (!value.empty() && (value.back() == '"' || value.back() == '\'')) {
                             value.pop_back(); // remove closing quote
                         } else {
                             // find closing quote

--- a/src/Region/RegionImportExport.cc
+++ b/src/Region/RegionImportExport.cc
@@ -201,7 +201,7 @@ void RegionImportExport::ParseRegionParameters(
                 } else {
                     std::string value = kvpair[1];
 
-		    if (!value.empty() && (value.front() == '"' || value.front() == '\'')) {
+                    if (!value.empty() && (value.front() == '"' || value.front() == '\'')) {
                         if (!value.empty() && (value.back() == '"' || value.back() == '\'')) {
                             value.pop_back(); // remove closing quote
                         } else {


### PR DESCRIPTION
**Description**

This PR fixes #1250 

It is similar to issue #1199 so I used the same idea to modify line 811 `src/Region/CrtfImportExport.cc` from
```
if (name.front() == '"' && name.back() == '"') {
```
to
```
if (!name.empty() && name.front() == '"' && name.back() == '"') {
```

With this change, the `CASA_REGION_IMPORT_EXPORT` test passes on RHEL9 again.

I notice there are similar lines in `Ds9ImportExport.cc` and `RegionImportExport.cc`, but I have not touched them as there are no other issues with the ICD tests at present. I'm not sure if there could be potential problems in future when the use of the newer GCC (>11.2.1) becomes more common?

**Checklist**

- [x] changelog updated / no changelog update needed
- [x] e2e test passing / added corresponding fix
- [x]  no protobuf update needed
- [ ] added reviewers and assignee
- [ ] added ZenHub estimate, milestone, and release
