### PR TITLE
Fix fixed-angular box regions for polyline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+* Fixed spatial profile for polyline in widefield image ([#1258](https://github.com/CARTAvis/carta-backend/issues/1258)).
+
 ## [4.0.0-beta.1]
 
 ### Added

--- a/src/Region/LineBoxRegions.cc
+++ b/src/Region/LineBoxRegions.cc
@@ -386,6 +386,7 @@ bool LineBoxRegions::GetFixedAngularRegions(const RegionState& line_region_state
             for (int iregion = 0; iregion < num_regions; ++iregion) {
                 if (trim_line) {
                     spdlog::debug("Polyline segment {} trimmed", iline);
+                    trim_line = false;
                     continue;
                 }
 
@@ -401,7 +402,9 @@ bool LineBoxRegions::GetFixedAngularRegions(const RegionState& line_region_state
                     polygon_region_state = GetPolygonRegionState(line_coord_sys, line_region_state.reference_file_id, region_start,
                         region_end, line_width, angular_width, rotation, tolerance);
                 }
-            } // Done with regions along line segment
+
+                region_states.push_back(polygon_region_state);
+            }
 
             // Check whether to trim next line's starting point
             if (line_points.back().empty()) {

--- a/src/Region/RegionHandler.cc
+++ b/src/Region/RegionHandler.cc
@@ -2362,9 +2362,9 @@ bool RegionHandler::GetLineSpatialData(int file_id, int region_id, const std::st
         return false;
     } else {
         if (cancelled) {
-            spdlog::info("Line region {} spatial profile {} was cancelled.", region_id, coordinate);
+            spdlog::info("Line region {} spatial profile was cancelled.", region_id);
         } else {
-            spdlog::error("Line region {} spatial profile {} failed: {}", region_id, coordinate, message);
+            spdlog::error("Line region {} spatial profile failed: {}", region_id, message);
         }
     }
 


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
Fixes #1258 
* How does this PR solve the issue? Give a brief summary.
Reset trim flag, for first region in line segment only.  Add computed box (polygon) regions to vector.
* Are there any companion PRs (frontend, protobuf)?
No
* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
Set polyline in widefield image, should be spatial profile for active region.

**Checklist**

- [x] changelog updated / ~no changelog update needed~
- [x] e2e test passing / added corresponding fix
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] added reviewers and assignee
- [x] added ZenHub estimate, milestone, and release
