### PR TITLE
Fix HDF5 PV generator regression failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Prevent the installation of pugixml library files ([#1261](https://github.com/CARTAvis/carta-backend/issues/1261)).
 * Fixed spatial profile for polyline in widefield image ([#1258](https://github.com/CARTAvis/carta-backend/issues/1258)).
+* Fixed regression failure of HDF5 PV image due to profile caching in the HDF5 loader ([#1259](https://github.com/CARTAvis/carta-backend/issues/1259)).
 
 ## [4.0.0-beta.1]
 

--- a/src/ImageData/Hdf5Loader.cc
+++ b/src/ImageData/Hdf5Loader.cc
@@ -424,7 +424,7 @@ bool Hdf5Loader::GetRegionSpectralData(int region_id, const AxisRange& spectral_
     _region_stats[region_stats_id].latest_x = max_x;
 
     if (progress >= 1.0) {
-        if (region_id == TEMP_REGION_ID) {
+        if (region_id <= TEMP_REGION_ID) {
             // clear for next temp region
             _region_stats.erase(region_stats_id);
         } else {

--- a/src/Region/Region.cc
+++ b/src/Region/Region.cc
@@ -458,12 +458,12 @@ bool Region::UseApproximatePolygon(std::shared_ptr<casacore::CoordinateSystem> o
 
             // Compare reference to converted length ratio
             double length_ratio_difference = fabs(ref_length_ratio - converted_length_ratio);
-            spdlog::debug("{} distortion check: length ratio difference={:.3e}", RegionName(region_type), length_ratio_difference);
+            // spdlog::debug("{} distortion check: length ratio difference={:.3e}", RegionName(region_type), length_ratio_difference);
 
             if (length_ratio_difference < 1e-4) {
                 // Passed ratio check; check dot product of converted region
                 double converted_dot_product = (v0_delta_x * v1_delta_x) + (v0_delta_y * v1_delta_y);
-                spdlog::debug("{} distortion check: dot product={:.3e}", RegionName(region_type), converted_dot_product);
+                // spdlog::debug("{} distortion check: dot product={:.3e}", RegionName(region_type), converted_dot_product);
 
                 if (fabs(converted_dot_product) < 1e-2) {
                     // passed distortion tests, do not use polygon approximation


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
#1259 
* How does this PR solve the issue? Give a brief summary.
The HDF5 PV image had duplicate profiles from the Hdf5Loader cache. The cache was deleted only for region id = TEMP_REGION_ID.  However, for parallel profiles each region now has a unique id decremented from the temp id, so the profile was being cached and reused when the same id was assigned later.  Now the cache is deleted if the region id <= TEMP_REGION_ID. Also removed distortion check output for matched regions, causing too much debug output; now the log only reports that the polygon approximation is being used.
* Are there any companion PRs (frontend, protobuf)?
No.
* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
See description in issue: create PV images from identical FITS and HDF5 source images, then compare them using a LEL expression.

**Checklist**

- [x] changelog updated / ~no changelog update needed~
- [ ] e2e test passing / added corresponding fix
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] added reviewers and assignee
- [x] added ZenHub estimate, milestone, and release
