### PR TITLE
Yuhsuan/matched frame animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+* Support animation playback with matched images in multi-panel view ([#1860](https://github.com/CARTAvis/carta-frontend/issues/1860)).
 ### Fixed
 * Prevent the installation of pugixml library files ([#1261](https://github.com/CARTAvis/carta-backend/issues/1261)).
 * Fixed spatial profile for polyline in widefield image ([#1258](https://github.com/CARTAvis/carta-backend/issues/1258)).

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -2107,10 +2107,8 @@ void Session::ExecuteAnimationFrameInner() {
                     // Send vector field data if required
                     SendVectorFieldData(file_id);
 
-                    // Send tile data for active frame
-                    if (is_active_frame) {
-                        OnAddRequiredTiles(active_frame->GetAnimationViewSettings());
-                    }
+                    // Send tile data
+                    OnAddRequiredTiles(_frames.at(file_id)->GetAnimationViewSettings());
 
                     // Send region histograms and profiles
                     UpdateRegionData(file_id, ALL_REGIONS, z_changed, stokes_changed);

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -665,10 +665,14 @@ void Session::OnAddRequiredTiles(const CARTA::AddRequiredTiles& message, bool sk
     auto z = _frames.at(file_id)->CurrentZ();
     auto stokes = _frames.at(file_id)->CurrentStokes();
     auto animation_id = AnimationRunning() ? _animation_id : 0;
-    if (!message.tiles().empty() && _frames.count(file_id)) {
+    if (_frames.count(file_id)) {
         if (skip_data) {
             // Update view settings and skip sending data
             _frames.at(file_id)->SetAnimationViewSettings(message);
+            return;
+        }
+
+        if (message.tiles().empty()) {
             return;
         }
 


### PR DESCRIPTION
**Description**

This PR is for frontend issue https://github.com/cartavis/carta-frontend/issues/1860: update raster tiles of visible spectrally matched images.

* Sends raster tile data of spectrally matched images in each animation step.
    With the corresponding frontend PR https://github.com/CARTAvis/carta-frontend/pull/2176, frontend sends back animation flow control message only for the active image when raster tile data are received.
* With the corresponding frontend PR, when a spatially matched image is invisible or becomes invisible during animation, frontend sends add required tile message with empty tiles. When the image becomes visible, frontend sends required tiles as usual.
     The empty tile message is updated to the animation view settings, and raster tile data of the image won't be sent in the animation step.
* Updated the animation section of the protobuf documentation in the corresponding protobuf PR https://github.com/CARTAvis/carta-protobuf/pull/85. The protobuf PR is only for updating documentation. Please check it for more details of the animation message flow.


**Checklist**

- [ ] changelog updated / ~no changelog update needed~
- [x] e2e test passing / ~added corresponding fix~
- [ ] protobuf updated to the latest dev commit / ~no protobuf update needed~
- [x] added reviewers and assignee
- [x] added ZenHub estimate, milestone, and release
