### PR TITLE
Added websockets download locations to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ coverage/
 
 # Doxygen
 docs/html
+
+# Dependency download locations
+third-party/uSockets/
+third-party/uWebSockets/


### PR DESCRIPTION
This fixes a minor issue introduced by the [websockets update](https://github.com/CARTAvis/carta-backend/pull/1298). The two directories into which the websockets source is downloaded (and which are created whenever `cmake` is run) should be ignored by git.