### PR TITLE
Yuhsuan/1318 fix fitting mad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+* Fixed incorrect std calculation when fitting images with nan values ([#1318](https://github.com/CARTAvis/carta-backend/issues/1318)).
+
 ## [4.0.0]
 
 ### Changed

--- a/src/ImageFitter/ImageFitter.cc
+++ b/src/ImageFitter/ImageFitter.cc
@@ -47,7 +47,7 @@ bool ImageFitter::FitImage(size_t width, size_t height, float* image, double bea
     _create_residual_data = create_residual_image;
     _progress_callback = progress_callback;
 
-    CalculateNanNum();
+    CalculateNanNumAndStd();
     SetInitialValues(initial_values, background_offset, fixed_params);
 
     // avoid SolveSystem crashes with insufficient data points
@@ -141,7 +141,7 @@ void ImageFitter::StopFitting() {
     _fit_data.stop_fitting = true;
 }
 
-void ImageFitter::CalculateNanNum() {
+void ImageFitter::CalculateNanNumAndStd() {
     std::vector<double> data_notnan;
 
     _fit_data.n_notnan = _fit_data.n;

--- a/src/ImageFitter/ImageFitter.cc
+++ b/src/ImageFitter/ImageFitter.cc
@@ -143,6 +143,7 @@ void ImageFitter::StopFitting() {
 
 void ImageFitter::CalculateNanNumAndStd() {
     std::vector<double> data_notnan;
+    data_notnan.reserve(_fit_data.n);
 
     _fit_data.n_notnan = _fit_data.n;
     for (size_t i = 0; i < _fit_data.n; i++) {

--- a/src/ImageFitter/ImageFitter.cc
+++ b/src/ImageFitter/ImageFitter.cc
@@ -142,12 +142,18 @@ void ImageFitter::StopFitting() {
 }
 
 void ImageFitter::CalculateNanNum() {
+    std::vector<double> data_notnan;
+
     _fit_data.n_notnan = _fit_data.n;
     for (size_t i = 0; i < _fit_data.n; i++) {
         if (isnan(_fit_data.data[i])) {
             _fit_data.n_notnan--;
+        } else {
+            data_notnan.push_back(_fit_data.data[i]);
         }
     }
+
+    _image_std = GetMedianAbsDeviation(_fit_data.n_notnan, data_notnan.data());
 }
 
 void ImageFitter::SetInitialValues(
@@ -220,9 +226,6 @@ int ImageFitter::SolveSystem(CARTA::FittingSolverType solver) {
     gsl_vector* f = gsl_multifit_nlinear_residual(work);
     gsl_vector* y = gsl_multifit_nlinear_position(work);
     gsl_matrix* covar = gsl_matrix_alloc(p, p);
-
-    gsl_multifit_nlinear_init(_fit_values, &_fdf, work); // work-around for filling in f
-    _image_std = GetMedianAbsDeviation(_fdf.n, f->data);
 
     gsl_vector* weights = gsl_vector_alloc(n);
     gsl_vector_set_all(weights, 1 / _image_std / _image_std);

--- a/src/ImageFitter/ImageFitter.cc
+++ b/src/ImageFitter/ImageFitter.cc
@@ -155,6 +155,7 @@ void ImageFitter::CalculateNanNumAndStd() {
     }
 
     _image_std = GetMedianAbsDeviation(_fit_data.n_notnan, data_notnan.data());
+    spdlog::debug("MAD = {}", _image_std);
 }
 
 void ImageFitter::SetInitialValues(

--- a/src/ImageFitter/ImageFitter.h
+++ b/src/ImageFitter/ImageFitter.h
@@ -139,9 +139,9 @@ private:
     GeneratorProgressCallback _progress_callback;
 
     /**
-     * @brief Calculate the number of NaN values in the image data.
+     * @brief Calculate the number of NaN values and standard deviation of the image data.
      */
-    void CalculateNanNum();
+    void CalculateNanNumAndStd();
     /**
      * @brief Set initial fitting parameters for the fitting.
      * @param initial_values Initial fitting parameters

--- a/test/TestImageFitting.cc
+++ b/test/TestImageFitting.cc
@@ -271,7 +271,7 @@ TEST_F(ImageFittingTest, FittingWithFov) {
     fixed_params.push_back(true);
     SetInitialValues(gaussian_model);
     SetFixedParams(fixed_params);
-    SetFov(CARTA::RegionType::RECTANGLE, {63.5, 63.5, 64, 64}, 10);
+    SetFov(CARTA::RegionType::RECTANGLE, {63.5, 63.5, 96, 96}, 10);
     FitImageWithFov(gaussian_model, 0);
 }
 


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
  Fixed #1318.
* How does this PR solve the issue? Give a brief summary.
  Exclude nans when calculating MAD (median absolute deviation). Instead of using the raw image data, create a tmp double array with image data excluding nans for the calculation.
* Other changes:
  Minor adjustment of the unit test - extend the area of FOV fitting to get a more precise result.
* Tested that:
  The fitting result and MAD does not change when additional nans are included.
  Fitting the entire test image does not get MAD 0 and does not fail.
  Also checked that the calculation time and the memory pattern do not change.

**Checklist**

- [x] changelog updated / ~no changelog update needed~
- [x] e2e test passing / corresponding fix added / ~new e2e test created~
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] added reviewers and assignee
- [x] added ZenHub estimate, milestone, and release
