### PR TITLE
Mark/1312 Consider the angle unit string from IRAM FITS images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+* Fixed the problem of opening old IRAM fits images ([#1312](https://github.com/CARTAvis/carta-backend/issues/1312)).
+
 ## [4.0.0]
 
 ### Changed

--- a/src/Util/Casacore.cc
+++ b/src/Util/Casacore.cc
@@ -186,6 +186,7 @@ void NormalizeUnit(casacore::String& unit) {
     unit.gsub("beam-1 Jy", "Jy/beam");
     unit.gsub("beam^-1 Jy", "Jy/beam");
     unit.gsub("Pixel", "pixel");
+    unit.gsub("DEGREE", "deg");
     unit.gsub("\"", "");
 
     // Convert unit without prefix


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
Closes #1312.

* How does this PR solve the issue? Give a brief summary.
Add a parser for the angle unit string from IRAM FITS images in the `NormalizeUnit` function.

* Are there any companion PRs (frontend, protobuf)?
No.

* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
The IRAM FITS images can be opened now.

**Checklist**

- [x] changelog updated ~/ no changelog update needed~
- [x] e2e test passing / ~corresponding fix added~ / ~new e2e test created~
- [x] ~protobuf updated to the latest dev commit /~ no protobuf update needed
- [ ] added reviewers and assignee
- [ ] added ZenHub estimate, milestone, and release
