### PR TITLE
Fix save image filepath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 * Support animation playback with matched images in multi-panel view ([#1860](https://github.com/CARTAvis/carta-frontend/issues/1860)).
+
 ### Fixed
 * Prevent the installation of pugixml library files ([#1261](https://github.com/CARTAvis/carta-backend/issues/1261)).
 * Fixed spatial profile for polyline in widefield image ([#1258](https://github.com/CARTAvis/carta-backend/issues/1258)).
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed the case-sensitive of reading BUNIT from a file header ([#1187](https://github.com/CARTAvis/carta-backend/issues/1187)).
 * Fixed the crash when reading beam table with 64-bit floats ([#1166](https://github.com/CARTAvis/carta-backend/issues/1166)).
 * Fixed region spectral profile from FITS gz image ([#1271](https://github.com/CARTAvis/carta-backend/issues/1271)).
+* Fixed file path to save generated image ([#1252](https://github.com/CARTAvis/carta-backend/issues/1252)).
 
 ## [4.0.0-beta.1]
 

--- a/src/FileList/FileListHandler.h
+++ b/src/FileList/FileListHandler.h
@@ -47,8 +47,8 @@ public:
 
 private:
     // ICD: File/Region list response
-    void GetFileList(CARTA::FileListResponse& file_list, std::string folder, ResultMsg& result_msg, CARTA::FileListFilterMode filter_mode,
-        bool region_list = false);
+    void GetFileList(CARTA::FileListResponse& file_list, const std::string& folder, ResultMsg& result_msg,
+        CARTA::FileListFilterMode filter_mode, bool region_list = false);
 
     bool FillRegionFileInfo(CARTA::FileInfo& file_info, const std::string& filename, CARTA::FileType type = CARTA::FileType::UNKNOWN,
         bool determine_file_type = true);

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -941,8 +941,7 @@ void FileLoader::SetStokesCdelt(int stokes_cdelt) {
 }
 
 bool FileLoader::SaveFile(const CARTA::FileType type, const std::string& output_filename, std::string& message) {
-    // Override in ExprLoader
-    message = "Cannot save image type from loader.";
+    // Override in ExprLoader to save LEL image
     return false;
 }
 


### PR DESCRIPTION
Saving an image using the file list fails when the frontend requests a file list for a relative path starting with '/'.  The file list is returned correctly with the same path (still prepended by '/') in the FileListResponse, then the save fails for this path.  A different implementation is used for path handling in file list (casacore) and save file (std::filesystem).  std::filesystem treats the requested folder as an absolute path and does not use the top folder, but casacore appends the requested folder to the top folder as commanded.

FileListHandler should be refactored but I did not want to do it now, so close to a release.  I did move repeated code to the common function and renamed variables referring to the "root" folder which is now the "top" folder.

* What is implemented or fixed?
Closes #1252 
* How does this PR solve the issue? Give a brief summary.
This PR returns a file path in the file list response which is relative to the top folder and does not start with '/' so that the save file path is correct.  It also removes a misleading error message "Cannot save image type from loader." which is returned when the loader is not for an LEL image (which has a special way to save) but then saves the image in the normal way for other image types.
* Are there any companion PRs (frontend, protobuf)?
No
* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
See issue #1252 for steps to reproduce: set a top level folder which is not /.

**Checklist**

- [x] changelog updated / ~no changelog update needed~
- [x] e2e test passing / ~added corresponding fix~
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] added reviewers and assignee
- [x] added ZenHub estimate, milestone, and release
