### PR TITLE
Custom URL

### DIFF
--- a/src/HttpServer/HttpServer.cc
+++ b/src/HttpServer/HttpServer.cc
@@ -56,54 +56,54 @@ void HttpServer::RegisterRoutes() {
     uWS::App& app = _session_manager->App();
 
     if (_enable_scripting) {
-        app.post(_url_prefix + "/api/scripting/action", [&](auto res, auto req) { HandleScriptingAction(res, req); });
+        app.post(fmt::format("/{}/api/scripting/action", _url_prefix), [&](auto res, auto req) { HandleScriptingAction(res, req); });
     } else {
-        app.post(_url_prefix + "/api/scripting/action", [&](auto res, auto req) { NotImplemented(res, req); });
+        app.post(fmt::format("/{}/api/scripting/action", _url_prefix), [&](auto res, auto req) { NotImplemented(res, req); });
     }
 
     if (_enable_database) {
         // Dynamic routes for preferences, layouts, snippets and workspaces
-        app.get(_url_prefix + "/api/database/preferences", [&](auto res, auto req) { HandleGetPreferences(res, req); });
-        app.put(_url_prefix + "/api/database/preferences", [&](auto res, auto req) { HandleSetPreferences(res, req); });
-        app.del(_url_prefix + "/api/database/preferences", [&](auto res, auto req) { HandleClearPreferences(res, req); });
+        app.get(fmt::format("/{}/api/database/preferences", _url_prefix), [&](auto res, auto req) { HandleGetPreferences(res, req); });
+        app.put(fmt::format("/{}/api/database/preferences", _url_prefix), [&](auto res, auto req) { HandleSetPreferences(res, req); });
+        app.del(fmt::format("/{}/api/database/preferences", _url_prefix), [&](auto res, auto req) { HandleClearPreferences(res, req); });
 
-        app.get(_url_prefix + "/api/database/list/layouts", [&](auto res, auto req) { HandleGetObjectList("layout", res, req); });
-        app.get(_url_prefix + "/api/database/layouts", [&](auto res, auto req) { HandleGetObjects("layout", res, req); });
-        app.get(_url_prefix + "/api/database/layout/:name", [&](auto res, auto req) { HandleGetObject("layout", res, req); });
-        app.put(_url_prefix + "/api/database/layout", [&](auto res, auto req) { HandleSetObject("layout", res, req); });
-        app.del(_url_prefix + "/api/database/layout", [&](auto res, auto req) { HandleClearObject("layout", res, req); });
+        app.get(fmt::format("/{}/api/database/list/layouts", _url_prefix), [&](auto res, auto req) { HandleGetObjectList("layout", res, req); });
+        app.get(fmt::format("/{}/api/database/layouts", _url_prefix), [&](auto res, auto req) { HandleGetObjects("layout", res, req); });
+        app.get(fmt::format("/{}/api/database/layout/:name", _url_prefix), [&](auto res, auto req) { HandleGetObject("layout", res, req); });
+        app.put(fmt::format("/{}/api/database/layout", _url_prefix), [&](auto res, auto req) { HandleSetObject("layout", res, req); });
+        app.del(fmt::format("/{}/api/database/layout", _url_prefix), [&](auto res, auto req) { HandleClearObject("layout", res, req); });
 
-        app.get(_url_prefix + "/api/database/list/snippets", [&](auto res, auto req) { HandleGetObjectList("snippet", res, req); });
-        app.get(_url_prefix + "/api/database/snippets", [&](auto res, auto req) { HandleGetObjects("snippet", res, req); });
-        app.get(_url_prefix + "/api/database/snippet/:name", [&](auto res, auto req) { HandleGetObject("snippet", res, req); });
-        app.put(_url_prefix + "/api/database/snippet", [&](auto res, auto req) { HandleSetObject("snippet", res, req); });
-        app.del(_url_prefix + "/api/database/snippet", [&](auto res, auto req) { HandleClearObject("snippet", res, req); });
+        app.get(fmt::format("/{}/api/database/list/snippets", _url_prefix), [&](auto res, auto req) { HandleGetObjectList("snippet", res, req); });
+        app.get(fmt::format("/{}/api/database/snippets", _url_prefix), [&](auto res, auto req) { HandleGetObjects("snippet", res, req); });
+        app.get(fmt::format("/{}/api/database/snippet/:name", _url_prefix), [&](auto res, auto req) { HandleGetObject("snippet", res, req); });
+        app.put(fmt::format("/{}/api/database/snippet", _url_prefix), [&](auto res, auto req) { HandleSetObject("snippet", res, req); });
+        app.del(fmt::format("/{}/api/database/snippet", _url_prefix), [&](auto res, auto req) { HandleClearObject("snippet", res, req); });
 
-        app.get(_url_prefix + "/api/database/list/workspaces", [&](auto res, auto req) { HandleGetObjectList("workspace", res, req); });
-        app.get(_url_prefix + "/api/database/workspaces", [&](auto res, auto req) { HandleGetObjects("workspace", res, req); });
-        app.get(_url_prefix + "/api/database/workspace/:name", [&](auto res, auto req) { HandleGetObject("workspace", res, req); });
-        app.put(_url_prefix + "/api/database/workspace", [&](auto res, auto req) { HandleSetObject("workspace", res, req); });
-        app.del(_url_prefix + "/api/database/workspace", [&](auto res, auto req) { HandleClearObject("workspace", res, req); });
+        app.get(fmt::format("/{}/api/database/list/workspaces", _url_prefix), [&](auto res, auto req) { HandleGetObjectList("workspace", res, req); });
+        app.get(fmt::format("/{}/api/database/workspaces", _url_prefix), [&](auto res, auto req) { HandleGetObjects("workspace", res, req); });
+        app.get(fmt::format("/{}/api/database/workspace/:name", _url_prefix), [&](auto res, auto req) { HandleGetObject("workspace", res, req); });
+        app.put(fmt::format("/{}/api/database/workspace", _url_prefix), [&](auto res, auto req) { HandleSetObject("workspace", res, req); });
+        app.del(fmt::format("/{}/api/database/workspace", _url_prefix), [&](auto res, auto req) { HandleClearObject("workspace", res, req); });
     } else {
-        app.get(_url_prefix + "/api/database/*", [&](auto res, auto req) { NotImplemented(res, req); });
-        app.put(_url_prefix + "/api/database/*", [&](auto res, auto req) { NotImplemented(res, req); });
-        app.del(_url_prefix + "/api/database/*", [&](auto res, auto req) { NotImplemented(res, req); });
+        app.get(fmt::format("/{}/api/database/*", _url_prefix), [&](auto res, auto req) { NotImplemented(res, req); });
+        app.put(fmt::format("/{}/api/database/*", _url_prefix), [&](auto res, auto req) { NotImplemented(res, req); });
+        app.del(fmt::format("/{}/api/database/*", _url_prefix), [&](auto res, auto req) { NotImplemented(res, req); });
     }
 
     if (_enable_frontend) {
         if (_enable_runtime_config) {
-            app.get(_url_prefix + "/config", [&](auto res, auto req) { HandleGetConfig(res, req); });
+            app.get(fmt::format("/{}/config", _url_prefix), [&](auto res, auto req) { HandleGetConfig(res, req); });
         } else {
-            app.get(_url_prefix + "/config", [&](auto res, auto req) { DefaultSuccess(res, req); });
+            app.get(fmt::format("/{}/config", _url_prefix), [&](auto res, auto req) { DefaultSuccess(res, req); });
         }
         // Static routes for all other files
-        app.get("/*", [&](Res* res, Req* req) { HandleStaticRequest(res, req); });
+        app.get(fmt::format("/{}/*", _url_prefix), [&](Res* res, Req* req) { HandleStaticRequest(res, req); });
     } else {
-        app.get("/*", [&](auto res, auto req) { NotImplemented(res, req); });
+        app.get(fmt::format("/{}/*", _url_prefix), [&](auto res, auto req) { NotImplemented(res, req); });
     }
 
     // CORS support for the API
-    app.options(_url_prefix + "/api/*", [&](auto res, auto req) {
+    app.options(fmt::format("/{}/api/*", _url_prefix), [&](auto res, auto req) {
         AddCorsHeaders(res);
         res->end();
     });
@@ -125,7 +125,7 @@ void HttpServer::HandleStaticRequest(Res* res, Req* req) {
         url = url.substr(1);
     }
     url.remove_prefix(_url_prefix.size());
-    // Trim all '/' are behind url_prefix
+    // Trim all '/' behind url_prefix
     while (url.size() && url[0] == '/') {
         url = url.substr(1);
     }

--- a/src/HttpServer/HttpServer.cc
+++ b/src/HttpServer/HttpServer.cc
@@ -56,45 +56,45 @@ void HttpServer::RegisterRoutes() {
     uWS::App& app = _session_manager->App();
 
     if (_enable_scripting) {
-        app.post("/api/scripting/action", [&](auto res, auto req) { HandleScriptingAction(res, req); });
+        app.post(_url_prefix + "/api/scripting/action", [&](auto res, auto req) { HandleScriptingAction(res, req); });
     } else {
-        app.post("/api/scripting/action", [&](auto res, auto req) { NotImplemented(res, req); });
+        app.post(_url_prefix + "/api/scripting/action", [&](auto res, auto req) { NotImplemented(res, req); });
     }
 
     if (_enable_database) {
         // Dynamic routes for preferences, layouts, snippets and workspaces
-        app.get("/api/database/preferences", [&](auto res, auto req) { HandleGetPreferences(res, req); });
-        app.put("/api/database/preferences", [&](auto res, auto req) { HandleSetPreferences(res, req); });
-        app.del("/api/database/preferences", [&](auto res, auto req) { HandleClearPreferences(res, req); });
+        app.get(_url_prefix + "/api/database/preferences", [&](auto res, auto req) { HandleGetPreferences(res, req); });
+        app.put(_url_prefix + "/api/database/preferences", [&](auto res, auto req) { HandleSetPreferences(res, req); });
+        app.del(_url_prefix + "/api/database/preferences", [&](auto res, auto req) { HandleClearPreferences(res, req); });
 
-        app.get("/api/database/list/layouts", [&](auto res, auto req) { HandleGetObjectList("layout", res, req); });
-        app.get("/api/database/layouts", [&](auto res, auto req) { HandleGetObjects("layout", res, req); });
-        app.get("/api/database/layout/:name", [&](auto res, auto req) { HandleGetObject("layout", res, req); });
-        app.put("/api/database/layout", [&](auto res, auto req) { HandleSetObject("layout", res, req); });
-        app.del("/api/database/layout", [&](auto res, auto req) { HandleClearObject("layout", res, req); });
+        app.get(_url_prefix + "/api/database/list/layouts", [&](auto res, auto req) { HandleGetObjectList("layout", res, req); });
+        app.get(_url_prefix + "/api/database/layouts", [&](auto res, auto req) { HandleGetObjects("layout", res, req); });
+        app.get(_url_prefix + "/api/database/layout/:name", [&](auto res, auto req) { HandleGetObject("layout", res, req); });
+        app.put(_url_prefix + "/api/database/layout", [&](auto res, auto req) { HandleSetObject("layout", res, req); });
+        app.del(_url_prefix + "/api/database/layout", [&](auto res, auto req) { HandleClearObject("layout", res, req); });
 
-        app.get("/api/database/list/snippets", [&](auto res, auto req) { HandleGetObjectList("snippet", res, req); });
-        app.get("/api/database/snippets", [&](auto res, auto req) { HandleGetObjects("snippet", res, req); });
-        app.get("/api/database/snippet/:name", [&](auto res, auto req) { HandleGetObject("snippet", res, req); });
-        app.put("/api/database/snippet", [&](auto res, auto req) { HandleSetObject("snippet", res, req); });
-        app.del("/api/database/snippet", [&](auto res, auto req) { HandleClearObject("snippet", res, req); });
+        app.get(_url_prefix + "/api/database/list/snippets", [&](auto res, auto req) { HandleGetObjectList("snippet", res, req); });
+        app.get(_url_prefix + "/api/database/snippets", [&](auto res, auto req) { HandleGetObjects("snippet", res, req); });
+        app.get(_url_prefix + "/api/database/snippet/:name", [&](auto res, auto req) { HandleGetObject("snippet", res, req); });
+        app.put(_url_prefix + "/api/database/snippet", [&](auto res, auto req) { HandleSetObject("snippet", res, req); });
+        app.del(_url_prefix + "/api/database/snippet", [&](auto res, auto req) { HandleClearObject("snippet", res, req); });
 
-        app.get("/api/database/list/workspaces", [&](auto res, auto req) { HandleGetObjectList("workspace", res, req); });
-        app.get("/api/database/workspaces", [&](auto res, auto req) { HandleGetObjects("workspace", res, req); });
-        app.get("/api/database/workspace/:name", [&](auto res, auto req) { HandleGetObject("workspace", res, req); });
-        app.put("/api/database/workspace", [&](auto res, auto req) { HandleSetObject("workspace", res, req); });
-        app.del("/api/database/workspace", [&](auto res, auto req) { HandleClearObject("workspace", res, req); });
+        app.get(_url_prefix + "/api/database/list/workspaces", [&](auto res, auto req) { HandleGetObjectList("workspace", res, req); });
+        app.get(_url_prefix + "/api/database/workspaces", [&](auto res, auto req) { HandleGetObjects("workspace", res, req); });
+        app.get(_url_prefix + "/api/database/workspace/:name", [&](auto res, auto req) { HandleGetObject("workspace", res, req); });
+        app.put(_url_prefix + "/api/database/workspace", [&](auto res, auto req) { HandleSetObject("workspace", res, req); });
+        app.del(_url_prefix + "/api/database/workspace", [&](auto res, auto req) { HandleClearObject("workspace", res, req); });
     } else {
-        app.get("/api/database/*", [&](auto res, auto req) { NotImplemented(res, req); });
-        app.put("/api/database/*", [&](auto res, auto req) { NotImplemented(res, req); });
-        app.del("/api/database/*", [&](auto res, auto req) { NotImplemented(res, req); });
+        app.get(_url_prefix + "/api/database/*", [&](auto res, auto req) { NotImplemented(res, req); });
+        app.put(_url_prefix + "/api/database/*", [&](auto res, auto req) { NotImplemented(res, req); });
+        app.del(_url_prefix + "/api/database/*", [&](auto res, auto req) { NotImplemented(res, req); });
     }
 
     if (_enable_frontend) {
         if (_enable_runtime_config) {
-            app.get("/config", [&](auto res, auto req) { HandleGetConfig(res, req); });
+            app.get(_url_prefix + "/config", [&](auto res, auto req) { HandleGetConfig(res, req); });
         } else {
-            app.get("/config", [&](auto res, auto req) { DefaultSuccess(res, req); });
+            app.get(_url_prefix + "/config", [&](auto res, auto req) { DefaultSuccess(res, req); });
         }
         // Static routes for all other files
         app.get("/*", [&](Res* res, Req* req) { HandleStaticRequest(res, req); });
@@ -103,7 +103,7 @@ void HttpServer::RegisterRoutes() {
     }
 
     // CORS support for the API
-    app.options("/api/*", [&](auto res, auto req) {
+    app.options(_url_prefix + "/api/*", [&](auto res, auto req) {
         AddCorsHeaders(res);
         res->end();
     });
@@ -121,11 +121,16 @@ void HttpServer::HandleStaticRequest(Res* res, Req* req) {
     fs::path path = _http_root_folder;
 
     // Trim all leading '/' and prefix
-    url.remove_prefix(url.find_first_not_of("/"));
+    while (url.size() && url[0] == '/') {
+        url = url.substr(1);
+    }
     url.remove_prefix(_url_prefix.size());
-    url.remove_prefix(url.find_first_not_of("/") - 1);
+    // Trim all '/' are behind url_prefix
+    while (url.size() && url[0] == '/') {
+        url = url.substr(1);
+    }
 
-    if (url.empty() || url == "/") {
+    if (url.empty()) {
         path /= "index.html";
     } else {
         path /= std::string(url);

--- a/src/HttpServer/HttpServer.cc
+++ b/src/HttpServer/HttpServer.cc
@@ -56,54 +56,54 @@ void HttpServer::RegisterRoutes() {
     uWS::App& app = _session_manager->App();
 
     if (_enable_scripting) {
-        app.post(fmt::format("/{}/api/scripting/action", _url_prefix), [&](auto res, auto req) { HandleScriptingAction(res, req); });
+        app.post(fmt::format("{}/api/scripting/action", _url_prefix), [&](auto res, auto req) { HandleScriptingAction(res, req); });
     } else {
-        app.post(fmt::format("/{}/api/scripting/action", _url_prefix), [&](auto res, auto req) { NotImplemented(res, req); });
+        app.post(fmt::format("{}/api/scripting/action", _url_prefix), [&](auto res, auto req) { NotImplemented(res, req); });
     }
 
     if (_enable_database) {
         // Dynamic routes for preferences, layouts, snippets and workspaces
-        app.get(fmt::format("/{}/api/database/preferences", _url_prefix), [&](auto res, auto req) { HandleGetPreferences(res, req); });
-        app.put(fmt::format("/{}/api/database/preferences", _url_prefix), [&](auto res, auto req) { HandleSetPreferences(res, req); });
-        app.del(fmt::format("/{}/api/database/preferences", _url_prefix), [&](auto res, auto req) { HandleClearPreferences(res, req); });
+        app.get(fmt::format("{}/api/database/preferences", _url_prefix), [&](auto res, auto req) { HandleGetPreferences(res, req); });
+        app.put(fmt::format("{}/api/database/preferences", _url_prefix), [&](auto res, auto req) { HandleSetPreferences(res, req); });
+        app.del(fmt::format("{}/api/database/preferences", _url_prefix), [&](auto res, auto req) { HandleClearPreferences(res, req); });
 
-        app.get(fmt::format("/{}/api/database/list/layouts", _url_prefix), [&](auto res, auto req) { HandleGetObjectList("layout", res, req); });
-        app.get(fmt::format("/{}/api/database/layouts", _url_prefix), [&](auto res, auto req) { HandleGetObjects("layout", res, req); });
-        app.get(fmt::format("/{}/api/database/layout/:name", _url_prefix), [&](auto res, auto req) { HandleGetObject("layout", res, req); });
-        app.put(fmt::format("/{}/api/database/layout", _url_prefix), [&](auto res, auto req) { HandleSetObject("layout", res, req); });
-        app.del(fmt::format("/{}/api/database/layout", _url_prefix), [&](auto res, auto req) { HandleClearObject("layout", res, req); });
+        app.get(fmt::format("{}/api/database/list/layouts", _url_prefix), [&](auto res, auto req) { HandleGetObjectList("layout", res, req); });
+        app.get(fmt::format("{}/api/database/layouts", _url_prefix), [&](auto res, auto req) { HandleGetObjects("layout", res, req); });
+        app.get(fmt::format("{}/api/database/layout/:name", _url_prefix), [&](auto res, auto req) { HandleGetObject("layout", res, req); });
+        app.put(fmt::format("{}/api/database/layout", _url_prefix), [&](auto res, auto req) { HandleSetObject("layout", res, req); });
+        app.del(fmt::format("{}/api/database/layout", _url_prefix), [&](auto res, auto req) { HandleClearObject("layout", res, req); });
 
-        app.get(fmt::format("/{}/api/database/list/snippets", _url_prefix), [&](auto res, auto req) { HandleGetObjectList("snippet", res, req); });
-        app.get(fmt::format("/{}/api/database/snippets", _url_prefix), [&](auto res, auto req) { HandleGetObjects("snippet", res, req); });
-        app.get(fmt::format("/{}/api/database/snippet/:name", _url_prefix), [&](auto res, auto req) { HandleGetObject("snippet", res, req); });
-        app.put(fmt::format("/{}/api/database/snippet", _url_prefix), [&](auto res, auto req) { HandleSetObject("snippet", res, req); });
-        app.del(fmt::format("/{}/api/database/snippet", _url_prefix), [&](auto res, auto req) { HandleClearObject("snippet", res, req); });
+        app.get(fmt::format("{}/api/database/list/snippets", _url_prefix), [&](auto res, auto req) { HandleGetObjectList("snippet", res, req); });
+        app.get(fmt::format("{}/api/database/snippets", _url_prefix), [&](auto res, auto req) { HandleGetObjects("snippet", res, req); });
+        app.get(fmt::format("{}/api/database/snippet/:name", _url_prefix), [&](auto res, auto req) { HandleGetObject("snippet", res, req); });
+        app.put(fmt::format("{}/api/database/snippet", _url_prefix), [&](auto res, auto req) { HandleSetObject("snippet", res, req); });
+        app.del(fmt::format("{}/api/database/snippet", _url_prefix), [&](auto res, auto req) { HandleClearObject("snippet", res, req); });
 
-        app.get(fmt::format("/{}/api/database/list/workspaces", _url_prefix), [&](auto res, auto req) { HandleGetObjectList("workspace", res, req); });
-        app.get(fmt::format("/{}/api/database/workspaces", _url_prefix), [&](auto res, auto req) { HandleGetObjects("workspace", res, req); });
-        app.get(fmt::format("/{}/api/database/workspace/:name", _url_prefix), [&](auto res, auto req) { HandleGetObject("workspace", res, req); });
-        app.put(fmt::format("/{}/api/database/workspace", _url_prefix), [&](auto res, auto req) { HandleSetObject("workspace", res, req); });
-        app.del(fmt::format("/{}/api/database/workspace", _url_prefix), [&](auto res, auto req) { HandleClearObject("workspace", res, req); });
+        app.get(fmt::format("{}/api/database/list/workspaces", _url_prefix), [&](auto res, auto req) { HandleGetObjectList("workspace", res, req); });
+        app.get(fmt::format("{}/api/database/workspaces", _url_prefix), [&](auto res, auto req) { HandleGetObjects("workspace", res, req); });
+        app.get(fmt::format("{}/api/database/workspace/:name", _url_prefix), [&](auto res, auto req) { HandleGetObject("workspace", res, req); });
+        app.put(fmt::format("{}/api/database/workspace", _url_prefix), [&](auto res, auto req) { HandleSetObject("workspace", res, req); });
+        app.del(fmt::format("{}/api/database/workspace", _url_prefix), [&](auto res, auto req) { HandleClearObject("workspace", res, req); });
     } else {
-        app.get(fmt::format("/{}/api/database/*", _url_prefix), [&](auto res, auto req) { NotImplemented(res, req); });
-        app.put(fmt::format("/{}/api/database/*", _url_prefix), [&](auto res, auto req) { NotImplemented(res, req); });
-        app.del(fmt::format("/{}/api/database/*", _url_prefix), [&](auto res, auto req) { NotImplemented(res, req); });
+        app.get(fmt::format("{}/api/database/*", _url_prefix), [&](auto res, auto req) { NotImplemented(res, req); });
+        app.put(fmt::format("{}/api/database/*", _url_prefix), [&](auto res, auto req) { NotImplemented(res, req); });
+        app.del(fmt::format("{}/api/database/*", _url_prefix), [&](auto res, auto req) { NotImplemented(res, req); });
     }
 
     if (_enable_frontend) {
         if (_enable_runtime_config) {
-            app.get(fmt::format("/{}/config", _url_prefix), [&](auto res, auto req) { HandleGetConfig(res, req); });
+            app.get(fmt::format("{}/config", _url_prefix), [&](auto res, auto req) { HandleGetConfig(res, req); });
         } else {
-            app.get(fmt::format("/{}/config", _url_prefix), [&](auto res, auto req) { DefaultSuccess(res, req); });
+            app.get(fmt::format("{}/config", _url_prefix), [&](auto res, auto req) { DefaultSuccess(res, req); });
         }
         // Static routes for all other files
-        app.get(fmt::format("/{}/*", _url_prefix), [&](Res* res, Req* req) { HandleStaticRequest(res, req); });
+        app.get(fmt::format("{}/*", _url_prefix), [&](Res* res, Req* req) { HandleStaticRequest(res, req); });
     } else {
-        app.get(fmt::format("/{}/*", _url_prefix), [&](auto res, auto req) { NotImplemented(res, req); });
+        app.get(fmt::format("{}/*", _url_prefix), [&](auto res, auto req) { NotImplemented(res, req); });
     }
 
     // CORS support for the API
-    app.options(fmt::format("/{}/api/*", _url_prefix), [&](auto res, auto req) {
+    app.options(fmt::format("{}/api/*", _url_prefix), [&](auto res, auto req) {
         AddCorsHeaders(res);
         res->end();
     });
@@ -124,7 +124,10 @@ void HttpServer::HandleStaticRequest(Res* res, Req* req) {
     while (url.size() && url[0] == '/') {
         url = url.substr(1);
     }
-    url.remove_prefix(_url_prefix.size());
+    // internal _url_prefix saved an additional '/'
+    if (_url_prefix.size()) {
+        url.remove_prefix(_url_prefix.size() - 1);
+    }
     // Trim all '/' behind url_prefix
     while (url.size() && url[0] == '/') {
         url = url.substr(1);

--- a/src/HttpServer/HttpServer.h
+++ b/src/HttpServer/HttpServer.h
@@ -40,7 +40,7 @@ class HttpServer {
 public:
     HttpServer(std::shared_ptr<SessionManager> session_manager, fs::path root_folder, fs::path user_directory, std::string auth_token,
         bool read_only_mode = false, bool enable_frontend = true, bool enable_database = true, bool enable_scripting = false,
-        bool enable_runtime_config = true);
+        bool enable_runtime_config = true, std::string url_prefix = "");
     bool CanServeFrontend() {
         return _frontend_found;
     }
@@ -96,6 +96,7 @@ private:
     bool _enable_database;
     bool _enable_scripting;
     bool _enable_runtime_config;
+    std::string _url_prefix;
     std::shared_ptr<SessionManager> _session_manager;
     static uint32_t _scripting_request_id;
 };

--- a/src/Main/Main.cc
+++ b/src/Main/Main.cc
@@ -101,7 +101,7 @@ int main(int argc, char* argv[]) {
         carta::OnMessageTask::SetSessionManager(session_manager);
 
         // HTTP server
-        std::string url_prefix = getenv("CARTA_URL_PREFIX");
+        std::string url_prefix = getenv("CARTA_URL_PREFIX") ? getenv("CARTA_URL_PREFIX") : "";
         for (auto it = url_prefix.begin(); it < url_prefix.end(); it++) {
             int iit = int(*it);
             if ((iit < 48 || (iit < 65 && iit > 57) || (iit > 90 && iit < 97) || iit > 122) && // [0-9], [A-Z], [a-z]

--- a/src/Main/Main.cc
+++ b/src/Main/Main.cc
@@ -101,6 +101,7 @@ int main(int argc, char* argv[]) {
         carta::OnMessageTask::SetSessionManager(session_manager);
 
         // HTTP server
+        auto url_prefix = getenv("URL_PREFIX");
         if (!settings.no_frontend || !settings.no_database || settings.enable_scripting) {
             fs::path frontend_path;
 
@@ -119,7 +120,7 @@ int main(int argc, char* argv[]) {
 
             http_server =
                 std::make_unique<HttpServer>(session_manager, frontend_path, settings.user_directory, auth_token, settings.read_only_mode,
-                    !settings.no_frontend, !settings.no_database, settings.enable_scripting, !settings.no_runtime_config);
+                    !settings.no_frontend, !settings.no_database, settings.enable_scripting, !settings.no_runtime_config, url_prefix);
             http_server->RegisterRoutes();
 
             if (!settings.no_frontend && !http_server->CanServeFrontend()) {
@@ -151,7 +152,7 @@ int main(int argc, char* argv[]) {
                     }
                 }
 
-                string base_url = fmt::format("http://{}:{}", default_host_string, port);
+                string base_url = fmt::format("http://{}:{}/{}", default_host_string, port, url_prefix);
 
                 if (!settings.no_frontend && http_server->CanServeFrontend()) {
                     string frontend_url = base_url;

--- a/src/Main/Main.cc
+++ b/src/Main/Main.cc
@@ -101,7 +101,17 @@ int main(int argc, char* argv[]) {
         carta::OnMessageTask::SetSessionManager(session_manager);
 
         // HTTP server
-        auto url_prefix = getenv("URL_PREFIX");
+        std::string url_prefix = getenv("CARTA_URL_PREFIX");
+        for (auto it = url_prefix.begin(); it < url_prefix.end(); it++) {
+            int iit = int(*it);
+            if ((iit < 48 || (iit < 65 && iit > 57) || (iit > 90 && iit < 97) || iit > 122) && // [0-9], [A-Z], [a-z]
+                (iit != 43 && iit != 45 && iit != 64 && iit != 95) // +, -, @, _
+                ) {
+                spdlog::critical("Custom prefix must be the following characters: [0-9], [A-Z], [a-z], +, -, @, _");
+                carta::logger::FlushLogFile();
+                return 1;
+            }
+        }
         if (!settings.no_frontend || !settings.no_database || settings.enable_scripting) {
             fs::path frontend_path;
 

--- a/src/Main/Main.cc
+++ b/src/Main/Main.cc
@@ -104,13 +104,18 @@ int main(int argc, char* argv[]) {
         auto carta_url_prefix = getenv("CARTA_URL_PREFIX");
         std::string url_prefix = "";
         if (carta_url_prefix && carta_url_prefix[0]) {
+            if (int(carta_url_prefix[0]) == 47) {
+                spdlog::critical("Custom url prefix is not allowed to start with '/'");
+                carta::logger::FlushLogFile();
+                return 1;
+            } 
             url_prefix = fmt::format("/{}", carta_url_prefix);
-            for (auto it = url_prefix.begin() + 1; it < url_prefix.end(); it++) {
+            for (auto it = url_prefix.begin(); it < url_prefix.end(); it++) {
                 int iit = int(*it);
                 if ((iit < 48 || (iit < 65 && iit > 57) || (iit > 90 && iit < 97) || iit > 122) && // [0-9], [A-Z], [a-z]
-                    (iit != 43 && iit != 45 && iit != 64 && iit != 95) // +, -, @, _
+                    (iit != 43 && iit != 45 && iit != 47 && iit != 64 && iit != 95) // +, -, /, @, _
                     ) {
-                    spdlog::critical("Custom prefix must be the following characters: [0-9], [A-Z], [a-z], +, -, @, _");
+                    spdlog::critical("Custom prefix must be the following characters: [0-9], [A-Z], [a-z], +, -, /, @, _");
                     carta::logger::FlushLogFile();
                     return 1;
                 }

--- a/src/Main/Main.cc
+++ b/src/Main/Main.cc
@@ -101,15 +101,19 @@ int main(int argc, char* argv[]) {
         carta::OnMessageTask::SetSessionManager(session_manager);
 
         // HTTP server
-        std::string url_prefix = getenv("CARTA_URL_PREFIX") ? getenv("CARTA_URL_PREFIX") : "";
-        for (auto it = url_prefix.begin(); it < url_prefix.end(); it++) {
-            int iit = int(*it);
-            if ((iit < 48 || (iit < 65 && iit > 57) || (iit > 90 && iit < 97) || iit > 122) && // [0-9], [A-Z], [a-z]
-                (iit != 43 && iit != 45 && iit != 64 && iit != 95) // +, -, @, _
-                ) {
-                spdlog::critical("Custom prefix must be the following characters: [0-9], [A-Z], [a-z], +, -, @, _");
-                carta::logger::FlushLogFile();
-                return 1;
+        auto carta_url_prefix = getenv("CARTA_URL_PREFIX");
+        std::string url_prefix = "";
+        if (carta_url_prefix && carta_url_prefix[0]) {
+            url_prefix = fmt::format("/{}", carta_url_prefix);
+            for (auto it = url_prefix.begin() + 1; it < url_prefix.end(); it++) {
+                int iit = int(*it);
+                if ((iit < 48 || (iit < 65 && iit > 57) || (iit > 90 && iit < 97) || iit > 122) && // [0-9], [A-Z], [a-z]
+                    (iit != 43 && iit != 45 && iit != 64 && iit != 95) // +, -, @, _
+                    ) {
+                    spdlog::critical("Custom prefix must be the following characters: [0-9], [A-Z], [a-z], +, -, @, _");
+                    carta::logger::FlushLogFile();
+                    return 1;
+                }
             }
         }
         if (!settings.no_frontend || !settings.no_database || settings.enable_scripting) {
@@ -162,7 +166,7 @@ int main(int argc, char* argv[]) {
                     }
                 }
 
-                string base_url = fmt::format("http://{}:{}/{}", default_host_string, port, url_prefix);
+                string base_url = fmt::format("http://{}:{}{}", default_host_string, port, url_prefix);
 
                 if (!settings.no_frontend && http_server->CanServeFrontend()) {
                     string frontend_url = base_url;


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
This function is implemented for deploying CARTA onto HPC servers controlled by job scheduler (e.g. slurm). If a user launches CARTA on a computing node, we need the URL prefix information to do the reverse proxy. The approach is used in [Open OnDemand to set interactive apps](https://osc.github.io/ood-documentation/release-1.8/app-development/interactive/setup/enable-reverse-proxy.html)

* How does this PR solve the issue? Give a brief summary.
This PR allows users to customize the URL by an environment variable `CARTA_URL_PREFIX`. If launching `CARTA_URL_PREFIX=foo ./carta_backend` locally, the URL will be changed to `http://localhost:port/foo/?token=....`.

* Are there any companion PRs (frontend, protobuf)?
No

* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
We have tested the frontend on our HPC server, but we are not sure the influence to the the scripting/database/config

**Checklist**

- [x] ~changelog updated~ / no changelog update needed
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [ ] added reviewers and assignee
- [ ] added ZenHub estimate, milestone, and release
