### PR TITLE
Mark/1281 Check if the frontend version is compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+* Added a check of compatibility with the frontend version ([#1281](https://github.com/CARTAvis/carta-backend/issues/1281)).
 
 ## [4.0.0]
 

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -41,8 +41,6 @@
 
 using namespace carta;
 
-static const std::set<std::string> COMPATIBLE_FRONTEND_VERSIONS{VERSION_ID, "4.0.0"};
-
 LoaderCache::LoaderCache(int capacity) : _capacity(capacity){};
 
 std::shared_ptr<FileLoader> LoaderCache::Get(const std::string& filename, const std::string& directory) {

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -41,7 +41,7 @@
 
 using namespace carta;
 
-static const std::set<std::string> COMPATIBLE_FRONTEND_VERSIONS{"4.0.0"};
+static const std::set<std::string> COMPATIBLE_FRONTEND_VERSIONS{VERSION_ID, "4.0.0"};
 
 LoaderCache::LoaderCache(int capacity) : _capacity(capacity){};
 

--- a/src/Util/App.h
+++ b/src/Util/App.h
@@ -8,9 +8,12 @@
 #define CARTA_BACKEND__UTIL_APP_H_
 
 #include <string>
+#include <unordered_set>
 
 // version
 #define VERSION_ID "4.0.0-rc.0"
+
+static const std::unordered_set<std::string> COMPATIBLE_FRONTEND_VERSIONS{VERSION_ID, "4.0.0"};
 
 bool FindExecutablePath(std::string& path);
 std::string GetReleaseInformation();

--- a/src/Util/Message.cc
+++ b/src/Util/Message.cc
@@ -7,12 +7,14 @@
 #include "Message.h"
 #include "Cache/RequirementsCache.h"
 #include "DataStream/Compression.h"
+#include "Util/App.h"
 
 #include <chrono>
 
 CARTA::RegisterViewer Message::RegisterViewer(uint32_t session_id, std::string api_key, uint32_t client_feature_flags) {
     CARTA::RegisterViewer register_viewer;
     register_viewer.set_session_id(session_id);
+    register_viewer.set_version(VERSION_ID);
     register_viewer.set_api_key(api_key);
     register_viewer.set_client_feature_flags(client_feature_flags);
     return register_viewer;


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
Fixes #1281.

* How does this PR solve the issue? Give a brief summary.
The frontend sends its version info, e.q., `4.0.0`, in the `RegisterViewer` message to the backend when connected. The backend then checks if the frontend version is compatible with it, plus the ICD version. If not, the backend sends `success == false` and an error message in the `RegisterViewerAck` to the frontend.

* Are there any companion PRs (frontend, protobuf)?
Both companions [frontend PR](https://github.com/CARTAvis/carta-frontend/pull/2264) and [protobuf PR](https://github.com/CARTAvis/carta-protobuf/pull/89) are needed.

* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
When connected to the frontend, if the frontend version is not compatible with the backend. Then the frontend will receive `success == false` and an error message in the `RegisterViewerAck` from the backend. The frontend could show the error message on the panel to remind the user and disconnect with the backend.

**Checklist**

- [x] changelog updated ~/ no changelog update needed~
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [x] protobuf updated to the latest dev commit ~/ no protobuf update needed~
- [ ] added reviewers and assignee
- [ ] added ZenHub estimate, milestone, and release
