### PR TITLE
Check for stoi out_of_range for FITS header parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+* Fix crash when parsing FITS header long value ([#1366](https://github.com/CARTAvis/carta-backend/issues/1366)).
+
 ### Changed
 * Move the loader cache to separate files ([#1021](https://github.com/CARTAvis/carta-backend/issues/1021)).
 * Improve the code style in HTTP server ([#1260](https://github.com/CARTAvis/carta-backend/issues/1260)).

--- a/src/ImageData/CompressedFits.cc
+++ b/src/ImageData/CompressedFits.cc
@@ -414,6 +414,10 @@ void CompressedFits::AddHeaderEntry(
             } catch (std::invalid_argument) {
                 // Set string value only
                 entry->set_entry_type(CARTA::EntryType::STRING);
+            } catch (std::out_of_range) {
+                long lvalue = std::stol(value);
+                entry->set_numeric_value(lvalue);
+                entry->set_entry_type(CARTA::EntryType::INT);
             }
         }
     }


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
Fixes #1366 
* How does this PR solve the issue? Give a brief summary.
Catch std::out_of_range exception from std::stoi and use std::stol instead.
* Are there any companion PRs (frontend, protobuf)?
No
* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
FITS gz image attached in issue.  Open without error or crash.

**Checklist**

- [x] changelog updated / ~no changelog update needed~
- [x] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~protobuf version bumped~ / protobuf version not bumped
- [x] added reviewers and assignee
- [x] added ZenHub estimate, milestone, and release
