### PR TITLE
Replace map with unordered map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+* Replace map with unordered_map ([#1295](https://github.com/CARTAvis/carta-backend/issues/1295)).
+
 ### Fixed
 * Fixed scripting interface and symlink directory issues ([#1283](https://github.com/CARTAvis/carta-frontend/issues/1283), [#1284](https://github.com/CARTAvis/carta-frontend/issues/1284), [#1314](https://github.com/CARTAvis/carta-frontend/issues/1314)).
 * Include casacore log messages in carta log ([#1169](https://github.com/CARTAvis/carta-backend/issues/1169)).

--- a/src/Cache/RequirementsCache.h
+++ b/src/Cache/RequirementsCache.h
@@ -174,10 +174,10 @@ struct RegionSpectralConfig {
 };
 
 struct SpectralCache {
-    std::map<CARTA::StatsType, std::vector<double>> profiles;
+    std::unordered_map<CARTA::StatsType, std::vector<double>> profiles;
 
     SpectralCache() {}
-    SpectralCache(std::map<CARTA::StatsType, std::vector<double>>& profiles_) : profiles(profiles_) {}
+    SpectralCache(std::unordered_map<CARTA::StatsType, std::vector<double>>& profiles_) : profiles(profiles_) {}
 
     bool GetProfile(CARTA::StatsType type_, std::vector<double>& profile_) {
         if (!profiles.empty() && profiles.count(type_)) {
@@ -200,14 +200,14 @@ struct RegionStatsConfig {
 };
 
 struct StatsCache {
-    std::map<CARTA::StatsType, double> stats;
+    std::unordered_map<CARTA::StatsType, double> stats;
 
     StatsCache() {}
-    StatsCache(std::map<CARTA::StatsType, double>& stats_) {
+    StatsCache(std::unordered_map<CARTA::StatsType, double>& stats_) {
         stats = stats_;
     }
 
-    bool GetStats(std::map<CARTA::StatsType, double>& stats_) {
+    bool GetStats(std::unordered_map<CARTA::StatsType, double>& stats_) {
         if (!stats.empty()) {
             stats_ = stats;
             return true;

--- a/src/FileList/FileExtInfoLoader.cc
+++ b/src/FileList/FileExtInfoLoader.cc
@@ -34,7 +34,7 @@ using namespace carta;
 FileExtInfoLoader::FileExtInfoLoader(std::shared_ptr<FileLoader> loader) : _loader(loader) {}
 
 bool FileExtInfoLoader::FillFitsFileInfoMap(
-    std::map<std::string, CARTA::FileInfoExtended>& hdu_info_map, const std::string& filename, std::string& message) {
+    std::unordered_map<std::string, CARTA::FileInfoExtended>& hdu_info_map, const std::string& filename, std::string& message) {
     // Fill map with FileInfoExtended for all FITS image HDUs
     bool map_ok(false);
 

--- a/src/FileList/FileExtInfoLoader.h
+++ b/src/FileList/FileExtInfoLoader.h
@@ -30,7 +30,7 @@ public:
 
     // Fill extended file info for all FITS image hdus
     bool FillFitsFileInfoMap(
-        std::map<std::string, CARTA::FileInfoExtended>& hdu_info_map, const std::string& filename, std::string& message);
+        std::unordered_map<std::string, CARTA::FileInfoExtended>& hdu_info_map, const std::string& filename, std::string& message);
 
     // Fill extended file info for specified hdu
     bool FillFileExtInfo(CARTA::FileInfoExtended& extended_info, const std::string& filename, const std::string& hdu, std::string& message);

--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -1010,10 +1010,10 @@ bool Frame::FillRegionStatsData(std::function<void(CARTA::RegionStatsData stats_
         // Calculate stats map using slicer
         StokesSlicer stokes_slicer = GetImageSlicer(AxisRange(z), stokes);
         bool per_z(false);
-        std::map<CARTA::StatsType, std::vector<double>> stats_vector_map;
+        std::unordered_map<CARTA::StatsType, std::vector<double>> stats_vector_map;
         if (GetSlicerStats(stokes_slicer, required_stats, per_z, stats_vector_map)) {
             // convert vector to single value in map
-            std::map<CARTA::StatsType, double> stats_map;
+            std::unordered_map<CARTA::StatsType, double> stats_map;
             for (auto& value : stats_vector_map) {
                 stats_map[value.first] = value.second[0];
             }
@@ -1671,7 +1671,7 @@ bool Frame::GetSlicerData(const StokesSlicer& stokes_slicer, float* data) {
 }
 
 bool Frame::GetRegionStats(const StokesRegion& stokes_region, const std::vector<CARTA::StatsType>& required_stats, bool per_z,
-    std::map<CARTA::StatsType, std::vector<double>>& stats_values) {
+    std::unordered_map<CARTA::StatsType, std::vector<double>>& stats_values) {
     // Get stats for image data with a region applied
     casacore::SubImage<float> sub_image;
     bool subimage_ok = GetRegionSubImage(stokes_region, sub_image);
@@ -1686,7 +1686,7 @@ bool Frame::GetRegionStats(const StokesRegion& stokes_region, const std::vector<
 }
 
 bool Frame::GetSlicerStats(const StokesSlicer& stokes_slicer, std::vector<CARTA::StatsType>& required_stats, bool per_z,
-    std::map<CARTA::StatsType, std::vector<double>>& stats_values) {
+    std::unordered_map<CARTA::StatsType, std::vector<double>>& stats_values) {
     // Get stats for image data with a slicer applied
     casacore::SubImage<float> sub_image;
     bool subimage_ok = GetSlicerSubImage(stokes_slicer, sub_image);
@@ -1709,7 +1709,7 @@ bool Frame::GetLoaderPointSpectralData(std::vector<float>& profile, int stokes, 
 }
 
 bool Frame::GetLoaderSpectralData(int region_id, const AxisRange& z_range, int stokes, const casacore::ArrayLattice<casacore::Bool>& mask,
-    const casacore::IPosition& origin, std::map<CARTA::StatsType, std::vector<double>>& results, float& progress) {
+    const casacore::IPosition& origin, std::unordered_map<CARTA::StatsType, std::vector<double>>& results, float& progress) {
     // Get spectral data from loader (add image mutex for swizzled data)
     return _loader->GetRegionSpectralData(region_id, z_range, stokes, mask, origin, _image_mutex, results, progress);
 }

--- a/src/Frame/Frame.h
+++ b/src/Frame/Frame.h
@@ -177,14 +177,14 @@ public:
     bool GetSlicerData(const StokesSlicer& stokes_slicer, float* data);
     // Returns stats_values map for spectral profiles and stats data
     bool GetRegionStats(const StokesRegion& stokes_region, const std::vector<CARTA::StatsType>& required_stats, bool per_z,
-        std::map<CARTA::StatsType, std::vector<double>>& stats_values);
+        std::unordered_map<CARTA::StatsType, std::vector<double>>& stats_values);
     bool GetSlicerStats(const StokesSlicer& stokes_slicer, std::vector<CARTA::StatsType>& required_stats, bool per_z,
-        std::map<CARTA::StatsType, std::vector<double>>& stats_values);
+        std::unordered_map<CARTA::StatsType, std::vector<double>>& stats_values);
     // Spectral profiles from loader
     bool UseLoaderSpectralData(const casacore::IPosition& region_shape);
     bool GetLoaderPointSpectralData(std::vector<float>& profile, int stokes, CARTA::Point& point);
     bool GetLoaderSpectralData(int region_id, const AxisRange& z_range, int stokes, const casacore::ArrayLattice<casacore::Bool>& mask,
-        const casacore::IPosition& origin, std::map<CARTA::StatsType, std::vector<double>>& results, float& progress);
+        const casacore::IPosition& origin, std::unordered_map<CARTA::StatsType, std::vector<double>>& results, float& progress);
 
     // Moments calculation
     bool CalculateMoments(int file_id, GeneratorProgressCallback progress_callback, const StokesRegion& stokes_region,
@@ -322,7 +322,7 @@ protected:
     // For image, key is cache key (z/stokes); for cube, key is stokes.
     std::unordered_map<int, std::vector<Histogram>> _image_histograms, _cube_histograms;
     std::unordered_map<int, BasicStats<float>> _image_basic_stats, _cube_basic_stats;
-    std::unordered_map<int, std::map<CARTA::StatsType, double>> _image_stats;
+    std::unordered_map<int, std::unordered_map<CARTA::StatsType, double>> _image_stats;
 
     // Moment generator
     std::unique_ptr<MomentGenerator> _moment_generator;

--- a/src/ImageData/CompressedFits.cc
+++ b/src/ImageData/CompressedFits.cc
@@ -27,7 +27,7 @@ CompressedFits::CompressedFits(const std::string& filename, bool support_aips_be
     SetDefaultTransformMatrix();
 }
 
-bool CompressedFits::GetFitsHeaderInfo(std::map<std::string, CARTA::FileInfoExtended>& hdu_info_map) {
+bool CompressedFits::GetFitsHeaderInfo(std::unordered_map<std::string, CARTA::FileInfoExtended>& hdu_info_map) {
     // Read compressed file headers to fill map
     auto zip_file = OpenGzFile();
     if (zip_file == Z_NULL) {

--- a/src/ImageData/CompressedFits.h
+++ b/src/ImageData/CompressedFits.h
@@ -93,7 +93,7 @@ public:
     CompressedFits(const std::string& filename, bool support_aips_beam = false);
 
     // Headers for file info
-    bool GetFitsHeaderInfo(std::map<std::string, CARTA::FileInfoExtended>& hdu_info_map);
+    bool GetFitsHeaderInfo(std::unordered_map<std::string, CARTA::FileInfoExtended>& hdu_info_map);
     bool GetFirstImageHdu(string& hduname);
 
     const casacore::ImageBeamSet& GetBeamSet(bool& is_history_beam);

--- a/src/ImageData/FileInfo.h
+++ b/src/ImageData/FileInfo.h
@@ -20,7 +20,7 @@ namespace carta {
 namespace FileInfo {
 
 struct ImageStats {
-    std::map<CARTA::StatsType, double> basic_stats;
+    std::unordered_map<CARTA::StatsType, double> basic_stats;
 
     std::vector<float> percentiles;
     std::vector<float> percentile_ranks;
@@ -42,12 +42,16 @@ struct RegionStatsId {
     bool operator<(const RegionStatsId& rhs) const {
         return (region_id < rhs.region_id) || ((region_id == rhs.region_id) && (stokes < rhs.stokes));
     }
+
+    bool operator==(const RegionStatsId& rhs) const {
+        return (this->region_id == rhs.region_id) && (this->stokes == rhs.stokes);
+    }
 };
 
 struct RegionSpectralStats {
     casacore::IPosition origin;
     casacore::IPosition shape;
-    std::map<CARTA::StatsType, std::vector<double>> stats;
+    std::unordered_map<CARTA::StatsType, std::vector<double>> stats;
     volatile bool completed = false;
     size_t latest_x = 0;
 

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -863,7 +863,7 @@ bool FileLoader::UseRegionSpectralData(const casacore::IPosition& region_shape, 
 
 bool FileLoader::GetRegionSpectralData(int region_id, const AxisRange& z_range, int stokes,
     const casacore::ArrayLattice<casacore::Bool>& mask, const casacore::IPosition& origin, std::mutex& image_mutex,
-    std::map<CARTA::StatsType, std::vector<double>>& results, float& progress) {
+    std::unordered_map<CARTA::StatsType, std::vector<double>>& results, float& progress) {
     // Must be implemented in subclasses
     return false;
 }

--- a/src/ImageData/FileLoader.h
+++ b/src/ImageData/FileLoader.h
@@ -104,7 +104,7 @@ public:
     virtual bool UseRegionSpectralData(const casacore::IPosition& region_shape, std::mutex& image_mutex);
     virtual bool GetRegionSpectralData(int region_id, const AxisRange& z_range, int stokes,
         const casacore::ArrayLattice<casacore::Bool>& mask, const casacore::IPosition& origin, std::mutex& image_mutex,
-        std::map<CARTA::StatsType, std::vector<double>>& results, float& progress);
+        std::unordered_map<CARTA::StatsType, std::vector<double>>& results, float& progress);
     virtual bool GetDownsampledRasterData(
         std::vector<float>& data, int z, int stokes, CARTA::ImageBounds& bounds, int mip, std::mutex& image_mutex);
     virtual bool GetChunk(

--- a/src/ImageData/Hdf5Loader.cc
+++ b/src/ImageData/Hdf5Loader.cc
@@ -265,7 +265,7 @@ bool Hdf5Loader::UseRegionSpectralData(const casacore::IPosition& region_shape, 
 
 bool Hdf5Loader::GetRegionSpectralData(int region_id, const AxisRange& spectral_range, int stokes,
     const casacore::ArrayLattice<casacore::Bool>& mask, const casacore::IPosition& origin, std::mutex& image_mutex,
-    std::map<CARTA::StatsType, std::vector<double>>& results, float& progress) {
+    std::unordered_map<CARTA::StatsType, std::vector<double>>& results, float& progress) {
     // Return calculated stats if valid and complete,
     // or return accumulated stats for the next incomplete "x" slice of swizzled data (chan vs y).
     // Calling function should check for complete progress when x-range of region is complete

--- a/src/ImageStats/StatsCalculator.cc
+++ b/src/ImageStats/StatsCalculator.cc
@@ -31,8 +31,8 @@ Histogram CalcHistogram(int num_bins, const HistogramBounds& bounds, const float
     return Histogram(num_bins, bounds, data, data_size);
 }
 
-bool CalcStatsValues(std::map<CARTA::StatsType, std::vector<double>>& stats_values, const std::vector<CARTA::StatsType>& requested_stats,
-    const casacore::ImageInterface<float>& image, bool per_channel) {
+bool CalcStatsValues(std::unordered_map<CARTA::StatsType, std::vector<double>>& stats_values,
+    const std::vector<CARTA::StatsType>& requested_stats, const casacore::ImageInterface<float>& image, bool per_channel) {
     // Use ImageStatistics to fill statistics values according to type;
     // template type matches image type
     casacore::ImageStatistics<float> image_stats = casacore::ImageStatistics<float>(image,

--- a/src/ImageStats/StatsCalculator.h
+++ b/src/ImageStats/StatsCalculator.h
@@ -23,8 +23,8 @@ void CalcBasicStats(BasicStats<float>& stats, const float* data, const size_t da
 
 Histogram CalcHistogram(int num_bins, const HistogramBounds& bounds, const float* data, const size_t data_size);
 
-bool CalcStatsValues(std::map<CARTA::StatsType, std::vector<double>>& stats_values, const std::vector<CARTA::StatsType>& requested_stats,
-    const casacore::ImageInterface<float>& image, bool per_channel = true);
+bool CalcStatsValues(std::unordered_map<CARTA::StatsType, std::vector<double>>& stats_values,
+    const std::vector<CARTA::StatsType>& requested_stats, const casacore::ImageInterface<float>& image, bool per_channel = true);
 
 } // namespace carta
 

--- a/src/Region/RegionHandler.h
+++ b/src/Region/RegionHandler.h
@@ -43,7 +43,7 @@ public:
     void ImportRegion(int file_id, std::shared_ptr<Frame> frame, CARTA::FileType region_file_type, const std::string& region_file,
         bool file_is_filename, CARTA::ImportRegionAck& import_ack);
     void ExportRegion(int file_id, std::shared_ptr<Frame> frame, CARTA::FileType region_file_type, CARTA::CoordinateType coord_type,
-        std::map<int, CARTA::RegionStyle>& region_styles, std::string& filename, CARTA::ExportRegionAck& export_ack);
+        std::unordered_map<int, CARTA::RegionStyle>& region_styles, std::string& filename, CARTA::ExportRegionAck& export_ack);
 
     // Frames
     void RemoveFrame(int file_id);
@@ -132,7 +132,7 @@ private:
         int region_id, int file_id, std::vector<HistogramConfig>& configs, std::vector<CARTA::RegionHistogramData>& histogram_messages);
     bool GetRegionSpectralData(int region_id, int file_id, const AxisRange& z_range, std::string& coordinate, int stokes_index,
         std::vector<CARTA::StatsType>& required_stats, bool report_error,
-        const std::function<void(std::map<CARTA::StatsType, std::vector<double>>, float)>& partial_results_callback);
+        const std::function<void(std::unordered_map<CARTA::StatsType, std::vector<double>>, float)>& partial_results_callback);
     bool GetRegionStatsData(
         int region_id, int file_id, int stokes, const std::vector<CARTA::StatsType>& required_stats, CARTA::RegionStatsData& stats_message);
     bool GetLineSpatialData(int file_id, int region_id, const std::string& coordinate, int stokes_index, int width,
@@ -148,7 +148,7 @@ private:
         std::shared_ptr<casacore::CoordinateSystem> csys, bool per_z, const AxisRange& z_range, int stokes_index, double& num_pixels);
 
     // Get computed stokes profiles for a region
-    using ProfilesMap = std::map<CARTA::StatsType, std::vector<double>>;
+    using ProfilesMap = std::unordered_map<CARTA::StatsType, std::vector<double>>;
     void GetStokesPtotal(
         const ProfilesMap& profiles_q, const ProfilesMap& profiles_u, const ProfilesMap& profiles_v, ProfilesMap& profiles_ptotal);
     void GetStokesPftotal(const ProfilesMap& profiles_i, const ProfilesMap& profiles_q, const ProfilesMap& profiles_u,

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -214,7 +214,7 @@ void Session::ConnectCalled() {
 // ********************************************************************************
 // File browser info
 
-bool Session::FillExtendedFileInfo(std::map<std::string, CARTA::FileInfoExtended>& hdu_info_map, CARTA::FileInfo& file_info,
+bool Session::FillExtendedFileInfo(std::unordered_map<std::string, CARTA::FileInfoExtended>& hdu_info_map, CARTA::FileInfo& file_info,
     const std::string& folder, const std::string& filename, const std::string& hdu, bool support_aips_beam, std::string& message) {
     // Fill CARTA::FileInfo and CARTA::FileInfoExtended
     // Map all hdus if no hdu_name supplied and FITS image
@@ -463,7 +463,7 @@ void Session::OnFileListRequest(const CARTA::FileListRequest& request, uint32_t 
 void Session::OnFileInfoRequest(const CARTA::FileInfoRequest& request, uint32_t request_id) {
     CARTA::FileInfoResponse response;
     auto& file_info = *response.mutable_file_info();
-    std::map<std::string, CARTA::FileInfoExtended> extended_info_map;
+    std::unordered_map<std::string, CARTA::FileInfoExtended> extended_info_map;
     string message;
     bool success = FillExtendedFileInfo(
         extended_info_map, file_info, request.directory(), request.file(), request.hdu(), request.support_aips_beam(), message);
@@ -972,7 +972,7 @@ void Session::OnExportRegion(const CARTA::ExportRegion& message, uint32_t reques
                 abs_filename = top_level_path.absoluteName();
             }
 
-            std::map<int, CARTA::RegionStyle> region_styles = {message.region_styles().begin(), message.region_styles().end()};
+            std::unordered_map<int, CARTA::RegionStyle> region_styles = {message.region_styles().begin(), message.region_styles().end()};
 
             _region_handler->ExportRegion(
                 file_id, _frames.at(file_id), message.type(), message.coord_type(), region_styles, abs_filename, export_ack);

--- a/src/Session/Session.h
+++ b/src/Session/Session.h
@@ -245,7 +245,7 @@ public:
 
 protected:
     // File info for file list (extended info for each hdu_name)
-    bool FillExtendedFileInfo(std::map<std::string, CARTA::FileInfoExtended>& hdu_info_map, CARTA::FileInfo& file_info,
+    bool FillExtendedFileInfo(std::unordered_map<std::string, CARTA::FileInfoExtended>& hdu_info_map, CARTA::FileInfo& file_info,
         const std::string& folder, const std::string& filename, const std::string& hdu, bool support_aips_beam, std::string& message);
     // File info for open file
     bool FillExtendedFileInfo(CARTA::FileInfoExtended& extended_info, CARTA::FileInfo& file_info, const std::string& folder,

--- a/src/Timer/Timer.cc
+++ b/src/Timer/Timer.cc
@@ -14,3 +14,7 @@ TimeDelta Timer::Elapsed() {
     auto t_end = std::chrono::high_resolution_clock::now();
     return {(double)std::chrono::duration_cast<std::chrono::microseconds>(t_end - _t_start).count()};
 }
+
+void Timer::Restart() {
+    _t_start = std::chrono::high_resolution_clock::now();
+}

--- a/src/Timer/Timer.h
+++ b/src/Timer/Timer.h
@@ -30,6 +30,7 @@ public:
     ~Timer() = default;
 
     TimeDelta Elapsed();
+    void Restart();
 
 private:
     std::chrono::high_resolution_clock::time_point _t_start;

--- a/src/Util/Message.cc
+++ b/src/Util/Message.cc
@@ -447,7 +447,7 @@ CARTA::EventType Message::EventType(std::vector<char>& message) {
 
 CARTA::SpectralProfileData Message::SpectralProfileData(int32_t file_id, int32_t region_id, int32_t stokes, float progress,
     std::string& coordinate, std::vector<CARTA::StatsType>& required_stats,
-    std::map<CARTA::StatsType, std::vector<double>>& spectral_data) {
+    std::unordered_map<CARTA::StatsType, std::vector<double>>& spectral_data) {
     CARTA::SpectralProfileData profile_message;
     profile_message.set_file_id(file_id);
     profile_message.set_region_id(region_id);
@@ -710,7 +710,7 @@ void FillHistogram(CARTA::Histogram* histogram, const carta::BasicStats<float>& 
 }
 
 void FillStatistics(CARTA::RegionStatsData& stats_data, const std::vector<CARTA::StatsType>& required_stats,
-    std::map<CARTA::StatsType, double>& stats_value_map) {
+    std::unordered_map<CARTA::StatsType, double>& stats_value_map) {
     // inserts values from map into message StatisticsValue field; needed by Frame and RegionDataHandler
     for (auto type : required_stats) {
         double value(0.0); // default

--- a/src/Util/Message.h
+++ b/src/Util/Message.h
@@ -118,7 +118,7 @@ public:
     // Response messages
     static CARTA::SpectralProfileData SpectralProfileData(int32_t file_id, int32_t region_id, int32_t stokes, float progress,
         std::string& coordinate, std::vector<CARTA::StatsType>& required_stats,
-        std::map<CARTA::StatsType, std::vector<double>>& spectral_data);
+        std::unordered_map<CARTA::StatsType, std::vector<double>>& spectral_data);
     static CARTA::SpectralProfileData SpectralProfileData(int32_t stokes, float progress);
     static CARTA::SpatialProfileData SpatialProfileData(int32_t file_id, int32_t region_id, int32_t x, int32_t y, int32_t channel,
         int32_t stokes, float value, int32_t start, int32_t end, std::vector<float>& profile, std::string& coordinate, int32_t mip,
@@ -161,7 +161,7 @@ void FillHistogram(CARTA::Histogram* histogram, int32_t num_bins, double bin_wid
     const std::vector<int32_t>& bins, double mean, double std_dev);
 void FillHistogram(CARTA::Histogram* histogram, const carta::BasicStats<float>& stats, const carta::Histogram& hist);
 void FillStatistics(CARTA::RegionStatsData& stats_data, const std::vector<CARTA::StatsType>& required_stats,
-    std::map<CARTA::StatsType, double>& stats_value_map);
+    std::unordered_map<CARTA::StatsType, double>& stats_value_map);
 
 #include "Message.tcc"
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -52,6 +52,7 @@ set(TEST_SOURCES
         TestImageFitting.cc
 		TestLineSpatialProfiles.cc
         TestMain.cc
+        TestMapPerf.cc
         TestMoment.cc
         TestNormalizedUnits.cc
         TestProgramSettings.cc

--- a/test/TestFileInfo.cc
+++ b/test/TestFileInfo.cc
@@ -51,7 +51,7 @@ public:
         FileExtInfoLoader ext_info_loader(loader);
         bool file_info_ok;
         std::string message;
-        std::map<std::string, CARTA::FileInfoExtended> file_info_extended_map;
+        std::unordered_map<std::string, CARTA::FileInfoExtended> file_info_extended_map;
 
         if (request_file_type == CARTA::FileType::FITS) {
             file_info_ok = ext_info_loader.FillFitsFileInfoMap(file_info_extended_map, fullname, message);
@@ -66,7 +66,7 @@ public:
         CheckFileInfoExtended(file_info_extended_map, request_filename, request_hdu);
     }
 
-    static void CheckFileInfoExtended(std::map<std::string, CARTA::FileInfoExtended> file_info_extended_map,
+    static void CheckFileInfoExtended(std::unordered_map<std::string, CARTA::FileInfoExtended> file_info_extended_map,
         const std::string& expect_filename, const std::string& expect_hdu) {
         EXPECT_NE(file_info_extended_map.find(expect_hdu), file_info_extended_map.end());
         if (file_info_extended_map.find(expect_hdu) == file_info_extended_map.end()) {
@@ -171,7 +171,8 @@ public:
 
         auto file_info_extended = response.file_info_extended();
         // convert protobuf map to std map
-        std::map<std::string, CARTA::FileInfoExtended> file_info_extended_map = {file_info_extended.begin(), file_info_extended.end()};
+        std::unordered_map<std::string, CARTA::FileInfoExtended> file_info_extended_map = {
+            file_info_extended.begin(), file_info_extended.end()};
 
         FileExtInfoLoaderTest::CheckFileInfoExtended(file_info_extended_map, expect_filename, expect_hdu);
     }
@@ -185,7 +186,7 @@ public:
         auto request = Message::FileInfoRequest(SAMPLE_FILES_PATH, request_filename, request_hdu);
         CARTA::FileInfoResponse response;
         auto& file_info = *response.mutable_file_info();
-        std::map<std::string, CARTA::FileInfoExtended> extended_info_map;
+        std::unordered_map<std::string, CARTA::FileInfoExtended> extended_info_map;
         bool support_aips_beam(false);
         string message;
         bool success = FillExtendedFileInfo(

--- a/test/TestMapPerf.cc
+++ b/test/TestMapPerf.cc
@@ -1,0 +1,117 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018-2022 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+#include <gtest/gtest.h>
+
+#include <map>
+#include <random>
+#include <unordered_map>
+
+#include <carta-protobuf/enums.pb.h>
+
+#include "Logger/Logger.h"
+#include "Timer/Timer.h"
+
+using namespace std;
+
+class MapPerfTest : public ::testing::Test {};
+
+TEST_F(MapPerfTest, CmpMapAndUnorderedMap) {
+    map<CARTA::StatsType, vector<double>> stats_map;
+    unordered_map<CARTA::StatsType, vector<double>> stats_unordered_map;
+
+    // Generate random numbers
+    int num(1000000);
+    vector<double> random_data(num);
+
+    double lower_bound(0);
+    double upper_bound(100);
+    uniform_real_distribution<double> unif(lower_bound, upper_bound);
+    default_random_engine re;
+
+    for (int i = 0; i < num; ++i) {
+        random_data[i] = unif(re);
+    }
+
+    // Test the time spent for inserting data into the map/unordered_map
+    vector<CARTA::StatsType> stats_types{CARTA::StatsType::Sum, CARTA::StatsType::Extrema, CARTA::StatsType::FluxDensity,
+        CARTA::StatsType::Max, CARTA::StatsType::Mean, CARTA::StatsType::Min, CARTA::StatsType::RMS, CARTA::StatsType::Sigma,
+        CARTA::StatsType::SumSq, CARTA::StatsType::Blc, CARTA::StatsType::Trc, CARTA::StatsType::NumPixels, CARTA::StatsType::MaxPos,
+        CARTA::StatsType::MinPos};
+
+    carta::Timer t;
+    for (auto stats_type : stats_types) {
+        // stats_map[stats_type] = random_data;
+        stats_map.emplace(stats_type, random_data);
+    }
+    auto dt1 = t.Elapsed().us();
+    fmt::print("Elapsed time for inserting the data into a map: {:.0f} us.\n", dt1);
+
+    t.Restart();
+    for (auto stats_type : stats_types) {
+        // stats_unordered_map[stats_type] = random_data;
+        stats_unordered_map.emplace(stats_type, random_data);
+    }
+    auto dt2 = t.Elapsed().us();
+    fmt::print("Elapsed time for inserting the data into an unordered_map: {:.0f} us.\n", dt2);
+
+    fmt::print("Elapsed time ratio inserting the data into an unordered_map/map: {:.2f}\n", dt2 / dt1);
+
+    // Test the time spent for finding and copying the data from the map/unordered_map
+    vector<double> copied_data;
+
+    t.Restart();
+    for (auto stats_type : stats_types) {
+        auto it = stats_map.find(stats_type);
+        if (it == stats_map.end()) {
+            cerr << fmt::format("Stats type {} not found from the map!\n");
+        } else {
+            copied_data = it->second;
+        }
+    }
+    auto dt3 = t.Elapsed().us();
+    fmt::print("Elapsed time for finding and copying the data from a map: {:.0f} us.\n", dt3);
+
+    t.Restart();
+    for (auto stats_type : stats_types) {
+        auto it = stats_unordered_map.find(stats_type);
+        if (it == stats_unordered_map.end()) {
+            cerr << fmt::format("Stats type {} not found from the unordered_map!\n");
+        } else {
+            copied_data = it->second;
+        }
+    }
+    auto dt4 = t.Elapsed().us();
+    fmt::print("Elapsed time for finding and copying the data from an unordered_map: {:.0f} us.\n", dt4);
+
+    fmt::print("Elapsed time ratio for finding and copying the data from a unordered_map/map: {:.2}\n", dt4 / dt3);
+
+    // Test the time spent for finding and erasing the data from the map/unordered_map
+    t.Restart();
+    for (auto stats_type : stats_types) {
+        auto it = stats_map.find(stats_type);
+        if (it == stats_map.end()) {
+            cerr << fmt::format("Stats type {} not found from the map!\n");
+        } else {
+            stats_map.erase(it);
+        }
+    }
+    auto dt5 = t.Elapsed().us();
+    fmt::print("Elapsed time for finding and erasing the data from a map: {:.0f} us.\n", dt5);
+
+    t.Restart();
+    for (auto stats_type : stats_types) {
+        auto it = stats_unordered_map.find(stats_type);
+        if (it == stats_unordered_map.end()) {
+            cerr << fmt::format("Stats type {} not found from the unordered_map!\n");
+        } else {
+            stats_unordered_map.erase(it);
+        }
+    }
+    auto dt6 = t.Elapsed().us();
+    fmt::print("Elapsed time for finding and erasing the data from an unordered_map: {:.0f} us.\n", dt6);
+
+    fmt::print("Elapsed time ratio for finding and erasing the data from a unordered_map/map: {:.2f}\n", dt6 / dt5);
+}


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
Closes #1295. Being a pure lookup table, `unordered_map` is supposed to perform better than `map`. According to the discussions from the [stake overflow](https://stackoverflow.com/questions/2196995/is-there-any-advantage-of-using-map-over-unordered-map-in-case-of-trivial-keys). However, using `unordered_map` would need more memory space than that for `map`. The new tester `TestMapPerf` simply tests the performances of `map` and `unordered_map`. `unordered_map` is a little bit faster than `map` when inserting a new data element or finding & copying a specific data element. But it is significantly slower than `map` when erasing map elements or manipulating the map structure. Ref: [map vs. unordered_map in C++](https://www.geeksforgeeks.org/map-vs-unordered_map-c/).

* How does this PR solve the issue? Give a brief summary.
Replace all `map` with `unordered_map`, except for the ordered array from `HttpServer`.

* Are there any companion PRs (frontend, protobuf)?
No.

* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
It will not affect the original tests. @acdo2002 could you please check if there are any performance differences compared to the dev branch?

**Checklist**

- [x] changelog updated ~/ no changelog update needed~
- [x] e2e test passing / ~corresponding fix added~ / ~new e2e test created~
- [x] ~protobuf updated to the latest dev commit /~ no protobuf update needed
- [x] ~protobuf version bumped /~ protobuf version not bumped
- [ ] added reviewers and assignee
- [ ] added ZenHub estimate, milestone, and release
