### PR TITLE
Fix gz spectral profile backend crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Removed duplicate image histogram data sent to the frontend ([#1266](https://github.com/CARTAvis/carta-backend/issues/1266)).
 * Fixed FITS header and data errors ([#1233](https://github.com/CARTAvis/carta-backend/issues/1233), [#1265](https://github.com/CARTAvis/carta-backend/issues/1265)).
 * Fixed the problem of resuming LEL images ([#1226](https://github.com/CARTAvis/carta-backend/issues/1226)).
+* Fixed region spectral profile from FITS gz image ([#1271](https://github.com/CARTAvis/carta-backend/issues/1271)).
 
 ## [4.0.0-beta.1]
 

--- a/src/FileList/FileExtInfoLoader.cc
+++ b/src/FileList/FileExtInfoLoader.cc
@@ -277,7 +277,7 @@ void FileExtInfoLoader::AddEntriesFromHeaderStrings(
         name.trim();
 
         // Flag whether to convert value to numeric
-        bool string_value(false);
+        bool is_string_value(false);
         casacore::String value, comment;
 
         if (eq_pos != std::string::npos) {
@@ -293,7 +293,7 @@ void FileExtInfoLoader::AddEntriesFromHeaderStrings(
                 // set value between quotes
                 value = remainder.substr(1, end_quote - 1);
                 value.trim();
-                string_value = true; // do not convert to numeric
+                is_string_value = true; // do not convert to numeric
 
                 // set beginning of comment
                 slash_pos = remainder.find('/', end_quote + 1);
@@ -323,19 +323,22 @@ void FileExtInfoLoader::AddEntriesFromHeaderStrings(
                 specsys = value.after('-');
                 value = "VELO";
             }
+            is_string_value = true;
         } else if (name.contains("UNIT")) {
             NormalizeUnit(value);
+            is_string_value = true;
         } else if (name == "EXTNAME") {
             extname = value;
+            is_string_value = true;
         } else if (name == "SIMPLE") {
             try {
                 // In some images, this is numeric value
                 int numval = std::stoi(value);
                 value = (numval ? "T" : "F");
-                string_value = true;
             } catch (std::invalid_argument& err) {
                 // not numeric
             }
+            is_string_value = true;
         }
 
         // Set name
@@ -343,7 +346,7 @@ void FileExtInfoLoader::AddEntriesFromHeaderStrings(
         entry->set_name(name);
 
         if (!value.empty()) {
-            if (string_value) {
+            if (is_string_value) {
                 *entry->mutable_value() = value;
             } else {
                 // Set numeric value

--- a/src/ImageData/CartaFitsImage.cc
+++ b/src/ImageData/CartaFitsImage.cc
@@ -113,33 +113,31 @@ casacore::DataType CartaFitsImage::internalDataType() const {
 casacore::Bool CartaFitsImage::doGetSlice(casacore::Array<float>& buffer, const casacore::Slicer& section) {
     // Read section of data using cfitsio implicit data type conversion.
     // cfitsio scales the data by BSCALE and BZERO
-    fitsfile* fptr = OpenFile();
-
     // Read data subset from image
     bool ok(false);
     switch (_equiv_bitpix) {
         case 8: {
-            ok = GetDataSubset<unsigned char>(fptr, _equiv_bitpix, section, buffer);
+            ok = GetDataSubset<unsigned char>(_equiv_bitpix, section, buffer);
             break;
         }
         case 16: {
-            ok = GetDataSubset<short>(fptr, _equiv_bitpix, section, buffer);
+            ok = GetDataSubset<short>(_equiv_bitpix, section, buffer);
             break;
         }
         case 32: {
-            ok = GetDataSubset<int>(fptr, _equiv_bitpix, section, buffer);
+            ok = GetDataSubset<int>(_equiv_bitpix, section, buffer);
             break;
         }
         case 64: {
-            ok = GetDataSubset<LONGLONG>(fptr, _equiv_bitpix, section, buffer);
+            ok = GetDataSubset<LONGLONG>(_equiv_bitpix, section, buffer);
             break;
         }
         case -32: {
-            ok = GetDataSubset<float>(fptr, _equiv_bitpix, section, buffer);
+            ok = GetDataSubset<float>(_equiv_bitpix, section, buffer);
             break;
         }
         case -64: {
-            ok = GetDataSubset<double>(fptr, _equiv_bitpix, section, buffer);
+            ok = GetDataSubset<double>(_equiv_bitpix, section, buffer);
             break;
         }
     }
@@ -221,6 +219,7 @@ casacore::Bool CartaFitsImage::doGetMaskSlice(casacore::Array<bool>& buffer, con
     }
 
     if (_pixel_mask) {
+        _pixel_mask->getSlice(buffer, section);
         return _pixel_mask->getSlice(buffer, section);
     }
 
@@ -230,11 +229,12 @@ casacore::Bool CartaFitsImage::doGetMaskSlice(casacore::Array<bool>& buffer, con
 // private
 
 fitsfile* CartaFitsImage::OpenFile() {
-    // Open file and return file pointer
+    // Open file and return file pointer, or return existing file pointer.
+    // Caller should protect with mutex before calling this then proceeding with cfitsio call using returned fptr.
     if (!_fptr) {
         fitsfile* fptr;
-        int status(0);
-        fits_open_file(&fptr, _filename.c_str(), 0, &status);
+        int iomode(READONLY), status(0);
+        fits_open_file(&fptr, _filename.c_str(), iomode, &status);
 
         if (status) {
             throw(casacore::AipsError("Error opening FITS file."));
@@ -256,6 +256,7 @@ fitsfile* CartaFitsImage::OpenFile() {
 void CartaFitsImage::CloseFile() {
     if (_fptr) {
         int status = 0;
+        std::unique_lock<std::mutex> ulock(_fptr_mutex);
         fits_close_file(_fptr, &status);
         _fptr = nullptr;
     }
@@ -349,6 +350,7 @@ void CartaFitsImage::GetFitsHeaderString(int& nheaders, std::string& hdrstr) {
     // Read header values into single string, and store some image parameters.
     // Returns string and number of keys contained in string.
     // Throws exception if any headers missing.
+    std::unique_lock<std::mutex> ulock(_fptr_mutex);
     fitsfile* fptr = OpenFile();
     int status(0);
 
@@ -428,6 +430,7 @@ void CartaFitsImage::GetFitsHeaderString(int& nheaders, std::string& hdrstr) {
     } else {
         fits_hdr2str(fptr, no_comments, nullptr, 0, header, &nheaders, &status);
     }
+    ulock.unlock();
 
     if (status) {
         // Free memory allocated by cfitsio, close file, throw exception
@@ -442,7 +445,7 @@ void CartaFitsImage::GetFitsHeaderString(int& nheaders, std::string& hdrstr) {
     int free_status(0);
     fits_free_memory(*header, &free_status);
 
-    // Done with file
+    // Done with file setup
     CloseFile();
 }
 
@@ -1409,27 +1412,24 @@ void CartaFitsImage::AddObsInfo(casacore::CoordinateSystem& coord_sys, casacore:
 }
 
 void CartaFitsImage::SetPixelMask() {
-    // Set pixel mask for entire image
-    fitsfile* fptr = OpenFile();
-
     // Read blanked mask from image
     bool ok(false);
     casacore::ArrayLattice<bool> mask_lattice;
     switch (_bitpix) {
         case 8: {
-            ok = GetPixelMask<unsigned char>(fptr, _bitpix, _shape, mask_lattice);
+            ok = GetPixelMask<unsigned char>(_bitpix, _shape, mask_lattice);
             break;
         }
         case 16: {
-            ok = GetPixelMask<short>(fptr, _bitpix, _shape, mask_lattice);
+            ok = GetPixelMask<short>(_bitpix, _shape, mask_lattice);
             break;
         }
         case 32: {
-            ok = GetPixelMask<int>(fptr, _bitpix, _shape, mask_lattice);
+            ok = GetPixelMask<int>(_bitpix, _shape, mask_lattice);
             break;
         }
         case 64: {
-            ok = GetPixelMask<LONGLONG>(fptr, _bitpix, _shape, mask_lattice);
+            ok = GetPixelMask<LONGLONG>(_bitpix, _shape, mask_lattice);
             break;
         }
         case -32: {
@@ -1452,8 +1452,6 @@ void CartaFitsImage::SetPixelMask() {
     } else {
         _pixel_mask = new casacore::ArrayLattice<bool>(mask_lattice);
     }
-
-    CloseFile();
 }
 
 bool CartaFitsImage::doGetNanMaskSlice(casacore::Array<bool>& buffer, const casacore::Slicer& section) {

--- a/src/ImageData/CartaFitsImage.h
+++ b/src/ImageData/CartaFitsImage.h
@@ -64,6 +64,7 @@ private:
     fitsfile* OpenFile();
     void CloseFile();
     void CloseFileIfError(const int& status, const std::string& error);
+    void CheckFileStatus(fitsfile* fptr);
 
     void SetUpImage();
     void GetFitsHeaderString(int& nheaders, std::string& hdrstr);
@@ -89,17 +90,20 @@ private:
     bool doGetNanMaskSlice(casacore::Array<bool>& buffer, const casacore::Slicer& section);
 
     template <typename T>
-    bool GetDataSubset(fitsfile* fptr, int datatype, const casacore::Slicer& section, casacore::Array<float>& buffer);
+    bool GetDataSubset(int datatype, const casacore::Slicer& section, casacore::Array<float>& buffer);
     template <typename T>
-    bool GetPixelMask(fitsfile* fptr, int datatype, const casacore::IPosition& shape, casacore::ArrayLattice<bool>& mask);
+    bool GetPixelMask(int datatype, const casacore::IPosition& shape, casacore::ArrayLattice<bool>& mask);
     template <typename T>
     bool GetNanPixelMask(casacore::ArrayLattice<bool>& mask);
 
     std::string _filename;
     unsigned int _hdu;
 
-    // File pointer for open file; nullptr when closed
+    // File pointer for open file; nullptr when closed.
+    // cfitsio docs: "Different threads should not share the same 'fitsfile' pointer to read an opened FITS file
+    // unless locks are placed around the calls to the CFITSIO reading routines."
     fitsfile* _fptr;
+    std::mutex _fptr_mutex;
 
     // FITS header values
     bool _is_compressed;

--- a/src/Util/Casacore.cc
+++ b/src/Util/Casacore.cc
@@ -178,6 +178,7 @@ void NormalizeUnit(casacore::String& unit) {
     unit.gsub("JY", "Jy");
     unit.gsub("Beam", "beam");
     unit.gsub("Pixel", "pixel");
+    casacore::UnitMap::addFITS();
 
     // Convert unit without prefix
     try {


### PR DESCRIPTION
**Description**
Fixes backend crash when a spectral profile for a FITS gz image region is requested.

* What is implemented or fixed? Mention the linked issue(s), if any.
Fixes #1271 

* How does this PR solve the issue? Give a brief summary.
The cfitsio fitsfile* pointer is protected with a mutex so that one thread does not close the file while another is using the pointer for a function call. The pixel mask is now correctly inverted since fits_read_pixnull true = invalid pixel, but casacore uses mask true = good pixel.   The file is no longer closed after reading the pixel mask, since compressed images are decompressed into memory.

* Are there any companion PRs (frontend, protobuf)?
No
* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
See image and description in issue.  Or you can use any FITS image with blanked data (BITPIX > 0 and BLANK is defined) opened with CartaFitsImage instead of casacore::FITSImage.

**Checklist**

- [x] changelog updated / no changelog update needed
- [x] e2e test passing / added corresponding fix
- [x] protobuf updated to the latest dev commit / no protobuf update needed
- [x] added reviewers and assignee
- [x] added ZenHub estimate, milestone, and release
