### PR TITLE
Fix NormalizeUnit function

### DIFF
--- a/src/FileList/FileExtInfoLoader.cc
+++ b/src/FileList/FileExtInfoLoader.cc
@@ -265,7 +265,7 @@ void FileExtInfoLoader::AddEntriesFromHeaderStrings(
             break;
         }
 
-        if (name.startsWith("HISTORY") || name.startsWith("COMMENT")) {
+        if (name.startsWith("HISTORY") || name.startsWith("COMMENT") || name.startsWith("HIERARCH")) {
             auto entry = extended_info.add_header_entries();
             entry->set_name(name);
             continue;

--- a/src/Util/Casacore.cc
+++ b/src/Util/Casacore.cc
@@ -174,12 +174,53 @@ std::string FormatQuantity(const casacore::Quantity& quantity) {
 
 void NormalizeUnit(casacore::String& unit) {
     // Convert unit string to "proper" units according to casacore
-    casacore::UnitMap::addFITS();
-    casacore::String unit_name(unit);
-    unit_name.upcase();
-    if (casacore::UnitVal::check(unit_name)) {
-        unit = casacore::UnitMap::fromFITS(unit_name).getName();
-        return;
+    unit.gsub("JY", "Jy");       // Nonstandard "JY" passes check
+    unit.gsub("Beam", "beam");   // Nonstandard "Beam" passes check
+    unit.gsub("Pixel", "pixel"); // Nonstandard "Pixel" passes check
+
+    // Convert unit without prefix
+    try {
+        // Convert upper to mixed/lower case if needed
+        auto normalized_unit = casacore::UnitMap::fromFITS(unit).getName();
+
+        if (casacore::UnitVal::check(normalized_unit)) {
+            unit = normalized_unit;
+            return;
+        }
+    } catch (const casacore::AipsError& err) {
+        // check() should catch the error and returned false, but does not
     }
-    // keep original unit
+
+    // Convert unit with (possible) prefix
+    casacore::String prefix(unit[0]);
+    casacore::UnitName unit_name;
+    if (casacore::UnitMap::getPref(prefix, unit_name)) {
+        try {
+            // Convert unit with "prefix" removed
+            casacore::String unit_no_prefix = unit.substr(1);
+            unit_no_prefix.upcase();
+            auto normalized_unit = casacore::UnitMap::fromFITS(unit_no_prefix).getName();
+
+            if (casacore::UnitVal::check(normalized_unit)) {
+                unit = prefix + normalized_unit;
+                return;
+            }
+        } catch (const casacore::AipsError& err) {
+            // not caught by check()
+        }
+    }
+
+    // Convert uppercase unit without prefix, else return unknown input unit
+    casacore::String up_unit(unit);
+    up_unit.upcase();
+    try {
+        // Convert upper to mixed/lower case
+        auto normalized_unit = casacore::UnitMap::fromFITS(up_unit).getName();
+
+        if (casacore::UnitVal::check(normalized_unit)) {
+            unit = normalized_unit;
+        }
+    } catch (const casacore::AipsError& err) {
+        // check() should catch the error and returned false, but does not
+    }
 }

--- a/src/Util/Casacore.cc
+++ b/src/Util/Casacore.cc
@@ -174,9 +174,10 @@ std::string FormatQuantity(const casacore::Quantity& quantity) {
 
 void NormalizeUnit(casacore::String& unit) {
     // Convert unit string to "proper" units according to casacore
-    unit.gsub("JY", "Jy");       // Nonstandard "JY" passes check
-    unit.gsub("Beam", "beam");   // Nonstandard "Beam" passes check
-    unit.gsub("Pixel", "pixel"); // Nonstandard "Pixel" passes check
+    // Fix nonstandard units which pass check
+    unit.gsub("JY", "Jy");
+    unit.gsub("Beam", "beam");
+    unit.gsub("Pixel", "pixel");
 
     // Convert unit without prefix
     try {
@@ -188,7 +189,7 @@ void NormalizeUnit(casacore::String& unit) {
             return;
         }
     } catch (const casacore::AipsError& err) {
-        // check() should catch the error and returned false, but does not
+        // check() should catch the error and return false, but does not
     }
 
     // Convert unit with (possible) prefix
@@ -221,6 +222,6 @@ void NormalizeUnit(casacore::String& unit) {
             unit = normalized_unit;
         }
     } catch (const casacore::AipsError& err) {
-        // check() should catch the error and returned false, but does not
+        // not caught by check()
     }
 }


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
Fixes failing cases found in #1269 for file info only.

* How does this PR solve the issue? Give a brief summary.
Manually converts nonstandard unit strings which pass the casacore::UnitVal::check function, and preserves the prefix while normalizing the rest of the unit string.  Also skips normalizing HIERARCH headers which contain "unit" (`HIERARCH  key.CUNIT1='cunit1'`).  *For headers only, does not change the BUNIT in an image.*

* Are there any companion PRs (frontend, protobuf)?
No

* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
Test cases in PR 1269: Jy/Beam, JY/BEAM, jy/beam, mJy/Beam, mJY/BEAM, mjy/beam, and from issue 1265 Degrees and degrees.  I also tested with pixel/Pixel/PIXEL in place of the per-beam unit (e.g. mJy/Pixel).  I used the astropy.io fits module to change the BUNIT header with [setval](https://docs.astropy.org/en/stable/generated/examples/io/modify-fits-header.html).

**Checklist**

- [x] ~changelog updated~ / no changelog update needed - I did not think this was necessary since it is a fix to a recent PR merged after the beta release.
- [x] e2e test passing / ~added corresponding fix~
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] added reviewers and assignee
- [x] added ZenHub estimate, milestone, and release
