### PR TITLE
Move loader cache to separate files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+* Move the loader cache to separate files ([#1021](https://github.com/CARTAvis/carta-backend/issues/1021)).
+
 ### Fixed
 * Fixed scripting interface and symlink directory issues ([#1283](https://github.com/CARTAvis/carta-frontend/issues/1283), [#1284](https://github.com/CARTAvis/carta-frontend/issues/1284), [#1314](https://github.com/CARTAvis/carta-frontend/issues/1314)).
 * Include casacore log messages in carta log ([#1169](https://github.com/CARTAvis/carta-backend/issues/1169)).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,7 @@ set(LINK_LIBS
 set(SOURCE_FILES
         ${SOURCE_FILES}
 	third-party/pugixml/src/pugixml.cpp
+        src/Cache/LoaderCache.cc
         src/Cache/TileCache.cc
         src/Cache/TilePool.cc
         src/DataStream/Compression.cc

--- a/src/Cache/LoaderCache.cc
+++ b/src/Cache/LoaderCache.cc
@@ -1,0 +1,63 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018-2022 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+#include "LoaderCache.h"
+
+#include "Logger/Logger.h"
+
+using namespace carta;
+
+LoaderCache::LoaderCache(int capacity) : _capacity(capacity){};
+
+std::shared_ptr<FileLoader> LoaderCache::Get(const std::string& filename, const std::string& directory) {
+    std::unique_lock<std::mutex> guard(_loader_cache_mutex);
+    auto key = GetKey(filename, directory);
+
+    // We have a cached loader, but the file has changed
+    if ((_map.find(key) != _map.end()) && _map[key] && _map[key]->ImageUpdated()) {
+        _map.erase(key);
+        _queue.remove(key);
+    }
+
+    // We don't have a cached loader
+    if (_map.find(key) == _map.end()) {
+        // Create the loader -- don't block while doing this
+        std::shared_ptr<FileLoader> loader_ptr;
+        guard.unlock();
+        loader_ptr = std::shared_ptr<FileLoader>(FileLoader::GetLoader(filename, directory));
+        guard.lock();
+
+        // Check if the loader was added in the meantime
+        if (_map.find(key) == _map.end()) {
+            // Evict oldest loader if necessary
+            if (_map.size() == _capacity) {
+                _map.erase(_queue.back());
+                _queue.pop_back();
+            }
+
+            // Insert the new loader
+            _map[key] = loader_ptr;
+            _queue.push_front(key);
+        }
+    } else {
+        // Touch the cache entry
+        _queue.remove(key);
+        _queue.push_front(key);
+    }
+
+    return _map[key];
+}
+
+void LoaderCache::Remove(const std::string& filename, const std::string& directory) {
+    std::unique_lock<std::mutex> guard(_loader_cache_mutex);
+    auto key = GetKey(filename, directory);
+    _map.erase(key);
+    _queue.remove(key);
+}
+
+std::string LoaderCache::GetKey(const std::string& filename, const std::string& directory) {
+    return (directory.empty() ? filename : fmt::format("{}/{}", directory, filename));
+}

--- a/src/Cache/LoaderCache.h
+++ b/src/Cache/LoaderCache.h
@@ -1,0 +1,35 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018-2022 Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+#ifndef CARTA_SRC_CACHE_LOADERCACHE_H_
+#define CARTA_SRC_CACHE_LOADERCACHE_H_
+
+#include <list>
+#include <mutex>
+#include <unordered_map>
+
+#include "ImageData/FileLoader.h"
+
+namespace carta {
+
+// Cache of loaders for reading images from disk.
+class LoaderCache {
+public:
+    LoaderCache(int capacity);
+    std::shared_ptr<FileLoader> Get(const std::string& filename, const std::string& directory = "");
+    void Remove(const std::string& filename, const std::string& directory = "");
+
+private:
+    std::string GetKey(const std::string& filename, const std::string& directory);
+    int _capacity;
+    std::unordered_map<std::string, std::shared_ptr<FileLoader>> _map;
+    std::list<std::string> _queue;
+    std::mutex _loader_cache_mutex;
+};
+
+} // namespace carta
+
+#endif // CARTA_SRC_CACHE_LOADERCACHE_H_

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -41,58 +41,6 @@
 
 using namespace carta;
 
-LoaderCache::LoaderCache(int capacity) : _capacity(capacity){};
-
-std::shared_ptr<FileLoader> LoaderCache::Get(const std::string& filename, const std::string& directory) {
-    std::unique_lock<std::mutex> guard(_loader_cache_mutex);
-    auto key = GetKey(filename, directory);
-
-    // We have a cached loader, but the file has changed
-    if ((_map.find(key) != _map.end()) && _map[key] && _map[key]->ImageUpdated()) {
-        _map.erase(key);
-        _queue.remove(key);
-    }
-
-    // We don't have a cached loader
-    if (_map.find(key) == _map.end()) {
-        // Create the loader -- don't block while doing this
-        std::shared_ptr<FileLoader> loader_ptr;
-        guard.unlock();
-        loader_ptr = std::shared_ptr<FileLoader>(FileLoader::GetLoader(filename, directory));
-        guard.lock();
-
-        // Check if the loader was added in the meantime
-        if (_map.find(key) == _map.end()) {
-            // Evict oldest loader if necessary
-            if (_map.size() == _capacity) {
-                _map.erase(_queue.back());
-                _queue.pop_back();
-            }
-
-            // Insert the new loader
-            _map[key] = loader_ptr;
-            _queue.push_front(key);
-        }
-    } else {
-        // Touch the cache entry
-        _queue.remove(key);
-        _queue.push_front(key);
-    }
-
-    return _map[key];
-}
-
-void LoaderCache::Remove(const std::string& filename, const std::string& directory) {
-    std::unique_lock<std::mutex> guard(_loader_cache_mutex);
-    auto key = GetKey(filename, directory);
-    _map.erase(key);
-    _queue.remove(key);
-}
-
-std::string LoaderCache::GetKey(const std::string& filename, const std::string& directory) {
-    return (directory.empty() ? filename : fmt::format("{}/{}", directory, filename));
-}
-
 volatile int Session::_num_sessions = 0;
 int Session::_exit_after_num_seconds = 5;
 bool Session::_exit_when_all_sessions_closed = false;

--- a/src/Session/Session.h
+++ b/src/Session/Session.h
@@ -24,6 +24,7 @@
 #include <casacore/casa/aips.h>
 
 #include "AnimationObject.h"
+#include "Cache/LoaderCache.h"
 #include "CursorSettings.h"
 #include "FileList/FileListHandler.h"
 #include "Frame/Frame.h"
@@ -47,21 +48,6 @@ typedef std::function<void()> ScriptingSessionClosedCallback;
 struct PerSocketData {
     uint32_t session_id;
     string address;
-};
-
-// Cache of loaders for reading images from disk.
-class LoaderCache {
-public:
-    LoaderCache(int capacity);
-    std::shared_ptr<FileLoader> Get(const std::string& filename, const std::string& directory = "");
-    void Remove(const std::string& filename, const std::string& directory = "");
-
-private:
-    std::string GetKey(const std::string& filename, const std::string& directory);
-    int _capacity;
-    std::unordered_map<std::string, std::shared_ptr<FileLoader>> _map;
-    std::list<std::string> _queue;
-    std::mutex _loader_cache_mutex;
 };
 
 class Session {


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
Closes #1021.

* How does this PR solve the issue? Give a brief summary.
Moving the `LoaderCache` class to separate files in the `Cache` subdirectory.

* Are there any companion PRs (frontend, protobuf)?
No.

* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
All tests are not affected.

**Checklist**

- [x] changelog updated ~/ no changelog update needed~
- [x] e2e test passing / ~corresponding fix added~ / ~new e2e test created~
- [x] ~protobuf updated to the latest dev commit /~ no protobuf update needed
- [x] ~protobuf version bumped /~ protobuf version not bumped
- [ ] added reviewers and assignee
- [ ] added ZenHub estimate, milestone, and release
