### PR TITLE
ajm/1266 pugixml fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+* Prevent the installation of pugixml library files ([#1261](https://github.com/CARTAvis/carta-backend/issues/1261)).
+
 ## [4.0.0-beta.1]
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,8 +155,6 @@ include_directories(${CMAKE_SOURCE_DIR}/third-party/include)
 install_uWebSockets()
 
 #pugixml
-SET(PUGIXML_COMPACT ON CACHE BOOL "" FORCE)
-add_subdirectory(third-party/pugixml)
 include_directories(${CMAKE_SOURCE_DIR}/third-party/pugixml/src)
 
 #spdlog
@@ -172,7 +170,6 @@ set(LINK_LIBS
         zfp
         zstd
         cfitsio
-        pugixml
         wcs
         gsl
         casa_casa
@@ -191,6 +188,7 @@ set(LINK_LIBS
 
 set(SOURCE_FILES
         ${SOURCE_FILES}
+	${CMAKE_SOURCE_DIR}/third-party/pugixml/src/pugixml.cpp
         src/Cache/TileCache.cc
         src/Cache/TilePool.cc
         src/DataStream/Compression.cc
@@ -250,7 +248,7 @@ set(SOURCE_FILES
         src/Util/Token.cc
         src/ImageFitter/ImageFitter.cc)
 
-add_definitions(-DHAVE_HDF5)
+add_definitions(-DHAVE_HDF5 -DPUGIXML_COMPACT)
 add_executable(carta_backend ${SOURCE_FILES})
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     list(REMOVE_ITEM LINK_LIBS uuid)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,7 @@ include_directories(${CMAKE_SOURCE_DIR}/third-party/include)
 install_uWebSockets()
 
 #pugixml
-include_directories(${CMAKE_SOURCE_DIR}/third-party/pugixml/src)
+#include_directories(${CMAKE_SOURCE_DIR}/third-party/pugixml/src)
 
 #spdlog
 add_subdirectory(third-party/spdlog)
@@ -188,7 +188,7 @@ set(LINK_LIBS
 
 set(SOURCE_FILES
         ${SOURCE_FILES}
-	${CMAKE_SOURCE_DIR}/third-party/pugixml/src/pugixml.cpp
+	third-party/pugixml/src/pugixml.cpp
         src/Cache/TileCache.cc
         src/Cache/TilePool.cc
         src/DataStream/Compression.cc
@@ -248,7 +248,7 @@ set(SOURCE_FILES
         src/Util/Token.cc
         src/ImageFitter/ImageFitter.cc)
 
-add_definitions(-DHAVE_HDF5 -DPUGIXML_COMPACT)
+add_definitions(-DHAVE_HDF5)
 add_executable(carta_backend ${SOURCE_FILES})
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     list(REMOVE_ITEM LINK_LIBS uuid)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,8 @@ include_directories(${CMAKE_SOURCE_DIR}/third-party/include)
 install_uWebSockets()
 
 #pugixml
-#include_directories(${CMAKE_SOURCE_DIR}/third-party/pugixml/src)
+SET(PUGIXML_COMPACT ON CACHE BOOL "" FORCE)
+include_directories(${CMAKE_SOURCE_DIR}/third-party/pugixml/src)
 
 #spdlog
 add_subdirectory(third-party/spdlog)
@@ -248,7 +249,7 @@ set(SOURCE_FILES
         src/Util/Token.cc
         src/ImageFitter/ImageFitter.cc)
 
-add_definitions(-DHAVE_HDF5)
+add_definitions(-DHAVE_HDF5 -DPUGIXML_COMPACT)
 add_executable(carta_backend ${SOURCE_FILES})
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     list(REMOVE_ITEM LINK_LIBS uuid)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,6 @@ include_directories(${CMAKE_SOURCE_DIR}/third-party/include)
 install_uWebSockets()
 
 #pugixml
-SET(PUGIXML_COMPACT ON CACHE BOOL "" FORCE)
 include_directories(${CMAKE_SOURCE_DIR}/third-party/pugixml/src)
 
 #spdlog

--- a/Dockerfiles/Dockerfile-AlmaLinux8
+++ b/Dockerfiles/Dockerfile-AlmaLinux8
@@ -9,7 +9,7 @@ RUN \
   dnf -y install autoconf automake bison blas-devel bzip2 cfitsio-devel cmake curl-devel flex gcc \
          gcc-c++ git git-lfs gsl-devel hdf5-devel lapack-devel libasan \
          libtool libxml2-devel libzstd-devel libuuid-devel make openssl-devel protobuf-devel \
-         python36 python3-pip pugixml-devel readline-devel subversion \
+         python36 python3-pip readline-devel subversion \
          wcslib-devel wget zlib-devel libuuid-devel zfp-devel && \
   pip3 install numpy astropy
 

--- a/Dockerfiles/Dockerfile-AlmaLinux9
+++ b/Dockerfiles/Dockerfile-AlmaLinux9
@@ -9,7 +9,7 @@ RUN \
   dnf -y install autoconf automake bison blas-devel bzip2 cfitsio-devel cmake curl-devel flex gcc \
          gcc-c++ git git-lfs gmock-devel gsl-devel gtest-devel hdf5-devel lapack-devel libasan \
          libtool libxml2-devel libzstd-devel libuuid-devel make openssl-devel protobuf-devel \
-         python3 python3-pip pugixml-devel readline-devel subversion \
+         python3 python3-pip readline-devel subversion \
          wget zlib-devel libuuid-devel && \
   pip3 install numpy astropy
 

--- a/Dockerfiles/Dockerfile-CentOS7
+++ b/Dockerfiles/Dockerfile-CentOS7
@@ -11,7 +11,7 @@ RUN \
   yum -y install epel-release && \
   yum install -y autoconf automake bison blas-devel bzip2 cfitsio-devel cmake3 curl-devel flex \
     git git-lfs hdf5-devel lapack-devel libtool libxml2-devel libzstd-devel \
-    make openssl-devel pugixml-devel python3 readline-devel subversion systemd-devel wcslib-devel wget \
+    make openssl-devel python3 readline-devel subversion systemd-devel wcslib-devel wget \
     zlib-devel libuuid-devel zfp-devel && \
   pip3 install numpy astropy && \
   ln -s /usr/bin/cmake3 /usr/bin/cmake

--- a/Dockerfiles/Dockerfile-ubuntu-18.04
+++ b/Dockerfiles/Dockerfile-ubuntu-18.04
@@ -6,7 +6,7 @@ RUN \
   apt-get -y upgrade && \
   apt-get install -y apt-utils autoconf bison build-essential byobu cmake curl default-jre dialog emacs \
     fftw3-dev flex gdb g++-8 gcc-8 gfortran git git-lfs htop libblas-dev \
-    libpugixml-dev libcfitsio-dev libhdf5-dev liblapack-dev libncurses-dev libreadline-dev libssl-dev \ 
+    libcfitsio-dev libhdf5-dev liblapack-dev libncurses-dev libreadline-dev libssl-dev \ 
     libstarlink-ast-dev libtool libxml2-dev libzstd-dev libgsl-dev man pkg-config python3-pip \
     software-properties-common unzip vim wcslib-dev wget uuid-dev && \
   pip3 install numpy astropy && \

--- a/Dockerfiles/Dockerfile-ubuntu-20.04
+++ b/Dockerfiles/Dockerfile-ubuntu-20.04
@@ -8,7 +8,7 @@ RUN \
   apt-get install -y apt-utils autoconf bison build-essential cmake curl fftw3-dev flex gcc g++ \
     gdb gfortran git git-lfs libgmock-dev googletest libblas-dev libcfitsio-dev \
     libgsl-dev libgtest-dev libhdf5-dev liblapack-dev libncurses-dev \
-    libprotobuf-dev libpugixml-dev libreadline-dev libssl-dev libstarlink-ast-dev \
+    libprotobuf-dev libreadline-dev libssl-dev libstarlink-ast-dev \
     libtool libxml2-dev libxslt1-dev libzstd-dev pkg-config protobuf-compiler \
     python3-numpy python3-astropy software-properties-common unzip wcslib-dev wget uuid-dev
 

--- a/Dockerfiles/Dockerfile-ubuntu-22.04
+++ b/Dockerfiles/Dockerfile-ubuntu-22.04
@@ -10,7 +10,7 @@ RUN \
   apt-get install -y apt-utils autoconf bison build-essential cmake curl fftw3-dev flex gcc g++ \
     gdb gfortran git git-lfs libgmock-dev googletest libblas-dev libcfitsio-dev \
     libgsl-dev libgtest-dev libhdf5-dev liblapack-dev libncurses-dev \
-    libprotobuf-dev libpugixml-dev libreadline-dev libssl-dev libstarlink-ast-dev \
+    libprotobuf-dev libreadline-dev libssl-dev libstarlink-ast-dev \
     libtool libxml2-dev libxslt1-dev libzstd-dev pkg-config protobuf-compiler \
     python3-numpy python3-astropy software-properties-common unzip wcslib-dev wget uuid-dev
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -63,11 +63,7 @@ set(TEST_SOURCES
 
 # Add all the sources in the main project and remove Main.cc
 foreach(src_file ${SOURCE_FILES})
-    if(IS_ABSOLUTE ${src_file})
-        list(APPEND SOURCES ${src_file})
-    else()
-        list(APPEND SOURCES ../${src_file})
-    endif()
+    list(APPEND SOURCES ../${src_file})
 endforeach()
 list(REMOVE_ITEM SOURCES REMOVE_ITEM ../src/Main/Main.cc)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -63,7 +63,11 @@ set(TEST_SOURCES
 
 # Add all the sources in the main project and remove Main.cc
 foreach(src_file ${SOURCE_FILES})
-    list(APPEND SOURCES ../${src_file})
+    if(IS_ABSOLUTE ${src_file})
+        list(APPEND SOURCES ${src_file})
+    else()
+        list(APPEND SOURCES ../${src_file})
+    endif()
 endforeach()
 list(REMOVE_ITEM SOURCES REMOVE_ITEM ../src/Main/Main.cc)
 


### PR DESCRIPTION
**Description**

This addresses issue #1261 

It uses @confluence's clever suggestion to simply include the pugixml cpp file directly in our build. It seems to work! I have attached 3 images as a demonstration. In each case, I open a catalog file.

1. The current v4.0.0-beta.1
![v4beta1](https://github.com/CARTAvis/carta-backend/assets/20802551/4d94c011-b079-45f8-bdc2-40342cfaa40b)

2. New method without the `-DPUGIXML_COMPACT` flag
![new_no_PUGIXML_COMPACT](https://github.com/CARTAvis/carta-backend/assets/20802551/b569d5ee-b5b1-4af4-b559-2fd6db738370)

3. New method with the `-DPUGIXML_COMPACT` flag
![new_PUGIXML_COMPACT](https://github.com/CARTAvis/carta-backend/assets/20802551/fbb1ff5f-089e-4fb7-96cf-fcacde3e5002)

We can see that the new method works, and it is clearly built using the compact mode because the RAM usage in plot 3 is practically identical to plot 1.

The new method also solves the pugixml install file issue:

In the old v4.0.0-beta.1 branch, when we do `make install` it installs pugixml files on your system that it should not install:
```
root@afe418483e39:/mount/carta-backend/build# make install
[  1%] Built target pugixml-static
[  8%] Built target uSockets
[ 59%] Built target carta-protobuf
[ 95%] Built target carta_backend
[100%] Built target spdlog
Install the project...
-- Install configuration: "RelWithDebInfo"
-- Installing: /usr/local/bin/carta_backend
-- Set runtime path of "/usr/local/bin/carta_backend" to ""
-- Up-to-date: /usr/local/bin/carta
-- Up-to-date: /usr/local/share/carta/default.fits
-- Installing: /usr/local/lib/libpugixml.a
-- Installing: /usr/local/lib/cmake/pugixml/pugixml-targets.cmake
-- Installing: /usr/local/lib/cmake/pugixml/pugixml-targets-relwithdebinfo.cmake
-- Installing: /usr/local/lib/cmake/pugixml/pugixml-config-version.cmake
-- Installing: /usr/local/lib/cmake/pugixml/pugixml-config.cmake
-- Installing: /usr/local/lib/pkgconfig/pugixml.pc
-- Up-to-date: /usr/local/include/pugiconfig.hpp
-- Up-to-date: /usr/local/include/pugixml.hpp
```

In the new branch, when we do `make install`, it now only installs the expected files:
```
root@150e535df8fd:/mount/carta-backend/build# make install
[ 34%] Built target carta-protobuf
[ 39%] Built target uSockets
[ 63%] Built target carta_backend
[ 66%] Built target spdlog
[100%] Built target carta_backend_tests
Install the project...
-- Install configuration: "RelWithDebInfo"
-- Installing: /usr/local/bin/carta_backend
-- Set runtime path of "/usr/local/bin/carta_backend" to ""
-- Installing: /usr/local/bin/carta
-- Installing: /usr/local/share/carta/default.fits
```

I also removed the installation of the pugixml packages from the Dockerfiles because they are no longer necessary. 

Changelog not updated yet. Do we add it to the "Fixed" section under [4.0.0-beta.1], or to a new [unreleased] "Fixed" section?

**Checklist**

- [x] changelog updated
- [ ] e2e test passing / added corresponding fix
- [x] no protobuf update needed
- [x] added reviewers and assignee
- [x] added ZenHub estimate, milestone, and release
