### PR TITLE
Fixes the case-sensitive of reading BUNIT from header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Prevent the installation of pugixml library files ([#1261](https://github.com/CARTAvis/carta-backend/issues/1261)).
 * Fixed spatial profile for polyline in widefield image ([#1258](https://github.com/CARTAvis/carta-backend/issues/1258)).
 * Fixed regression failure of HDF5 PV image due to profile caching in the HDF5 loader ([#1259](https://github.com/CARTAvis/carta-backend/issues/1259)).
+* Fixed the case-sensitive of reading BUNIT from a file header ([#1187](https://github.com/CARTAvis/carta-backend/issues/1187)).
 
 ## [4.0.0-beta.1]
 

--- a/src/FileList/FileExtInfoLoader.cc
+++ b/src/FileList/FileExtInfoLoader.cc
@@ -265,7 +265,7 @@ void FileExtInfoLoader::AddEntriesFromHeaderStrings(
             break;
         }
 
-        if (name.startsWith("HISTORY") || name.startsWith("COMMENT")) {
+        if (name.startsWith("HISTORY") || name.startsWith("COMMENT") || name.startsWith("HIERARCH")) {
             auto entry = extended_info.add_header_entries();
             entry->set_name(name);
             continue;

--- a/src/ImageData/CasaLoader.h
+++ b/src/ImageData/CasaLoader.h
@@ -20,15 +20,14 @@ class CasaLoader : public FileLoader {
 public:
     CasaLoader(const std::string& filename);
 
-    void OpenFile(const std::string& hdu) override;
-
 private:
+    void AllocateImage(const std::string& hdu) override;
     casacore::TempImage<float>* ConvertImageToFloat(casacore::LatticeBase* lattice);
 };
 
 CasaLoader::CasaLoader(const std::string& filename) : FileLoader(filename) {}
 
-void CasaLoader::OpenFile(const std::string& /*hdu*/) {
+void CasaLoader::AllocateImage(const std::string& /*hdu*/) {
     if (!_image) {
         // Check if image is locked; PagedImage AutoNoReadLocking option tries to acquire a lock and blocks until it is free
         bool create(false), add_request(false), must_exist(false);
@@ -69,8 +68,6 @@ void CasaLoader::OpenFile(const std::string& /*hdu*/) {
             _data_type = _image->dataType();
         }
     }
-
-    NormalizeBunit();
 }
 
 casacore::TempImage<float>* CasaLoader::ConvertImageToFloat(casacore::LatticeBase* lattice) {

--- a/src/ImageData/CasaLoader.h
+++ b/src/ImageData/CasaLoader.h
@@ -70,7 +70,7 @@ void CasaLoader::OpenFile(const std::string& /*hdu*/) {
         }
     }
 
-    ResetBunit();
+    NormalizeBunit();
 }
 
 casacore::TempImage<float>* CasaLoader::ConvertImageToFloat(casacore::LatticeBase* lattice) {

--- a/src/ImageData/CasaLoader.h
+++ b/src/ImageData/CasaLoader.h
@@ -69,6 +69,8 @@ void CasaLoader::OpenFile(const std::string& /*hdu*/) {
             _data_type = _image->dataType();
         }
     }
+
+    ResetBunit();
 }
 
 casacore::TempImage<float>* CasaLoader::ConvertImageToFloat(casacore::LatticeBase* lattice) {

--- a/src/ImageData/CompListLoader.h
+++ b/src/ImageData/CompListLoader.h
@@ -38,6 +38,8 @@ void CompListLoader::OpenFile(const std::string& /*hdu*/) {
         _coord_sys = std::shared_ptr<casacore::CoordinateSystem>(static_cast<casacore::CoordinateSystem*>(_image->coordinates().clone()));
         _data_type = _image->dataType();
     }
+
+    ResetBunit();
 }
 
 } // namespace carta

--- a/src/ImageData/CompListLoader.h
+++ b/src/ImageData/CompListLoader.h
@@ -39,7 +39,7 @@ void CompListLoader::OpenFile(const std::string& /*hdu*/) {
         _data_type = _image->dataType();
     }
 
-    ResetBunit();
+    NormalizeBunit();
 }
 
 } // namespace carta

--- a/src/ImageData/CompListLoader.h
+++ b/src/ImageData/CompListLoader.h
@@ -19,12 +19,13 @@ class CompListLoader : public FileLoader {
 public:
     CompListLoader(const std::string& filename);
 
-    void OpenFile(const std::string& hdu) override;
+private:
+    void AllocateImage(const std::string& hdu) override;
 };
 
 CompListLoader::CompListLoader(const std::string& filename) : FileLoader(filename) {}
 
-void CompListLoader::OpenFile(const std::string& /*hdu*/) {
+void CompListLoader::AllocateImage(const std::string& /*hdu*/) {
     if (!_image) {
         _image.reset(new casa::ComponentListImage(_filename));
 
@@ -38,8 +39,6 @@ void CompListLoader::OpenFile(const std::string& /*hdu*/) {
         _coord_sys = std::shared_ptr<casacore::CoordinateSystem>(static_cast<casacore::CoordinateSystem*>(_image->coordinates().clone()));
         _data_type = _image->dataType();
     }
-
-    NormalizeBunit();
 }
 
 } // namespace carta

--- a/src/ImageData/ConcatLoader.h
+++ b/src/ImageData/ConcatLoader.h
@@ -19,12 +19,13 @@ class ConcatLoader : public FileLoader {
 public:
     ConcatLoader(const std::string& filename);
 
-    void OpenFile(const std::string& hdu) override;
+private:
+    void AllocateImage(const std::string& hdu) override;
 };
 
 ConcatLoader::ConcatLoader(const std::string& filename) : FileLoader(filename) {}
 
-void ConcatLoader::OpenFile(const std::string& /*hdu*/) {
+void ConcatLoader::AllocateImage(const std::string& /*hdu*/) {
     if (!_image) {
         casacore::JsonKVMap _jmap = casacore::JsonParser::parseFile(this->GetFileName() + "/imageconcat.json");
         _image.reset(new casacore::ImageConcat<float>(_jmap, this->GetFileName()));
@@ -39,8 +40,6 @@ void ConcatLoader::OpenFile(const std::string& /*hdu*/) {
         _coord_sys = std::shared_ptr<casacore::CoordinateSystem>(static_cast<casacore::CoordinateSystem*>(_image->coordinates().clone()));
         _data_type = _image->dataType();
     }
-
-    NormalizeBunit();
 }
 
 } // namespace carta

--- a/src/ImageData/ConcatLoader.h
+++ b/src/ImageData/ConcatLoader.h
@@ -40,7 +40,7 @@ void ConcatLoader::OpenFile(const std::string& /*hdu*/) {
         _data_type = _image->dataType();
     }
 
-    ResetBunit();
+    NormalizeBunit();
 }
 
 } // namespace carta

--- a/src/ImageData/ConcatLoader.h
+++ b/src/ImageData/ConcatLoader.h
@@ -39,6 +39,8 @@ void ConcatLoader::OpenFile(const std::string& /*hdu*/) {
         _coord_sys = std::shared_ptr<casacore::CoordinateSystem>(static_cast<casacore::CoordinateSystem*>(_image->coordinates().clone()));
         _data_type = _image->dataType();
     }
+
+    ResetBunit();
 }
 
 } // namespace carta

--- a/src/ImageData/ExprLoader.h
+++ b/src/ImageData/ExprLoader.h
@@ -63,6 +63,8 @@ void ExprLoader::OpenFile(const std::string& /*hdu*/) {
         _coord_sys = std::shared_ptr<casacore::CoordinateSystem>(static_cast<casacore::CoordinateSystem*>(_image->coordinates().clone()));
         _data_type = _image->dataType();
     }
+
+    ResetBunit();
 }
 
 bool ExprLoader::SaveFile(const CARTA::FileType type, const std::string& output_filename, std::string& message) {

--- a/src/ImageData/ExprLoader.h
+++ b/src/ImageData/ExprLoader.h
@@ -24,13 +24,15 @@ class ExprLoader : public FileLoader {
 public:
     ExprLoader(const std::string& filename, const std::string& directory = "");
 
-    void OpenFile(const std::string& hdu) override;
     bool SaveFile(const CARTA::FileType type, const std::string& output_filename, std::string& message) override;
+
+private:
+    void AllocateImage(const std::string& hdu) override;
 };
 
 ExprLoader::ExprLoader(const std::string& filename, const std::string& directory) : FileLoader(filename, directory) {}
 
-void ExprLoader::OpenFile(const std::string& /*hdu*/) {
+void ExprLoader::AllocateImage(const std::string& /*hdu*/) {
     if (!_image) {
         if (!_directory.empty()) {
             // create image from LEL expression stored in _filename
@@ -63,8 +65,6 @@ void ExprLoader::OpenFile(const std::string& /*hdu*/) {
         _coord_sys = std::shared_ptr<casacore::CoordinateSystem>(static_cast<casacore::CoordinateSystem*>(_image->coordinates().clone()));
         _data_type = _image->dataType();
     }
-
-    NormalizeBunit();
 }
 
 bool ExprLoader::SaveFile(const CARTA::FileType type, const std::string& output_filename, std::string& message) {

--- a/src/ImageData/ExprLoader.h
+++ b/src/ImageData/ExprLoader.h
@@ -64,7 +64,7 @@ void ExprLoader::OpenFile(const std::string& /*hdu*/) {
         _data_type = _image->dataType();
     }
 
-    ResetBunit();
+    NormalizeBunit();
 }
 
 bool ExprLoader::SaveFile(const CARTA::FileType type, const std::string& output_filename, std::string& message) {

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -873,11 +873,12 @@ double FileLoader::CalculateBeamArea() {
 void FileLoader::ResetBunit() {
     auto image = GetImage();
     if (image) {
+        std::unordered_map<std::string, std::string> bunits = {{"jy/beam", "Jy/beam"}, {"mjy/beam", "mJy/beam"}};
         std::string bunit = image->units().getName();
         std::string lower_bunit = image->units().getName();
         std::transform(lower_bunit.begin(), lower_bunit.end(), lower_bunit.begin(), [](unsigned char c) { return std::tolower(c); });
-        if (lower_bunit == "jy/beam" && bunit != "Jy/beam") {
-            casacore::Unit new_units("Jy/beam");
+        if (bunits.count(lower_bunit) && bunit != bunits[lower_bunit]) {
+            casacore::Unit new_units(bunits[lower_bunit]);
             image->setUnits(new_units);
         }
     }

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -877,17 +877,10 @@ double FileLoader::CalculateBeamArea() {
 
 void FileLoader::NormalizeBunit() {
     if (_image) {
-        std::string bunit = _image->units().getName();
+        auto bunit = _image->units().getName();
         bunit.erase(std::remove(bunit.begin(), bunit.end(), '"'), bunit.end());
-
-        std::string lower_bunit = bunit;
-        std::transform(lower_bunit.begin(), lower_bunit.end(), lower_bunit.begin(), [](unsigned char c) { return std::tolower(c); });
-
-        std::unordered_map<std::string, std::string> bunits = {{"jy/beam", "Jy/beam"}, {"mjy/beam", "mJy/beam"}};
-        if (bunits.count(lower_bunit) && bunit != bunits[lower_bunit]) {
-            casacore::Unit new_units(bunits[lower_bunit]);
-            _image->setUnits(new_units);
-        }
+        NormalizeUnit(bunit);
+        _image->setUnits(bunit);
     }
 }
 

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -873,10 +873,13 @@ double FileLoader::CalculateBeamArea() {
 void FileLoader::ResetBunit() {
     auto image = GetImage();
     if (image) {
-        std::unordered_map<std::string, std::string> bunits = {{"jy/beam", "Jy/beam"}, {"mjy/beam", "mJy/beam"}};
         std::string bunit = image->units().getName();
-        std::string lower_bunit = image->units().getName();
+        bunit.erase(std::remove(bunit.begin(), bunit.end(), '"'), bunit.end());
+
+        std::string lower_bunit = bunit;
         std::transform(lower_bunit.begin(), lower_bunit.end(), lower_bunit.begin(), [](unsigned char c) { return std::tolower(c); });
+
+        std::unordered_map<std::string, std::string> bunits = {{"jy/beam", "Jy/beam"}, {"mjy/beam", "mJy/beam"}};
         if (bunits.count(lower_bunit) && bunit != bunits[lower_bunit]) {
             casacore::Unit new_units(bunits[lower_bunit]);
             image->setUnits(new_units);

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -92,31 +92,10 @@ void FileLoader::OpenFile(const std::string& hdu) {
 
     // Normalize the upper/lower cases of BUNIT string from header
     if (_image) {
-        std::string bunit = _image->units().getName();
-        bunit.erase(std::remove(bunit.begin(), bunit.end(), '"'), bunit.end());
-
-        if (bunit.size() > 1) {
-            std::string prefix = bunit.substr(0, 1);
-            bool concat(false);
-            if (prefix == "M" || prefix == "m") {
-                bunit = bunit.substr(1, bunit.size() - 1);
-                concat = true;
-            }
-
-            std::string lower_bunit = bunit;
-            std::transform(lower_bunit.begin(), lower_bunit.end(), lower_bunit.begin(), ::tolower);
-            std::unordered_set<std::string> lower_bunits = {"jy/beam", "jypb", "jy beam-1", "jy beam^-1"};
-            std::string norm_bunit("Jy/beam");
-
-            if (lower_bunits.count(lower_bunit) && bunit != norm_bunit) {
-                casacore::Unit new_bunit;
-                if (concat) {
-                    new_bunit.setName(prefix + norm_bunit);
-                } else {
-                    new_bunit.setName(norm_bunit);
-                }
-                _image->setUnits(new_bunit);
-            }
+        casacore::String bunit = _image->units().getName();
+        NormalizeUnit(bunit);
+        if (bunit != _image->units().getName() && casacore::UnitVal::check(bunit)) {
+            _image->setUnits(casacore::Unit(bunit));
         }
     }
 }

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -871,9 +871,8 @@ double FileLoader::CalculateBeamArea() {
 }
 
 void FileLoader::NormalizeBunit() {
-    auto image = GetImage();
-    if (image) {
-        std::string bunit = image->units().getName();
+    if (_image) {
+        std::string bunit = _image->units().getName();
         bunit.erase(std::remove(bunit.begin(), bunit.end(), '"'), bunit.end());
 
         std::string lower_bunit = bunit;
@@ -882,7 +881,7 @@ void FileLoader::NormalizeBunit() {
         std::unordered_map<std::string, std::string> bunits = {{"jy/beam", "Jy/beam"}, {"mjy/beam", "mJy/beam"}};
         if (bunits.count(lower_bunit) && bunit != bunits[lower_bunit]) {
             casacore::Unit new_units(bunits[lower_bunit]);
-            image->setUnits(new_units);
+            _image->setUnits(new_units);
         }
     }
 }

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -87,6 +87,11 @@ bool FileLoader::CanOpenFile(std::string& /*error*/) {
     return true;
 }
 
+void FileLoader::OpenFile(const std::string& hdu) {
+    AllocateImage(hdu);
+    NormalizeBunit();
+}
+
 typename FileLoader::ImageRef FileLoader::GetImage(bool check_data_type) {
     if (!_image) {
         OpenFile(_hdu);

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -876,7 +876,7 @@ void FileLoader::ResetBunit() {
         std::string bunit = image->units().getName();
         std::string lower_bunit = image->units().getName();
         std::transform(lower_bunit.begin(), lower_bunit.end(), lower_bunit.begin(), [](unsigned char c) { return std::tolower(c); });
-        if (bunit != "Jy/beam" && lower_bunit == "jy/beam") {
+        if (lower_bunit == "jy/beam" && bunit != "Jy/beam") {
             casacore::Unit new_units("Jy/beam");
             image->setUnits(new_units);
         }

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -870,7 +870,7 @@ double FileLoader::CalculateBeamArea() {
     return info.getBeamAreaInPixels(-1, -1, _coord_sys->directionCoordinate());
 }
 
-void FileLoader::ResetBunit() {
+void FileLoader::NormalizeBunit() {
     auto image = GetImage();
     if (image) {
         std::string bunit = image->units().getName();

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -870,6 +870,19 @@ double FileLoader::CalculateBeamArea() {
     return info.getBeamAreaInPixels(-1, -1, _coord_sys->directionCoordinate());
 }
 
+void FileLoader::ResetBunit() {
+    auto image = GetImage();
+    if (image) {
+        std::string bunit = image->units().getName();
+        std::string lower_bunit = image->units().getName();
+        std::transform(lower_bunit.begin(), lower_bunit.end(), lower_bunit.begin(), [](unsigned char c) { return std::tolower(c); });
+        if (bunit != "Jy/beam" && lower_bunit == "jy/beam") {
+            casacore::Unit new_units("Jy/beam");
+            image->setUnits(new_units);
+        }
+    }
+}
+
 bool FileLoader::GetStokesTypeIndex(const CARTA::PolarizationType& stokes_type, int& stokes_index) {
     if (_stokes_indices.count(stokes_type)) {
         stokes_index = _stokes_indices[stokes_type];

--- a/src/ImageData/FileLoader.h
+++ b/src/ImageData/FileLoader.h
@@ -184,9 +184,6 @@ protected:
 
     // Set the image object and its parameters
     virtual void AllocateImage(const std::string& hdu) = 0;
-
-    // Ignore the upper or lower cases of BUNIT from header
-    void NormalizeBunit();
 };
 
 } // namespace carta

--- a/src/ImageData/FileLoader.h
+++ b/src/ImageData/FileLoader.h
@@ -181,6 +181,9 @@ protected:
 
     // Basic flux density calculation
     double CalculateBeamArea();
+
+    // Ignore the upper or lower cases of BUNIT from header
+    void ResetBunit();
 };
 
 } // namespace carta

--- a/src/ImageData/FileLoader.h
+++ b/src/ImageData/FileLoader.h
@@ -183,7 +183,7 @@ protected:
     double CalculateBeamArea();
 
     // Ignore the upper or lower cases of BUNIT from header
-    void ResetBunit();
+    void NormalizeBunit();
 };
 
 } // namespace carta

--- a/src/ImageData/FileLoader.h
+++ b/src/ImageData/FileLoader.h
@@ -55,7 +55,7 @@ public:
     // check for mirlib (MIRIAD) error; returns true for other image types
     virtual bool CanOpenFile(std::string& error);
     // Open and close file
-    virtual void OpenFile(const std::string& hdu) = 0;
+    virtual void OpenFile(const std::string& hdu);
     // Check to see if the file has a particular HDU/group/table/etc
     virtual bool HasData(FileInfo::Data ds) const;
 
@@ -181,6 +181,9 @@ protected:
 
     // Basic flux density calculation
     double CalculateBeamArea();
+
+    // Set the image object and its parameters
+    virtual void AllocateImage(const std::string& hdu) = 0;
 
     // Ignore the upper or lower cases of BUNIT from header
     void NormalizeBunit();

--- a/src/ImageData/FitsLoader.h
+++ b/src/ImageData/FitsLoader.h
@@ -139,6 +139,8 @@ void FitsLoader::OpenFile(const std::string& hdu) {
             _data_type = fits_image->internalDataType();
         }
     }
+
+    ResetBunit();
 }
 
 int FitsLoader::GetNumHeaders(const std::string& filename, int hdu) {

--- a/src/ImageData/FitsLoader.h
+++ b/src/ImageData/FitsLoader.h
@@ -24,12 +24,11 @@ public:
     FitsLoader(const std::string& filename, bool is_gz = false);
     ~FitsLoader();
 
-    void OpenFile(const std::string& hdu) override;
-
 private:
     std::string _unzip_file;
     casacore::uInt _hdu_num;
 
+    void AllocateImage(const std::string& hdu) override;
     int GetNumHeaders(const std::string& filename, int hdu);
     void RemoveHistoryBeam(unsigned int hdu_num);
 };
@@ -45,7 +44,7 @@ FitsLoader::~FitsLoader() {
     }
 }
 
-void FitsLoader::OpenFile(const std::string& hdu) {
+void FitsLoader::AllocateImage(const std::string& hdu) {
     // Convert string to FITS hdu number
     casacore::uInt hdu_num(FileInfo::GetFitsHdu(hdu));
 
@@ -139,8 +138,6 @@ void FitsLoader::OpenFile(const std::string& hdu) {
             _data_type = fits_image->internalDataType();
         }
     }
-
-    NormalizeBunit();
 }
 
 int FitsLoader::GetNumHeaders(const std::string& filename, int hdu) {

--- a/src/ImageData/FitsLoader.h
+++ b/src/ImageData/FitsLoader.h
@@ -140,7 +140,7 @@ void FitsLoader::OpenFile(const std::string& hdu) {
         }
     }
 
-    ResetBunit();
+    NormalizeBunit();
 }
 
 int FitsLoader::GetNumHeaders(const std::string& filename, int hdu) {

--- a/src/ImageData/Hdf5Loader.cc
+++ b/src/ImageData/Hdf5Loader.cc
@@ -13,7 +13,7 @@ namespace carta {
 
 Hdf5Loader::Hdf5Loader(const std::string& filename) : FileLoader(filename), _hdu("0") {}
 
-void Hdf5Loader::OpenFile(const std::string& hdu) {
+void Hdf5Loader::AllocateImage(const std::string& hdu) {
     // Explicitly handle empty HDU as the default 0
     std::string selected_hdu = hdu.empty() ? "0" : hdu;
 
@@ -56,8 +56,6 @@ void Hdf5Loader::OpenFile(const std::string& hdu) {
             }
         }
     }
-
-    NormalizeBunit();
 }
 
 bool Hdf5Loader::HasData(std::string ds_name) const {

--- a/src/ImageData/Hdf5Loader.cc
+++ b/src/ImageData/Hdf5Loader.cc
@@ -57,7 +57,7 @@ void Hdf5Loader::OpenFile(const std::string& hdu) {
         }
     }
 
-    ResetBunit();
+    NormalizeBunit();
 }
 
 bool Hdf5Loader::HasData(std::string ds_name) const {

--- a/src/ImageData/Hdf5Loader.cc
+++ b/src/ImageData/Hdf5Loader.cc
@@ -56,6 +56,8 @@ void Hdf5Loader::OpenFile(const std::string& hdu) {
             }
         }
     }
+
+    ResetBunit();
 }
 
 bool Hdf5Loader::HasData(std::string ds_name) const {

--- a/src/ImageData/Hdf5Loader.h
+++ b/src/ImageData/Hdf5Loader.h
@@ -25,8 +25,6 @@ class Hdf5Loader : public FileLoader {
 public:
     Hdf5Loader(const std::string& filename);
 
-    void OpenFile(const std::string& hdu) override;
-
     bool HasData(FileInfo::Data ds) const override;
 
     bool GetCursorSpectralData(
@@ -52,6 +50,8 @@ private:
     std::map<FileInfo::RegionStatsId, FileInfo::RegionSpectralStats> _region_stats;
 
     H5D_layout_t _layout;
+
+    void AllocateImage(const std::string& hdu) override;
 
     std::string DataSetToString(FileInfo::Data ds) const;
     bool HasData(std::string ds_name) const;

--- a/src/ImageData/ImagePtrLoader.h
+++ b/src/ImageData/ImagePtrLoader.h
@@ -15,7 +15,8 @@ class ImagePtrLoader : public FileLoader {
 public:
     ImagePtrLoader(std::shared_ptr<casacore::ImageInterface<float>> image, const std::string& filename);
 
-    void OpenFile(const std::string& hdu) override;
+private:
+    void AllocateImage(const std::string& hdu) override;
 };
 
 ImagePtrLoader::ImagePtrLoader(std::shared_ptr<casacore::ImageInterface<float>> image, const std::string& filename)
@@ -29,7 +30,7 @@ ImagePtrLoader::ImagePtrLoader(std::shared_ptr<casacore::ImageInterface<float>> 
     _data_type = _image->dataType();
 }
 
-void ImagePtrLoader::OpenFile(const std::string& /*hdu*/) {}
+void ImagePtrLoader::AllocateImage(const std::string& /*hdu*/) {}
 
 } // namespace carta
 

--- a/src/ImageData/MiriadLoader.h
+++ b/src/ImageData/MiriadLoader.h
@@ -66,6 +66,8 @@ void MiriadLoader::OpenFile(const std::string& /*hdu*/) {
         _coord_sys = std::shared_ptr<casacore::CoordinateSystem>(static_cast<casacore::CoordinateSystem*>(_image->coordinates().clone()));
         _data_type = _image->dataType();
     }
+
+    ResetBunit();
 }
 
 } // namespace carta

--- a/src/ImageData/MiriadLoader.h
+++ b/src/ImageData/MiriadLoader.h
@@ -20,7 +20,8 @@ public:
 
     bool CanOpenFile(std::string& error) override;
 
-    void OpenFile(const std::string& hdu) override;
+private:
+    void AllocateImage(const std::string& hdu) override;
 };
 
 MiriadLoader::MiriadLoader(const std::string& filename) : FileLoader(filename) {}
@@ -52,7 +53,7 @@ bool MiriadLoader::CanOpenFile(std::string& error) {
     return miriad_ok;
 }
 
-void MiriadLoader::OpenFile(const std::string& /*hdu*/) {
+void MiriadLoader::AllocateImage(const std::string& /*hdu*/) {
     if (!_image) {
         _image.reset(new CartaMiriadImage(_filename));
 
@@ -66,8 +67,6 @@ void MiriadLoader::OpenFile(const std::string& /*hdu*/) {
         _coord_sys = std::shared_ptr<casacore::CoordinateSystem>(static_cast<casacore::CoordinateSystem*>(_image->coordinates().clone()));
         _data_type = _image->dataType();
     }
-
-    NormalizeBunit();
 }
 
 } // namespace carta

--- a/src/ImageData/MiriadLoader.h
+++ b/src/ImageData/MiriadLoader.h
@@ -67,7 +67,7 @@ void MiriadLoader::OpenFile(const std::string& /*hdu*/) {
         _data_type = _image->dataType();
     }
 
-    ResetBunit();
+    NormalizeBunit();
 }
 
 } // namespace carta

--- a/src/Util/Casacore.cc
+++ b/src/Util/Casacore.cc
@@ -174,12 +174,53 @@ std::string FormatQuantity(const casacore::Quantity& quantity) {
 
 void NormalizeUnit(casacore::String& unit) {
     // Convert unit string to "proper" units according to casacore
-    casacore::UnitMap::addFITS();
-    casacore::String unit_name(unit);
-    unit_name.upcase();
-    if (casacore::UnitVal::check(unit_name)) {
-        unit = casacore::UnitMap::fromFITS(unit_name).getName();
-        return;
+    unit.gsub("JY", "Jy");       // Nonstandard "JY" passes check
+    unit.gsub("Beam", "beam");   // Nonstandard "Beam" passes check
+    unit.gsub("Pixel", "pixel"); // Nonstandard "Pixel" passes check
+
+    // Convert unit without prefix
+    try {
+        // Convert upper to mixed/lower case if needed
+        auto normalized_unit = casacore::UnitMap::fromFITS(unit).getName();
+
+        if (casacore::UnitVal::check(normalized_unit)) {
+            unit = normalized_unit;
+            return;
+        }
+    } catch (const casacore::AipsError& err) {
+        // check() should catch the error and returned false, but does not
     }
-    // keep original unit
+
+    // Convert unit with (possible) prefix
+    casacore::String prefix(unit[0]);
+    casacore::UnitName unit_name;
+    if (casacore::UnitMap::getPref(prefix, unit_name)) {
+        try {
+            // Convert unit with "prefix" removed
+            casacore::String unit_no_prefix = unit.substr(1);
+            unit_no_prefix.upcase();
+            auto normalized_unit = casacore::UnitMap::fromFITS(unit_no_prefix).getName();
+
+            if (casacore::UnitVal::check(normalized_unit)) {
+                unit = prefix + normalized_unit;
+                return;
+            }
+        } catch (const casacore::AipsError& err) {
+            // not caught by check()
+        }
+    }
+
+    // Convert uppercase unit without prefix, else return unknown input unit
+    casacore::String up_unit(unit);
+    up_unit.upcase();
+    try {
+        // Convert upper to mixed/lower case
+        auto normalized_unit = casacore::UnitMap::fromFITS(up_unit).getName();
+
+        if (casacore::UnitVal::check(normalized_unit)) {
+            unit = normalized_unit;
+        }
+    } catch (const casacore::AipsError& err) {
+        // check() should catch the error and returned false, but does not
+    }
 }

--- a/src/Util/Casacore.cc
+++ b/src/Util/Casacore.cc
@@ -176,12 +176,16 @@ void NormalizeUnit(casacore::String& unit) {
     // Convert unit string to "proper" units according to casacore
     // Fix nonstandard units which pass check
     unit.gsub("JY", "Jy");
+    unit.gsub("jy", "Jy");
     unit.gsub("Beam", "beam");
     unit.gsub("BEAM", "beam");
+    unit.gsub("Jypb", "Jy/beam");
+    unit.gsub("JyPB", "Jy/beam");
+    unit.gsub("Jy beam-1", "Jy/beam");
+    unit.gsub("Jy beam^-1", "Jy/beam");
+    unit.gsub("beam-1 Jy", "Jy/beam");
+    unit.gsub("beam^-1 Jy", "Jy/beam");
     unit.gsub("Pixel", "pixel");
-    unit.gsub("jypb", "Jy/beam");
-    unit.gsub("jy beam-1", "Jy/beam");
-    unit.gsub("jy beam^-1", "Jy/beam");
     unit.gsub("\"", "");
 
     // Convert unit without prefix

--- a/src/Util/Casacore.cc
+++ b/src/Util/Casacore.cc
@@ -177,7 +177,12 @@ void NormalizeUnit(casacore::String& unit) {
     // Fix nonstandard units which pass check
     unit.gsub("JY", "Jy");
     unit.gsub("Beam", "beam");
+    unit.gsub("BEAM", "beam");
     unit.gsub("Pixel", "pixel");
+    unit.gsub("jypb", "Jy/beam");
+    unit.gsub("jy beam-1", "Jy/beam");
+    unit.gsub("jy beam^-1", "Jy/beam");
+    unit.gsub("\"", "");
 
     // Convert unit without prefix
     try {

--- a/src/Util/Casacore.cc
+++ b/src/Util/Casacore.cc
@@ -174,9 +174,10 @@ std::string FormatQuantity(const casacore::Quantity& quantity) {
 
 void NormalizeUnit(casacore::String& unit) {
     // Convert unit string to "proper" units according to casacore
-    unit.gsub("JY", "Jy");       // Nonstandard "JY" passes check
-    unit.gsub("Beam", "beam");   // Nonstandard "Beam" passes check
-    unit.gsub("Pixel", "pixel"); // Nonstandard "Pixel" passes check
+    // Fix nonstandard units which pass check
+    unit.gsub("JY", "Jy");
+    unit.gsub("Beam", "beam");
+    unit.gsub("Pixel", "pixel");
 
     // Convert unit without prefix
     try {
@@ -188,7 +189,7 @@ void NormalizeUnit(casacore::String& unit) {
             return;
         }
     } catch (const casacore::AipsError& err) {
-        // check() should catch the error and returned false, but does not
+        // check() should catch the error and return false, but does not
     }
 
     // Convert unit with (possible) prefix
@@ -221,6 +222,6 @@ void NormalizeUnit(casacore::String& unit) {
             unit = normalized_unit;
         }
     } catch (const casacore::AipsError& err) {
-        // check() should catch the error and returned false, but does not
+        // not caught by check()
     }
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -53,6 +53,7 @@ set(TEST_SOURCES
 		TestLineSpatialProfiles.cc
         TestMain.cc
         TestMoment.cc
+        TestNormalizedUnits.cc
         TestProgramSettings.cc
         TestPvGenerator.cc
         TestRestApi.cc

--- a/test/TestNormalizedUnits.cc
+++ b/test/TestNormalizedUnits.cc
@@ -8,19 +8,26 @@
 
 #include "Util/Casacore.h"
 
-TEST(NormalizedUnitsTest, ValidBunits) {
-    std::vector<casacore::String> input_bunits = {"Jy/beam", "mJy/beam", "MJy/beam"};
+std::vector<casacore::String> TEST_BUNITS = {"Jy/beam", "Jy/Beam", "JY/Beam", "JY/BEAM", "jypb", "Jypb", "JYpb", "jy beam-1", "jy beam^-1",
+    "Jy beam-1", "Jy beam^-1", "JY beam-1", "JY beam^-1", "jy Beam-1", "jy Beam^-1", "Jy Beam-1", "Jy Beam^-1", "JY Beam-1", "JY Beam^-1",
+    "beam-1 jy", "beam^-1 jy", "beam-1 Jy", "beam^-1 Jy", "beam-1 JY", "beam^-1 JY", "Beam-1 jy", "jy Beam^-1", "Beam-1 Jy", "Beam^-1 Jy",
+    "Beam-1 JY", "Beam^-1 JY"};
 
-    for (auto bunit : input_bunits) {
+TEST(NormalizedUnitsTest, ValidBunits) {
+    std::vector<casacore::String> valid_bunits = {"Jy/beam", "mJy/beam", "MJy/beam"};
+    for (auto bunit : valid_bunits) {
         EXPECT_TRUE(casacore::UnitVal::check(bunit));
+    }
+
+    std::vector<casacore::String> invalid_bunits = {"Jy/Beam", "\"jy/beam\"", "counts/s", "MYJy/beam"};
+    for (auto bunit : invalid_bunits) {
+        EXPECT_FALSE(casacore::UnitVal::check(bunit));
     }
 }
 
 TEST(NormalizedUnitsTest, Bunit) {
     casacore::String norm_bunit("Jy/beam");
-    std::vector<casacore::String> input_bunits = {"Jy/beam", "Jy/Beam", "JY/Beam", "JY/BEAM", "jypb", "jy beam-1", "jy beam^-1"};
-
-    for (auto bunit : input_bunits) {
+    for (auto bunit : TEST_BUNITS) {
         NormalizeUnit(bunit);
         EXPECT_EQ(bunit, norm_bunit);
     }
@@ -28,9 +35,8 @@ TEST(NormalizedUnitsTest, Bunit) {
 
 TEST(NormalizedUnitsTest, BunitPrefixUpperM) {
     casacore::String norm_bunit("MJy/beam");
-    std::vector<casacore::String> input_bunits = {"MJy/beam", "MJy/Beam", "MJY/Beam", "MJY/BEAM", "Mjypb", "Mjy beam-1", "Mjy beam^-1"};
-
-    for (auto bunit : input_bunits) {
+    for (auto bunit : TEST_BUNITS) {
+        bunit = "M" + bunit;
         NormalizeUnit(bunit);
         EXPECT_EQ(bunit, norm_bunit);
     }
@@ -38,9 +44,8 @@ TEST(NormalizedUnitsTest, BunitPrefixUpperM) {
 
 TEST(NormalizedUnitsTest, BunitPrefixLowerM) {
     casacore::String norm_bunit("mJy/beam");
-    std::vector<casacore::String> input_bunits = {"mJy/beam", "mJy/Beam", "mJY/Beam", "mJY/BEAM", "mjypb", "mjy beam-1", "mjy beam^-1"};
-
-    for (auto bunit : input_bunits) {
+    for (auto bunit : TEST_BUNITS) {
+        bunit = "m" + bunit;
         NormalizeUnit(bunit);
         EXPECT_EQ(bunit, norm_bunit);
     }

--- a/test/TestNormalizedUnits.cc
+++ b/test/TestNormalizedUnits.cc
@@ -1,0 +1,47 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018-2022 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+#include <gtest/gtest.h>
+
+#include "Util/Casacore.h"
+
+TEST(NormalizedUnitsTest, ValidBunits) {
+    std::vector<casacore::String> input_bunits = {"Jy/beam", "mJy/beam", "MJy/beam"};
+
+    for (auto bunit : input_bunits) {
+        EXPECT_TRUE(casacore::UnitVal::check(bunit));
+    }
+}
+
+TEST(NormalizedUnitsTest, Bunit) {
+    casacore::String norm_bunit("Jy/beam");
+    std::vector<casacore::String> input_bunits = {"Jy/beam", "Jy/Beam", "JY/Beam", "JY/BEAM", "jypb", "jy beam-1", "jy beam^-1"};
+
+    for (auto bunit : input_bunits) {
+        NormalizeUnit(bunit);
+        EXPECT_EQ(bunit, norm_bunit);
+    }
+}
+
+TEST(NormalizedUnitsTest, BunitPrefixUpperM) {
+    casacore::String norm_bunit("MJy/beam");
+    std::vector<casacore::String> input_bunits = {"MJy/beam", "MJy/Beam", "MJY/Beam", "MJY/BEAM", "Mjypb", "Mjy beam-1", "Mjy beam^-1"};
+
+    for (auto bunit : input_bunits) {
+        NormalizeUnit(bunit);
+        EXPECT_EQ(bunit, norm_bunit);
+    }
+}
+
+TEST(NormalizedUnitsTest, BunitPrefixLowerM) {
+    casacore::String norm_bunit("mJy/beam");
+    std::vector<casacore::String> input_bunits = {"mJy/beam", "mJy/Beam", "mJY/Beam", "mJY/BEAM", "mjypb", "mjy beam-1", "mjy beam^-1"};
+
+    for (auto bunit : input_bunits) {
+        NormalizeUnit(bunit);
+        EXPECT_EQ(bunit, norm_bunit);
+    }
+}


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
Closes #1187. 

* How does this PR solve the issue? Give a brief summary.
It appears that the casacore is case-sensitive to BUNIT setting reads from the file header. To solve it, CARTA will convert any case combinations such as `Jy/Beam`, `jy/beam`, or `JY/BEAM`, etc. to `Jy/beam` while opening a file. 

* Are there any companion PRs (frontend, protobuf)?
No.

* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
The statistics calculation for `FluxDensity` is now available for any files with the case combinations of BUNIT `Jy/beam`.

**Checklist**

- [x] changelog updated ~/ no changelog update needed~
- [x] e2e test passing / ~added corresponding fix~
- [x] ~protobuf updated to the latest dev commit /~ no protobuf update needed
- [x] added reviewers and assignee
- [x] added ZenHub estimate, milestone, and release
