### PR TITLE
Mark/829 customize histogram calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added automatically generated documentation with Doxygen ([#1215](https://github.com/CARTAvis/carta-backend/issues/1215)).
 * Added support for loading swapped-axes image cubes ([#1178](https://github.com/CARTAvis/carta-backend/issues/1178)).
 * Added support for annotation regions ([#340](https://github.com/CARTAvis/carta-backend/issues/340)).
+* Added support for customizing histogram calculations ([#829](https://github.com/CARTAvis/carta-backend/issues/829)).
 
 ### Changed
 * Removed CASA CRTF parser for performance and annotation region support ([#1219](https://github.com/CARTAvis/carta-backend/issues/1219)).

--- a/src/Cache/RequirementsCache.h
+++ b/src/Cache/RequirementsCache.h
@@ -67,7 +67,7 @@ struct HistogramConfig {
     bool fixed_num_bins;
     int num_bins;
     bool fixed_bounds;
-    Bounds<float> bounds;
+    HistogramBounds bounds;
 
     HistogramConfig() : coordinate("z"), channel(CURRENT_Z), fixed_num_bins(false), num_bins(AUTO_BIN_SIZE), fixed_bounds(false) {}
 
@@ -77,17 +77,17 @@ struct HistogramConfig {
           fixed_num_bins(config.fixed_num_bins()),
           num_bins(config.num_bins()),
           fixed_bounds(config.fixed_bounds()),
-          bounds(Bounds<float>(config.bounds())) {}
+          bounds(HistogramBounds(config.bounds())) {}
 
     bool operator!=(const HistogramConfig& rhs) const {
         return (coordinate != rhs.coordinate) || (channel != rhs.channel) || (fixed_num_bins != rhs.fixed_num_bins) ||
                (fixed_bounds != rhs.fixed_bounds) || (num_bins != rhs.num_bins) || (bounds != rhs.bounds);
     }
 
-    Bounds<float> GetBounds(const BasicStats<float>& stats) const {
+    HistogramBounds GetBounds(const BasicStats<float>& stats) const {
         float min = fixed_bounds ? bounds.min : stats.min_val;
         float max = fixed_bounds ? bounds.max : stats.max_val;
-        return Bounds<float>(min, max);
+        return HistogramBounds(min, max);
     }
 };
 
@@ -113,7 +113,7 @@ struct HistogramCache {
         stats = stats_;
     }
 
-    bool GetHistogram(int num_bins_, const Bounds<float>& bounds, Histogram& histogram_) {
+    bool GetHistogram(int num_bins_, const HistogramBounds& bounds, Histogram& histogram_) {
         if (histograms.count(num_bins_)) {
             const auto& hist = histograms.at(num_bins_);
             if (bounds == hist.GetBounds()) {

--- a/src/Cache/RequirementsCache.h
+++ b/src/Cache/RequirementsCache.h
@@ -95,6 +95,16 @@ struct HistogramConfig {
     }
 };
 
+struct HistogramBounds {
+    float min;
+    float max;
+
+    HistogramBounds(const HistogramConfig& config, const BasicStats<float>& stats) {
+        min = config.fixed_bounds ? config.min_val : stats.min_val;
+        max = config.fixed_bounds ? config.max_val : stats.max_val;
+    }
+};
+
 struct RegionHistogramConfig {
     std::vector<HistogramConfig> configs;
 };

--- a/src/Cache/RequirementsCache.h
+++ b/src/Cache/RequirementsCache.h
@@ -90,6 +90,12 @@ struct HistogramConfig {
           fixed_bounds(config.fixed_bounds()),
           min_val(config.bounds().min()),
           max_val(config.bounds().max()) {}
+
+    bool operator!=(const HistogramConfig& rhs) const {
+        return (coordinate != rhs.coordinate) || (channel != rhs.channel) || (fixed_num_bins != rhs.fixed_num_bins) ||
+               (fixed_bounds != rhs.fixed_bounds) || (num_bins != rhs.num_bins) || !AreEqual(bin_width, rhs.bin_width) ||
+               !AreEqual(min_val, rhs.min_val) || !AreEqual(max_val, rhs.max_val);
+    }
 };
 
 struct RegionHistogramConfig {

--- a/src/Cache/RequirementsCache.h
+++ b/src/Cache/RequirementsCache.h
@@ -66,7 +66,6 @@ struct HistogramConfig {
     int channel;
     bool fixed_num_bins;
     int num_bins;
-    double bin_width;
     bool fixed_bounds;
     float min_val;
     float max_val;
@@ -76,7 +75,6 @@ struct HistogramConfig {
           channel(CURRENT_Z),
           fixed_num_bins(false),
           num_bins(AUTO_BIN_SIZE),
-          bin_width(0),
           fixed_bounds(false),
           min_val(0),
           max_val(0) {}
@@ -86,15 +84,14 @@ struct HistogramConfig {
           channel(config.channel()),
           fixed_num_bins(config.fixed_num_bins()),
           num_bins(config.num_bins()),
-          bin_width(config.bin_width()),
           fixed_bounds(config.fixed_bounds()),
           min_val(config.bounds().min()),
           max_val(config.bounds().max()) {}
 
     bool operator!=(const HistogramConfig& rhs) const {
         return (coordinate != rhs.coordinate) || (channel != rhs.channel) || (fixed_num_bins != rhs.fixed_num_bins) ||
-               (fixed_bounds != rhs.fixed_bounds) || (num_bins != rhs.num_bins) || !AreEqual(bin_width, rhs.bin_width) ||
-               !AreEqual(min_val, rhs.min_val) || !AreEqual(max_val, rhs.max_val);
+               (fixed_bounds != rhs.fixed_bounds) || (num_bins != rhs.num_bins) || !AreEqual(min_val, rhs.min_val) ||
+               !AreEqual(max_val, rhs.max_val);
     }
 };
 

--- a/src/Cache/RequirementsCache.h
+++ b/src/Cache/RequirementsCache.h
@@ -71,7 +71,7 @@ struct HistogramConfig {
 
     HistogramConfig() : coordinate("z"), channel(CURRENT_Z), num_bins(AUTO_BIN_SIZE), fixed_bounds(false), min_val(0), max_val(0) {}
 
-    HistogramConfig(const CARTA::SetHistogramRequirements_HistogramConfig& config)
+    HistogramConfig(const CARTA::HistogramConfig& config)
         : coordinate(config.coordinate()),
           channel(config.channel()),
           num_bins(config.num_bins()),

--- a/src/Cache/RequirementsCache.h
+++ b/src/Cache/RequirementsCache.h
@@ -64,17 +64,29 @@ struct CacheIdHash {
 struct HistogramConfig {
     std::string coordinate;
     int channel;
+    bool fixed_num_bins;
     int num_bins;
+    double bin_width;
     bool fixed_bounds;
     float min_val;
     float max_val;
 
-    HistogramConfig() : coordinate("z"), channel(CURRENT_Z), num_bins(AUTO_BIN_SIZE), fixed_bounds(false), min_val(0), max_val(0) {}
+    HistogramConfig()
+        : coordinate("z"),
+          channel(CURRENT_Z),
+          fixed_num_bins(false),
+          num_bins(AUTO_BIN_SIZE),
+          bin_width(0),
+          fixed_bounds(false),
+          min_val(0),
+          max_val(0) {}
 
     HistogramConfig(const CARTA::HistogramConfig& config)
         : coordinate(config.coordinate()),
           channel(config.channel()),
+          fixed_num_bins(config.fixed_num_bins()),
           num_bins(config.num_bins()),
+          bin_width(config.bin_width()),
           fixed_bounds(config.fixed_bounds()),
           min_val(config.bounds().min()),
           max_val(config.bounds().max()) {}

--- a/src/Cache/RequirementsCache.h
+++ b/src/Cache/RequirementsCache.h
@@ -67,17 +67,9 @@ struct HistogramConfig {
     bool fixed_num_bins;
     int num_bins;
     bool fixed_bounds;
-    float min_val;
-    float max_val;
+    Bounds<float> bounds;
 
-    HistogramConfig()
-        : coordinate("z"),
-          channel(CURRENT_Z),
-          fixed_num_bins(false),
-          num_bins(AUTO_BIN_SIZE),
-          fixed_bounds(false),
-          min_val(0),
-          max_val(0) {}
+    HistogramConfig() : coordinate("z"), channel(CURRENT_Z), fixed_num_bins(false), num_bins(AUTO_BIN_SIZE), fixed_bounds(false) {}
 
     HistogramConfig(const CARTA::HistogramConfig& config)
         : coordinate(config.coordinate()),
@@ -85,23 +77,17 @@ struct HistogramConfig {
           fixed_num_bins(config.fixed_num_bins()),
           num_bins(config.num_bins()),
           fixed_bounds(config.fixed_bounds()),
-          min_val(config.bounds().min()),
-          max_val(config.bounds().max()) {}
+          bounds(Bounds<float>(config.bounds())) {}
 
     bool operator!=(const HistogramConfig& rhs) const {
         return (coordinate != rhs.coordinate) || (channel != rhs.channel) || (fixed_num_bins != rhs.fixed_num_bins) ||
-               (fixed_bounds != rhs.fixed_bounds) || (num_bins != rhs.num_bins) || !AreEqual(min_val, rhs.min_val) ||
-               !AreEqual(max_val, rhs.max_val);
+               (fixed_bounds != rhs.fixed_bounds) || (num_bins != rhs.num_bins) || (bounds != rhs.bounds);
     }
-};
 
-struct HistogramBounds {
-    float min;
-    float max;
-
-    HistogramBounds(const HistogramConfig& config, const BasicStats<float>& stats) {
-        min = config.fixed_bounds ? config.min_val : stats.min_val;
-        max = config.fixed_bounds ? config.max_val : stats.max_val;
+    Bounds<float> GetBounds(const BasicStats<float>& stats) const {
+        float min = fixed_bounds ? bounds.min : stats.min_val;
+        float max = fixed_bounds ? bounds.max : stats.max_val;
+        return Bounds<float>(min, max);
     }
 };
 
@@ -127,10 +113,10 @@ struct HistogramCache {
         stats = stats_;
     }
 
-    bool GetHistogram(int num_bins_, float min_val, float max_val, Histogram& histogram_) {
+    bool GetHistogram(int num_bins_, const Bounds<float>& bounds, Histogram& histogram_) {
         if (histograms.count(num_bins_)) {
             const auto& hist = histograms.at(num_bins_);
-            if (AreEqual(hist.GetMinVal(), min_val) && AreEqual(hist.GetMaxVal(), max_val)) {
+            if (bounds == hist.GetBounds()) {
                 histogram_ = hist;
                 return true;
             }

--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -683,14 +683,16 @@ bool Frame::SetHistogramRequirements(int region_id, const std::vector<CARTA::His
 
     if (region_id == IMAGE_REGION_ID) {
         _image_histogram_configs.clear();
+        _image_histogram_configs.push_back(HistogramConfig()); // histogram config for image rendering
     } else {
         _cube_histogram_configs.clear();
     }
 
-    for (auto& histogram_config : histogram_configs) {
+    for (const auto& histogram_config : histogram_configs) {
         // set histogram requirements for histogram widgets
         HistogramConfig config(histogram_config);
-        if (region_id == IMAGE_REGION_ID) {
+        if (region_id == IMAGE_REGION_ID && config != _image_histogram_configs[0]) {
+            // only add histogram config for an image which is not the same with the one for image rendering
             _image_histogram_configs.push_back(config);
         } else {
             _cube_histogram_configs.push_back(config);

--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -805,7 +805,7 @@ bool Frame::FillHistogramFromLoaderCache(int z, int stokes, int num_bins, CARTA:
     return false;
 }
 
-bool Frame::FillHistogramFromFrameCache(int z, int stokes, int num_bins, const Bounds<float>& bounds, CARTA::Histogram* histogram) {
+bool Frame::FillHistogramFromFrameCache(int z, int stokes, int num_bins, const HistogramBounds& bounds, CARTA::Histogram* histogram) {
     // Get stats and histogram results from cache; also used for cube histogram
     if (num_bins == AUTO_BIN_SIZE) {
         num_bins = AutoBinSize();
@@ -867,7 +867,7 @@ bool Frame::GetBasicStats(int z, int stokes, BasicStats<float>& stats) {
     return false;
 }
 
-bool Frame::GetCachedImageHistogram(int z, int stokes, int num_bins, const Bounds<float>& bounds, Histogram& hist) {
+bool Frame::GetCachedImageHistogram(int z, int stokes, int num_bins, const HistogramBounds& bounds, Histogram& hist) {
     // Get image histogram results from cache
     int cache_key(CacheKey(z, stokes));
     if (_image_histograms.count(cache_key)) {
@@ -884,7 +884,7 @@ bool Frame::GetCachedImageHistogram(int z, int stokes, int num_bins, const Bound
     return false;
 }
 
-bool Frame::GetCachedCubeHistogram(int stokes, int num_bins, const Bounds<float>& bounds, Histogram& hist) {
+bool Frame::GetCachedCubeHistogram(int stokes, int num_bins, const HistogramBounds& bounds, Histogram& hist) {
     // Get cube histogram results from cache
     if (_cube_histograms.count(stokes)) {
         for (auto& result : _cube_histograms[stokes]) {
@@ -898,7 +898,7 @@ bool Frame::GetCachedCubeHistogram(int stokes, int num_bins, const Bounds<float>
     return false;
 }
 
-bool Frame::CalculateHistogram(int region_id, int z, int stokes, int num_bins, const Bounds<float>& bounds, Histogram& hist) {
+bool Frame::CalculateHistogram(int region_id, int z, int stokes, int num_bins, const HistogramBounds& bounds, Histogram& hist) {
     // Calculate histogram for given parameters, return results
     if ((region_id > IMAGE_REGION_ID) || (region_id < CUBE_REGION_ID)) { // does not handle other regions
         return false;

--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -675,7 +675,7 @@ bool Frame::ContourImage(ContourCallback& partial_contour_callback) {
 // ****************************************************
 // Histogram Requirements and Data
 
-bool Frame::SetHistogramRequirements(int region_id, const std::vector<CARTA::SetHistogramRequirements_HistogramConfig>& histogram_configs) {
+bool Frame::SetHistogramRequirements(int region_id, const std::vector<CARTA::HistogramConfig>& histogram_configs) {
     // Set histogram requirements for image or cube
     if ((region_id > IMAGE_REGION_ID) || (region_id < CUBE_REGION_ID)) { // does not handle other regions
         return false;

--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -734,7 +734,7 @@ bool Frame::FillRegionHistogramData(
         }
 
         // create and fill region histogram data message
-        auto histogram_data = Message::RegionHistogramData(file_id, region_id, z, stokes, 1.0);
+        auto histogram_data = Message::RegionHistogramData(file_id, region_id, z, stokes, 1.0, histogram_config);
         auto* histogram = histogram_data.mutable_histograms();
 
         // Fill histogram submessage from loader cache, if any

--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -691,10 +691,7 @@ bool Frame::SetHistogramRequirements(int region_id, const std::vector<CARTA::Set
 
     for (auto& histogram_config : histogram_configs) {
         // set histogram requirements for histogram widgets
-        HistogramConfig config;
-        config.coordinate = histogram_config.coordinate();
-        config.channel = histogram_config.channel();
-        config.num_bins = histogram_config.num_bins();
+        HistogramConfig config(histogram_config);
         if (region_id == IMAGE_REGION_ID) {
             _image_histogram_configs.push_back(config);
         } else {
@@ -740,10 +737,10 @@ bool Frame::FillRegionHistogramData(
 
         // create and fill region histogram data message
         auto histogram_data = Message::RegionHistogramData(file_id, region_id, z, stokes, 1.0);
-
-        // fill histogram submessage from cache (loader or local)
         auto* histogram = histogram_data.mutable_histograms();
-        bool histogram_filled = FillHistogramFromCache(z, stokes, num_bins, histogram);
+
+        // Fill histogram submessage from loader cache, if any
+        bool histogram_filled = !histogram_config.fixed_bounds && FillHistogramFromLoaderCache(z, stokes, num_bins, histogram);
 
         if (!histogram_filled) {
             // must calculate cube histogram from Session
@@ -754,17 +751,24 @@ bool Frame::FillRegionHistogramData(
             // calculate image histogram
             BasicStats<float> stats;
             if (GetBasicStats(z, stokes, stats)) {
-                Histogram hist;
-                histogram_filled = CalculateHistogram(region_id, z, stokes, num_bins, stats, hist);
-                if (histogram_filled) {
+                // Set histogram bounds
+                float min_val = histogram_config.fixed_bounds ? histogram_config.min_val : stats.min_val;
+                float max_val = histogram_config.fixed_bounds ? histogram_config.max_val : stats.max_val;
+
+                // Fill histogram submessage from Frame cache, if any
+                histogram_filled = FillHistogramFromFrameCache(z, stokes, num_bins, min_val, max_val, histogram);
+
+                if (!histogram_filled) {
+                    Histogram hist;
+                    histogram_filled = CalculateHistogram(region_id, z, stokes, num_bins, min_val, max_val, hist);
                     FillHistogram(histogram, stats, hist);
-                    region_histogram_callback(histogram_data); // send region histogram data message
                 }
             }
 
             if (histogram_filled) {
                 auto dt = t.Elapsed();
                 spdlog::performance("Fill image histogram in {:.3f} ms at {:.3f} MPix/s", dt.ms(), (float)stats.num_pixels / dt.us());
+                region_histogram_callback(histogram_data); // send region histogram data message
             }
         } else {
             region_histogram_callback(histogram_data); // send region histogram data message
@@ -778,15 +782,6 @@ bool Frame::FillRegionHistogramData(
 
 int Frame::AutoBinSize() {
     return int(std::max(sqrt(_width * _height), 2.0));
-}
-
-bool Frame::FillHistogramFromCache(int z, int stokes, int num_bins, CARTA::Histogram* histogram) {
-    // Fill Histogram submessage for given z, stokes, and num_bins
-    bool filled = FillHistogramFromLoaderCache(z, stokes, num_bins, histogram);
-    if (!filled) {
-        filled = FillHistogramFromFrameCache(z, stokes, num_bins, histogram);
-    }
-    return filled;
 }
 
 bool Frame::FillHistogramFromLoaderCache(int z, int stokes, int num_bins, CARTA::Histogram* histogram) {
@@ -811,7 +806,7 @@ bool Frame::FillHistogramFromLoaderCache(int z, int stokes, int num_bins, CARTA:
     return false;
 }
 
-bool Frame::FillHistogramFromFrameCache(int z, int stokes, int num_bins, CARTA::Histogram* histogram) {
+bool Frame::FillHistogramFromFrameCache(int z, int stokes, int num_bins, float min_val, float max_val, CARTA::Histogram* histogram) {
     // Get stats and histogram results from cache; also used for cube histogram
     if (num_bins == AUTO_BIN_SIZE) {
         num_bins = AutoBinSize();
@@ -820,9 +815,9 @@ bool Frame::FillHistogramFromFrameCache(int z, int stokes, int num_bins, CARTA::
     bool have_histogram(false);
     Histogram hist;
     if (z == ALL_Z) {
-        have_histogram = GetCachedCubeHistogram(stokes, num_bins, hist);
+        have_histogram = GetCachedCubeHistogram(stokes, num_bins, min_val, max_val, hist);
     } else {
-        have_histogram = GetCachedImageHistogram(z, stokes, num_bins, hist);
+        have_histogram = GetCachedImageHistogram(z, stokes, num_bins, min_val, max_val, hist);
     }
 
     if (have_histogram) {
@@ -873,7 +868,7 @@ bool Frame::GetBasicStats(int z, int stokes, BasicStats<float>& stats) {
     return false;
 }
 
-bool Frame::GetCachedImageHistogram(int z, int stokes, int num_bins, Histogram& hist) {
+bool Frame::GetCachedImageHistogram(int z, int stokes, int num_bins, int min_val, int max_val, Histogram& hist) {
     // Get image histogram results from cache
     int cache_key(CacheKey(z, stokes));
     if (_image_histograms.count(cache_key)) {
@@ -881,7 +876,7 @@ bool Frame::GetCachedImageHistogram(int z, int stokes, int num_bins, Histogram& 
         auto results_for_key = _image_histograms[cache_key];
 
         for (auto& result : results_for_key) {
-            if (result.GetNbins() == num_bins) {
+            if (result.GetNbins() == num_bins && AreEqual(result.GetMinVal(), min_val) && AreEqual(result.GetMaxVal(), max_val)) {
                 hist = result;
                 return true;
             }
@@ -890,12 +885,12 @@ bool Frame::GetCachedImageHistogram(int z, int stokes, int num_bins, Histogram& 
     return false;
 }
 
-bool Frame::GetCachedCubeHistogram(int stokes, int num_bins, Histogram& hist) {
+bool Frame::GetCachedCubeHistogram(int stokes, int num_bins, int min_val, int max_val, Histogram& hist) {
     // Get cube histogram results from cache
     if (_cube_histograms.count(stokes)) {
         for (auto& result : _cube_histograms[stokes]) {
             // get from cache if correct num_bins
-            if (result.GetNbins() == num_bins) {
+            if (result.GetNbins() == num_bins && AreEqual(result.GetMinVal(), min_val) && AreEqual(result.GetMaxVal(), max_val)) {
                 hist = result;
                 return true;
             }
@@ -904,7 +899,7 @@ bool Frame::GetCachedCubeHistogram(int stokes, int num_bins, Histogram& hist) {
     return false;
 }
 
-bool Frame::CalculateHistogram(int region_id, int z, int stokes, int num_bins, BasicStats<float>& stats, Histogram& hist) {
+bool Frame::CalculateHistogram(int region_id, int z, int stokes, int num_bins, float min_val, float max_val, Histogram& hist) {
     // Calculate histogram for given parameters, return results
     if ((region_id > IMAGE_REGION_ID) || (region_id < CUBE_REGION_ID)) { // does not handle other regions
         return false;
@@ -925,12 +920,12 @@ bool Frame::CalculateHistogram(int region_id, int z, int stokes, int num_bins, B
         }
         bool write_lock(false);
         queuing_rw_mutex_scoped cache_lock(&_cache_mutex, write_lock);
-        hist = CalcHistogram(num_bins, stats, _image_cache.get(), _image_cache_size);
+        hist = CalcHistogram(num_bins, min_val, max_val, _image_cache.get(), _image_cache_size);
     } else {
         // calculate histogram for z/stokes data
         std::vector<float> data;
         GetZMatrix(data, z, stokes);
-        hist = CalcHistogram(num_bins, stats, data.data(), data.size());
+        hist = CalcHistogram(num_bins, min_val, max_val, data.data(), data.size());
     }
 
     // cache image histogram
@@ -2275,11 +2270,7 @@ void Frame::InitImageHistogramConfigs() {
     _image_histogram_configs.clear();
 
     // set histogram requirements for the image
-    HistogramConfig config;
-    config.coordinate = "z"; // current stokes type
-    config.channel = CURRENT_Z;
-    config.num_bins = AUTO_BIN_SIZE;
-    _image_histogram_configs.push_back(config);
+    _image_histogram_configs.push_back(HistogramConfig());
 }
 
 void Frame::CloseCachedImage(const std::string& file) {

--- a/src/Frame/Frame.h
+++ b/src/Frame/Frame.h
@@ -135,7 +135,7 @@ public:
     bool ContourImage(ContourCallback& partial_contour_callback);
 
     // Histograms: image and cube
-    bool SetHistogramRequirements(int region_id, const std::vector<CARTA::SetHistogramRequirements_HistogramConfig>& histogram_configs);
+    bool SetHistogramRequirements(int region_id, const std::vector<CARTA::HistogramConfig>& histogram_configs);
     bool FillRegionHistogramData(
         std::function<void(CARTA::RegionHistogramData histogram_data)> region_histogram_callback, int region_id, int file_id);
     bool GetBasicStats(int z, int stokes, BasicStats<float>& stats);

--- a/src/Frame/Frame.h
+++ b/src/Frame/Frame.h
@@ -139,7 +139,7 @@ public:
     bool FillRegionHistogramData(
         std::function<void(CARTA::RegionHistogramData histogram_data)> region_histogram_callback, int region_id, int file_id);
     bool GetBasicStats(int z, int stokes, BasicStats<float>& stats);
-    bool CalculateHistogram(int region_id, int z, int stokes, int num_bins, const HistogramBounds& bounds, Histogram& hist);
+    bool CalculateHistogram(int region_id, int z, int stokes, int num_bins, const Bounds<float>& bounds, Histogram& hist);
     bool GetCubeHistogramConfig(HistogramConfig& config);
     void CacheCubeStats(int stokes, BasicStats<float>& stats);
     void CacheCubeHistogram(int stokes, Histogram& hist);
@@ -239,9 +239,9 @@ protected:
     int AutoBinSize();
     bool FillHistogramFromLoaderCache(int z, int stokes, int num_bins, CARTA::Histogram* histogram); // histogram message
     bool FillHistogramFromFrameCache(
-        int z, int stokes, int num_bins, const HistogramBounds& bounds, CARTA::Histogram* histogram);              // histogram message
-    bool GetCachedImageHistogram(int z, int stokes, int num_bins, const HistogramBounds& bounds, Histogram& hist); // internal histogram
-    bool GetCachedCubeHistogram(int stokes, int num_bins, const HistogramBounds& bounds, Histogram& hist);         // internal histogram
+        int z, int stokes, int num_bins, const Bounds<float>& bounds, CARTA::Histogram* histogram);              // histogram message
+    bool GetCachedImageHistogram(int z, int stokes, int num_bins, const Bounds<float>& bounds, Histogram& hist); // internal histogram
+    bool GetCachedCubeHistogram(int stokes, int num_bins, const Bounds<float>& bounds, Histogram& hist);         // internal histogram
 
     // Check for cancel
     bool HasSpectralConfig(const SpectralConfig& config);

--- a/src/Frame/Frame.h
+++ b/src/Frame/Frame.h
@@ -139,7 +139,7 @@ public:
     bool FillRegionHistogramData(
         std::function<void(CARTA::RegionHistogramData histogram_data)> region_histogram_callback, int region_id, int file_id);
     bool GetBasicStats(int z, int stokes, BasicStats<float>& stats);
-    bool CalculateHistogram(int region_id, int z, int stokes, int num_bins, const Bounds<float>& bounds, Histogram& hist);
+    bool CalculateHistogram(int region_id, int z, int stokes, int num_bins, const HistogramBounds& bounds, Histogram& hist);
     bool GetCubeHistogramConfig(HistogramConfig& config);
     void CacheCubeStats(int stokes, BasicStats<float>& stats);
     void CacheCubeHistogram(int stokes, Histogram& hist);
@@ -239,9 +239,9 @@ protected:
     int AutoBinSize();
     bool FillHistogramFromLoaderCache(int z, int stokes, int num_bins, CARTA::Histogram* histogram); // histogram message
     bool FillHistogramFromFrameCache(
-        int z, int stokes, int num_bins, const Bounds<float>& bounds, CARTA::Histogram* histogram);              // histogram message
-    bool GetCachedImageHistogram(int z, int stokes, int num_bins, const Bounds<float>& bounds, Histogram& hist); // internal histogram
-    bool GetCachedCubeHistogram(int stokes, int num_bins, const Bounds<float>& bounds, Histogram& hist);         // internal histogram
+        int z, int stokes, int num_bins, const HistogramBounds& bounds, CARTA::Histogram* histogram);              // histogram message
+    bool GetCachedImageHistogram(int z, int stokes, int num_bins, const HistogramBounds& bounds, Histogram& hist); // internal histogram
+    bool GetCachedCubeHistogram(int stokes, int num_bins, const HistogramBounds& bounds, Histogram& hist);         // internal histogram
 
     // Check for cancel
     bool HasSpectralConfig(const SpectralConfig& config);

--- a/src/Frame/Frame.h
+++ b/src/Frame/Frame.h
@@ -139,7 +139,7 @@ public:
     bool FillRegionHistogramData(
         std::function<void(CARTA::RegionHistogramData histogram_data)> region_histogram_callback, int region_id, int file_id);
     bool GetBasicStats(int z, int stokes, BasicStats<float>& stats);
-    bool CalculateHistogram(int region_id, int z, int stokes, int num_bins, BasicStats<float>& stats, Histogram& hist);
+    bool CalculateHistogram(int region_id, int z, int stokes, int num_bins, float min_val, float max_val, Histogram& hist);
     bool GetCubeHistogramConfig(HistogramConfig& config);
     void CacheCubeStats(int stokes, BasicStats<float>& stats);
     void CacheCubeHistogram(int stokes, Histogram& hist);
@@ -237,11 +237,11 @@ protected:
 
     // Histograms: z is single z index or ALL_Z for cube
     int AutoBinSize();
-    bool FillHistogramFromCache(int z, int stokes, int num_bins, CARTA::Histogram* histogram);       // histogram message
     bool FillHistogramFromLoaderCache(int z, int stokes, int num_bins, CARTA::Histogram* histogram); // histogram message
-    bool FillHistogramFromFrameCache(int z, int stokes, int num_bins, CARTA::Histogram* histogram);  // histogram message
-    bool GetCachedImageHistogram(int z, int stokes, int num_bins, Histogram& hist);                  // internal histogram
-    bool GetCachedCubeHistogram(int stokes, int num_bins, Histogram& hist);                          // internal histogram
+    bool FillHistogramFromFrameCache(
+        int z, int stokes, int num_bins, float min_val, float max_val, CARTA::Histogram* histogram);          // histogram message
+    bool GetCachedImageHistogram(int z, int stokes, int num_bins, int min_val, int max_val, Histogram& hist); // internal histogram
+    bool GetCachedCubeHistogram(int stokes, int num_bins, int min_val, int max_val, Histogram& hist);         // internal histogram
 
     // Check for cancel
     bool HasSpectralConfig(const SpectralConfig& config);

--- a/src/Frame/Frame.h
+++ b/src/Frame/Frame.h
@@ -139,7 +139,7 @@ public:
     bool FillRegionHistogramData(
         std::function<void(CARTA::RegionHistogramData histogram_data)> region_histogram_callback, int region_id, int file_id);
     bool GetBasicStats(int z, int stokes, BasicStats<float>& stats);
-    bool CalculateHistogram(int region_id, int z, int stokes, int num_bins, float min_val, float max_val, Histogram& hist);
+    bool CalculateHistogram(int region_id, int z, int stokes, int num_bins, const HistogramBounds& bounds, Histogram& hist);
     bool GetCubeHistogramConfig(HistogramConfig& config);
     void CacheCubeStats(int stokes, BasicStats<float>& stats);
     void CacheCubeHistogram(int stokes, Histogram& hist);
@@ -239,9 +239,9 @@ protected:
     int AutoBinSize();
     bool FillHistogramFromLoaderCache(int z, int stokes, int num_bins, CARTA::Histogram* histogram); // histogram message
     bool FillHistogramFromFrameCache(
-        int z, int stokes, int num_bins, float min_val, float max_val, CARTA::Histogram* histogram);          // histogram message
-    bool GetCachedImageHistogram(int z, int stokes, int num_bins, int min_val, int max_val, Histogram& hist); // internal histogram
-    bool GetCachedCubeHistogram(int stokes, int num_bins, int min_val, int max_val, Histogram& hist);         // internal histogram
+        int z, int stokes, int num_bins, const HistogramBounds& bounds, CARTA::Histogram* histogram);              // histogram message
+    bool GetCachedImageHistogram(int z, int stokes, int num_bins, const HistogramBounds& bounds, Histogram& hist); // internal histogram
+    bool GetCachedCubeHistogram(int stokes, int num_bins, const HistogramBounds& bounds, Histogram& hist);         // internal histogram
 
     // Check for cancel
     bool HasSpectralConfig(const SpectralConfig& config);

--- a/src/ImageStats/BasicStatsCalculator.h
+++ b/src/ImageStats/BasicStatsCalculator.h
@@ -29,8 +29,10 @@ struct Bounds {
         return fabs(num1 - num2) <= std::numeric_limits<T>::epsilon();
     }
 
+    // U is the type of statistics value. When a statistics value is not available, they are assigned to the extreme value of such type
+    template <typename U>
     bool Invalid() const {
-        return min == std::numeric_limits<T>::max() || max == std::numeric_limits<T>::min();
+        return min == std::numeric_limits<U>::max() || max == std::numeric_limits<U>::lowest();
     }
 
     bool operator==(const Bounds<T>& rhs) const {

--- a/src/ImageStats/BasicStatsCalculator.h
+++ b/src/ImageStats/BasicStatsCalculator.h
@@ -29,7 +29,7 @@ struct Bounds {
         return fabs(num1 - num2) <= std::numeric_limits<T>::epsilon();
     }
 
-    // U is the type of statistics value. When a statistics value is not available, they are assigned to the extreme value of such type
+    // U is the type of statistics values. When statistics values are unavailable, they are assigned to extreme values of U type
     template <typename U>
     bool Invalid() const {
         return min == std::numeric_limits<U>::max() || max == std::numeric_limits<U>::lowest();

--- a/src/ImageStats/BasicStatsCalculator.h
+++ b/src/ImageStats/BasicStatsCalculator.h
@@ -32,7 +32,7 @@ struct Bounds {
     // U is the type of statistics values. When statistics values are unavailable, they are assigned to extreme values of U type
     template <typename U>
     bool Invalid() const {
-        return min == std::numeric_limits<U>::max() || max == std::numeric_limits<U>::lowest();
+        return min == std::numeric_limits<U>::max() || max == std::numeric_limits<U>::lowest() || min >= max;
     }
 
     bool operator==(const Bounds<T>& rhs) const {

--- a/src/ImageStats/BasicStatsCalculator.h
+++ b/src/ImageStats/BasicStatsCalculator.h
@@ -8,6 +8,7 @@
 #define CARTA_BACKEND_IMAGESTATS_BASICSTATSCALCULATOR_H_
 
 #include <algorithm>
+#include <cmath>
 
 #include <carta-protobuf/defs.pb.h>
 

--- a/src/ImageStats/BasicStatsCalculator.h
+++ b/src/ImageStats/BasicStatsCalculator.h
@@ -23,7 +23,7 @@ struct Bounds {
 
     Bounds<T>(T min_, T max_) : min(min_), max(max_) {}
 
-    Bounds<T>(const CARTA::FloatBounds& bounds) : min(bounds.min()), max(bounds.max()) {}
+    Bounds<T>(const CARTA::DoubleBounds& bounds) : min(bounds.min()), max(bounds.max()) {}
 
     bool Equal(T num1, T num2) const {
         return fabs(num1 - num2) <= std::numeric_limits<T>::epsilon();

--- a/src/ImageStats/BasicStatsCalculator.h
+++ b/src/ImageStats/BasicStatsCalculator.h
@@ -9,7 +9,37 @@
 
 #include <algorithm>
 
+#include <carta-protobuf/defs.pb.h>
+
 namespace carta {
+
+template <typename T>
+struct Bounds {
+    T min;
+    T max;
+
+    Bounds<T>() : min(0), max(0) {}
+
+    Bounds<T>(T min_, T max_) : min(min_), max(max_) {}
+
+    Bounds<T>(const CARTA::FloatBounds& bounds) : min(bounds.min()), max(bounds.max()) {}
+
+    bool Equal(T num1, T num2) const {
+        return fabs(num1 - num2) <= std::numeric_limits<T>::epsilon();
+    }
+
+    bool Invalid() const {
+        return min == std::numeric_limits<T>::max() || max == std::numeric_limits<T>::min();
+    }
+
+    bool operator==(const Bounds<T>& rhs) const {
+        return Equal(min, rhs.min) && Equal(max, rhs.max);
+    }
+
+    bool operator!=(const Bounds<T>& rhs) const {
+        return !Equal(min, rhs.min) || !Equal(max, rhs.max);
+    }
+};
 
 template <typename T>
 struct BasicStats {

--- a/src/ImageStats/Histogram.cc
+++ b/src/ImageStats/Histogram.cc
@@ -15,11 +15,11 @@
 
 using namespace carta;
 
-Histogram::Histogram(int num_bins, float min_value, float max_value, const float* data, const size_t data_size)
-    : _bin_width((max_value - min_value) / num_bins),
-      _min_val(min_value),
-      _max_val(max_value),
-      _bin_center(min_value + (_bin_width * 0.5)),
+Histogram::Histogram(int num_bins, const Bounds<float>& bounds, const float* data, const size_t data_size)
+    : _bin_width((bounds.max - bounds.min) / num_bins),
+      _min_val(bounds.min),
+      _max_val(bounds.max),
+      _bin_center(bounds.min + (_bin_width * 0.5)),
       _histogram_bins(num_bins, 0) {
     Fill(data, data_size);
 }
@@ -78,12 +78,8 @@ bool Histogram::ConsistencyCheck(const Histogram& a, const Histogram& b) {
         spdlog::warn("Histograms don't have the same number of bins: {} and {}", a.GetNbins(), b.GetNbins());
         return false;
     }
-    if (fabs(a.GetMinVal() - b.GetMinVal()) > std::numeric_limits<float>::epsilon()) {
-        spdlog::warn("Lower histogram limits are not equal: {} and {}", a.GetMinVal(), b.GetMinVal());
-        return false;
-    }
-    if (fabs(a.GetMaxVal() - b.GetMaxVal()) > std::numeric_limits<float>::epsilon()) {
-        spdlog::warn("Upper histogram limits are not equal: {} and {}", a.GetMaxVal(), b.GetMaxVal());
+    if (a.GetBounds() != b.GetBounds()) {
+        spdlog::warn("Histogram bounds are not equal: [{}, {}] and [{}, {}]", a.GetMinVal(), a.GetMaxVal(), b.GetMinVal(), b.GetMaxVal());
         return false;
     }
     return true;

--- a/src/ImageStats/Histogram.cc
+++ b/src/ImageStats/Histogram.cc
@@ -15,7 +15,7 @@
 
 using namespace carta;
 
-Histogram::Histogram(int num_bins, const Bounds<float>& bounds, const float* data, const size_t data_size)
+Histogram::Histogram(int num_bins, const HistogramBounds& bounds, const float* data, const size_t data_size)
     : _bin_width((bounds.max - bounds.min) / num_bins),
       _min_val(bounds.min),
       _max_val(bounds.max),

--- a/src/ImageStats/Histogram.h
+++ b/src/ImageStats/Histogram.h
@@ -7,6 +7,8 @@
 #ifndef CARTA_BACKEND_IMAGESTATS_HISTOGRAM_H_
 #define CARTA_BACKEND_IMAGESTATS_HISTOGRAM_H_
 
+#include "BasicStatsCalculator.h"
+
 #include <cstddef>
 #include <vector>
 
@@ -24,7 +26,7 @@ class Histogram {
 
 public:
     Histogram() = default; // required to create empty histograms used in references
-    Histogram(int num_bins, float min_value, float max_value, const float* data, const size_t data_size);
+    Histogram(int num_bins, const Bounds<float>& bounds, const float* data, const size_t data_size);
 
     Histogram(const Histogram& h);
 
@@ -35,6 +37,9 @@ public:
     }
     float GetMaxVal() const {
         return _max_val;
+    }
+    Bounds<float> GetBounds() const {
+        return Bounds<float>(_min_val, _max_val);
     }
     size_t GetNbins() const {
         return _histogram_bins.size();

--- a/src/ImageStats/Histogram.h
+++ b/src/ImageStats/Histogram.h
@@ -14,7 +14,7 @@
 
 namespace carta {
 
-using HistogramBounds = Bounds<float>;
+using HistogramBounds = Bounds<double>;
 
 class Histogram {
     float _min_val;                   // lower bound of the histogram (inclusive)

--- a/src/ImageStats/Histogram.h
+++ b/src/ImageStats/Histogram.h
@@ -14,6 +14,8 @@
 
 namespace carta {
 
+using HistogramBounds = Bounds<float>;
+
 class Histogram {
     float _min_val;                   // lower bound of the histogram (inclusive)
     float _max_val;                   // upper bound of the histogram (inclusive)
@@ -26,7 +28,7 @@ class Histogram {
 
 public:
     Histogram() = default; // required to create empty histograms used in references
-    Histogram(int num_bins, const Bounds<float>& bounds, const float* data, const size_t data_size);
+    Histogram(int num_bins, const HistogramBounds& bounds, const float* data, const size_t data_size);
 
     Histogram(const Histogram& h);
 
@@ -38,8 +40,8 @@ public:
     float GetMaxVal() const {
         return _max_val;
     }
-    Bounds<float> GetBounds() const {
-        return Bounds<float>(_min_val, _max_val);
+    HistogramBounds GetBounds() const {
+        return HistogramBounds(_min_val, _max_val);
     }
     size_t GetNbins() const {
         return _histogram_bins.size();

--- a/src/ImageStats/StatsCalculator.cc
+++ b/src/ImageStats/StatsCalculator.cc
@@ -23,10 +23,10 @@ void CalcBasicStats(BasicStats<float>& stats, const float* data, const size_t da
     stats = mm.GetStats();
 }
 
-Histogram CalcHistogram(int num_bins, const Bounds<float>& bounds, const float* data, const size_t data_size) {
+Histogram CalcHistogram(int num_bins, const HistogramBounds& bounds, const float* data, const size_t data_size) {
     if (bounds.Invalid() || data_size == 0) {
         // empty / NaN region
-        return Histogram(1, Bounds<float>(0, 0), data, data_size);
+        return Histogram(1, HistogramBounds(0, 0), data, data_size);
     }
     return Histogram(num_bins, bounds, data, data_size);
 }

--- a/src/ImageStats/StatsCalculator.cc
+++ b/src/ImageStats/StatsCalculator.cc
@@ -23,13 +23,12 @@ void CalcBasicStats(BasicStats<float>& stats, const float* data, const size_t da
     stats = mm.GetStats();
 }
 
-Histogram CalcHistogram(int num_bins, const BasicStats<float>& stats, const float* data, const size_t data_size) {
-    if ((stats.min_val == std::numeric_limits<float>::max()) || (stats.max_val == std::numeric_limits<float>::min()) || data_size == 0) {
+Histogram CalcHistogram(int num_bins, float min_val, float max_val, const float* data, const size_t data_size) {
+    if ((min_val == std::numeric_limits<float>::max()) || (max_val == std::numeric_limits<float>::min()) || data_size == 0) {
         // empty / NaN region
         return Histogram(1, 0, 0, data, data_size);
-    } else {
-        return Histogram(num_bins, stats.min_val, stats.max_val, data, data_size);
     }
+    return Histogram(num_bins, min_val, max_val, data, data_size);
 }
 
 bool CalcStatsValues(std::map<CARTA::StatsType, std::vector<double>>& stats_values, const std::vector<CARTA::StatsType>& requested_stats,

--- a/src/ImageStats/StatsCalculator.cc
+++ b/src/ImageStats/StatsCalculator.cc
@@ -23,12 +23,12 @@ void CalcBasicStats(BasicStats<float>& stats, const float* data, const size_t da
     stats = mm.GetStats();
 }
 
-Histogram CalcHistogram(int num_bins, const HistogramBounds& bounds, const float* data, const size_t data_size) {
-    if ((bounds.min == std::numeric_limits<float>::max()) || (bounds.max == std::numeric_limits<float>::min()) || data_size == 0) {
+Histogram CalcHistogram(int num_bins, const Bounds<float>& bounds, const float* data, const size_t data_size) {
+    if (bounds.Invalid() || data_size == 0) {
         // empty / NaN region
-        return Histogram(1, 0, 0, data, data_size);
+        return Histogram(1, Bounds<float>(0, 0), data, data_size);
     }
-    return Histogram(num_bins, bounds.min, bounds.max, data, data_size);
+    return Histogram(num_bins, bounds, data, data_size);
 }
 
 bool CalcStatsValues(std::map<CARTA::StatsType, std::vector<double>>& stats_values, const std::vector<CARTA::StatsType>& requested_stats,

--- a/src/ImageStats/StatsCalculator.cc
+++ b/src/ImageStats/StatsCalculator.cc
@@ -23,12 +23,12 @@ void CalcBasicStats(BasicStats<float>& stats, const float* data, const size_t da
     stats = mm.GetStats();
 }
 
-Histogram CalcHistogram(int num_bins, float min_val, float max_val, const float* data, const size_t data_size) {
-    if ((min_val == std::numeric_limits<float>::max()) || (max_val == std::numeric_limits<float>::min()) || data_size == 0) {
+Histogram CalcHistogram(int num_bins, const HistogramBounds& bounds, const float* data, const size_t data_size) {
+    if ((bounds.min == std::numeric_limits<float>::max()) || (bounds.max == std::numeric_limits<float>::min()) || data_size == 0) {
         // empty / NaN region
         return Histogram(1, 0, 0, data, data_size);
     }
-    return Histogram(num_bins, min_val, max_val, data, data_size);
+    return Histogram(num_bins, bounds.min, bounds.max, data, data_size);
 }
 
 bool CalcStatsValues(std::map<CARTA::StatsType, std::vector<double>>& stats_values, const std::vector<CARTA::StatsType>& requested_stats,

--- a/src/ImageStats/StatsCalculator.cc
+++ b/src/ImageStats/StatsCalculator.cc
@@ -24,7 +24,7 @@ void CalcBasicStats(BasicStats<float>& stats, const float* data, const size_t da
 }
 
 Histogram CalcHistogram(int num_bins, const HistogramBounds& bounds, const float* data, const size_t data_size) {
-    if (bounds.Invalid() || data_size == 0) {
+    if (bounds.Invalid<float>() || data_size == 0) {
         // empty / NaN region
         return Histogram(1, HistogramBounds(0, 0), data, data_size);
     }

--- a/src/ImageStats/StatsCalculator.h
+++ b/src/ImageStats/StatsCalculator.h
@@ -21,7 +21,7 @@ namespace carta {
 
 void CalcBasicStats(BasicStats<float>& stats, const float* data, const size_t data_size);
 
-Histogram CalcHistogram(int num_bins, const BasicStats<float>& stats, const float* data, const size_t data_size);
+Histogram CalcHistogram(int num_bins, float min_val, float max_val, const float* data, const size_t data_size);
 
 bool CalcStatsValues(std::map<CARTA::StatsType, std::vector<double>>& stats_values, const std::vector<CARTA::StatsType>& requested_stats,
     const casacore::ImageInterface<float>& image, bool per_channel = true);

--- a/src/ImageStats/StatsCalculator.h
+++ b/src/ImageStats/StatsCalculator.h
@@ -15,13 +15,14 @@
 
 #include <carta-protobuf/enums.pb.h>
 #include "BasicStatsCalculator.h"
+#include "Cache/RequirementsCache.h"
 #include "Histogram.h"
 
 namespace carta {
 
 void CalcBasicStats(BasicStats<float>& stats, const float* data, const size_t data_size);
 
-Histogram CalcHistogram(int num_bins, float min_val, float max_val, const float* data, const size_t data_size);
+Histogram CalcHistogram(int num_bins, const HistogramBounds& bounds, const float* data, const size_t data_size);
 
 bool CalcStatsValues(std::map<CARTA::StatsType, std::vector<double>>& stats_values, const std::vector<CARTA::StatsType>& requested_stats,
     const casacore::ImageInterface<float>& image, bool per_channel = true);

--- a/src/ImageStats/StatsCalculator.h
+++ b/src/ImageStats/StatsCalculator.h
@@ -21,7 +21,7 @@ namespace carta {
 
 void CalcBasicStats(BasicStats<float>& stats, const float* data, const size_t data_size);
 
-Histogram CalcHistogram(int num_bins, const Bounds<float>& bounds, const float* data, const size_t data_size);
+Histogram CalcHistogram(int num_bins, const HistogramBounds& bounds, const float* data, const size_t data_size);
 
 bool CalcStatsValues(std::map<CARTA::StatsType, std::vector<double>>& stats_values, const std::vector<CARTA::StatsType>& requested_stats,
     const casacore::ImageInterface<float>& image, bool per_channel = true);

--- a/src/ImageStats/StatsCalculator.h
+++ b/src/ImageStats/StatsCalculator.h
@@ -16,13 +16,12 @@
 #include <carta-protobuf/enums.pb.h>
 #include "BasicStatsCalculator.h"
 #include "Cache/RequirementsCache.h"
-#include "Histogram.h"
 
 namespace carta {
 
 void CalcBasicStats(BasicStats<float>& stats, const float* data, const size_t data_size);
 
-Histogram CalcHistogram(int num_bins, const HistogramBounds& bounds, const float* data, const size_t data_size);
+Histogram CalcHistogram(int num_bins, const Bounds<float>& bounds, const float* data, const size_t data_size);
 
 bool CalcStatsValues(std::map<CARTA::StatsType, std::vector<double>>& stats_values, const std::vector<CARTA::StatsType>& requested_stats,
     const casacore::ImageInterface<float>& image, bool per_channel = true);

--- a/src/Region/RegionHandler.cc
+++ b/src/Region/RegionHandler.cc
@@ -1158,7 +1158,7 @@ bool RegionHandler::GetRegionHistogramData(
         }
 
         // Set histogram fields
-        auto histogram_message = Message::RegionHistogramData(file_id, region_id, z, stokes, 1.0);
+        auto histogram_message = Message::RegionHistogramData(file_id, region_id, z, stokes, 1.0, hist_config);
 
         // Get image region
         if (!ApplyRegionToFile(region_id, file_id, z_range, stokes, stokes_region, lc_region)) {

--- a/src/Region/RegionHandler.cc
+++ b/src/Region/RegionHandler.cc
@@ -1124,7 +1124,7 @@ bool RegionHandler::FillRegionHistogramData(
 }
 
 bool RegionHandler::GetRegionHistogramData(
-    int region_id, int file_id, const std::vector<HistogramConfig>& configs, std::vector<CARTA::RegionHistogramData>& histogram_messages) {
+    int region_id, int file_id, std::vector<HistogramConfig>& configs, std::vector<CARTA::RegionHistogramData>& histogram_messages) {
     // Fill stats message for given region, file
     Timer t;
 
@@ -1184,9 +1184,9 @@ bool RegionHandler::GetRegionHistogramData(
             have_basic_stats = _histogram_cache[cache_id].GetBasicStats(stats);
             if (have_basic_stats) {
                 // Set histogram bounds
-                HistogramBounds bounds(hist_config, stats);
+                auto bounds = hist_config.GetBounds(stats);
                 Histogram hist;
-                if (_histogram_cache[cache_id].GetHistogram(num_bins, bounds.min, bounds.max, hist)) {
+                if (_histogram_cache[cache_id].GetHistogram(num_bins, bounds, hist)) {
                     auto* histogram = histogram_message.mutable_histograms();
                     FillHistogram(histogram, stats, hist);
 
@@ -1214,7 +1214,7 @@ bool RegionHandler::GetRegionHistogramData(
         }
 
         // Set histogram bounds
-        HistogramBounds bounds(hist_config, stats);
+        Bounds bounds = hist_config.GetBounds(stats);
 
         // Calculate and cache histogram for number of bins
         Histogram histo = CalcHistogram(num_bins, bounds, data[stokes].data(), data[stokes].size());

--- a/src/Region/RegionHandler.cc
+++ b/src/Region/RegionHandler.cc
@@ -342,7 +342,7 @@ void RegionHandler::RemoveFrame(int file_id) {
 // Region requirements handling
 
 bool RegionHandler::SetHistogramRequirements(
-    int region_id, int file_id, std::shared_ptr<Frame> frame, const std::vector<CARTA::SetHistogramRequirements_HistogramConfig>& configs) {
+    int region_id, int file_id, std::shared_ptr<Frame> frame, const std::vector<CARTA::HistogramConfig>& configs) {
     // Set histogram requirements for closed region
 
     if (configs.empty() && !RegionSet(region_id)) {

--- a/src/Region/RegionHandler.cc
+++ b/src/Region/RegionHandler.cc
@@ -1184,11 +1184,9 @@ bool RegionHandler::GetRegionHistogramData(
             have_basic_stats = _histogram_cache[cache_id].GetBasicStats(stats);
             if (have_basic_stats) {
                 // Set histogram bounds
-                float min_val = hist_config.fixed_bounds ? hist_config.min_val : stats.min_val;
-                float max_val = hist_config.fixed_bounds ? hist_config.max_val : stats.max_val;
-
+                HistogramBounds bounds(hist_config, stats);
                 Histogram hist;
-                if (_histogram_cache[cache_id].GetHistogram(num_bins, min_val, max_val, hist)) {
+                if (_histogram_cache[cache_id].GetHistogram(num_bins, bounds.min, bounds.max, hist)) {
                     auto* histogram = histogram_message.mutable_histograms();
                     FillHistogram(histogram, stats, hist);
 
@@ -1216,11 +1214,10 @@ bool RegionHandler::GetRegionHistogramData(
         }
 
         // Set histogram bounds
-        float min_val = hist_config.fixed_bounds ? hist_config.min_val : stats.min_val;
-        float max_val = hist_config.fixed_bounds ? hist_config.max_val : stats.max_val;
+        HistogramBounds bounds(hist_config, stats);
 
         // Calculate and cache histogram for number of bins
-        Histogram histo = CalcHistogram(num_bins, min_val, max_val, data[stokes].data(), data[stokes].size());
+        Histogram histo = CalcHistogram(num_bins, bounds, data[stokes].data(), data[stokes].size());
         _histogram_cache[cache_id].SetHistogram(num_bins, histo);
 
         // Complete Histogram submessage

--- a/src/Region/RegionHandler.h
+++ b/src/Region/RegionHandler.h
@@ -115,8 +115,8 @@ private:
         std::shared_ptr<casacore::LCRegion> region_2D);
 
     // Data stream helpers
-    bool GetRegionHistogramData(int region_id, int file_id, const std::vector<HistogramConfig>& configs,
-        std::vector<CARTA::RegionHistogramData>& histogram_messages);
+    bool GetRegionHistogramData(
+        int region_id, int file_id, std::vector<HistogramConfig>& configs, std::vector<CARTA::RegionHistogramData>& histogram_messages);
     bool GetRegionSpectralData(int region_id, int file_id, const AxisRange& z_range, std::string& coordinate, int stokes_index,
         std::vector<CARTA::StatsType>& required_stats, bool report_error,
         const std::function<void(std::map<CARTA::StatsType, std::vector<double>>, float)>& partial_results_callback);

--- a/src/Region/RegionHandler.h
+++ b/src/Region/RegionHandler.h
@@ -47,8 +47,8 @@ public:
     void RemoveFrame(int file_id);
 
     // Requirements
-    bool SetHistogramRequirements(int region_id, int file_id, std::shared_ptr<Frame> frame,
-        const std::vector<CARTA::SetHistogramRequirements_HistogramConfig>& configs);
+    bool SetHistogramRequirements(
+        int region_id, int file_id, std::shared_ptr<Frame> frame, const std::vector<CARTA::HistogramConfig>& configs);
     bool SetSpatialRequirements(int region_id, int file_id, std::shared_ptr<Frame> frame,
         const std::vector<CARTA::SetSpatialRequirements_SpatialConfig>& spatial_profiles);
     bool SetSpectralRequirements(int region_id, int file_id, std::shared_ptr<Frame> frame,

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -1464,6 +1464,10 @@ bool Session::CalculateCubeHistogram(int file_id, CARTA::RegionHistogramData& cu
                 }
             }
 
+            // Set histogram bounds
+            float min_val = cube_histogram_config.fixed_bounds ? cube_histogram_config.min_val : cube_stats.min_val;
+            float max_val = cube_histogram_config.fixed_bounds ? cube_histogram_config.max_val : cube_stats.max_val;
+
             // check cancel and proceed
             if (!_histogram_context.is_group_execution_cancelled()) {
                 _frames.at(file_id)->CacheCubeStats(stokes, cube_stats);
@@ -1478,7 +1482,7 @@ bool Session::CalculateCubeHistogram(int file_id, CARTA::RegionHistogramData& cu
                 Histogram z_histogram; // histogram for each z using cube stats
                 Histogram cube_histogram;
                 for (size_t z = 0; z < depth; ++z) {
-                    if (!_frames.at(file_id)->CalculateHistogram(CUBE_REGION_ID, z, stokes, num_bins, cube_stats, z_histogram)) {
+                    if (!_frames.at(file_id)->CalculateHistogram(CUBE_REGION_ID, z, stokes, num_bins, min_val, max_val, z_histogram)) {
                         return calculated; // z histogram failed
                     }
 

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -1465,7 +1465,7 @@ bool Session::CalculateCubeHistogram(int file_id, CARTA::RegionHistogramData& cu
             }
 
             // Set histogram bounds
-            HistogramBounds bounds(cube_histogram_config, cube_stats);
+            auto bounds = cube_histogram_config.GetBounds(cube_stats);
 
             // check cancel and proceed
             if (!_histogram_context.is_group_execution_cancelled()) {

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -1465,8 +1465,7 @@ bool Session::CalculateCubeHistogram(int file_id, CARTA::RegionHistogramData& cu
             }
 
             // Set histogram bounds
-            float min_val = cube_histogram_config.fixed_bounds ? cube_histogram_config.min_val : cube_stats.min_val;
-            float max_val = cube_histogram_config.fixed_bounds ? cube_histogram_config.max_val : cube_stats.max_val;
+            HistogramBounds bounds(cube_histogram_config, cube_stats);
 
             // check cancel and proceed
             if (!_histogram_context.is_group_execution_cancelled()) {
@@ -1483,7 +1482,7 @@ bool Session::CalculateCubeHistogram(int file_id, CARTA::RegionHistogramData& cu
                 Histogram z_histogram; // histogram for each z using cube stats
                 Histogram cube_histogram;
                 for (size_t z = 0; z < depth; ++z) {
-                    if (!_frames.at(file_id)->CalculateHistogram(CUBE_REGION_ID, z, stokes, num_bins, min_val, max_val, z_histogram)) {
+                    if (!_frames.at(file_id)->CalculateHistogram(CUBE_REGION_ID, z, stokes, num_bins, bounds, z_histogram)) {
                         return calculated; // z histogram failed
                     }
 

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -1456,7 +1456,8 @@ bool Session::CalculateCubeHistogram(int file_id, CARTA::RegionHistogramData& cu
                     // send progress
                     float this_z(z);
                     _histogram_progress = this_z / total_z;
-                    auto progress_msg = Message::RegionHistogramData(file_id, CUBE_REGION_ID, ALL_Z, stokes, _histogram_progress);
+                    auto progress_msg =
+                        Message::RegionHistogramData(file_id, CUBE_REGION_ID, ALL_Z, stokes, _histogram_progress, cube_histogram_config);
                     auto* message_histogram = progress_msg.mutable_histograms();
                     SendFileEvent(file_id, CARTA::EventType::REGION_HISTOGRAM_DATA, request_id, progress_msg);
                     t_start = t_end;
@@ -1473,7 +1474,8 @@ bool Session::CalculateCubeHistogram(int file_id, CARTA::RegionHistogramData& cu
 
                 // send progress message: half done
                 _histogram_progress = 0.50;
-                auto half_progress = Message::RegionHistogramData(file_id, CUBE_REGION_ID, ALL_Z, stokes, _histogram_progress);
+                auto half_progress =
+                    Message::RegionHistogramData(file_id, CUBE_REGION_ID, ALL_Z, stokes, _histogram_progress, cube_histogram_config);
                 auto* message_histogram = half_progress.mutable_histograms();
                 SendFileEvent(file_id, CARTA::EventType::REGION_HISTOGRAM_DATA, request_id, half_progress);
 
@@ -1502,7 +1504,8 @@ bool Session::CalculateCubeHistogram(int file_id, CARTA::RegionHistogramData& cu
                         // Send progress update
                         float this_z(z);
                         _histogram_progress = 0.5 + (this_z / total_z);
-                        auto progress_msg = Message::RegionHistogramData(file_id, CUBE_REGION_ID, ALL_Z, stokes, _histogram_progress);
+                        auto progress_msg = Message::RegionHistogramData(
+                            file_id, CUBE_REGION_ID, ALL_Z, stokes, _histogram_progress, cube_histogram_config);
                         auto* message_histogram = progress_msg.mutable_histograms();
                         FillHistogram(message_histogram, cube_stats, cube_histogram);
                         SendFileEvent(file_id, CARTA::EventType::REGION_HISTOGRAM_DATA, request_id, progress_msg);

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -947,8 +947,7 @@ void Session::OnSetHistogramRequirements(const CARTA::SetHistogramRequirements& 
             return;
         }
 
-        std::vector<CARTA::SetHistogramRequirements_HistogramConfig> requirements = {
-            message.histograms().begin(), message.histograms().end()};
+        std::vector<CARTA::HistogramConfig> requirements = {message.histograms().begin(), message.histograms().end()};
 
         if (region_id > CURSOR_REGION_ID) {
             if (!_region_handler) {

--- a/src/Util/Image.cc
+++ b/src/Util/Image.cc
@@ -29,3 +29,7 @@ bool IsComputedStokes(int stokes) {
 bool IsComputedStokes(const std::string& stokes) {
     return IsComputedStokes(StokesValues[StokesStringTypes[stokes]]);
 }
+
+bool AreEqual(float val1, float val2) {
+    return fabs(val1 - val2) < 1e-6;
+}

--- a/src/Util/Image.cc
+++ b/src/Util/Image.cc
@@ -29,7 +29,3 @@ bool IsComputedStokes(int stokes) {
 bool IsComputedStokes(const std::string& stokes) {
     return IsComputedStokes(StokesValues[StokesStringTypes[stokes]]);
 }
-
-bool AreEqual(float val1, float val2) {
-    return fabs(val1 - val2) < 1e-6;
-}

--- a/src/Util/Image.h
+++ b/src/Util/Image.h
@@ -185,6 +185,4 @@ struct StokesSource {
     }
 };
 
-bool AreEqual(float val1, float val2);
-
 #endif // CARTA_BACKEND__UTIL_IMAGE_H_

--- a/src/Util/Image.h
+++ b/src/Util/Image.h
@@ -185,4 +185,6 @@ struct StokesSource {
     }
 };
 
+bool AreEqual(float val1, float val2);
+
 #endif // CARTA_BACKEND__UTIL_IMAGE_H_

--- a/src/Util/Message.cc
+++ b/src/Util/Message.cc
@@ -591,8 +591,8 @@ CARTA::RegionHistogramData Message::RegionHistogramData(
     config->set_num_bins(hist_config.num_bins);
     config->set_fixed_bounds(hist_config.fixed_bounds);
     auto* bounds = config->mutable_bounds();
-    bounds->set_min(hist_config.min_val);
-    bounds->set_max(hist_config.max_val);
+    bounds->set_min(hist_config.bounds.min);
+    bounds->set_max(hist_config.bounds.max);
     return message;
 }
 

--- a/src/Util/Message.cc
+++ b/src/Util/Message.cc
@@ -5,6 +5,7 @@
 */
 
 #include "Message.h"
+#include "Cache/RequirementsCache.h"
 #include "DataStream/Compression.h"
 
 #include <chrono>
@@ -578,13 +579,21 @@ CARTA::FittingProgress Message::FittingProgress(int32_t file_id, float progress)
 }
 
 CARTA::RegionHistogramData Message::RegionHistogramData(
-    int32_t file_id, int32_t region_id, int32_t channel, int32_t stokes, float progress) {
+    int32_t file_id, int32_t region_id, int32_t channel, int32_t stokes, float progress, const carta::HistogramConfig& hist_config) {
     CARTA::RegionHistogramData message;
     message.set_file_id(file_id);
     message.set_region_id(region_id);
     message.set_channel(channel);
     message.set_stokes(stokes);
     message.set_progress(progress);
+    auto* config = message.mutable_config();
+    config->set_fixed_num_bins(hist_config.fixed_num_bins);
+    config->set_num_bins(hist_config.num_bins);
+    config->set_bin_width(hist_config.bin_width);
+    config->set_fixed_bounds(hist_config.fixed_bounds);
+    auto* bounds = config->mutable_bounds();
+    bounds->set_min(hist_config.min_val);
+    bounds->set_max(hist_config.max_val);
     return message;
 }
 

--- a/src/Util/Message.cc
+++ b/src/Util/Message.cc
@@ -589,7 +589,6 @@ CARTA::RegionHistogramData Message::RegionHistogramData(
     auto* config = message.mutable_config();
     config->set_fixed_num_bins(hist_config.fixed_num_bins);
     config->set_num_bins(hist_config.num_bins);
-    config->set_bin_width(hist_config.bin_width);
     config->set_fixed_bounds(hist_config.fixed_bounds);
     auto* bounds = config->mutable_bounds();
     bounds->set_min(hist_config.min_val);

--- a/src/Util/Message.h
+++ b/src/Util/Message.h
@@ -52,6 +52,7 @@ struct EventHeader {
     uint16_t icd_version;
     uint32_t request_id;
 };
+struct HistogramConfig;
 } // namespace carta
 
 class Message {
@@ -133,7 +134,7 @@ public:
     static CARTA::PvProgress PvProgress(int32_t file_id, float progress);
     static CARTA::FittingProgress FittingProgress(int32_t file_id, float progress);
     static CARTA::RegionHistogramData RegionHistogramData(
-        int32_t file_id, int32_t region_id, int32_t channel, int32_t stokes, float progress);
+        int32_t file_id, int32_t region_id, int32_t channel, int32_t stokes, float progress, const carta::HistogramConfig& hist_config);
     static CARTA::ContourImageData ContourImageData(
         int32_t file_id, uint32_t reference_file_id, int32_t channel, int32_t stokes, double progress);
     static CARTA::VectorOverlayTileData VectorOverlayTileData(int32_t file_id, int32_t channel, int32_t stokes_intensity,

--- a/test/TestHistogram.cc
+++ b/test/TestHistogram.cc
@@ -50,7 +50,7 @@ TEST_F(HistogramTest, TestHistogramBehaviour) {
     data.push_back(00.0 - 1e-9); // should not appear
     data.push_back(10.0 + 1e+9); // should not appear
     data.push_back(11.0);        // should not appear
-    carta::Histogram hist(10, Bounds<float>(0.0, 10.0), data.data(), data.size());
+    carta::Histogram hist(10, HistogramBounds(0.0, 10.0), data.data(), data.size());
     auto counts = accumulate(hist.GetHistogramBins().begin(), hist.GetHistogramBins().end(), 0);
     EXPECT_EQ(counts, 12);
     EXPECT_EQ(hist.GetHistogramBins()[0], 2);
@@ -63,7 +63,7 @@ TEST_F(HistogramTest, TestHistogramBehaviour) {
     data.push_back(NAN);
     data.push_back(NAN);
     data.push_back(NAN);
-    carta::Histogram hist2(10, Bounds<float>(0.0, 10.0), data.data(), data.size());
+    carta::Histogram hist2(10, HistogramBounds(0.0, 10.0), data.data(), data.size());
     // expect 0 counts
     auto bins = hist2.GetHistogramBins();
     EXPECT_EQ(accumulate(bins.begin(), bins.end(), 0), 0);
@@ -72,7 +72,7 @@ TEST_F(HistogramTest, TestHistogramBehaviour) {
 TEST_F(HistogramTest, TestHistogramConstructor) {
     std::vector<float> data(1024 * 1024);
     std::for_each(data.begin(), data.end(), [&](float& v) { v = float_random(mt); });
-    carta::Histogram hist(1024, Bounds<float>(0.0, 1.0), data.data(), data.size());
+    carta::Histogram hist(1024, HistogramBounds(0.0, 1.0), data.data(), data.size());
     carta::Histogram hist2(hist);
     EXPECT_TRUE(CmpHistograms(hist, hist2));
 }
@@ -80,14 +80,14 @@ TEST_F(HistogramTest, TestHistogramConstructor) {
 TEST_F(HistogramTest, TestHistogramAdd) {
     std::vector<float> data(1024 * 1024);
     std::for_each(data.begin(), data.end(), [&](float& v) { v = float_random(mt); });
-    carta::Histogram hist(1024, Bounds<float>(0.0, 1.0), data.data(), data.size());
+    carta::Histogram hist(1024, HistogramBounds(0.0, 1.0), data.data(), data.size());
     const auto total_counts = accumulate(hist.GetHistogramBins().begin(), hist.GetHistogramBins().end(), 0);
-    carta::Histogram hist2(1024, Bounds<float>(0.0, 1.0), data.data(), data.size());
+    carta::Histogram hist2(1024, HistogramBounds(0.0, 1.0), data.data(), data.size());
     EXPECT_TRUE(CmpHistograms(hist, hist2)); // naive?
     hist.Add(hist2);
     const auto total_counts2 = accumulate(hist.GetHistogramBins().begin(), hist.GetHistogramBins().end(), 0);
     EXPECT_EQ(2 * total_counts, total_counts2);
-    carta::Histogram hist3(512, Bounds<float>(0.0, 1.0), data.data(), data.size());
+    carta::Histogram hist3(512, HistogramBounds(0.0, 1.0), data.data(), data.size());
     EXPECT_FALSE(hist.Add(hist3));
 }
 
@@ -97,9 +97,9 @@ TEST_F(HistogramTest, TestSingleThreading) {
         v = float_random(mt);
     }
     carta::ThreadManager::SetThreadLimit(1);
-    carta::Histogram hist_st(1024, Bounds<float>(0.0, 1.0), data.data(), data.size());
+    carta::Histogram hist_st(1024, HistogramBounds(0.0, 1.0), data.data(), data.size());
     for (auto i = 2; i < 24; i++) {
-        carta::Histogram hist_mt(1024, Bounds<float>(0.0, 1.0), data.data(), data.size());
+        carta::Histogram hist_mt(1024, HistogramBounds(0.0, 1.0), data.data(), data.size());
         EXPECT_TRUE(CmpHistograms(hist_st, hist_mt));
     }
 }
@@ -111,10 +111,10 @@ TEST_F(HistogramTest, TestMultithreading) {
     }
 
     carta::ThreadManager::SetThreadLimit(1);
-    carta::Histogram hist_st(1024, Bounds<float>(0.0, 1.0), data.data(), data.size());
+    carta::Histogram hist_st(1024, HistogramBounds(0.0, 1.0), data.data(), data.size());
     for (auto i = 2; i < 24; i++) {
         carta::ThreadManager::SetThreadLimit(i);
-        carta::Histogram hist_mt(1024, Bounds<float>(0.0, 1.0), data.data(), data.size());
+        carta::Histogram hist_mt(1024, HistogramBounds(0.0, 1.0), data.data(), data.size());
         EXPECT_TRUE(CmpHistograms(hist_st, hist_mt));
     }
 }

--- a/test/TestHistogram.cc
+++ b/test/TestHistogram.cc
@@ -50,7 +50,7 @@ TEST_F(HistogramTest, TestHistogramBehaviour) {
     data.push_back(00.0 - 1e-9); // should not appear
     data.push_back(10.0 + 1e+9); // should not appear
     data.push_back(11.0);        // should not appear
-    carta::Histogram hist(10, 0.0f, 10.0f, data.data(), data.size());
+    carta::Histogram hist(10, Bounds<float>(0.0, 10.0), data.data(), data.size());
     auto counts = accumulate(hist.GetHistogramBins().begin(), hist.GetHistogramBins().end(), 0);
     EXPECT_EQ(counts, 12);
     EXPECT_EQ(hist.GetHistogramBins()[0], 2);
@@ -63,7 +63,7 @@ TEST_F(HistogramTest, TestHistogramBehaviour) {
     data.push_back(NAN);
     data.push_back(NAN);
     data.push_back(NAN);
-    carta::Histogram hist2(10, 0.0f, 10.0f, data.data(), data.size());
+    carta::Histogram hist2(10, Bounds<float>(0.0, 10.0), data.data(), data.size());
     // expect 0 counts
     auto bins = hist2.GetHistogramBins();
     EXPECT_EQ(accumulate(bins.begin(), bins.end(), 0), 0);
@@ -72,7 +72,7 @@ TEST_F(HistogramTest, TestHistogramBehaviour) {
 TEST_F(HistogramTest, TestHistogramConstructor) {
     std::vector<float> data(1024 * 1024);
     std::for_each(data.begin(), data.end(), [&](float& v) { v = float_random(mt); });
-    carta::Histogram hist(1024, 0.0f, 1.0f, data.data(), data.size());
+    carta::Histogram hist(1024, Bounds<float>(0.0, 1.0), data.data(), data.size());
     carta::Histogram hist2(hist);
     EXPECT_TRUE(CmpHistograms(hist, hist2));
 }
@@ -80,14 +80,14 @@ TEST_F(HistogramTest, TestHistogramConstructor) {
 TEST_F(HistogramTest, TestHistogramAdd) {
     std::vector<float> data(1024 * 1024);
     std::for_each(data.begin(), data.end(), [&](float& v) { v = float_random(mt); });
-    carta::Histogram hist(1024, 0.0f, 1.0f, data.data(), data.size());
+    carta::Histogram hist(1024, Bounds<float>(0.0, 1.0), data.data(), data.size());
     const auto total_counts = accumulate(hist.GetHistogramBins().begin(), hist.GetHistogramBins().end(), 0);
-    carta::Histogram hist2(1024, 0.0f, 1.0f, data.data(), data.size());
+    carta::Histogram hist2(1024, Bounds<float>(0.0, 1.0), data.data(), data.size());
     EXPECT_TRUE(CmpHistograms(hist, hist2)); // naive?
     hist.Add(hist2);
     const auto total_counts2 = accumulate(hist.GetHistogramBins().begin(), hist.GetHistogramBins().end(), 0);
     EXPECT_EQ(2 * total_counts, total_counts2);
-    carta::Histogram hist3(512, 0.0f, 1.0f, data.data(), data.size());
+    carta::Histogram hist3(512, Bounds<float>(0.0, 1.0), data.data(), data.size());
     EXPECT_FALSE(hist.Add(hist3));
 }
 
@@ -97,9 +97,9 @@ TEST_F(HistogramTest, TestSingleThreading) {
         v = float_random(mt);
     }
     carta::ThreadManager::SetThreadLimit(1);
-    carta::Histogram hist_st(1024, 0.0f, 1.0f, data.data(), data.size());
+    carta::Histogram hist_st(1024, Bounds<float>(0.0, 1.0), data.data(), data.size());
     for (auto i = 2; i < 24; i++) {
-        carta::Histogram hist_mt(1024, 0.0f, 1.0f, data.data(), data.size());
+        carta::Histogram hist_mt(1024, Bounds<float>(0.0, 1.0), data.data(), data.size());
         EXPECT_TRUE(CmpHistograms(hist_st, hist_mt));
     }
 }
@@ -111,10 +111,10 @@ TEST_F(HistogramTest, TestMultithreading) {
     }
 
     carta::ThreadManager::SetThreadLimit(1);
-    carta::Histogram hist_st(1024, 0.0f, 1.0f, data.data(), data.size());
+    carta::Histogram hist_st(1024, Bounds<float>(0.0, 1.0), data.data(), data.size());
     for (auto i = 2; i < 24; i++) {
         carta::ThreadManager::SetThreadLimit(i);
-        carta::Histogram hist_mt(1024, 0.0f, 1.0f, data.data(), data.size());
+        carta::Histogram hist_mt(1024, Bounds<float>(0.0, 1.0), data.data(), data.size());
         EXPECT_TRUE(CmpHistograms(hist_st, hist_mt));
     }
 }


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
Customized the histogram calculations as described in #829.

* How does this PR solve the issue? Give a brief summary.
Modified the protobuf message `HistogramConfig` and added options for the number of bins or pixel bounds which will be applied in histogram calculations.

* Are there any companion PRs (frontend, protobuf)?
Yes. The companion [frontend PR](https://github.com/CARTAvis/carta-frontend/pull/2141) and [protobuf PR](https://github.com/CARTAvis/carta-protobuf/pull/83) are shown on the hyperlinks.

* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
The ICD tests related to the histogram calculations need to be changed.

**Checklist**

- [x] changelog updated ~/ no changelog update needed~
- [x] e2e test passing / ~added corresponding fix~
- [x] protobuf updated to the latest dev commit ~/ no protobuf update needed~
- [x] added reviewers and assignee
- [x] added ZenHub estimate, milestone, and release
