### PR TITLE
Fix scripting interface and symlink issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+* Fixed scripting interface and symlink directory issues ([#1283](https://github.com/CARTAvis/carta-frontend/issues/1283), [#1284](https://github.com/CARTAvis/carta-frontend/issues/1284), [#1314](https://github.com/CARTAvis/carta-frontend/issues/1314)).
+
 ## [4.0.0]
 
 ### Changed

--- a/src/FileList/FileListHandler.cc
+++ b/src/FileList/FileListHandler.cc
@@ -55,6 +55,9 @@ void FileListHandler::GetRelativePath(std::string& folder) {
             folder = folder.substr(1); // remove leading '/'
         }
     }
+    if (folder.empty()) {
+        folder = ".";
+    }
 }
 
 void FileListHandler::GetFileList(CARTA::FileListResponse& file_list_response, const std::string& folder, ResultMsg& result_msg,
@@ -72,65 +75,51 @@ void FileListHandler::GetFileList(CARTA::FileListResponse& file_list_response, c
         requested_folder = folder_string;
     }
 
-    std::string absolute_path(requested_folder), directory;
+    // Normalize requested folder relative to top (top + requested = full path)
+    GetRelativePath(requested_folder);
 
-    if (requested_folder == _top_level_folder) {
-        // Set directory relative to top (current directory). Parent is empty string.
-        file_list_response.set_directory(".");
-    } else {
-        // Normalize folder relative to top, restore path
-        GetRelativePath(requested_folder);
-        casacore::Path path(_top_level_folder);
-        path.append(requested_folder);
+    // Resolve path (., .., ~, symlinks)
+    std::string message;
+    auto resolved_path = GetResolvedFilename(_top_level_folder, requested_folder, "", message);
 
-        // Resolve path (., .., ~, symlinks)
-        try {
-            absolute_path = path.resolvedName();
-        } catch (casacore::AipsError& err) {
-            try {
-                absolute_path = path.absoluteName();
-            } catch (casacore::AipsError& err) {
-                file_list_response.set_success(false);
-                file_list_response.set_message("Cannot resolve directory path for file list.");
-                return;
-            }
-        }
-
-        // Set parent relative to top
-        std::string parent(path.dirName());
-        GetRelativePath(parent);
-        file_list_response.set_parent(parent);
-
-        // Set directory relative to top
-        directory = absolute_path;
-        GetRelativePath(directory);
-        file_list_response.set_directory(directory);
-    }
-
-    if ((_top_level_folder.find(absolute_path) == 0) && (absolute_path.length() < _top_level_folder.length())) {
-        // absolute path is above top folder
+    // Check resolved path
+    if (resolved_path.empty()) {
+        file_list_response.set_success(false);
+        file_list_response.set_message("File list failed: " + message);
+        return;
+    } else if ((_top_level_folder.find(resolved_path) == 0) && (resolved_path.length() < _top_level_folder.length())) {
+        // path is above top folder!
         file_list_response.set_success(false);
         file_list_response.set_message("Forbidden path.");
         return;
     }
 
-    casacore::File folder_path(absolute_path);
-    std::string message;
+    casacore::File folder_path(resolved_path);
+    if (!folder_path.isDirectory()) {
+        file_list_response.set_success(false);
+        file_list_response.set_message("File list failed: requested path " + folder + " is not a directory.");
+        return;
+    }
 
+    // Set response parent and directory
+    if (requested_folder == ".") {
+        // is top folder; no directory
+        file_list_response.set_parent(requested_folder);
+    } else {
+        // Make full path to separate directory and base names
+        casacore::Path full_path(_top_level_folder);
+        full_path.append(requested_folder);
+        // parent
+        std::string parent(full_path.dirName());
+        GetRelativePath(parent);
+        file_list_response.set_parent(parent);
+        // directory
+        std::string directory(full_path.baseName());
+        file_list_response.set_directory(requested_folder);
+    }
+
+    // Iterate through directory to generate file list
     try {
-        if (!folder_path.exists()) {
-            file_list_response.set_success(false);
-            file_list_response.set_message("Requested directory " + directory + " does not exist.");
-            return;
-        }
-
-        if (!folder_path.isDirectory()) {
-            file_list_response.set_success(false);
-            file_list_response.set_message("Requested path " + directory + " is not a directory.");
-            return;
-        }
-
-        // Iterate through directory to generate file list
         casacore::Directory start_dir(folder_path);
         casacore::DirectoryIterator dir_iter(start_dir);
 
@@ -326,37 +315,38 @@ bool FileListHandler::FillRegionFileInfo(
 void FileListHandler::OnRegionFileInfoRequest(
     const CARTA::RegionFileInfoRequest& request, CARTA::RegionFileInfoResponse& response, ResultMsg& result_msg) {
     // Fill response message with file info and contents
-    casacore::Path top_path(_top_level_folder);
-    top_path.append(request.directory());
-    auto filename = request.file();
-    top_path.append(filename);
-    casacore::File cc_file(top_path);
-    std::string message, contents;
-    bool success(false);
+    auto directory = request.directory();
+    auto file = request.file();
+    std::string message;
 
-    if (!cc_file.exists()) {
-        message = "File " + filename + " does not exist.";
-        response.add_contents(contents);
-    } else if (!cc_file.isRegular(true)) {
-        message = "File " + filename + " is not a region file.";
-        response.add_contents(contents);
-    } else if (!cc_file.isReadable()) {
-        message = "File " + filename + " is not readable.";
-        response.add_contents(contents);
-    } else {
-        casacore::String full_name(cc_file.path().resolvedName());
-        auto& file_info = *response.mutable_file_info();
-        FillRegionFileInfo(file_info, full_name);
-        std::vector<std::string> file_contents;
-        if (file_info.type() == CARTA::FileType::UNKNOWN) {
-            message = "File " + filename + " is not a region file.";
-            response.add_contents(contents);
+    casacore::String full_name = GetResolvedFilename(_top_level_folder, directory, file, message);
+
+    bool success(false), add_contents(true);
+    if (!full_name.empty()) {
+        casacore::File cc_file(full_name);
+        if (!cc_file.isRegular(true)) {
+            message = "File " + file + " is not a region file.";
         } else {
-            GetRegionFileContents(full_name, file_contents);
-            success = true;
-            *response.mutable_contents() = {file_contents.begin(), file_contents.end()};
+            auto& file_info = *response.mutable_file_info();
+            FillRegionFileInfo(file_info, full_name);
+
+            if (file_info.type() == CARTA::FileType::UNKNOWN) {
+                message = "File " + file + " is not a region file.";
+            } else {
+                std::vector<std::string> file_contents;
+                GetRegionFileContents(full_name, file_contents);
+                success = true;
+                *response.mutable_contents() = {file_contents.begin(), file_contents.end()};
+                add_contents = false;
+            }
         }
     }
+
+    if (add_contents) {
+        std::string contents;
+        response.add_contents(contents);
+    }
+
     response.set_success(success);
     response.set_message(message);
 }

--- a/src/ImageData/StokesFilesConnector.cc
+++ b/src/ImageData/StokesFilesConnector.cc
@@ -201,28 +201,28 @@ bool StokesFilesConnector::OpenStokesFiles(const CARTA::ConcatStokesFiles& messa
     for (int i = 0; i < message.stokes_files_size(); ++i) {
         auto stokes_file = message.stokes_files(i);
         auto stokes_type = message.stokes_files(i).polarization_type();
-        casacore::String hdu(stokes_file.hdu());
-        casacore::String full_name(GetResolvedFilename(_top_level_folder, stokes_file.directory(), stokes_file.file()));
 
         if (_loaders.count(stokes_type)) {
             err = "Duplicate Stokes type found!";
             return false;
         }
 
+        casacore::String full_name(GetResolvedFilename(_top_level_folder, stokes_file.directory(), stokes_file.file(), err));
+
         // open an image file
-        if (!full_name.empty()) {
-            try {
-                if (hdu.empty()) { // use first when required
-                    hdu = "0";
-                }
-                _loaders[stokes_type].reset(FileLoader::GetLoader(full_name));
-                _loaders[stokes_type]->OpenFile(hdu);
-            } catch (casacore::AipsError& ex) {
-                err = fmt::format("Failed to open the file: {}", ex.getMesg());
-                return false;
+        if (full_name.empty()) {
+            return false;
+        }
+
+        try {
+            casacore::String hdu(stokes_file.hdu());
+            if (hdu.empty()) { // use first when required
+                hdu = "0";
             }
-        } else {
-            err = "File name is empty or does not exist!";
+            _loaders[stokes_type].reset(FileLoader::GetLoader(full_name));
+            _loaders[stokes_type]->OpenFile(hdu);
+        } catch (casacore::AipsError& ex) {
+            err = fmt::format("Failed to open the file: {}", ex.getMesg());
             return false;
         }
 

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -362,9 +362,8 @@ bool Session::FillFileInfo(
     // Resolve filename and fill file info submessage
     bool file_info_ok(false);
 
-    fullname = GetResolvedFilename(_top_level_folder, folder, filename);
+    fullname = GetResolvedFilename(_top_level_folder, folder, filename, message);
     if (fullname.empty()) {
-        message = fmt::format("File {} does not exist.", filename);
         return file_info_ok;
     }
 
@@ -523,18 +522,17 @@ bool Session::OnOpenFile(const CARTA::OpenFile& message, uint32_t request_id, bo
 
     if (lel_expr) {
         // filename field is LEL expression
-        auto dir_path = GetResolvedFilename(_top_level_folder, directory, "");
-        auto loader = _loaders.Get(filename, dir_path);
-
-        try {
-            loader->OpenFile(hdu);
-
-            auto image = loader->GetImage();
-            success = OnOpenFile(file_id, filename, image, &ack);
-        } catch (const casacore::AipsError& err) {
-            _loaders.Remove(filename, dir_path);
-            success = false;
-            err_message = err.getMesg();
+        auto dir_path = GetResolvedFilename(_top_level_folder, directory, "", err_message);
+        if (!dir_path.empty()) {
+            auto loader = _loaders.Get(filename, dir_path);
+            try {
+                loader->OpenFile(hdu);
+                auto image = loader->GetImage();
+                success = OnOpenFile(file_id, filename, image, &ack);
+            } catch (const casacore::AipsError& err) {
+                _loaders.Remove(filename, dir_path);
+                err_message = err.getMesg();
+            }
         }
     } else {
         ack.set_file_id(file_id);
@@ -908,10 +906,10 @@ void Session::OnImportRegion(const CARTA::ImportRegion& message, uint32_t reques
         std::string region_file; // name or contents
         if (import_file) {
             // check that file can be opened
-            region_file = GetResolvedFilename(_top_level_folder, directory, filename);
-            casacore::File ccfile(region_file);
-            if (!ccfile.exists() || !ccfile.isReadable()) {
-                auto import_ack = Message::ImportRegionAck(false, "Import region failed: cannot open file.");
+            std::string error;
+            region_file = GetResolvedFilename(_top_level_folder, directory, filename, error);
+            if (region_file.empty()) {
+                auto import_ack = Message::ImportRegionAck(false, "Import region failed: " + error);
                 SendFileEvent(file_id, CARTA::EventType::IMPORT_REGION_ACK, request_id, import_ack);
                 return;
             }
@@ -2440,8 +2438,12 @@ std::chrono::high_resolution_clock::time_point Session::GetLastMessageTimestamp(
 }
 
 void Session::CloseCachedImage(const std::string& directory, const std::string& file) {
-    std::string fullname = GetResolvedFilename(_top_level_folder, directory, file);
-    for (auto& frame : _frames) {
-        frame.second->CloseCachedImage(fullname);
+    std::string message;
+    std::string fullname = GetResolvedFilename(_top_level_folder, directory, file, message);
+
+    if (!fullname.empty()) {
+        for (auto& frame : _frames) {
+            frame.second->CloseCachedImage(fullname);
+        }
     }
 }

--- a/src/Util/Casacore.cc
+++ b/src/Util/Casacore.cc
@@ -98,19 +98,37 @@ bool IsSubdirectory(string folder, string top_folder) {
     return false;
 }
 
-casacore::String GetResolvedFilename(const string& root_dir, const string& directory, const string& file) {
+casacore::String GetResolvedFilename(const string& root_dir, const string& directory, const string& file, string& message) {
     // Given directory (relative to root folder) and file, return resolved path and filename
     // (absolute pathname with symlinks resolved)
     casacore::String resolved_filename;
-    casacore::Path root_path(root_dir);
-    root_path.append(directory);
-    root_path.append(file);
-    casacore::File cc_file(root_path);
-    if (cc_file.exists()) {
-        try {
-            resolved_filename = cc_file.path().resolvedName();
-        } catch (casacore::AipsError& err) {
-            // return empty string
+    casacore::Path path(root_dir);
+    path.append(directory);
+    casacore::File cc_directory(path);
+
+    if (!cc_directory.exists()) {
+        message = "Directory " + directory + " does not exist.";
+    } else if (!cc_directory.isReadable()) {
+        message = "Directory " + directory + " is not readable.";
+    } else {
+        path.append(file);
+        casacore::File cc_file(path);
+
+        if (!cc_file.exists()) {
+            message = "File " + file + " does not exist.";
+        } else if (!cc_file.isReadable()) {
+            message = "File " + file + " is not readable.";
+        } else {
+            try {
+                resolved_filename = cc_file.path().resolvedName();
+            } catch (const casacore::AipsError& err) {
+                try {
+                    resolved_filename = cc_file.path().absoluteName();
+                } catch (const casacore::AipsError& err) {
+                    // return empty string
+                    message = "Cannot resolve file path.";
+                }
+            }
         }
     }
     return resolved_filename;

--- a/src/Util/Casacore.h
+++ b/src/Util/Casacore.h
@@ -12,8 +12,11 @@
 #include <casacore/scimath/Mathematics/GaussianBeam.h>
 
 bool CheckFolderPaths(std::string& top_level_string, std::string& starting_string);
+
 bool IsSubdirectory(std::string folder, std::string top_folder);
-casacore::String GetResolvedFilename(const std::string& root_dir, const std::string& directory, const std::string& file);
+
+casacore::String GetResolvedFilename(
+    const std::string& root_dir, const std::string& directory, const std::string& file, std::string& message);
 
 // Determine image type from filename
 inline casacore::ImageOpener::ImageTypes CasacoreImageType(const std::string& filename) {


### PR DESCRIPTION
**Description**
 Fix file list issues concerning invalid directories through scripting interface and symlinks which were dereferenced to the symlink directory path
* What is implemented or fixed? Mention the linked issue(s), if any.
Fixes #1283 #1284  #1314
* How does this PR solve the issue? Give a brief summary.
The directory path is checked before adding the filename for an appropriate error message. The symlink path uses the requested path rather than the absolute path of the actual location for the parent and directory in the response.
* Are there any companion PRs (frontend, protobuf)?
No
* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
Set invalid directory in scripting interface session.open_image and session.open_LEL_image, should get error that directory (not file) does not exist. In file browser, select symlinked directory and check directory breadcrumbs, should be previous path with directory added.

**Checklist**

- [x] changelog updated / ~no changelog update needed~
- [x] e2e test passing / ~corresponding fix added~ / ~new e2e test created~
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] added reviewers and assignee
- [ ] added ZenHub estimate, milestone, and release
