### PR TITLE
Fix file info formatting error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed failure loading CASA image due to FITS headers error ([#1239](https://github.com/CARTAvis/carta-backend/issues/1239)).
 * Fixed incorrect PV image orientation if the cube has projection distortion ([#1244](https://github.com/CARTAvis/carta-backend/issues/1244)).
 * Fixed crash following use of an incorrect session ID ([#1248](https://github.com/CARTAvis/carta-backend/issues/1248)).
-* Fixed FITS header error non-standard keyword ([#1218](https://github.com/CARTAvis/carta-backend/issues/1218)).
+* Fixed header angle formatting error with non-angle unit ([#1218](https://github.com/CARTAvis/carta-backend/issues/1218)).
 
 ## [3.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed failure loading CASA image due to FITS headers error ([#1239](https://github.com/CARTAvis/carta-backend/issues/1239)).
 * Fixed incorrect PV image orientation if the cube has projection distortion ([#1244](https://github.com/CARTAvis/carta-backend/issues/1244)).
 * Fixed crash following use of an incorrect session ID ([#1248](https://github.com/CARTAvis/carta-backend/issues/1248)).
+* Fixed FITS header error non-standard keyword ([#1218](https://github.com/CARTAvis/carta-backend/issues/1218)).
 
 ## [3.0.0]
 

--- a/src/FileList/FileExtInfoLoader.h
+++ b/src/FileList/FileExtInfoLoader.h
@@ -63,6 +63,9 @@ private:
     void AddCoordRanges(
         CARTA::FileInfoExtended& extended_info, const casacore::CoordinateSystem& coord_system, const casacore::IPosition& image_shape);
 
+    // Convert non-standard unit string to casacore Unit
+    void ConvertUnitToCasacore(casacore::String& unit);
+
     // Convert MVAngle to string; returns Quantity string if not direction
     std::string MakeAngleString(const std::string& type, double val, const std::string& unit);
 


### PR DESCRIPTION
**Description**

* What is implemented or fixed?
Fix #1218  error converting RA/Dec or Lat/Long headers to formatted string (angle or time format using casacore::MVAngle) when unit is pixel.
* How does this PR solve the issue?
  - Check if angle unit before formatting, else just use value + unit. 
  - Improved converting header unit for casacore Quantity.
  - Improved error message for future failures: "Header error or no image HDUs found" instead of "No image hdus found".
* Are there any companion PRs (frontend, protobuf)?
No
* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
Load image attached to issue, should load instead of error message.

**Checklist**

- [x] changelog updated / ~no changelog update needed~
- [x] e2e test passing / ~added corresponding fix~
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] added reviewers and assignee
- [x] added ZenHub estimate, milestone, and release
