### PR TITLE
Fix the hanging problem of region spectral profiles when a region is deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Include casacore log messages in carta log ([#1169](https://github.com/CARTAvis/carta-backend/issues/1169)).
 * Fixed the problem of opening old IRAM fits images ([#1312](https://github.com/CARTAvis/carta-backend/issues/1312)).
 * Fixed incorrect std calculation when fitting images with nan values ([#1318](https://github.com/CARTAvis/carta-backend/issues/1318)).
+* Fixed the hanging problem when deleting a region during the spectral profile process ([#1328](https://github.com/CARTAvis/carta-backend/issues/1328)).
 
 ## [4.0.0]
 

--- a/src/Region/RegionHandler.cc
+++ b/src/Region/RegionHandler.cc
@@ -137,7 +137,6 @@ std::shared_ptr<Region> RegionHandler::GetRegion(int region_id) {
 bool RegionHandler::RegionSet(int region_id, bool check_annotation) {
     // Check whether a particular region is set or any regions are set
     bool region_set(false);
-    std::lock_guard<std::mutex> region_guard(_region_mutex);
     if (region_id == ALL_REGIONS) {
         region_set = _regions.size() > 0;
     } else {


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
Closes #1328.

* How does this PR solve the issue? Give a brief summary.
This problem is due to the deadlock of two mutexes, `_active_task_mutex` and `_region_mutex`, in the RegionHandler methods. When a region spectral profile process starts, `_active_task_mutex` is taken in the method [GetRegionSpectralData](https://github.com/CARTAvis/carta-backend/blob/dev/src/Region/RegionHandler.cc#L1847). Then the `_region_mutex` will be frequently taken inside this method [RegionFileIdsValid](https://github.com/CARTAvis/carta-backend/blob/dev/src/Region/RegionHandler.cc#L2080) to check whether the region object exists or it is disconnected. If we delete the region during this process, the `RemoveRegion` method is called, and the `_region_mutex` is taken [here](https://github.com/CARTAvis/carta-backend/blob/dev/src/Region/RegionHandler.cc#L113) inside this function. Then it waits to take `_active_task_mutex` in the [WaitForTaskCancellation](https://github.com/CARTAvis/carta-backend/blob/dev/src/Region/RegionHandler.cc#L116). Two methods `GetRegionSpectralData` and `RemoveRegion` are waiting for the same mutexes `_active_task_mutex` and `_region_mutex`. The solution is to remove the `_region_mutex` from the `RegionSet` method. Since it only reads the status of region objects and does not modify the `_regions` map. Removing this mutex allows the [RegionFileIdsValid](https://github.com/CARTAvis/carta-backend/blob/dev/src/Region/RegionHandler.cc#L2080) to get rid of `_region_mutex` (since it can be taken by `RemoveRegion` at the same time), so it can pass the disconnected signal and stop the region spectral profile process. Finally, the region object can be deleted.

* Are there any companion PRs (frontend, protobuf)?
No.

* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
The hanging problem of region spectral profiles should be solved.

**Checklist**

- [x] changelog updated ~/ no changelog update needed~
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ~protobuf updated to the latest dev commit /~ no protobuf update needed
- [x] ~protobuf version bumped /~ protobuf version not bumped
- [ ] added reviewers and assignee
- [ ] added ZenHub estimate, milestone, and release
