### PR TITLE
Sends histogram data for image rendering only when the channel is changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Prevent the installation of pugixml library files ([#1261](https://github.com/CARTAvis/carta-backend/issues/1261)).
 * Fixed spatial profile for polyline in widefield image ([#1258](https://github.com/CARTAvis/carta-backend/issues/1258)).
+* Removed duplicate image histogram data sent to the frontend ([#1266](https://github.com/CARTAvis/carta-backend/issues/1266)).
 
 ## [4.0.0-beta.1]
 

--- a/src/Frame/Frame.h
+++ b/src/Frame/Frame.h
@@ -138,8 +138,8 @@ public:
 
     // Histograms: image and cube
     bool SetHistogramRequirements(int region_id, const std::vector<CARTA::HistogramConfig>& histogram_configs);
-    bool FillRegionHistogramData(
-        std::function<void(CARTA::RegionHistogramData histogram_data)> region_histogram_callback, int region_id, int file_id);
+    bool FillRegionHistogramData(std::function<void(CARTA::RegionHistogramData histogram_data)> region_histogram_callback, int region_id,
+        int file_id, bool channel_changed);
     bool GetBasicStats(int z, int stokes, BasicStats<float>& stats);
     bool CalculateHistogram(int region_id, int z, int stokes, int num_bins, const HistogramBounds& bounds, Histogram& hist);
     bool GetCubeHistogramConfig(HistogramConfig& config);
@@ -257,8 +257,6 @@ protected:
     casacore::Slicer GetExportImageSlicer(const CARTA::SaveFile& save_file_msg, casacore::IPosition image_shape);
     casacore::Slicer GetExportRegionSlicer(const CARTA::SaveFile& save_file_msg, casacore::IPosition image_shape,
         casacore::IPosition region_shape, casacore::LattRegionHolder& latt_region_holder);
-
-    void InitImageHistogramConfigs();
 
     // For convenience, create int map key for storing cache by z and stokes
     inline int CacheKey(int z, int stokes) {

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -1904,14 +1904,11 @@ void Session::UpdateRegionData(int file_id, int region_id, bool z_changed, bool 
 
     bool channel_changed(z_changed || stokes_changed);
     SendRegionHistogramData(file_id, region_id, channel_changed);
+    SendRegionStatsData(file_id, region_id);
 
-    if (channel_changed) {
-        SendRegionStatsData(file_id, region_id);
-        // SpatialProfileData sent after new requirements received
-    } else { // region changed, update all
+    if (!channel_changed) { // Region changed, update all
         SendSpatialProfileDataByRegionId(region_id);
         SendSpectralProfileData(file_id, region_id, stokes_changed);
-        SendRegionStatsData(file_id, region_id);
     }
 }
 

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -565,9 +565,10 @@ bool Session::OnOpenFile(const CARTA::OpenFile& message, uint32_t request_id, bo
 
     if (success) {
         // send histogram with default requirements
-        if (!SendRegionHistogramData(file_id, IMAGE_REGION_ID)) {
-            std::string message = fmt::format("Image histogram for file id {} failed", file_id);
-            SendLogEvent(message, {"open_file"}, CARTA::ErrorSeverity::ERROR);
+        bool channel_changed(true);
+        if (!SendRegionHistogramData(file_id, IMAGE_REGION_ID, channel_changed)) {
+            err_message = fmt::format("Image histogram for file id {} failed", file_id);
+            SendLogEvent(err_message, {"open_file"}, CARTA::ErrorSeverity::ERROR);
         }
     } else if (!err_message.empty()) {
         spdlog::error(err_message);
@@ -976,8 +977,8 @@ void Session::OnSetHistogramRequirements(const CARTA::SetHistogramRequirements& 
 
         if (requirements_set) {
             if ((message.histograms_size() > 0) && !SendRegionHistogramData(file_id, region_id)) {
-                std::string message = fmt::format("Histogram calculation for region {} failed", region_id);
-                SendLogEvent(message, {"histogram"}, CARTA::ErrorSeverity::WARNING);
+                std::string error = fmt::format("Histogram calculation for region {} failed", region_id);
+                SendLogEvent(error, {"histogram"}, CARTA::ErrorSeverity::WARNING);
             }
         } else {
             std::string error = fmt::format("Histogram requirements not valid for region id {}", region_id);
@@ -1704,7 +1705,7 @@ bool Session::SendSpectralProfileData(int file_id, int region_id, bool stokes_ch
     return data_sent;
 }
 
-bool Session::SendRegionHistogramData(int file_id, int region_id) {
+bool Session::SendRegionHistogramData(int file_id, int region_id, bool channel_changed) {
     // return true if data sent
     bool data_sent(false);
     if (region_id == ALL_REGIONS && !_region_handler) {
@@ -1724,7 +1725,8 @@ bool Session::SendRegionHistogramData(int file_id, int region_id) {
     } else if (region_id < CURSOR_REGION_ID) {
         // Image or cube histogram
         if (_frames.count(file_id)) {
-            bool filled_by_frame(_frames.at(file_id)->FillRegionHistogramData(region_histogram_data_callback, region_id, file_id));
+            bool filled_by_frame(
+                _frames.at(file_id)->FillRegionHistogramData(region_histogram_data_callback, region_id, file_id, channel_changed));
 
             if (!filled_by_frame && region_id == CUBE_REGION_ID) { // not in cache, calculate cube histogram
                 CARTA::RegionHistogramData histogram_data;
@@ -1878,9 +1880,10 @@ void Session::UpdateImageData(int file_id, bool send_image_histogram, bool z_cha
             SendSpectralProfileData(file_id, CURSOR_REGION_ID, stokes_changed);
         }
 
-        if (z_changed || stokes_changed) {
+        bool channel_changed(z_changed || stokes_changed);
+        if (channel_changed) {
             if (send_image_histogram) {
-                SendRegionHistogramData(file_id, IMAGE_REGION_ID);
+                SendRegionHistogramData(file_id, IMAGE_REGION_ID, channel_changed);
             }
 
             SendRegionStatsData(file_id, IMAGE_REGION_ID);
@@ -1898,17 +1901,16 @@ void Session::UpdateRegionData(int file_id, int region_id, bool z_changed, bool 
         SendSpectralProfileData(file_id, region_id, stokes_changed);
     }
 
-    if (z_changed || stokes_changed) {
-        SendRegionStatsData(file_id, region_id);
-        SendRegionHistogramData(file_id, region_id);
-        // SpatialProfileData sent after new requirements received
-    }
+    bool channel_changed(z_changed || stokes_changed);
+    SendRegionHistogramData(file_id, region_id, channel_changed);
 
-    if (!z_changed && !stokes_changed) { // region changed, update all
+    if (channel_changed) {
+        SendRegionStatsData(file_id, region_id);
+        // SpatialProfileData sent after new requirements received
+    } else { // region changed, update all
         SendSpatialProfileDataByRegionId(region_id);
         SendSpectralProfileData(file_id, region_id, stokes_changed);
         SendRegionStatsData(file_id, region_id);
-        SendRegionHistogramData(file_id, region_id);
     }
 }
 

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -620,7 +620,8 @@ bool Session::OnOpenFile(
     open_file_ack->set_message(err_message);
 
     if (success) {
-        UpdateRegionData(file_id, IMAGE_REGION_ID, false, false);
+        bool changed(true); // channel and stokes
+        UpdateRegionData(file_id, IMAGE_REGION_ID, changed, changed);
     } else if (!err_message.empty()) {
         spdlog::error(err_message);
     }

--- a/src/Session/Session.h
+++ b/src/Session/Session.h
@@ -264,7 +264,7 @@ protected:
     bool SendSpatialProfileData(int file_id, int region_id);
     void SendSpatialProfileDataByFileId(int file_id);
     void SendSpatialProfileDataByRegionId(int region_id);
-    bool SendRegionHistogramData(int file_id, int region_id);
+    bool SendRegionHistogramData(int file_id, int region_id, bool channel_changed = false);
     bool SendRegionStatsData(int file_id, int region_id);
 
     void UpdateImageData(int file_id, bool send_image_histogram, bool z_changed, bool stokes_changed);


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
Closes #1266.

* How does this PR solve the issue? Give a brief summary.
The backend only sends histogram data for the image rendering only when the channel is changed. There are also a few changes to clean up the codes.

* Are there any companion PRs (frontend, protobuf)?
No.

* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
The duplicated histogram data for the image region should be gone now.

**Checklist**

- [x] changelog updated ~/ no changelog update needed~
- [x] e2e test passing ~/ added corresponding fix~
- [x] ~protobuf updated to the latest dev commit /~ no protobuf update needed
- [ ] added reviewers and assignee
- [ ] added ZenHub estimate, milestone, and release
