### PR TITLE
Fix FITS header and data errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed failure loading CASA image due to FITS headers error ([#1239](https://github.com/CARTAvis/carta-backend/issues/1239)).
 * Fixed incorrect PV image orientation if the cube has projection distortion ([#1244](https://github.com/CARTAvis/carta-backend/issues/1244)).
 * Fixed crash following use of an incorrect session ID ([#1248](https://github.com/CARTAvis/carta-backend/issues/1248)).
+* Fixed crash following compressed fits parsing error ([#1233](https://github.com/CARTAvis/carta-backend/issues/1233)).
 
 ## [3.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Prevent the installation of pugixml library files ([#1261](https://github.com/CARTAvis/carta-backend/issues/1261)).
 * Fixed spatial profile for polyline in widefield image ([#1258](https://github.com/CARTAvis/carta-backend/issues/1258)).
-* Fixed crash following compressed fits parsing error ([#1233](https://github.com/CARTAvis/carta-backend/issues/1233)).
+* Fixed FITS header and data errors ([#1233](https://github.com/CARTAvis/carta-backend/issues/1233), [#1265](https://github.com/CARTAvis/carta-backend/issues/1265)).
 
 ## [4.0.0-beta.1]
 

--- a/src/FileList/FileExtInfoLoader.cc
+++ b/src/FileList/FileExtInfoLoader.cc
@@ -13,7 +13,6 @@
 #include <spdlog/fmt/ostr.h>
 
 #include <casacore/casa/Quanta/MVAngle.h>
-#include <casacore/casa/Quanta/UnitMap.h>
 #include <casacore/coordinates/Coordinates/DirectionCoordinate.h>
 #include <casacore/coordinates/Coordinates/SpectralCoordinate.h>
 #include <casacore/images/Images/FITSImage.h>
@@ -324,6 +323,8 @@ void FileExtInfoLoader::AddEntriesFromHeaderStrings(
                 specsys = value.after('-');
                 value = "VELO";
             }
+        } else if (name.contains("UNIT")) {
+            NormalizeUnit(value);
         } else if (name == "EXTNAME") {
             extname = value;
         } else if (name == "SIMPLE") {
@@ -1050,16 +1051,16 @@ void FileExtInfoLoader::AddComputedEntriesFromHeaders(CARTA::FileInfoExtended& e
                 if (disp1_cunit.contains("/")) {
                     disp1_cunit = disp1_ctype.before("/");
                 }
-                NormalizeHeaderUnit(disp1_cunit);
+                NormalizeUnit(disp1_cunit);
             } else if (entry_name.find("CUNIT" + disp2_suffix) == 0) {
                 disp2_cunit = entry.value();
                 if (disp2_cunit.contains("/")) {
                     disp2_cunit = disp2_cunit.before("/");
                 }
-                NormalizeHeaderUnit(disp2_cunit);
+                NormalizeUnit(disp2_cunit);
             } else if (entry_name.find("CUNIT" + spectral_suffix) == 0) {
                 spectral_cunit = entry.value();
-                NormalizeHeaderUnit(spectral_cunit);
+                NormalizeUnit(spectral_cunit);
             }
         } else if (!found_frame &&
                    ((entry_name.find("EQUINOX") == 0) || (entry_name.find("TELEQUIN") == 0) || (entry_name.find("EPOCH") == 0))) {
@@ -1084,7 +1085,7 @@ void FileExtInfoLoader::AddComputedEntriesFromHeaders(CARTA::FileInfoExtended& e
             found_velref = true;
         } else if (entry_name.find("BUNIT") == 0) {
             bunit = entry.value();
-            NormalizeHeaderUnit(bunit);
+            NormalizeUnit(bunit);
         } else if ((entry_name.find("RESTFREQ") == 0) || (entry_name.find("RESTFRQ") == 0)) {
             rest_freq = entry.numeric_value();
         }
@@ -1301,34 +1302,6 @@ void FileExtInfoLoader::AddBeamEntry(CARTA::FileInfoExtended& extended_info, con
         entry->set_entry_type(CARTA::EntryType::STRING);
         entry->set_value(beam_info);
     }
-}
-
-void FileExtInfoLoader::NormalizeHeaderUnit(casacore::String& unit) {
-    // Convert unit string to FITS unit
-    casacore::String unit_name(unit);
-    if (casacore::UnitVal::check(unit_name)) {
-        unit = unit_name;
-        return;
-    }
-
-    unit_name.downcase();
-    if (casacore::UnitVal::check(unit_name)) {
-        unit = unit_name;
-        return;
-    }
-
-    unit_name.capitalize();
-    if (casacore::UnitVal::check(unit_name)) {
-        unit = unit_name;
-        return;
-    }
-
-    unit_name.upcase();
-    if (casacore::UnitVal::check(unit_name)) {
-        unit = unit_name;
-        return;
-    }
-    // keep original unit
 }
 
 std::string FileExtInfoLoader::MakeAngleString(const std::string& type, double val, const std::string& unit) {

--- a/src/FileList/FileExtInfoLoader.cc
+++ b/src/FileList/FileExtInfoLoader.cc
@@ -67,6 +67,7 @@ bool FileExtInfoLoader::FillFitsFileInfoMap(
         fits_hdu_list.GetHduList(hdu_list, message);
 
         if (hdu_list.empty()) {
+            message = "No image HDUs found.";
             return map_ok;
         }
 
@@ -84,7 +85,7 @@ bool FileExtInfoLoader::FillFitsFileInfoMap(
 
     map_ok = !hdu_info_map.empty();
     if (!map_ok) {
-        message = "Header error or no image HDUs found.";
+        message = "Error loading headers or image.";
     }
 
     return map_ok;

--- a/src/FileList/FileExtInfoLoader.cc
+++ b/src/FileList/FileExtInfoLoader.cc
@@ -1034,16 +1034,16 @@ void FileExtInfoLoader::AddComputedEntriesFromHeaders(CARTA::FileInfoExtended& e
                 if (disp1_cunit.contains("/")) {
                     disp1_cunit = disp1_ctype.before("/");
                 }
-                ConvertUnitToCasacore(disp1_cunit);
+                NormalizeHeaderUnit(disp1_cunit);
             } else if (entry_name.find("CUNIT" + disp2_suffix) == 0) {
                 disp2_cunit = entry.value();
                 if (disp2_cunit.contains("/")) {
                     disp2_cunit = disp2_cunit.before("/");
                 }
-                ConvertUnitToCasacore(disp2_cunit);
+                NormalizeHeaderUnit(disp2_cunit);
             } else if (entry_name.find("CUNIT" + spectral_suffix) == 0) {
                 spectral_cunit = entry.value();
-                ConvertUnitToCasacore(spectral_cunit);
+                NormalizeHeaderUnit(spectral_cunit);
             }
         } else if (!found_frame &&
                    ((entry_name.find("EQUINOX") == 0) || (entry_name.find("TELEQUIN") == 0) || (entry_name.find("EPOCH") == 0))) {
@@ -1068,6 +1068,7 @@ void FileExtInfoLoader::AddComputedEntriesFromHeaders(CARTA::FileInfoExtended& e
             found_velref = true;
         } else if (entry_name.find("BUNIT") == 0) {
             bunit = entry.value();
+            NormalizeHeaderUnit(bunit);
         } else if ((entry_name.find("RESTFREQ") == 0) || (entry_name.find("RESTFRQ") == 0)) {
             rest_freq = entry.numeric_value();
         }
@@ -1286,7 +1287,7 @@ void FileExtInfoLoader::AddBeamEntry(CARTA::FileInfoExtended& extended_info, con
     }
 }
 
-void FileExtInfoLoader::ConvertUnitToCasacore(casacore::String& unit) {
+void FileExtInfoLoader::NormalizeHeaderUnit(casacore::String& unit) {
     // Check that string is in unit map with various cases
     if (casacore::UnitVal::check(unit)) {
         return;

--- a/src/FileList/FileExtInfoLoader.cc
+++ b/src/FileList/FileExtInfoLoader.cc
@@ -39,7 +39,6 @@ bool FileExtInfoLoader::FillFitsFileInfoMap(
     bool map_ok(false);
 
     if (IsCompressedFits(filename)) {
-        spdlog::debug("Compressed FITS");
         CompressedFits cfits(filename);
         if (!cfits.GetFitsHeaderInfo(hdu_info_map)) {
             message = "Compressed FITS headers failed.";

--- a/src/FileList/FileExtInfoLoader.cc
+++ b/src/FileList/FileExtInfoLoader.cc
@@ -686,12 +686,8 @@ void FileExtInfoLoader::AddInitialComputedEntries(const std::string& hdu, CARTA:
 
     if (compressed_fits) {
         compressed_fits->SetShape(shape);
-        if (depth_axis > -1) {
-            compressed_fits->SetSpectralAxis(depth_axis);
-        }
-        if (stokes_axis > -1) {
-            compressed_fits->SetStokesAxis(stokes_axis);
-        }
+        compressed_fits->SetSpectralAxis(depth_axis);
+        compressed_fits->SetStokesAxis(stokes_axis);
     }
 }
 

--- a/src/FileList/FileExtInfoLoader.h
+++ b/src/FileList/FileExtInfoLoader.h
@@ -64,7 +64,7 @@ private:
         CARTA::FileInfoExtended& extended_info, const casacore::CoordinateSystem& coord_system, const casacore::IPosition& image_shape);
 
     // Convert unit to one recognized by casacore (case-sensitive)
-    void ConvertUnitToCasacore(casacore::String& unit);
+    void NormalizeHeaderUnit(casacore::String& unit);
 
     // Convert MVAngle to string; returns Quantity string if not direction
     std::string MakeAngleString(const std::string& type, double val, const std::string& unit);

--- a/src/FileList/FileExtInfoLoader.h
+++ b/src/FileList/FileExtInfoLoader.h
@@ -49,7 +49,7 @@ private:
     void FitsHeaderInfoToHeaderEntries(casacore::ImageFITSHeaderInfo& fhi, CARTA::FileInfoExtended& extended_info);
 
     // Computed entries
-    void AddDataTypeEntry(CARTA::FileInfoExtended& extended_info, casacore::DataType data_type);
+    void AddDataTypeEntry(CARTA::FileInfoExtended& extended_info, casacore::DataType data_type, casacore::DataType internal_type);
     void AddShapeEntries(CARTA::FileInfoExtended& extended_info, const casacore::IPosition& shape, const std::vector<int>& spatial_axes,
         int spectral_axis, int stokes_axis, const std::vector<int>& render_axes, int depth_axis,
         casacore::Vector<casacore::String>& axes_names);

--- a/src/FileList/FileExtInfoLoader.h
+++ b/src/FileList/FileExtInfoLoader.h
@@ -63,7 +63,7 @@ private:
     void AddCoordRanges(
         CARTA::FileInfoExtended& extended_info, const casacore::CoordinateSystem& coord_system, const casacore::IPosition& image_shape);
 
-    // Convert non-standard unit string to casacore Unit
+    // Convert unit to one recognized by casacore (case-sensitive)
     void ConvertUnitToCasacore(casacore::String& unit);
 
     // Convert MVAngle to string; returns Quantity string if not direction

--- a/src/FileList/FileExtInfoLoader.h
+++ b/src/FileList/FileExtInfoLoader.h
@@ -56,9 +56,9 @@ private:
     void AddInitialComputedEntries(const std::string& hdu, CARTA::FileInfoExtended& extended_info, const std::string& filename,
         const std::vector<int>& render_axes, CompressedFits* compressed_fits = nullptr);
     void AddComputedEntries(CARTA::FileInfoExtended& extended_info, casacore::ImageInterface<float>* image,
-        const std::vector<int>& display_axes, bool use_image_for_entries);
-    void AddComputedEntriesFromHeaders(
-        CARTA::FileInfoExtended& extended_info, const std::vector<int>& display_axes, CompressedFits* compressed_fits = nullptr);
+        const std::vector<int>& display_axes, int spectral_axis, int stokes_axis, bool use_image_for_entries);
+    void AddComputedEntriesFromHeaders(CARTA::FileInfoExtended& extended_info, const std::vector<int>& display_axes, int spectral_axis,
+        int stokes_axis, CompressedFits* compressed_fits = nullptr);
     void AddBeamEntry(CARTA::FileInfoExtended& extended_info, const casacore::ImageBeamSet& beam_set);
     void AddCoordRanges(
         CARTA::FileInfoExtended& extended_info, const casacore::CoordinateSystem& coord_system, const casacore::IPosition& image_shape);
@@ -73,8 +73,8 @@ private:
     std::string ConvertCoordsToDeg(const std::string& type, const casacore::Quantity& coord);
     std::string ConvertIncrementToArcsec(const casacore::Quantity& inc0, const casacore::Quantity& inc1);
 
-    void GetCoordNames(std::string& ctype1, std::string& ctype2, std::string& radesys, std::string& coord_name1, std::string& coord_name2,
-        std::string& projection);
+    void GetCoordNames(std::string& ctype1, std::string& ctype2, std::string& radesys, std::string& projection);
+    void SplitCtypeDescriptor(std::string& ctype, std::string& descriptor);
 
     std::shared_ptr<FileLoader> _loader;
     CARTA::FileType _type;

--- a/src/FileList/FileExtInfoLoader.h
+++ b/src/FileList/FileExtInfoLoader.h
@@ -49,7 +49,7 @@ private:
     void FitsHeaderInfoToHeaderEntries(casacore::ImageFITSHeaderInfo& fhi, CARTA::FileInfoExtended& extended_info);
 
     // Computed entries
-    void AddDataTypeEntry(CARTA::FileInfoExtended& extended_info, casacore::DataType data_type, casacore::DataType internal_type);
+    void AddDataTypeEntry(CARTA::FileInfoExtended& extended_info, casacore::DataType data_type, casacore::DataType equivalent_type);
     void AddShapeEntries(CARTA::FileInfoExtended& extended_info, const casacore::IPosition& shape, const std::vector<int>& spatial_axes,
         int spectral_axis, int stokes_axis, const std::vector<int>& render_axes, int depth_axis,
         casacore::Vector<casacore::String>& axes_names);

--- a/src/FileList/FileExtInfoLoader.h
+++ b/src/FileList/FileExtInfoLoader.h
@@ -63,9 +63,6 @@ private:
     void AddCoordRanges(
         CARTA::FileInfoExtended& extended_info, const casacore::CoordinateSystem& coord_system, const casacore::IPosition& image_shape);
 
-    // Convert unit to one recognized by casacore (case-sensitive)
-    void NormalizeHeaderUnit(casacore::String& unit);
-
     // Convert MVAngle to string; returns Quantity string if not direction
     std::string MakeAngleString(const std::string& type, double val, const std::string& unit);
 

--- a/src/FileList/FileInfoLoader.h
+++ b/src/FileList/FileInfoLoader.h
@@ -21,7 +21,6 @@ public:
     FileInfoLoader(const std::string& filename, const CARTA::FileType& type);
 
     bool FillFileInfo(CARTA::FileInfo& file_info);
-    bool FillFileExtInfo(CARTA::FileInfoExtended& extended_info, std::string& hdu, std::string& message);
 
 private:
     CARTA::FileType GetCartaFileType(const std::string& filename);

--- a/src/ImageData/CartaFitsImage.cc
+++ b/src/ImageData/CartaFitsImage.cc
@@ -392,7 +392,7 @@ void CartaFitsImage::GetFitsHeaderString(int& nheaders, std::string& hdrstr) {
         int blank_value;
         char* comment(nullptr); // ignore
         status = 0;
-        fits_read_key(fptr, TLONG, key.c_str(), &blank_value, comment, &status);
+        fits_read_key(fptr, TINT, key.c_str(), &blank_value, comment, &status);
         _has_blanks = !status;
     } else {
         // For float (-32) and double (-64) mask is represented by NaN

--- a/src/ImageData/CartaFitsImage.h
+++ b/src/ImageData/CartaFitsImage.h
@@ -21,6 +21,10 @@
 
 namespace carta {
 
+static std::unordered_map<int, casacore::DataType> bitpix_types(
+    {{8, casacore::DataType::TpChar}, {16, casacore::DataType::TpShort}, {32, casacore::DataType::TpInt}, {64, casacore::DataType::TpInt64},
+        {-32, casacore::DataType::TpFloat}, {-64, casacore::DataType::TpDouble}});
+
 class CartaFitsImage : public casacore::ImageInterface<float> {
 public:
     // Construct an image from a pre-existing file.
@@ -100,7 +104,8 @@ private:
     // FITS header values
     bool _is_compressed;
     casacore::IPosition _shape;
-    int _datatype; // bitpix value
+    int _bitpix;
+    int _equiv_bitpix;
     bool _has_blanks;
     casacore::Vector<casacore::String> _all_header_strings;
     casacore::Vector<casacore::String> _image_header_strings;

--- a/src/ImageData/CartaFitsImage.tcc
+++ b/src/ImageData/CartaFitsImage.tcc
@@ -38,7 +38,6 @@ bool CartaFitsImage::GetDataSubset(fitsfile* fptr, int datatype, const casacore:
     // cfitsio params
     int anynul(0), status(0);
     T null_val(0);
-    int dtype(TFLOAT);
 
     switch (datatype) {
         case 8: {

--- a/src/ImageData/CompressedFits.cc
+++ b/src/ImageData/CompressedFits.cc
@@ -328,8 +328,7 @@ void CompressedFits::ParseFitsCard(
         return;
     }
 
-    if (fits_card.startsWith("HISTORY")) {
-        // Do not parse HISTORY
+    if (fits_card.startsWith("HISTORY") || fits_card.startsWith("COMMENT")) {
         keyword = fits_card;
         return;
     }

--- a/src/ImageData/CompressedFits.cc
+++ b/src/ImageData/CompressedFits.cc
@@ -20,7 +20,7 @@
 
 using namespace carta;
 
-CompressedFits::CompressedFits(const std::string& filename) : _filename(filename) {
+CompressedFits::CompressedFits(const std::string& filename) : _filename(filename), _spectral_axis(-1), _stokes_axis(-1) {
     // Initialize linear transformation matrix for the direction coordinate
     SetDefaultTransformMatrix();
 }

--- a/src/ImageData/CompressedFits.h
+++ b/src/ImageData/CompressedFits.h
@@ -109,17 +109,17 @@ public:
     casacore::IPosition& GetShape() {
         return _shape;
     }
-    void SetSpecSuffix(int spec_axis) {
-        _spec_suffix = std::to_string(spec_axis + 1);
+    void SetSpectralAxis(int spectral_axis) {
+        _spectral_axis = spectral_axis;
     }
-    void SetStokesSuffix(int stokes_axis) {
-        _stokes_suffix = std::to_string(stokes_axis + 1);
+    void SetStokesAxis(int stokes_axis) {
+        _stokes_axis = stokes_axis;
     }
-    std::string GetSpecSuffix() {
-        return _spec_suffix;
+    int GetSpectralAxis() {
+        return _spectral_axis;
     }
-    std::string GetStokesSuffix() {
-        return _stokes_suffix;
+    int GetStokesAxis() {
+        return _stokes_axis;
     }
 
     // File decompression
@@ -149,8 +149,8 @@ private:
     casacore::ImageBeamSet _beam_set;
     casacore::Matrix<casacore::Double> _xform; // Linear transform matrix for the direction coordinate
     casacore::IPosition _shape;                // Image shape
-    std::string _spec_suffix;                  // Spectral suffix from the header
-    std::string _stokes_suffix;                // Stokes suffix from the header
+    int _spectral_axis;                        // Spectral axis from the header
+    int _stokes_axis;                          // Stokes axis from the header
 };
 
 } // namespace carta

--- a/src/Util/Casacore.cc
+++ b/src/Util/Casacore.cc
@@ -7,6 +7,7 @@
 #include "Casacore.h"
 
 #include <casacore/casa/OS/File.h>
+#include <casacore/casa/Quanta/UnitMap.h>
 
 #include "ImageData/CartaMiriadImage.h"
 #include "Logger/Logger.h"
@@ -169,4 +170,16 @@ std::string FormatBeam(const casacore::GaussianBeam& gaussian_beam) {
 
 std::string FormatQuantity(const casacore::Quantity& quantity) {
     return fmt::format("{:.6f} {}", quantity.getValue(), quantity.getUnit());
+}
+
+void NormalizeUnit(casacore::String& unit) {
+    // Convert unit string to "proper" units according to casacore
+    casacore::UnitMap::addFITS();
+    casacore::String unit_name(unit);
+    unit_name.upcase();
+    if (casacore::UnitVal::check(unit_name)) {
+        unit = casacore::UnitMap::fromFITS(unit_name).getName();
+        return;
+    }
+    // keep original unit
 }

--- a/src/Util/Casacore.h
+++ b/src/Util/Casacore.h
@@ -26,4 +26,7 @@ void GetSpectralCoordPreferences(
 std::string FormatBeam(const casacore::GaussianBeam& gaussian_beam);
 std::string FormatQuantity(const casacore::Quantity& quantity);
 
+// Convert unit to one recognized by casacore (case-sensitive)
+void NormalizeUnit(casacore::String& unit);
+
 #endif // CARTA_BACKEND__UTIL_CASACORE_H_


### PR DESCRIPTION
**Description**

* What is implemented or fixed?
Fixes #1233 and #1265 
* How does this PR solve the issue? 

1. CompressedFits: fix header parsing error for "COMMENT ================================"
2. CartaFitsImage: read rescaled 16-bit int data correctly with cfitsio (using equivalent bitpix=float)
3. FileExtInfoLoader: fix unit string ("degrees") in FITS image header unrecognized by casacore (regression failure)

* Are there any companion PRs (frontend, protobuf)?
No
* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
Open compressed fits.gz image attached to issue 1233 and FITS image attached to issue 1265.  Images should be opened and displayed properly.

**Checklist**

- [x] changelog updated / ~no changelog update needed~
- [x] e2e test passing / ~added corresponding fix~
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] added reviewers and assignee
- [x] added ZenHub estimate, milestone, and release
