### PR TITLE
Fix macos warnings in Ds9ImportExport.cc

### DIFF
--- a/src/Region/Ds9ImportExport.cc
+++ b/src/Region/Ds9ImportExport.cc
@@ -346,7 +346,7 @@ bool Ds9ImportExport::SetFileReferenceFrame(std::string& ds9_coord) {
     if (_coord_map.find(ds9_coord) != _coord_map.end()) {
         _file_ref_frame = _coord_map[ds9_coord];
     } else {
-        _file_ref_frame == "UNSUPPORTED";
+        _file_ref_frame = "UNSUPPORTED";
         _pixel_coord = false;
         return false;
     }

--- a/src/Region/Ds9ImportExport.cc
+++ b/src/Region/Ds9ImportExport.cc
@@ -1468,36 +1468,49 @@ void Ds9ImportExport::ExportAnnotationStyleParameters(
 
 void Ds9ImportExport::ExportAnnPointParameters(const CARTA::RegionStyle& region_style, std::string& region_line) {
     std::string point_shape("circle");
-    bool fill(false);
+    bool fill(true);
 
     switch (region_style.annotation_style().point_shape()) {
-        case CARTA::PointAnnotationShape::SQUARE:
-            point_shape = "box";
-            fill = true;
-            break;
-        case CARTA::PointAnnotationShape::BOX:
+        case CARTA::PointAnnotationShape::SQUARE: {
             point_shape = "box";
             break;
-        case CARTA::PointAnnotationShape::CIRCLE:
+        }
+        case CARTA::PointAnnotationShape::BOX: {
+            point_shape = "box";
+            fill = false;
+            break;
+        }
+        case CARTA::PointAnnotationShape::CIRCLE: {
             point_shape = "circle";
-            fill = true;
             break;
-        case CARTA::PointAnnotationShape::CIRCLE_LINED:
+        }
+        case CARTA::PointAnnotationShape::CIRCLE_LINED: {
             point_shape = "circle";
+            fill = false;
             break;
-        case CARTA::PointAnnotationShape::DIAMOND:
-            point_shape = "diamond";
-            fill = true;
-            break;
-        case CARTA::PointAnnotationShape::DIAMOND_LINED:
+        }
+        case CARTA::PointAnnotationShape::DIAMOND: {
             point_shape = "diamond";
             break;
-        case CARTA::PointAnnotationShape::CROSS:
+        }
+        case CARTA::PointAnnotationShape::DIAMOND_LINED: {
+            point_shape = "diamond";
+            fill = false;
+            break;
+        }
+        case CARTA::PointAnnotationShape::CROSS: {
             point_shape = "cross";
+            fill = false;
             break;
-        case CARTA::PointAnnotationShape::X:
+        }
+        case CARTA::PointAnnotationShape::X: {
             point_shape = "x";
+            fill = false;
             break;
+        }
+        default: {
+            break;
+        }
     }
 
     auto point_size = region_style.annotation_style().point_width();


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
Fix compile warnings on macOS (no issue).  Seems to be harmless but should be fixed.
* How does this PR solve the issue? Give a brief summary.
Fixes assignment operator and adds default case to switch (missing DO_NOT_USE enum value in compiled protobuf).  Also changed to initialize with default values before switch.
* Are there any companion PRs (frontend, protobuf)?
No.
* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
Compile on macOS and look for warnings.  For assignment operator, import DS9 file with unsupported coordinate.  For switch, create annotation point regions with various shapes, export to DS9, check reg file.

**Checklist**

- [x] ~changelog updated~ / no changelog update needed
- [x] e2e test passing / ~added corresponding fix~
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] added reviewers and assignee
- [x] added ZenHub estimate, milestone, and release
