### PR TITLE
Bump version to 5.0.0-dev

### DIFF
--- a/src/Util/App.h
+++ b/src/Util/App.h
@@ -10,7 +10,7 @@
 #include <string>
 
 // version
-#define VERSION_ID "4.0.0-rc.0"
+#define VERSION_ID "5.0.0-dev"
 
 bool FindExecutablePath(std::string& path);
 std::string GetReleaseInformation();


### PR DESCRIPTION
**Description**

Following the discussion on Slack, I suggest that we bump the version to `5.0.0-dev` in our dev branches, to reflect the current state of the code (the v5 release is currently in development). When it's time for the beta release, we would change this to `5.0.0-beta.1`, etc..

**Checklist**

No change to functionality.