### PR TITLE
Fixed the lack of mask for LEL images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed the case-sensitive of reading BUNIT from a file header ([#1187](https://github.com/CARTAvis/carta-backend/issues/1187)).
 * Fixed the crash when reading beam table with 64-bit floats ([#1166](https://github.com/CARTAvis/carta-backend/issues/1166)).
 * Fixed region spectral profile from FITS gz image ([#1271](https://github.com/CARTAvis/carta-backend/issues/1271)).
+* Fixed the lack of mask for LEL images ([#1291](https://github.com/CARTAvis/carta-backend/issues/1291)).
 
 ## [4.0.0-beta.1]
 

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -340,16 +340,20 @@ bool FileLoader::GetSlice(casacore::Array<float>& data, const StokesSlicer& stok
             casacore::Array<float> slice_data;
             image->doGetSlice(slice_data, slicer);
 
-            // Get mask data
-            casacore::Array<bool> mask_data;
-            image->getMaskSlice(mask_data, slicer);
+            if (image->isMasked()) {
+                // Get mask data
+                casacore::Array<bool> mask_data;
+                image->getMaskSlice(mask_data, slicer);
 
-            // Reset the pixel value as NaN if its mask is false
-            casacore::Array<float>::iterator slice_data_iter = slice_data.begin();
-            casacore::Array<bool>::iterator mask_data_iter = mask_data.begin();
-            for (; slice_data_iter != slice_data.end(); ++slice_data_iter, ++mask_data_iter) {
-                if (!*mask_data_iter) {
-                    *slice_data_iter = NAN;
+                if (mask_data.shape() == slice_data.shape()) {
+                    // Reset the pixel value as NaN if its mask is false
+                    casacore::Array<float>::iterator slice_data_iter = slice_data.begin();
+                    casacore::Array<bool>::iterator mask_data_iter = mask_data.begin();
+                    for (; slice_data_iter != slice_data.end(); ++slice_data_iter, ++mask_data_iter) {
+                        if (!*mask_data_iter) {
+                            *slice_data_iter = NAN;
+                        }
+                    }
                 }
             }
 

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -339,6 +339,20 @@ bool FileLoader::GetSlice(casacore::Array<float>& data, const StokesSlicer& stok
             // Use ImageExpr for slice
             casacore::Array<float> slice_data;
             image->doGetSlice(slice_data, slicer);
+
+            // Get mask data
+            casacore::Array<bool> mask_data;
+            image->getMaskSlice(mask_data, slicer);
+
+            // Reset the pixel value as NaN if its mask is false
+            casacore::Array<float>::iterator slice_data_iter = slice_data.begin();
+            casacore::Array<bool>::iterator mask_data_iter = mask_data.begin();
+            for (; slice_data_iter != slice_data.end(); ++slice_data_iter, ++mask_data_iter) {
+                if (!*mask_data_iter) {
+                    *slice_data_iter = NAN;
+                }
+            }
+
             data = slice_data; // copy from reference
             return true;
         } else if (image_type == "RebinImage") {


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
Fixed #1291.

* How does this PR solve the issue? Give a brief summary.
Get mask data from the LEL image, and then reset the pixel value as NaN if its mask is false.

* Are there any companion PRs (frontend, protobuf)?
No. 

* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
The rendered image will show a mask if we apply a boolean check in LEL syntax, like `"dice_one.fits"["dice_one.fits" >2]`.

**Checklist**

- [x] changelog updated ~/ no changelog update needed~
- [x] e2e test passing / ~added corresponding fix~
- [x] ~protobuf updated to the latest dev commit /~ no protobuf update needed
- [ ] added reviewers and assignee
- [ ] added ZenHub estimate, milestone, and release
