### PR TITLE
Check whether the FITS beam table consists of 64-bit floats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Removed duplicate image histogram data sent to the frontend ([#1266](https://github.com/CARTAvis/carta-backend/issues/1266)).
 * Fixed FITS header and data errors ([#1233](https://github.com/CARTAvis/carta-backend/issues/1233), [#1265](https://github.com/CARTAvis/carta-backend/issues/1265)).
 * Fixed the problem of resuming LEL images ([#1226](https://github.com/CARTAvis/carta-backend/issues/1226)).
+* Fixed the crash when reading beam table with 64-bit floats ([#1166](https://github.com/CARTAvis/carta-backend/issues/1166)).
 
 ## [4.0.0-beta.1]
 

--- a/src/ImageData/CartaFitsImage.cc
+++ b/src/ImageData/CartaFitsImage.cc
@@ -1347,48 +1347,51 @@ void CartaFitsImage::ReadBeamsTable(casacore::ImageInfo& image_info) {
     }
 
     // Read columns into vectors
-    int casesen(CASEINSEN), colnum(0), fdatatype(TFLOAT), idatatype(TINT), anynul(0);
+    int casesen(CASEINSEN), colnum(0), anynul(0), datatype(0);
+    long repeat, width;
     LONGLONG firstrow(1), firstelem(1);
     float* fnulval(nullptr);
     int* inulval(nullptr);
 
-    std::vector<float> bmaj(nrow), bmin(nrow), bpa(nrow);
-    std::vector<int> chan(nrow), pol(nrow);
+    std::unordered_map<std::string, std::vector<casacore::Quantity>> beam_qualities = {{"BMAJ", std::vector<casacore::Quantity>(nrow)},
+        {"BMIN", std::vector<casacore::Quantity>(nrow)}, {"BPA", std::vector<casacore::Quantity>(nrow)}};
 
-    char bmaj_name[] = "BMAJ";
-    status = 0;
-    fits_get_colnum(fptr, casesen, bmaj_name, &colnum, &status);
-    fits_read_col(fptr, fdatatype, colnum, firstrow, firstelem, nrow, fnulval, bmaj.data(), &anynul, &status);
+    for (auto& beam_quality : beam_qualities) {
+        auto name = beam_quality.first;
+        status = 0;
+        fits_get_colnum(fptr, casesen, name.data(), &colnum, &status);
+        fits_get_coltype(fptr, colnum, &datatype, &repeat, &width, &status);
 
-    char bmin_name[] = "BMIN";
-    status = 0;
-    fits_get_colnum(fptr, casesen, bmin_name, &colnum, &status);
-    fits_read_col(fptr, fdatatype, colnum, firstrow, firstelem, nrow, fnulval, bmin.data(), &anynul, &status);
+        if (datatype == TDOUBLE) {
+            std::vector<double> values(nrow);
+            fits_read_col(fptr, TDOUBLE, colnum, firstrow, firstelem, nrow, fnulval, values.data(), &anynul, &status);
+            for (int i = 0; i < nrow; ++i) {
+                beam_quality.second[i] = casacore::Quantity(values[i], beam_units[name]);
+            }
+        } else {
+            std::vector<float> values(nrow);
+            fits_read_col(fptr, TFLOAT, colnum, firstrow, firstelem, nrow, fnulval, values.data(), &anynul, &status);
+            for (int i = 0; i < nrow; ++i) {
+                beam_quality.second[i] = casacore::Quantity(values[i], beam_units[name]);
+            }
+        }
+    }
 
-    char bpa_name[] = "BPA";
-    status = 0;
-    fits_get_colnum(fptr, casesen, bpa_name, &colnum, &status);
-    fits_read_col(fptr, fdatatype, colnum, firstrow, firstelem, nrow, fnulval, bpa.data(), &anynul, &status);
+    std::unordered_map<std::string, std::vector<int>> beam_indices = {{"CHAN", std::vector<int>(nrow)}, {"POL", std::vector<int>(nrow)}};
 
-    char chan_name[] = "CHAN";
-    status = 0;
-    fits_get_colnum(fptr, casesen, chan_name, &colnum, &status);
-    fits_read_col(fptr, idatatype, colnum, firstrow, firstelem, nrow, inulval, chan.data(), &anynul, &status);
-
-    char pol_name[] = "POL";
-    status = 0;
-    fits_get_colnum(fptr, casesen, pol_name, &colnum, &status);
-    fits_read_col(fptr, idatatype, colnum, firstrow, firstelem, nrow, inulval, pol.data(), &anynul, &status);
+    for (auto& beam_index : beam_indices) {
+        auto name = beam_index.first;
+        status = 0;
+        fits_get_colnum(fptr, casesen, name.data(), &colnum, &status);
+        fits_read_col(fptr, TINT, colnum, firstrow, firstelem, nrow, inulval, beam_index.second.data(), &anynul, &status);
+    }
 
     fits_close_file(fptr, &status);
 
     image_info.setAllBeams(nchan, npol, casacore::GaussianBeam::NULL_BEAM);
     for (int i = 0; i < nrow; ++i) {
-        casacore::Quantity bmajq(bmaj[i], beam_units["BMAJ"]);
-        casacore::Quantity bminq(bmin[i], beam_units["BMIN"]);
-        casacore::Quantity bpaq(bpa[i], beam_units["BPA"]);
-        casacore::GaussianBeam beam(bmajq, bminq, bpaq);
-        image_info.setBeam(chan[i], pol[i], beam);
+        casacore::GaussianBeam beam(beam_qualities["BMAJ"][i], beam_qualities["BMIN"][i], beam_qualities["BPA"][i]);
+        image_info.setBeam(beam_indices["CHAN"][i], beam_indices["POL"][i], beam);
     }
 }
 

--- a/src/ImageData/FitsLoader.h
+++ b/src/ImageData/FitsLoader.h
@@ -246,7 +246,7 @@ bool FitsLoader::Is64BitBeamsTable(const std::string& filename) {
         fits_get_coltype(fptr, colnum, &typecode, &repeat, &width, &status);
         if (typecode == TDOUBLE) {
             fits_close_file(fptr, &status);
-            spdlog::warn("BEAMS table consists of 64-bit parameters. Convert these values to 32-bit.");
+            spdlog::warn("BEAMS table consists of 64-bit parameters.");
             return true;
         }
     }

--- a/src/ImageData/FitsLoader.h
+++ b/src/ImageData/FitsLoader.h
@@ -32,6 +32,7 @@ private:
 
     int GetNumHeaders(const std::string& filename, int hdu);
     void RemoveHistoryBeam(unsigned int hdu_num);
+    bool Is64BitFitsBeamTable(const std::string& filename);
 };
 
 FitsLoader::FitsLoader(const std::string& filename, bool is_gz) : FileLoader(filename, "", is_gz) {}
@@ -100,8 +101,13 @@ void FitsLoader::OpenFile(const std::string& hdu) {
                     _image.reset(new casacore::FITSImage(_unzip_file, 0, hdu_num));
                 }
             } else if (use_casacore_fits) {
-                _image.reset(new casacore::FITSImage(_filename, 0, hdu_num));
-                RemoveHistoryBeam(hdu_num);
+                if (Is64BitFitsBeamTable(_filename)) {
+                    use_casacore_fits = false;
+                    _image.reset(new CartaFitsImage(_filename, hdu_num));
+                } else {
+                    _image.reset(new casacore::FITSImage(_filename, 0, hdu_num));
+                    RemoveHistoryBeam(hdu_num);
+                }
             } else {
                 _image.reset(new CartaFitsImage(_filename, hdu_num));
             }
@@ -205,6 +211,50 @@ void FitsLoader::RemoveHistoryBeam(unsigned int hdu_num) {
             _image->setImageInfo(image_info);
         }
     }
+}
+
+bool FitsLoader::Is64BitFitsBeamTable(const std::string& filename) {
+    fitsfile* fptr;
+    int status(0);
+    fits_open_file(&fptr, filename.c_str(), 0, &status);
+
+    if (status) {
+        spdlog::error("Error opening FITS file.");
+        return false;
+    }
+
+    // Open binary table extension with name BEAMS
+    int hdutype(BINARY_TBL), extver(0);
+    std::string extname("BEAMS");
+    status = 0;
+    fits_movnam_hdu(fptr, hdutype, extname.data(), extver, &status);
+
+    if (status) {
+        status = 0;
+        fits_close_file(fptr, &status);
+        spdlog::info("Could not find BEAMS table.");
+        return false;
+    }
+
+    // Read columns into vectors
+    int casesen(CASEINSEN), colnum(0);
+    char ttype, tunit, tform, nulstr, tdisp;
+    long tbcol;
+    double scale, zero;
+
+    std::vector<std::string> keys = {"BMAJ", "BMIN", "BPA", "CHAN", "POL"};
+    for (auto& key : keys) {
+        status = 0;
+        fits_get_colnum(fptr, casesen, key.data(), &colnum, &status);
+        fits_get_acolparms(fptr, colnum, &ttype, &tbcol, &tunit, &tform, &scale, &zero, &nulstr, &tdisp, &status);
+        if (tform == 'K' || tform == 'D') {
+            spdlog::warn("BEAMS table consists of 64-bit parameters. Convert these values to 32-bit.");
+            return true;
+        }
+    }
+
+    fits_close_file(fptr, &status);
+    return false;
 }
 
 } // namespace carta


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
Closes #1166.

* How does this PR solve the issue? Give a brief summary.
Using `cfitsio` to check whether the FITS beam table consists of 64-bit floats. If so, open the file via `CartaFitsImage` object. Otherwise, open the file with `casacore::FITSImage`.

* Are there any companion PRs (frontend, protobuf)?
No.

* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
The crash could be avoided when opening the FITS file with beams table consisting of 64-bit floats.

**Checklist**

- [x] changelog updated ~/ no changelog update needed~
- [ ] e2e test passing ~/ added corresponding fix~
- [x] ~protobuf updated to the latest dev commit /~ no protobuf update needed
- [ ] added reviewers and assignee
- [ ] added ZenHub estimate, milestone, and release
