### PR TITLE
ajm/GitHub actions icd tests

### DIFF
--- a/.github/actions/run-apptainer/action.yml
+++ b/.github/actions/run-apptainer/action.yml
@@ -1,0 +1,52 @@
+name: 'Run ICD tests via Apptainer'
+description: 'Start carta_backend and run ICD tests'
+inputs:
+  os_version:
+    description: 'Platfrom'
+    required: true
+  image:
+    description: 'Apptainer image'
+    required: true
+  port:
+    description: 'Port number for carta_backend'
+    required: true
+  test_stage_name:
+    description: 'ICD test stage'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - run: |
+        SRC_DIR=$GITHUB_WORKSPACE/source
+        BUILD_DIR=$GITHUB_WORKSPACE/build-${{ inputs.os_version }}
+        TEST_STAGE="$BUILD_DIR/ICD-RxJS/ICD_test_stages/${{ inputs.test_stage_name }}.tests"
+        LOG_FILE="/tmp/carta_icd_${{ inputs.os_version }}_${{ inputs.test_stage_name }}.log"
+        apptainer exec \
+          --bind $GITHUB_WORKSPACE:$GITHUB_WORKSPACE \
+          --bind /images:/images \
+          --pwd $BUILD_DIR \
+          ${{ inputs.image }} /bin/bash -c "\
+            # Start the carta_backend
+            ASAN_OPTIONS=suppressions=$SRC_DIR/debug/asan/myasan.supp \
+            LSAN_OPTIONS=suppressions=$SRC_DIR/debug/asan/myasan-leaks.supp \
+            ASAN_SYMBOLIZER_PATH=llvm-symbolizer \
+            ./carta_backend /images \
+              --top_level_folder /images \
+              --port ${{ inputs.port }} \
+              --omp_threads=4 \
+              --debug_no_auth \
+              --no_frontend \
+              --no_database \
+              --no_log \
+              --verbosity=5 >> $LOG_FILE 2>&1 & \
+            CARTA_BACKEND_PID=\$(pgrep -f 'carta_backend.*${{ inputs.port }}' | head -n 1) && \
+            echo 'carta_backend started with PID' \$CARTA_BACKEND_PID && \
+            # Run the ICD tests
+            cd $BUILD_DIR/ICD-RxJS && \
+            pwd && \
+            cat $TEST_STAGE && \
+            while IFS= read -r test_file || [[ -n "\$test_file" ]]; do
+              CI=true npm test -- "\$test_file"
+            done < $TEST_STAGE"
+      shell: bash

--- a/.github/actions/run-macos/action.yml
+++ b/.github/actions/run-macos/action.yml
@@ -9,8 +9,8 @@ runs:
   steps:
     - name: Start the carta-backend
       run: |
-        SRC_DIR=${{ inputs.github_workspace }}/source
-        BUILD_DIR=${{ inputs.github_workspace }}/build
+        SRC_DIR=$GITHUB_WORKSPACE/source
+        BUILD_DIR=$GITHUB_WORKSPACE/build
         cd $BUILD_DIR
         ASAN_OPTIONS=suppressions=$SRC_DIR/debug/asan/myasan.supp \
         LSAN_OPTIONS=suppressions=$SRC_DIR/debug/asan/myasan-leaks.supp \
@@ -23,8 +23,8 @@ runs:
 
     - name: ICD tests
       run: |
-        ICD_RXJS_DIR=${{ inputs.github_workspace }}/build/ICD-RxJS
-        cd $ICD_RXJS_DIR
+        ICD_DIR=$GITHUB_WORKSPACE/ICD_RxJS
+        cd $ICD_DIR
         for test_file in $(cat ICD_test_stages/${{ inputs.test_stage_name }}.tests); do
           CI=true npm test $test_file
           sleep 3 && pgrep carta_backend

--- a/.github/actions/run-macos/action.yml
+++ b/.github/actions/run-macos/action.yml
@@ -23,7 +23,7 @@ runs:
 
     - name: ICD tests
       run: |
-        ICD_DIR=$GITHUB_WORKSPACE/ICD_RxJS
+        ICD_DIR=$GITHUB_WORKSPACE/ICD-RxJS
         cd $ICD_DIR
         for test_file in $(cat ICD_test_stages/${{ inputs.test_stage_name }}.tests); do
           CI=true npm test $test_file

--- a/.github/actions/run-macos/action.yml
+++ b/.github/actions/run-macos/action.yml
@@ -16,7 +16,7 @@ runs:
         LSAN_OPTIONS=suppressions=$SRC_DIR/debug/asan/myasan-leaks.supp \
         ASAN_SYMBOLIZER_PATH=llvm-symbolizer \
         ./carta_backend /images --top_level_folder /images \
-        --port $PORT \
+        --port 5555 \
         --omp_threads=4 --debug_no_auth --no_frontend --no_database --verbosity=5 &
         echo "CARTA_BACKEND_PID=$!" >> $GITHUB_ENV
       shell: bash

--- a/.github/actions/run-macos/action.yml
+++ b/.github/actions/run-macos/action.yml
@@ -1,0 +1,36 @@
+name: 'Run ICD tests on macOS'
+description: 'Start the carta_backend, run the ICD tests, and stop the carta_backend'
+inputs:
+  test_stage_name:
+    description: 'ICD test stage'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Start the carta-backend
+      run: |
+        SRC_DIR=${{ inputs.github_workspace }}/source
+        BUILD_DIR=${{ inputs.github_workspace }}/build
+        cd $BUILD_DIR
+        ASAN_OPTIONS=suppressions=$SRC_DIR/debug/asan/myasan.supp \
+        LSAN_OPTIONS=suppressions=$SRC_DIR/debug/asan/myasan-leaks.supp \
+        ASAN_SYMBOLIZER_PATH=llvm-symbolizer \
+        ./carta_backend /images --top_level_folder /images \
+        --port $PORT \
+        --omp_threads=4 --debug_no_auth --no_frontend --no_database --verbosity=5 &
+        echo "CARTA_BACKEND_PID=$!" >> $GITHUB_ENV
+      shell: bash
+
+    - name: ICD tests
+      run: |
+        ICD_RXJS_DIR=${{ inputs.github_workspace }}/build/ICD-RxJS
+        cd $ICD_RXJS_DIR
+        for test_file in $(cat ICD_test_stages/${{ inputs.test_stage_name }}.tests); do
+          CI=true npm test $test_file
+          sleep 3 && pgrep carta_backend
+        done
+      shell: bash
+
+    - name: Stop carta-backend
+      run: kill ${{ env.CARTA_BACKEND_PID }}
+      shell: bash

--- a/.github/workflows/icd_tests.yml
+++ b/.github/workflows/icd_tests.yml
@@ -1,6 +1,5 @@
 name: ICD tests
 on:
-  push:
   schedule:
     - cron: '0 0 * * *' # UTC time
 env:

--- a/.github/workflows/icd_tests.yml
+++ b/.github/workflows/icd_tests.yml
@@ -165,7 +165,7 @@ jobs:
       - name: Prepare ICD-RxJS (macOS)
         if: matrix.os == 'macos'
         run: |
-          ICD_DIR=$GITHUB_WORKSPACE/ICD_RxJS
+          ICD_DIR=$GITHUB_WORKSPACE/ICD-RxJS
           cd $ICD_DIR
           git submodule init && git submodule update && npm install
           cd protobuf
@@ -177,7 +177,7 @@ jobs:
         if: matrix.os == 'linux'
         run: |
           BUILD_DIR=$GITHUB_WORKSPACE/build-${{ matrix.os_version }}
-          ICD_DIR=$GITHUB_WORKSPACE/ICD_RxJS
+          ICD_DIR=$GITHUB_WORKSPACE/ICD-RxJS
           cp -r $ICD_DIR $BUILD_DIR
           apptainer exec --bind $GITHUB_WORKSPACE:$GITHUB_WORKSPACE --pwd $BUILD_DIR ${{ matrix.image }} /bin/bash -c "\
             cd ICD-RxJS && \

--- a/.github/workflows/icd_tests.yml
+++ b/.github/workflows/icd_tests.yml
@@ -21,7 +21,7 @@ jobs:
             runner: macOS-11
           - os_version: macOS-12
             os: macos
-            runner: macOS-12
+            runner: [macOS-12, ICD]
           - os_version: macOS-13
             os: macos
             runner: macOS-13
@@ -124,7 +124,7 @@ jobs:
             runner: macOS-11
           - os_version: macOS-12
             os: macos
-            runner: macOS-12
+            runner: [macOS-12, ICD]
           - os_version: macOS-13
             os: macos
             runner: macOS-13
@@ -200,7 +200,7 @@ jobs:
             runner: macOS-11
           - os_version: macOS-12
             os: macos
-            runner: macOS-12
+            runner: [macOS-12, ICD]
           - os_version: macOS-13
             os: macos
             runner: macOS-13          
@@ -261,7 +261,7 @@ jobs:
             runner: macOS-11
           - os_version: macOS-12
             os: macos
-            runner: macOS-12
+            runner: [macOS-12, ICD]
           - os_version: macOS-13
             os: macos
             runner: macOS-13
@@ -322,7 +322,7 @@ jobs:
             runner: macOS-11
           - os_version: macOS-12
             os: macos
-            runner: macOS-12
+            runner: [macOS-12, ICD]
           - os_version: macOS-13
             os: macos
             runner: macOS-13
@@ -383,7 +383,7 @@ jobs:
             runner: macOS-11
           - os_version: macOS-12
             os: macos
-            runner: macOS-12
+            runner: [macOS-12, ICD]
           - os_version: macOS-13
             os: macos
             runner: macOS-13
@@ -444,7 +444,7 @@ jobs:
             runner: macOS-11
           - os_version: macOS-12
             os: macos
-            runner: macOS-12
+            runner: [macOS-12, ICD]
           - os_version: macOS-13
             os: macos
             runner: macOS-13
@@ -505,7 +505,7 @@ jobs:
             runner: macOS-11
           - os_version: macOS-12
             os: macos
-            runner: macOS-12
+            runner: [macOS-12, ICD]
           - os_version: macOS-13
             os: macos
             runner: macOS-13
@@ -566,7 +566,7 @@ jobs:
             runner: macOS-11
           - os_version: macOS-12
             os: macos  
-            runner: macOS-12
+            runner: [macOS-12, ICD]
           - os_version: macOS-13
             os: macos
             runner: macOS-13
@@ -627,7 +627,7 @@ jobs:
             runner: macOS-11
           - os_version: macOS-12
             os: macos
-            runner: macOS-12
+            runner: [macOS-12, ICD]
           - os_version: macOS-13
             os: macos
             runner: macOS-13
@@ -688,7 +688,7 @@ jobs:
             runner: macOS-11
           - os_version: macOS-12
             os: macos
-            runner: macOS-12
+            runner: [macOS-12, ICD]
           - os_version: macOS-13
             os: macos
             runner: macOS-13
@@ -749,7 +749,7 @@ jobs:
             runner: macOS-11
           - os_version: macOS-12
             os: macos
-            runner: macOS-12
+            runner: [macOS-12, ICD]
           - os_version: macOS-13
             os: macos
             runner: macOS-13
@@ -810,7 +810,7 @@ jobs:
             runner: macOS-11
           - os_version: macOS-12
             os: macos
-            runner: macOS-12
+            runner: [macOS-12, ICD]
           - os_version: macOS-13
             os: macos
             runner: macOS-13
@@ -871,7 +871,7 @@ jobs:
             runner: macOS-11
           - os_version: macOS-12
             os: macos
-            runner: macOS-12
+            runner: [macOS-12, ICD]
           - os_version: macOS-13
             os: macos
             runner: macOS-13
@@ -932,7 +932,7 @@ jobs:
             runner: macOS-11
           - os_version: macOS-12
             os: macos
-            runner: macOS-12
+            runner: [macOS-12, ICD]
           - os_version: macOS-13
             os: macos
             runner: macOS-13
@@ -993,7 +993,7 @@ jobs:
             runner: macOS-11
           - os_version: macOS-12
             os: macos
-            runner: macOS-12
+            runner: [macOS-12, ICD]
           - os_version: macOS-13
             os: macos
             runner: macOS-13
@@ -1017,7 +1017,7 @@ jobs:
             runner: [self-hosted, Linux, Apptainer, ICD4]
             image: /opt/apptainer/almalinux8-dec2023.sif
             port: 9004
-          - os_version: rhel-9   
+          - os_version: rhel-9
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD5]
             image: /opt/apptainer/almalinux9-dec2023.sif

--- a/.github/workflows/icd_tests.yml
+++ b/.github/workflows/icd_tests.yml
@@ -298,7 +298,7 @@ jobs:
             runner: [self-hosted, Linux, Apptainer, ICD5]
             image: /opt/apptainer/almalinux9-dec2023.sif
             port: 9005
-    needs: Prepare-ICD-RxJS
+    needs: [File-Browser-ICD-Tests, Prepare-ICD-RxJS]
     if: always()
     steps:
       # macOS steps

--- a/.github/workflows/icd_tests.yml
+++ b/.github/workflows/icd_tests.yml
@@ -52,7 +52,7 @@ jobs:
             port: 9005
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: source
 
@@ -156,11 +156,11 @@ jobs:
     needs: Build
     steps:
       - name: Checkout ICD-RxJS repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: CARTAvis/ICD-RxJS
           ref: ${{ env.ICD_RXJS_BRANCH_NAME }}
-          path: $GITHUB_WORKSPACE/ICD-RxJS
+          path: ICD-RxJS
 
       - name: Prepare ICD-RxJS (macOS)
         if: matrix.os == 'macos'

--- a/.github/workflows/icd_tests.yml
+++ b/.github/workflows/icd_tests.yml
@@ -155,20 +155,18 @@ jobs:
             port: 9005
     needs: Build
     steps:
+      - name: Checkout ICD-RxJS repository
+        uses: actions/checkout@v3
+        with:
+          repository: CARTAvis/ICD-RxJS
+          ref: ${{ env.ICD_RXJS_BRANCH_NAME }}
+          path: $GITHUB_WORKSPACE/ICD-RxJS
+
       - name: Prepare ICD-RxJS (macOS)
         if: matrix.os == 'macos'
         run: |
-          BUILD_DIR=$GITHUB_WORKSPACE/build
-          ICD_RXJS_DIR=$BUILD_DIR/ICD-RxJS
-          cd $BUILD_DIR
-          if [ -d '$ICD_RXJS_DIR' ]; then
-            cd $ICD_RXJS_DIR && git pull
-          else
-            echo 'Cloning ICD-RxJS repository...'
-            git clone https://github.com/CARTAvis/ICD-RxJS.git
-            cd ICD-RxJS
-          fi
-          git checkout ${{ env.ICD_RXJS_BRANCH_NAME }}
+          ICD_DIR=$GITHUB_WORKSPACE/ICD_RxJS
+          cd $ICD_DIR
           git submodule init && git submodule update && npm install
           cd protobuf
           ./build_proto.sh
@@ -179,16 +177,10 @@ jobs:
         if: matrix.os == 'linux'
         run: |
           BUILD_DIR=$GITHUB_WORKSPACE/build-${{ matrix.os_version }}
-          ICD_RXJS_DIR=$BUILD_DIR/ICD-RxJS
+          ICD_DIR=$GITHUB_WORKSPACE/ICD_RxJS
+          cp -r $ICD_DIR $BUILD_DIR
           apptainer exec --bind $GITHUB_WORKSPACE:$GITHUB_WORKSPACE --pwd $BUILD_DIR ${{ matrix.image }} /bin/bash -c "\
-            if [ -d '$ICD_RXJS_DIR' ]; then
-                cd $ICD_RXJS_DIR && git pull
-            else
-                echo 'Cloning ICD-RxJS repository...'
-                git clone https://github.com/CARTAvis/ICD-RxJS.git
-                cd ICD-RxJS
-            fi && \
-            git checkout ${{ env.ICD_RXJS_BRANCH_NAME }} && \
+            cd ICD-RxJS && \
             git submodule init && git submodule update && npm install && \
             cd protobuf && \
             ./build_proto.sh && \

--- a/.github/workflows/icd_tests.yml
+++ b/.github/workflows/icd_tests.yml
@@ -1,0 +1,1050 @@
+name: ICD tests
+on:
+  push:
+  schedule:
+    - cron: '0 0 * * *' # UTC time
+env:
+  ICD_RXJS_BRANCH_NAME: dev
+
+jobs:
+
+  Build:
+    name: Build ${{ matrix.os_version }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os_version: macOS-11
+            os: macos
+            runner: macOS-11
+          - os_version: macOS-12
+            os: macos
+            runner: macOS-12
+          - os_version: macOS-13
+            os: macos
+            runner: macOS-13
+          - os_version: ubuntu-20.04
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD1]
+            image: /opt/apptainer/ubuntu-2004-dec2023.sif
+            port: 9001
+          - os_version: ubuntu-22.04
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD2]
+            image: /opt/apptainer/ubuntu-2204-dec2023.sif
+            port: 9002
+          - os_version: rhel-7
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD3]
+            image: /opt/apptainer/centos7-dec2023.sif
+            port: 9003
+          - os_version: rhel-8
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD4]
+            image: /opt/apptainer/almalinux8-dec2023.sif
+            port: 9004
+          - os_version: rhel-9
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD5]
+            image: /opt/apptainer/almalinux9-dec2023.sif
+            port: 9005
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: source
+
+      - name: System information (macOS)
+        if: matrix.os == 'macos'
+        shell: bash
+        run: |
+          uname -a
+          sw_vers
+
+      - name: Build carta-backend (macOS)
+        if: matrix.os == 'macos'
+        shell: bash
+        run: |
+          SRC_DIR=$GITHUB_WORKSPACE/source
+          BUILD_DIR=$GITHUB_WORKSPACE/build
+          cd $SRC_DIR && git submodule update --init --recursive
+          rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
+          cd $BUILD_DIR
+          cmake $SRC_DIR \
+            -Dtest=on \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DDevSuppressExternalWarnings=ON \
+            -DCMAKE_CXX_FLAGS='-O0 -g -fsanitize=address -fno-omit-frame-pointer' \
+            -DCMAKE_EXE_LINKER_FLAGS='-fsanitize=address'
+          make -j 16
+
+      - name: Build carta-backend (Linux)
+        if: matrix.os == 'linux'
+        shell: bash
+        run: |
+          SRC_DIR=$GITHUB_WORKSPACE/source
+          BUILD_DIR=$GITHUB_WORKSPACE/build-${{ matrix.os_version }}
+          rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
+          apptainer exec --bind $GITHUB_WORKSPACE:$GITHUB_WORKSPACE --pwd $SRC_DIR ${{ matrix.image }} /bin/bash -c "\
+            git submodule update --init --recursive && \
+            cd $BUILD_DIR && \
+            cmake $SRC_DIR \
+              -Dtest=on \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DDevSuppressExternalWarnings=ON \
+              -DCMAKE_CXX_FLAGS='-O0 -g -fsanitize=address -fno-omit-frame-pointer' \
+              -DCMAKE_EXE_LINKER_FLAGS='-fsanitize=address' && \
+            make -j 16"
+
+      - name: Check backend runs (macOS)
+        if: matrix.os == 'macos'
+        shell: bash
+        run: |
+          ./build/carta_backend --version
+
+      - name: Check backend runs (Linux)
+        if: matrix.os == 'linux'
+        shell: bash
+        run: |
+          BUILD_DIR=$GITHUB_WORKSPACE/build-${{ matrix.os_version }}
+          apptainer exec --bind $GITHUB_WORKSPACE:$GITHUB_WORKSPACE --pwd $BUILD_DIR ${{ matrix.image }} /bin/bash -c "./carta_backend --version"
+
+  Prepare-ICD-RxJS:
+    name: Prepare-ICD-RxJS ${{ matrix.os_version }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os_version: macOS-11
+            os: macos
+            runner: macOS-11
+          - os_version: macOS-12
+            os: macos
+            runner: macOS-12
+          - os_version: macOS-13
+            os: macos
+            runner: macOS-13
+          - os_version: ubuntu-20.04
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD1]
+            image: /opt/apptainer/ubuntu-2004-dec2023.sif
+            port: 9001
+          - os_version: ubuntu-22.04
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD2]
+            image: /opt/apptainer/ubuntu-2204-dec2023.sif
+            port: 9002
+          - os_version: rhel-7
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD3]
+            image: /opt/apptainer/centos7-dec2023.sif
+            port: 9003
+          - os_version: rhel-8
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD4]
+            image: /opt/apptainer/almalinux8-dec2023.sif
+            port: 9004
+          - os_version: rhel-9
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD5]
+            image: /opt/apptainer/almalinux9-dec2023.sif
+            port: 9005
+    needs: Build
+    steps:
+      - name: Prepare ICD-RxJS (macOS)
+        if: matrix.os == 'macos'
+        run: |
+          BUILD_DIR=$GITHUB_WORKSPACE/build
+          ICD_RXJS_DIR=$BUILD_DIR/ICD-RxJS
+          cd $BUILD_DIR
+          if [ -d '$ICD_RXJS_DIR' ]; then
+            cd $ICD_RXJS_DIR && git pull
+          else
+            echo 'Cloning ICD-RxJS repository...'
+            git clone https://github.com/CARTAvis/ICD-RxJS.git
+            cd ICD-RxJS
+          fi
+          git checkout ${{ env.ICD_RXJS_BRANCH_NAME }}
+          git submodule init && git submodule update && npm install
+          cd protobuf
+          ./build_proto.sh
+          cd ../src/test
+          perl -p -i -e 's/3002/5555/' config.json
+
+      - name: Prepare ICD-RxJS (Linux)
+        if: matrix.os == 'linux'
+        run: |
+          BUILD_DIR=$GITHUB_WORKSPACE/build-${{ matrix.os_version }}
+          ICD_RXJS_DIR=$BUILD_DIR/ICD-RxJS
+          apptainer exec --bind $GITHUB_WORKSPACE:$GITHUB_WORKSPACE --pwd $BUILD_DIR ${{ matrix.image }} /bin/bash -c "\
+            if [ -d '$ICD_RXJS_DIR' ]; then
+                cd $ICD_RXJS_DIR && git pull
+            else
+                echo 'Cloning ICD-RxJS repository...'
+                git clone https://github.com/CARTAvis/ICD-RxJS.git
+                cd ICD-RxJS
+            fi && \
+            git checkout ${{ env.ICD_RXJS_BRANCH_NAME }} && \
+            git submodule init && git submodule update && npm install && \
+            cd protobuf && \
+            ./build_proto.sh && \
+            cd ../src/test && \
+            perl -p -i -e 's/3002/${{ matrix.port }}/' config.json"
+
+  File-Browser-ICD-Tests:
+    name: File-Browser ${{ matrix.os_version }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os_version: macOS-11
+            os: macos
+            runner: macOS-11
+          - os_version: macOS-12
+            os: macos
+            runner: macOS-12
+          - os_version: macOS-13
+            os: macos
+            runner: macOS-13          
+          - os_version: ubuntu-20.04
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD1]
+            image: /opt/apptainer/ubuntu-2004-dec2023.sif
+            port: 9001
+          - os_version: ubuntu-22.04
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD2]
+            image: /opt/apptainer/ubuntu-2204-dec2023.sif
+            port: 9002
+          - os_version: rhel-7
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD3]
+            image: /opt/apptainer/centos7-dec2023.sif
+            port: 9003
+          - os_version: rhel-8
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD4]
+            image: /opt/apptainer/almalinux8-dec2023.sif
+            port: 9004
+          - os_version: rhel-9
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD5]
+            image: /opt/apptainer/almalinux9-dec2023.sif
+            port: 9005
+    needs: Prepare-ICD-RxJS
+    if: always()
+    steps:
+      # macOS steps
+      - name: File Browser ICD tests
+        if: matrix.os == 'macos'
+        uses: ./source/.github/actions/run-macos
+        with:
+          test_stage_name: 'file_browser'
+      # Linux steps    
+      - name: File Browser ICD tests
+        if: matrix.os == 'linux'
+        uses: ./source/.github/actions/run-apptainer
+        with:
+          os_version: ${{ matrix.os_version }}
+          image: ${{ matrix.image }}
+          port: ${{ matrix.port }}
+          test_stage_name: 'file_browser'
+
+  Animator-ICD-Tests:
+    name: Animator ${{ matrix.os_version }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os_version: macOS-11
+            os: macos
+            runner: macOS-11
+          - os_version: macOS-12
+            os: macos
+            runner: macOS-12
+          - os_version: macOS-13
+            os: macos
+            runner: macOS-13
+          - os_version: ubuntu-20.04
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD1]
+            image: /opt/apptainer/ubuntu-2004-dec2023.sif
+            port: 9001
+          - os_version: ubuntu-22.04
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD2]
+            image: /opt/apptainer/ubuntu-2204-dec2023.sif
+            port: 9002
+          - os_version: rhel-7
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD3]
+            image: /opt/apptainer/centos7-dec2023.sif
+            port: 9003
+          - os_version: rhel-8
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD4]
+            image: /opt/apptainer/almalinux8-dec2023.sif
+            port: 9004
+          - os_version: rhel-9
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD5]
+            image: /opt/apptainer/almalinux9-dec2023.sif
+            port: 9005
+    needs: Prepare-ICD-RxJS
+    if: always()
+    steps:
+      # macOS steps
+      - name: Animator ICD tests
+        if: matrix.os == 'macos'
+        uses: ./source/.github/actions/run-macos
+        with:
+          test_stage_name: 'animator'
+      # Linux steps
+      - name: Animator ICD tests
+        if: matrix.os == 'linux'
+        uses: ./source/.github/actions/run-apptainer
+        with:
+          os_version: ${{ matrix.os_version }}
+          image: ${{ matrix.image }}
+          port: ${{ matrix.port }}
+          test_stage_name: 'animator'
+
+  Region-Statistics-ICD-Tests:
+    name: Region Statistics ${{ matrix.os_version }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os_version: macOS-11
+            os: macos
+            runner: macOS-11
+          - os_version: macOS-12
+            os: macos
+            runner: macOS-12
+          - os_version: macOS-13
+            os: macos
+            runner: macOS-13
+          - os_version: ubuntu-20.04
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD1]
+            image: /opt/apptainer/ubuntu-2004-dec2023.sif
+            port: 9001
+          - os_version: ubuntu-22.04
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD2]
+            image: /opt/apptainer/ubuntu-2204-dec2023.sif
+            port: 9002
+          - os_version: rhel-7
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD3]
+            image: /opt/apptainer/centos7-dec2023.sif
+            port: 9003
+          - os_version: rhel-8
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD4]
+            image: /opt/apptainer/almalinux8-dec2023.sif
+            port: 9004
+          - os_version: rhel-9
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD5]
+            image: /opt/apptainer/almalinux9-dec2023.sif
+            port: 9005
+    needs: [Animator-ICD-Tests, Prepare-ICD-RxJS]
+    if: always()
+    steps:
+      # macOS steps
+      - name: Region-Statistics ICD tests
+        if: matrix.os == 'macos'
+        uses: ./source/.github/actions/run-macos
+        with:
+          test_stage_name: 'region_statistics'
+      # Linux steps
+      - name: Region-Statistics ICD tests
+        if: matrix.os == 'linux'
+        uses: ./source/.github/actions/run-apptainer
+        with:
+          os_version: ${{ matrix.os_version }}
+          image: ${{ matrix.image }}
+          port: ${{ matrix.port }}
+          test_stage_name: 'region_statistics'
+
+  Region-Manipulation-ICD-Tests:
+    name: Region Manipulation ${{ matrix.os_version }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os_version: macOS-11
+            os: macos
+            runner: macOS-11
+          - os_version: macOS-12
+            os: macos
+            runner: macOS-12
+          - os_version: macOS-13
+            os: macos
+            runner: macOS-13
+          - os_version: ubuntu-20.04
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD1]
+            image: /opt/apptainer/ubuntu-2004-dec2023.sif
+            port: 9001
+          - os_version: ubuntu-22.04
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD2]
+            image: /opt/apptainer/ubuntu-2204-dec2023.sif
+            port: 9002
+          - os_version: rhel-7
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD3]
+            image: /opt/apptainer/centos7-dec2023.sif
+            port: 9003
+          - os_version: rhel-8
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD4]
+            image: /opt/apptainer/almalinux8-dec2023.sif
+            port: 9004
+          - os_version: rhel-9
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD5]
+            image: /opt/apptainer/almalinux9-dec2023.sif
+            port: 9005
+    needs: [Region-Statistics-ICD-Tests, Prepare-ICD-RxJS]
+    if: always()
+    steps:
+      # macOS steps
+      - name: Region Manipulation ICD tests
+        if: matrix.os == 'macos'
+        uses: ./source/.github/actions/run-macos
+        with:
+          test_stage_name: 'region_manipulation'
+      # Linux steps
+      - name: Region Manipulation ICD tests
+        if: matrix.os == 'linux'
+        uses: ./source/.github/actions/run-apptainer
+        with:
+          os_version: ${{ matrix.os_version }}
+          image: ${{ matrix.image }}
+          port: ${{ matrix.port }}
+          test_stage_name: 'region_manipulation'
+
+  Cube-Histogram-ICD-Tests:
+    name: Cube Histogram ${{ matrix.os_version }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os_version: macOS-11
+            os: macos
+            runner: macOS-11
+          - os_version: macOS-12
+            os: macos
+            runner: macOS-12
+          - os_version: macOS-13
+            os: macos
+            runner: macOS-13
+          - os_version: ubuntu-20.04
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD1]
+            image: /opt/apptainer/ubuntu-2004-dec2023.sif
+            port: 9001
+          - os_version: ubuntu-22.04
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD2]
+            image: /opt/apptainer/ubuntu-2204-dec2023.sif
+            port: 9002
+          - os_version: rhel-7
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD3]
+            image: /opt/apptainer/centos7-dec2023.sif
+            port: 9003
+          - os_version: rhel-8
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD4]
+            image: /opt/apptainer/almalinux8-dec2023.sif
+            port: 9004
+          - os_version: rhel-9
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD5]
+            image: /opt/apptainer/almalinux9-dec2023.sif
+            port: 9005
+    needs: [Region-Manipulation-ICD-Tests, Prepare-ICD-RxJS]
+    if: always()
+    steps:
+      # macOS steps
+      - name: Cube Histogram ICD tests
+        if: matrix.os == 'macos'
+        uses: ./source/.github/actions/run-macos
+        with:
+          test_stage_name: 'cube_histogram'
+      # Linux steps
+      - name: Cube Histogram ICD tests
+        if: matrix.os == 'linux'
+        uses: ./source/.github/actions/run-apptainer
+        with:
+          os_version: ${{ matrix.os_version }}
+          image: ${{ matrix.image }}
+          port: ${{ matrix.port }}
+          test_stage_name: 'cube_histogram'
+
+  PV-Generator-ICD-Tests:
+    name: PV Generator ${{ matrix.os_version }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os_version: macOS-11
+            os: macos
+            runner: macOS-11
+          - os_version: macOS-12
+            os: macos
+            runner: macOS-12
+          - os_version: macOS-13
+            os: macos
+            runner: macOS-13
+          - os_version: ubuntu-20.04
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD1]
+            image: /opt/apptainer/ubuntu-2004-dec2023.sif
+            port: 9001
+          - os_version: ubuntu-22.04
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD2]
+            image: /opt/apptainer/ubuntu-2204-dec2023.sif
+            port: 9002
+          - os_version: rhel-7
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD3]
+            image: /opt/apptainer/centos7-dec2023.sif
+            port: 9003
+          - os_version: rhel-8
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD4]
+            image: /opt/apptainer/almalinux8-dec2023.sif
+            port: 9004
+          - os_version: rhel-9
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD5]
+            image: /opt/apptainer/almalinux9-dec2023.sif
+            port: 9005
+    needs: [Cube-Histogram-ICD-Tests, Prepare-ICD-RxJS]
+    if: always()
+    steps:
+      # macOS steps
+      - name: PV Generator ICD tests
+        if: matrix.os == 'macos'
+        uses: ./source/.github/actions/run-macos
+        with:
+          test_stage_name: 'pv_generator'
+      # Linux steps
+      - name: PV Generator ICD tests
+        if: matrix.os == 'linux'
+        uses: ./source/.github/actions/run-apptainer
+        with:
+          os_version: ${{ matrix.os_version }}
+          image: ${{ matrix.image }}
+          port: ${{ matrix.port }}
+          test_stage_name: 'pv_generator'
+
+  Raster-Tiles-ICD-Tests:
+    name: Raster Tiles ${{ matrix.os_version }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:  
+        include:
+          - os_version: macOS-11
+            os: macos
+            runner: macOS-11
+          - os_version: macOS-12
+            os: macos  
+            runner: macOS-12
+          - os_version: macOS-13
+            os: macos
+            runner: macOS-13
+          - os_version: ubuntu-20.04
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD1]
+            image: /opt/apptainer/ubuntu-2004-dec2023.sif
+            port: 9001
+          - os_version: ubuntu-22.04
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD2]
+            image: /opt/apptainer/ubuntu-2204-dec2023.sif
+            port: 9002
+          - os_version: rhel-7
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD3]
+            image: /opt/apptainer/centos7-dec2023.sif
+            port: 9003
+          - os_version: rhel-8
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD4]
+            image: /opt/apptainer/almalinux8-dec2023.sif
+            port: 9004
+          - os_version: rhel-9
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD5]
+            image: /opt/apptainer/almalinux9-dec2023.sif
+            port: 9005
+    needs: [PV-Generator-ICD-Tests, Prepare-ICD-RxJS]
+    if: always()
+    steps:
+      # macOS steps
+      - name: Raster Tiles ICD tests
+        if: matrix.os == 'macos'
+        uses: ./source/.github/actions/run-macos
+        with:
+          test_stage_name: 'raster_tiles'
+      # Linux steps
+      - name: Raster Tiles ICD tests
+        if: matrix.os == 'linux'
+        uses: ./source/.github/actions/run-apptainer
+        with:
+          os_version: ${{ matrix.os_version }}
+          image: ${{ matrix.image }}
+          port: ${{ matrix.port }}
+          test_stage_name: 'raster_tiles'
+
+  Catalog-ICD-Tests:
+    name: Catalog ${{ matrix.os_version }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os_version: macOS-11
+            os: macos
+            runner: macOS-11
+          - os_version: macOS-12
+            os: macos
+            runner: macOS-12
+          - os_version: macOS-13
+            os: macos
+            runner: macOS-13
+          - os_version: ubuntu-20.04
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD1]
+            image: /opt/apptainer/ubuntu-2004-dec2023.sif
+            port: 9001
+          - os_version: ubuntu-22.04
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD2]
+            image: /opt/apptainer/ubuntu-2204-dec2023.sif
+            port: 9002
+          - os_version: rhel-7
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD3]
+            image: /opt/apptainer/centos7-dec2023.sif
+            port: 9003
+          - os_version: rhel-8
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD4]
+            image: /opt/apptainer/almalinux8-dec2023.sif
+            port: 9004
+          - os_version: rhel-9
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD5]
+            image: /opt/apptainer/almalinux9-dec2023.sif
+            port: 9005
+    needs: [Raster-Tiles-ICD-Tests, Prepare-ICD-RxJS]
+    if: always()
+    steps:
+      # macOS steps
+      - name: Catalog ICD tests
+        if: matrix.os == 'macos'
+        uses: ./source/.github/actions/run-macos
+        with:
+          test_stage_name: 'catalog'
+      # Linux steps
+      - name: Catalog ICD tests
+        if: matrix.os == 'linux'
+        uses: ./source/.github/actions/run-apptainer
+        with:
+          os_version: ${{ matrix.os_version }}
+          image: ${{ matrix.image }}
+          port: ${{ matrix.port }}
+          test_stage_name: 'catalog'
+
+  Moment-ICD-Tests:
+    name: Moment ${{ matrix.os_version }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os_version: macOS-11
+            os: macos
+            runner: macOS-11
+          - os_version: macOS-12
+            os: macos
+            runner: macOS-12
+          - os_version: macOS-13
+            os: macos
+            runner: macOS-13
+          - os_version: ubuntu-20.04   
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD1]
+            image: /opt/apptainer/ubuntu-2004-dec2023.sif
+            port: 9001
+          - os_version: ubuntu-22.04
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD2]
+            image: /opt/apptainer/ubuntu-2204-dec2023.sif
+            port: 9002
+          - os_version: rhel-7
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD3]
+            image: /opt/apptainer/centos7-dec2023.sif
+            port: 9003
+          - os_version: rhel-8
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD4]
+            image: /opt/apptainer/almalinux8-dec2023.sif
+            port: 9004
+          - os_version: rhel-9
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD5]
+            image: /opt/apptainer/almalinux9-dec2023.sif
+            port: 9005
+    needs: [Catalog-ICD-Tests, Prepare-ICD-RxJS]
+    if: always()
+    steps:
+      # macOS steps
+      - name: Moment ICD tests
+        if: matrix.os == 'macos'
+        uses: ./source/.github/actions/run-macos
+        with:
+          test_stage_name: 'moment'
+      # Linux steps
+      - name: Moment ICD tests
+        if: matrix.os == 'linux'
+        uses: ./source/.github/actions/run-apptainer
+        with:
+          os_version: ${{ matrix.os_version }}
+          image: ${{ matrix.image }}
+          port: ${{ matrix.port }}
+          test_stage_name: 'moment'
+
+  Match-ICD-Tests:
+    name: Match ${{ matrix.os_version }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os_version: macOS-11
+            os: macos   
+            runner: macOS-11
+          - os_version: macOS-12
+            os: macos
+            runner: macOS-12
+          - os_version: macOS-13
+            os: macos
+            runner: macOS-13
+          - os_version: ubuntu-20.04
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD1]
+            image: /opt/apptainer/ubuntu-2004-dec2023.sif
+            port: 9001
+          - os_version: ubuntu-22.04
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD2]
+            image: /opt/apptainer/ubuntu-2204-dec2023.sif
+            port: 9002
+          - os_version: rhel-7  
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD3]
+            image: /opt/apptainer/centos7-dec2023.sif
+            port: 9003
+          - os_version: rhel-8
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD4]
+            image: /opt/apptainer/almalinux8-dec2023.sif
+            port: 9004
+          - os_version: rhel-9     
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD5]
+            image: /opt/apptainer/almalinux9-dec2023.sif
+            port: 9005
+    needs: [Moment-ICD-Tests, Prepare-ICD-RxJS]
+    if: always()
+    steps:
+      # macOS steps
+      - name: Match ICD tests
+        if: matrix.os == 'macos'
+        uses: ./source/.github/actions/run-macos
+        with:
+          test_stage_name: 'match'
+      # Linux steps
+      - name: Match ICD tests
+        if: matrix.os == 'linux'
+        uses: ./source/.github/actions/run-apptainer
+        with:
+          os_version: ${{ matrix.os_version }}
+          image: ${{ matrix.image }}
+          port: ${{ matrix.port }}
+          test_stage_name: 'match'
+
+  Close-File-ICD-Tests:
+    name: Close File ${{ matrix.os_version }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        include:  
+          - os_version: macOS-11
+            os: macos     
+            runner: macOS-11
+          - os_version: macOS-12
+            os: macos
+            runner: macOS-12
+          - os_version: macOS-13
+            os: macos
+            runner: macOS-13
+          - os_version: ubuntu-20.04
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD1]
+            image: /opt/apptainer/ubuntu-2004-dec2023.sif
+            port: 9001
+          - os_version: ubuntu-22.04
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD2]
+            image: /opt/apptainer/ubuntu-2204-dec2023.sif
+            port: 9002
+          - os_version: rhel-7      
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD3]
+            image: /opt/apptainer/centos7-dec2023.sif
+            port: 9003
+          - os_version: rhel-8
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD4]
+            image: /opt/apptainer/almalinux8-dec2023.sif
+            port: 9004
+          - os_version: rhel-9   
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD5]
+            image: /opt/apptainer/almalinux9-dec2023.sif
+            port: 9005
+    needs: [Match-ICD-Tests, Prepare-ICD-RxJS]
+    if: always()
+    steps:
+      # macOS steps
+      - name: Close File ICD tests
+        if: matrix.os == 'macos'
+        uses: ./source/.github/actions/run-macos
+        with:
+          test_stage_name: 'close_file'
+      # Linux steps
+      - name: Close File ICD tests
+        if: matrix.os == 'linux'
+        uses: ./source/.github/actions/run-apptainer
+        with:
+          os_version: ${{ matrix.os_version }}
+          image: ${{ matrix.image }}
+          port: ${{ matrix.port }}
+          test_stage_name: 'close_file'
+
+  Image-Fitting-ICD-Tests:
+    name: Image Fitting ${{ matrix.os_version }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:  
+          - os_version: macOS-11
+            os: macos     
+            runner: macOS-11
+          - os_version: macOS-12
+            os: macos
+            runner: macOS-12
+          - os_version: macOS-13
+            os: macos
+            runner: macOS-13
+          - os_version: ubuntu-20.04
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD1]
+            image: /opt/apptainer/ubuntu-2004-dec2023.sif
+            port: 9001
+          - os_version: ubuntu-22.04
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD2]
+            image: /opt/apptainer/ubuntu-2204-dec2023.sif
+            port: 9002
+          - os_version: rhel-7      
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD3]
+            image: /opt/apptainer/centos7-dec2023.sif
+            port: 9003
+          - os_version: rhel-8
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD4]
+            image: /opt/apptainer/almalinux8-dec2023.sif
+            port: 9004
+          - os_version: rhel-9   
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD5]
+            image: /opt/apptainer/almalinux9-dec2023.sif
+            port: 9005
+    needs: [Close-File-ICD-Tests, Prepare-ICD-RxJS]
+    if: always()
+    steps:
+      # macOS steps
+      - name: Image Fitting ICD tests
+        if: matrix.os == 'macos'
+        uses: ./source/.github/actions/run-macos
+        with:
+          test_stage_name: 'image_fitting'
+      # Linux steps
+      - name: Image Fitting ICD tests
+        if: matrix.os == 'linux'
+        uses: ./source/.github/actions/run-apptainer
+        with:
+          os_version: ${{ matrix.os_version }}
+          image: ${{ matrix.image }}
+          port: ${{ matrix.port }}
+          test_stage_name: 'image_fitting'
+
+  Vector-Overlay-ICD-Tests:
+    name: Vector Overlay ${{ matrix.os_version }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        include:  
+          - os_version: macOS-11
+            os: macos     
+            runner: macOS-11
+          - os_version: macOS-12
+            os: macos
+            runner: macOS-12
+          - os_version: macOS-13
+            os: macos
+            runner: macOS-13
+          - os_version: ubuntu-20.04
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD1]
+            image: /opt/apptainer/ubuntu-2004-dec2023.sif
+            port: 9001
+          - os_version: ubuntu-22.04
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD2]
+            image: /opt/apptainer/ubuntu-2204-dec2023.sif
+            port: 9002
+          - os_version: rhel-7      
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD3]
+            image: /opt/apptainer/centos7-dec2023.sif
+            port: 9003
+          - os_version: rhel-8
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD4]
+            image: /opt/apptainer/almalinux8-dec2023.sif
+            port: 9004
+          - os_version: rhel-9   
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD5]
+            image: /opt/apptainer/almalinux9-dec2023.sif
+            port: 9005
+    needs: [Image-Fitting-ICD-Tests, Prepare-ICD-RxJS]
+    if: always()
+    steps:
+      # macOS steps
+      - name: Vector Overlay ICD tests
+        if: matrix.os == 'macos'
+        uses: ./source/.github/actions/run-macos
+        with:
+          test_stage_name: 'vector_overlay'
+      # Linux steps
+      - name: Vector Overlay ICD tests
+        if: matrix.os == 'linux'
+        uses: ./source/.github/actions/run-apptainer
+        with:
+          os_version: ${{ matrix.os_version }}
+          image: ${{ matrix.image }}
+          port: ${{ matrix.port }}
+          test_stage_name: 'vector_overlay'
+
+  Resume-ICD-Tests:
+    name: Resume ${{ matrix.os_version }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        include:  
+          - os_version: macOS-11
+            os: macos     
+            runner: macOS-11
+          - os_version: macOS-12
+            os: macos
+            runner: macOS-12
+          - os_version: macOS-13
+            os: macos
+            runner: macOS-13
+          - os_version: ubuntu-20.04
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD1]
+            image: /opt/apptainer/ubuntu-2004-dec2023.sif
+            port: 9001
+          - os_version: ubuntu-22.04
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD2]
+            image: /opt/apptainer/ubuntu-2204-dec2023.sif
+            port: 9002
+          - os_version: rhel-7      
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD3]
+            image: /opt/apptainer/centos7-dec2023.sif
+            port: 9003
+          - os_version: rhel-8
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD4]
+            image: /opt/apptainer/almalinux8-dec2023.sif
+            port: 9004
+          - os_version: rhel-9   
+            os: linux
+            runner: [self-hosted, Linux, Apptainer, ICD5]
+            image: /opt/apptainer/almalinux9-dec2023.sif
+            port: 9005
+    needs: [Vector-Overlay-ICD-Tests, Prepare-ICD-RxJS]
+    if: always()
+    steps:
+      # macOS steps
+      - name: Resume ICD tests
+        if: matrix.os == 'macos'
+        uses: ./source/.github/actions/run-macos
+        with:
+          test_stage_name: 'resume'
+      # Linux steps
+      - name: Resume ICD tests
+        if: matrix.os == 'linux'
+        uses: ./source/.github/actions/run-apptainer
+        with:
+          os_version: ${{ matrix.os_version }}
+          image: ${{ matrix.image }}
+          port: ${{ matrix.port }}
+          test_stage_name: 'resume'


### PR DESCRIPTION
**Description**

This one took a lot of trial and error. It effectively moves the daily ICD tests from Jenkins to Github Actions.

The 3 macOS and 5 Linux platforms are combined in one workflow file called `ICD Tests`. They use local runners hosted at ASIAA. The macOS platforms run natively on the Mac hardware. The 5 Linux platforms run via Apptainer (Singularity) on three different Linux servers. It is a long story, but I found Apptainer easier to use instead of Docker and the workflow file can be a lot shorter and simpler.

To reduce the length of the workflow file, we use two different actions; `run-macos/action.yml` and `run-apptainer/action/yml` that start a carta-backend and run the ICD tests for each "job" (ICD test stage) on macOS and Linux, respectively. I don't think the workflow file can be shortened much more. Each "job" requires that long matrix block. Unless we consolidate stages. But I did not do that as I was trying to keep the layout similar to the previous Jenkins ICD tests where we can visually see each test stage.

I have put a list of the actual ICD tests per stage in the ICD-RxJS repo in ICD-RxJS/ICD_test_stages. The workflow file reads that list of tests. This means we can easily add or remove tests to existing stages without needing to make any commits to the carta-backend repo. However, we would need to make a commit to icd_tests.yml on the carta-backend repo if we were to add or remove test stages.

Just like on Jenkins, the ICD test stages run sequentially. e.g. Animator only runs after File-Browser. This was not necessary for Linux/Apptainer, but for some strange reason it is necessary for the macOS platforms. I was unable to figure out why. But is not really important. It still works fine running sequentially and would not be any faster because one runner only runs one job at a time.

The status of all the jobs and steps and the log files can be seen, for example, here: https://github.com/CARTAvis/carta-backend/actions/runs/7259363238

The final part that I have not been able to test is the schedule:
> on:
>   schedule:
>     - cron: '0 0 * * *' # UTC time

This _should_ allow it to run daily at 08:00 Taiwan time. I believe 'schedule' only runs on the default branch, which is 'dev' in our case. So we can not actually test this until it is merged.

I guess this is an unusual PR. It does not affect the carta-backend code base so doesn't require much review or testing.

**Checklist**

- [x] changelog updated / no changelog update needed
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [x] no protobuf update needed
- [x] protobuf version not bumped
- [x] added reviewers and assignee
- [ ] added ZenHub estimate, milestone, and release
