### PR TITLE
Fix PV preview updates for matched image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed file path to save generated image ([#1252](https://github.com/CARTAvis/carta-backend/issues/1252)).
 * Fixed missing tiles issue ([#1282](https://github.com/CARTAvis/carta-backend/issues/1282)).
 * Fixed the crash of loading JCMT-SCUBA2 FITS images ([#1301](https://github.com/CARTAvis/carta-backend/issues/1301)).
+* Fixed updating the PV preview for a matched image ([#1304](https://github.com/CARTAvis/carta-backend/issues/1304)).
 
 ## [4.0.0-beta.1]
 

--- a/src/ImageGenerators/PvPreviewCut.cc
+++ b/src/ImageGenerators/PvPreviewCut.cc
@@ -22,9 +22,14 @@ bool PvPreviewCut::HasSameParameters(const PreviewCutParameters& parameters) {
     return _cut_parameters == parameters;
 }
 
-bool PvPreviewCut::HasFileRegionIds(int file_id, int region_id) {
-    // Check if file and region ids are for this cut
-    return _cut_parameters.HasFileRegionIds(file_id, region_id);
+bool PvPreviewCut::HasPreviewFileRegionIds(int file_id, int region_id) {
+    // Check if preview file and region ids are for this cut
+    return _cut_parameters.HasPreviewFileRegionIds(file_id, region_id);
+}
+
+bool PvPreviewCut::HasPreviewCutRegion(int region_id, int region_reference_file) {
+    // Check if region id and reference file are for this cut
+    return _cut_parameters.HasPreviewCutRegion(region_id, region_reference_file);
 }
 
 int PvPreviewCut::GetWidth() {

--- a/src/ImageGenerators/PvPreviewCut.h
+++ b/src/ImageGenerators/PvPreviewCut.h
@@ -24,25 +24,32 @@ struct PreviewCutParameters {
     CARTA::CompressionType compression;
     float image_quality;
     float animation_quality;
+    int region_reference_file;
 
     PreviewCutParameters() : file_id(-1), region_id(-1) {}
     PreviewCutParameters(int file_id_, int region_id_, int width_, bool reverse_, CARTA::CompressionType compression_, float image_quality_,
-        float animation_quality_)
+        float animation_quality_, int reference_file_id_)
         : file_id(file_id_),
           region_id(region_id_),
           width(width_),
           reverse(reverse_),
           compression(compression_),
           image_quality(image_quality_),
-          animation_quality(animation_quality_) {}
+          animation_quality(animation_quality_),
+          region_reference_file(reference_file_id_) {}
 
     bool operator==(const PreviewCutParameters& other) {
-        return (HasFileRegionIds(other.file_id, other.region_id) && width == other.width && reverse == other.reverse &&
-                compression == other.compression && image_quality == other.image_quality && animation_quality == other.animation_quality);
+        return ((other.file_id == file_id) && (region_id == other.region_id) && (width == other.width) && (reverse == other.reverse) &&
+                (compression == other.compression) && (image_quality == other.image_quality) &&
+                (animation_quality == other.animation_quality) && (region_reference_file == other.region_reference_file));
     }
 
-    bool HasFileRegionIds(int file_id_, int region_id_) {
+    bool HasPreviewFileRegionIds(int file_id_, int region_id_) {
         return ((file_id_ == ALL_FILES || file_id_ == file_id) && (region_id_ == ALL_REGIONS || region_id_ == region_id));
+    }
+
+    bool HasPreviewCutRegion(int region_id_, int region_reference_file_) {
+        return ((region_id_ == region_id) && (region_reference_file_ == region_reference_file));
     }
 };
 
@@ -53,7 +60,8 @@ public:
 
     // Preview settings
     bool HasSameParameters(const PreviewCutParameters& parameters);
-    bool HasFileRegionIds(int file_id, int region_id);
+    bool HasPreviewFileRegionIds(int file_id, int region_id);
+    bool HasPreviewCutRegion(int region_id, int region_reference_file);
     int GetWidth();
     int GetReverse();
 

--- a/src/Region/RegionHandler.h
+++ b/src/Region/RegionHandler.h
@@ -84,7 +84,7 @@ public:
     bool CalculatePvImage(const CARTA::PvRequest& pv_request, std::shared_ptr<Frame>& frame, GeneratorProgressCallback progress_callback,
         CARTA::PvResponse& pv_response, GeneratedImage& pv_image);
     // Update PV preview image when PV cut region (region_id) changes
-    bool UpdatePvPreviewRegion(int file_id, int region_id, RegionState& region_state);
+    bool UpdatePvPreviewRegion(int region_id, RegionState& region_state);
     bool UpdatePvPreviewImage(
         int file_id, int region_id, bool quick_update, std::function<void(CARTA::PvResponse& pv_response, GeneratedImage& pv_image)> cb);
     void StopPvCalc(int file_id);

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -869,7 +869,7 @@ bool Session::OnSetRegion(const CARTA::SetRegion& message, uint32_t request_id, 
 
     if (success) {
         // Move data streams off main thread by queueing tasks
-        if (_region_handler->UpdatePvPreviewRegion(file_id, region_id, region_state)) {
+        if (_region_handler->UpdatePvPreviewRegion(region_id, region_state)) {
             // Update pv preview (if region is pv cut for preview)
             OnMessageTask* tsk = new PvPreviewUpdateTask(this, ALL_FILES, region_id, preview_region);
             ThreadManager::QueueTask(tsk);


### PR DESCRIPTION
**Description**
The PV preview for a matched image does not update when the PV cut is moved.  The original PV request uses the matched image file_id but the cut region updates (SetRegion) use the reference file_id.

* What is implemented or fixed? Mention the linked issue(s), if any.
Fixes #1304 
* How does this PR solve the issue? Give a brief summary.
The cut region's reference file_id is saved in PvCutParameters in addition to the file_id for the PV request.  When SetRegion is sent, this reference file id is checked to see if an update should be generated.
* Are there any companion PRs (frontend, protobuf)?
This issue is described in [frontend #2240](https://github.com/CARTAvis/carta-frontend/issues/2240) but it is a backend fix only.
* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
See frontend issue; start a PV preview for a matched image and move the PV cut.  The preview should update.

**Checklist**

- [x] changelog updated / ~no changelog update needed~
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] added reviewers and assignee
- [x] added ZenHub estimate, milestone, and release
