### PR TITLE
Fixes the problem of resuming LEL images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * Fixed spatial profile for polyline in widefield image ([#1258](https://github.com/CARTAvis/carta-backend/issues/1258)).
+* Fixed the problem of resuming LEL images ([#1226](https://github.com/CARTAvis/carta-backend/issues/1226)).
 
 ## [4.0.0-beta.1]
 

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -507,7 +507,7 @@ bool Session::OnOpenFile(const CARTA::OpenFile& message, uint32_t request_id, bo
 
                 std::string expression = "AMPLITUDE(" + filename + ")";
                 bool is_lel_expr(true);
-                auto open_file_message = Message::OpenFile(directory, expression, hdu, file_id, message.render_mode(), is_lel_expr);
+                auto open_file_message = Message::OpenFile(directory, expression, is_lel_expr, hdu, file_id, message.render_mode());
                 return OnOpenFile(open_file_message, request_id, silent);
             }
 
@@ -1113,7 +1113,7 @@ void Session::OnResumeSession(const CARTA::ResumeSession& message, uint32_t requ
                 err_file_ids.append(std::to_string(image.file_id()) + " ");
             }
         } else {
-            auto open_file_msg = Message::OpenFile(image.directory(), image.file(), image.hdu(), image.file_id());
+            auto open_file_msg = Message::OpenFile(image.directory(), image.file(), image.lel_expr(), image.hdu(), image.file_id());
 
             // Open a file
             if (!OnOpenFile(open_file_msg, request_id, true)) {

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -466,14 +466,14 @@ bool Session::OnOpenFile(const CARTA::OpenFile& message, uint32_t request_id, bo
     const auto& filename(message.file());
     std::string hdu(message.hdu());
     auto file_id(message.file_id());
-    bool is_lel_expr(message.lel_expr());
+    bool lel_expr(message.lel_expr());
 
     // response message:
     CARTA::OpenFileAck ack;
     bool success(false);
     string err_message;
 
-    if (is_lel_expr) {
+    if (lel_expr) {
         // filename field is LEL expression
         auto dir_path = GetResolvedFilename(_top_level_folder, directory, "");
         auto loader = _loaders.Get(filename, dir_path);

--- a/src/Util/Message.cc
+++ b/src/Util/Message.cc
@@ -25,7 +25,7 @@ CARTA::CloseFile Message::CloseFile(int32_t file_id) {
 }
 
 CARTA::OpenFile Message::OpenFile(
-    std::string directory, std::string file, std::string hdu, int32_t file_id, CARTA::RenderMode render_mode, bool lel_expr) {
+    std::string directory, std::string file, bool lel_expr, std::string hdu, int32_t file_id, CARTA::RenderMode render_mode) {
     CARTA::OpenFile open_file;
     open_file.set_directory(directory);
     open_file.set_file(file);

--- a/src/Util/Message.h
+++ b/src/Util/Message.h
@@ -63,8 +63,8 @@ public:
     // Request messages
     static CARTA::RegisterViewer RegisterViewer(uint32_t session_id, std::string api_key, uint32_t client_feature_flags);
     static CARTA::CloseFile CloseFile(int32_t file_id);
-    static CARTA::OpenFile OpenFile(std::string directory, std::string file, std::string hdu, int32_t file_id,
-        CARTA::RenderMode render_mode = CARTA::RenderMode::RASTER, bool lel_expr = false);
+    static CARTA::OpenFile OpenFile(std::string directory, std::string file, bool lel_expr, std::string hdu, int32_t file_id,
+        CARTA::RenderMode render_mode = CARTA::RenderMode::RASTER);
     static CARTA::SetImageChannels SetImageChannels(int32_t file_id, int32_t channel, int32_t stokes,
         CARTA::CompressionType compression_type = CARTA::CompressionType::NONE, float compression_quality = -1);
     static CARTA::SetCursor SetCursor(int32_t file_id, float x, float y);

--- a/test/TestIcd.cc
+++ b/test/TestIcd.cc
@@ -64,7 +64,7 @@ public:
         std::filesystem::path filename_path(filename_path_string);
 
         CARTA::OpenFile open_file =
-            Message::OpenFile(filename_path.parent_path(), filename_path.filename(), "0", 0, CARTA::RenderMode::RASTER);
+            Message::OpenFile(filename_path.parent_path(), filename_path.filename(), false, "0", 0, CARTA::RenderMode::RASTER);
 
         _dummy_backend->Receive(open_file);
 
@@ -159,7 +159,7 @@ public:
         std::filesystem::path second_filename_path(second_filename_path_string);
 
         CARTA::OpenFile open_file =
-            Message::OpenFile(first_filename_path.parent_path(), first_filename_path.filename(), "0", 0, CARTA::RenderMode::RASTER);
+            Message::OpenFile(first_filename_path.parent_path(), first_filename_path.filename(), false, "0", 0, CARTA::RenderMode::RASTER);
 
         _dummy_backend->Receive(open_file);
 
@@ -187,8 +187,8 @@ public:
 
         EXPECT_EQ(_message_count, 3);
 
-        open_file =
-            Message::OpenFile(second_filename_path.parent_path(), second_filename_path.filename(), "0", 1, CARTA::RenderMode::RASTER);
+        open_file = Message::OpenFile(
+            second_filename_path.parent_path(), second_filename_path.filename(), false, "0", 1, CARTA::RenderMode::RASTER);
 
         _dummy_backend->Receive(open_file);
 
@@ -266,7 +266,7 @@ public:
         std::filesystem::path filename_path(filename_path_string);
 
         CARTA::OpenFile open_file =
-            Message::OpenFile(filename_path.parent_path(), filename_path.filename(), "0", 0, CARTA::RenderMode::RASTER);
+            Message::OpenFile(filename_path.parent_path(), filename_path.filename(), false, "0", 0, CARTA::RenderMode::RASTER);
 
         _dummy_backend->Receive(open_file);
 
@@ -455,7 +455,7 @@ public:
         std::filesystem::path filename_path(filename_path_string);
 
         CARTA::OpenFile open_file =
-            Message::OpenFile(filename_path.parent_path(), filename_path.filename(), "0", 0, CARTA::RenderMode::RASTER);
+            Message::OpenFile(filename_path.parent_path(), filename_path.filename(), false, "0", 0, CARTA::RenderMode::RASTER);
 
         _dummy_backend->Receive(open_file);
 


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
Fixes the problem of resuming LEL images, #1226.

* How does this PR solve the issue? Give a brief summary.
Modifies the protobuf message for resuming images. Adds a new bool variable used to determine whether it is an LEL image when re-opening it.

* Are there any companion PRs (frontend, protobuf)?
Yes. It accompanies the [frontend PR](https://github.com/CARTAvis/carta-frontend/pull/2159) and [protobuf PR](https://github.com/CARTAvis/carta-protobuf/pull/84).

* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
The ICD tests for opening images may need to be modified. 

**Checklist**

- [x] changelog updated ~/ no changelog update needed~
- [x] e2e test passing / ~added corresponding fix~
- [x] protobuf updated to the latest dev commit ~/ no protobuf update needed~
- [ ] added reviewers and assignee
- [ ] added ZenHub estimate, milestone, and release
