### PR TITLE
Include casacore log messages in carta log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+* Include casacore log messages in carta log ([#1169](https://github.com/CARTAvis/carta-backend/issues/1169)).
+
 ## [4.0.0]
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,6 +224,7 @@ set(SOURCE_FILES
         src/ImageStats/Histogram.cc
         src/ImageStats/StatsCalculator.cc
         src/Logger/Logger.cc
+		src/Logger/CartaLogSink.cc
         src/Main/Main.cc
         src/Main/ProgramSettings.cc
         src/Main/WebBrowser.cc

--- a/src/Logger/CartaLogSink.cc
+++ b/src/Logger/CartaLogSink.cc
@@ -1,0 +1,44 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018-2022 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+#include "CartaLogSink.h"
+#include "Logger.h"
+
+#include <casacore/casa/Logging/LogFilter.h>
+#include <casacore/casa/Logging/LogSinkInterface.h>
+
+namespace carta {
+
+CartaLogSink::CartaLogSink(casacore::LogMessage::Priority filter) : casacore::LogSinkInterface(casacore::LogFilter(filter)) {}
+
+bool CartaLogSink::postLocally(const casacore::LogMessage& message) {
+    if (filter().pass(message)) {
+        auto priority = message.priority();
+        auto log_message = "[casacore] " + message.message();
+        if (message.priority() <= casacore::LogMessage::DEBUG1) {
+            spdlog::debug(log_message);
+        } else if (priority <= casacore::LogMessage::NORMAL) {
+            spdlog::info(log_message);
+        } else if (priority == casacore::LogMessage::WARN) {
+            spdlog::warn(log_message);
+        } else {
+            spdlog::error(log_message);
+        }
+        return true;
+    }
+
+    return false;
+}
+
+casacore::String CartaLogSink::localId() {
+    return casacore::String("CartaLogSink");
+}
+
+casacore::String CartaLogSink::id() const {
+    return casacore::String("CartaLogSink");
+}
+
+} // namespace carta

--- a/src/Logger/CartaLogSink.h
+++ b/src/Logger/CartaLogSink.h
@@ -1,0 +1,35 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018-2022 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+#ifndef CARTA_BACKEND_LOGGER_CARTALOGSINK_H_
+#define CARTA_BACKEND_LOGGER_CARTALOGSINK_H_
+
+#include <casacore/casa/Logging/LogSinkInterface.h>
+
+namespace carta {
+
+class CartaLogSink : public casacore::LogSinkInterface {
+public:
+    CartaLogSink() = default;
+    explicit CartaLogSink(casacore::LogMessage::Priority filter);
+    ~CartaLogSink() = default;
+
+    // Write message to the spdlog if it passes the filter.
+    virtual bool postLocally(const casacore::LogMessage& message);
+
+    // OVERRIDE? Write any pending output.
+    // virtual void flush (bool global=True) override;
+
+    // Returns the id for this class.
+    static casacore::String localId();
+
+    // Returns the id of the LogSink in use.
+    virtual casacore::String id() const;
+};
+
+} // namespace carta
+
+#endif // CARTA_BACKEND_LOGGER_LOGGER_H_

--- a/src/Logger/Logger.cc
+++ b/src/Logger/Logger.cc
@@ -30,7 +30,7 @@ void InitLogger(bool no_log_file, int verbosity, bool log_performance, bool log_
         log_fullname = (user_directory / "log/carta.log").string();
         auto stdout_log_file_sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(log_fullname, LOG_FILE_SIZE, ROTATED_LOG_FILES);
         stdout_log_file_sink->set_formatter(
-            std::make_unique<spdlog::pattern_formatter>(CARTA_LOGGER_PATTERN, spdlog::pattern_time_type::utc));
+            std::make_unique<spdlog::pattern_formatter>(CARTA_FILE_LOGGER_PATTERN, spdlog::pattern_time_type::utc));
         console_sinks.push_back(stdout_log_file_sink);
     }
 

--- a/src/Logger/Logger.h
+++ b/src/Logger/Logger.h
@@ -19,12 +19,14 @@
 
 #include "Util/FileSystem.h"
 
+// Time format Z is zero UTC offset (ISO 8601)
 #define LOG_FILE_SIZE 1024 * 1024 * 5 // (Bytes)
 #define ROTATED_LOG_FILES 5
 #define CARTA_LOGGER_TAG "CARTA"
-#define CARTA_LOGGER_PATTERN "[%Y-%m-%d %H:%M:%S.%e] [%^%l%$] %v"
+#define CARTA_LOGGER_PATTERN "[%Y-%m-%d %H:%M:%S.%eZ] [%n] [%^%l%$] %v"
+#define CARTA_FILE_LOGGER_PATTERN "[%Y-%m-%d %H:%M:%S.%eZ] [%^%l%$] %v"
 #define PERF_TAG "performance"
-#define PERF_PATTERN "[%Y-%m-%d %H:%M:%S.%e] [%^%l%$] [%n] %v"
+#define PERF_PATTERN "[%Y-%m-%d %H:%M:%S.%eZ] [%^%l%$] [%n] %v"
 
 // customize the log function for performance
 namespace spdlog {
@@ -48,7 +50,7 @@ public:
     carta_sink()
         : ansicolor_sink<details::console_mutex>(stdout, color_mode::automatic),
           mutex_(details::console_mutex::mutex()),
-          formatter_(details::make_unique<spdlog::pattern_formatter>(pattern_time_type::utc)) {
+          formatter_(details::make_unique<spdlog::pattern_formatter>(CARTA_LOGGER_PATTERN, pattern_time_type::utc)) {
         target_file_ = stdout;
         colors_[level::trace] = to_string_(white);
         colors_[level::debug] = to_string_(cyan);

--- a/src/Main/Main.cc
+++ b/src/Main/Main.cc
@@ -11,6 +11,7 @@
 
 #include "FileList/FileListHandler.h"
 #include "HttpServer/HttpServer.h"
+#include "Logger/CartaLogSink.h"
 #include "Logger/Logger.h"
 #include "ProgramSettings.h"
 #include "Session/SessionManager.h"
@@ -19,6 +20,8 @@
 #include "Util/FileSystem.h"
 #include "Util/Token.h"
 #include "WebBrowser.h"
+
+#include <casacore/casa/Logging/LogIO.h>
 
 // Entry point. Parses command line arguments and starts server listening
 int main(int argc, char* argv[]) {
@@ -51,6 +54,30 @@ int main(int argc, char* argv[]) {
         carta::logger::InitLogger(
             settings.no_log, settings.verbosity, settings.log_performance, settings.log_protocol_messages, settings.user_directory);
         settings.FlushMessages(); // flush log messages produced during Program Settings setup
+
+        // Send casacore log messages to sink
+        casacore::LogSink log_sink;                          // null sink, throws messages away
+        casacore::LogSinkInterface* carta_log_sink(nullptr); // sends messages to spdlog
+        switch (settings.verbosity) {
+            case 0:
+                break; // use null sink
+            case 1:
+            case 2:
+                carta_log_sink = new CartaLogSink(casacore::LogMessage::SEVERE);
+                break;
+            case 3:
+                carta_log_sink = new CartaLogSink(casacore::LogMessage::WARN);
+                break;
+            case 4:
+            case 5:
+            default:
+                carta_log_sink = new CartaLogSink(casacore::LogMessage::NORMAL);
+        }
+        if (carta_log_sink) {
+            log_sink = casacore::LogSink(carta_log_sink->filter(), casacore::CountedPtr<LogSinkInterface>(carta_log_sink));
+            casacore::LogSink::globalSink(carta_log_sink);
+        }
+        casacore::LogIO casacore_log(log_sink);
 
         if (settings.wait_time >= 0) {
             Session::SetExitTimeout(settings.wait_time);


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
Fixes #1169 

* How does this PR solve the issue? Give a brief summary.
After initializing the spdlog logger in main( ), a casacore LogSink is created (CartaLogSink or NullLogSink) to receive the casacore log messages.  CartaLogSink calls the appropriate spdlog function for the message's priority level, using the message text with an added "[casacore]" tag.  If carta logging is off (level 0), the null sink is used to discard the messages.  Verbosity levels 1 and 2 (critical and error) set the log sink to SEVERE priority, level 3 (warning) set the log sink to WARN priority, and levels 4 and 5 (info, debug) set the log sink to NORMAL priority since the casacore debugging priority is too verbose for our needs.  I also changed the log pattern to append a "Z" after the timestamp to indicate UTC as specified in the [ISO 8601 standard](https://en.wikipedia.org/wiki/ISO_8601#Coordinated_Universal_Time_(UTC)).

* Are there any companion PRs (frontend, protobuf)?
No

* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
Run carta and check the backend console logging output (stdout/stderr) and the log file.  casacore messages should be formatted like the carta messages with an additional [casacore] tag.

**Checklist**

- [x] changelog updated / ~no changelog update needed~
- [x] e2e test passing / ~corresponding fix added~ / ~new e2e test created~
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] added reviewers and assignee
- [ ] added ZenHub estimate, milestone, and release
