### PR TITLE
Check FITS hdu for valid image when opened by URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+* Fixed crash when loading non-image HDU by URL ([#1365](https://github.com/CARTAvis/carta-backend/issues/1365)).
+
 ### Changed
 * Move the loader cache to separate files ([#1021](https://github.com/CARTAvis/carta-backend/issues/1021)).
 * Improve the code style in HTTP server ([#1260](https://github.com/CARTAvis/carta-backend/issues/1260)).

--- a/src/ImageData/FitsLoader.cc
+++ b/src/ImageData/FitsLoader.cc
@@ -62,14 +62,14 @@ void FitsLoader::AllocateImage(const std::string& hdu) {
             }
         }
 
-        // Default is casacore::FITSImage; if fails, try CartaFitsImage
-        bool use_casacore_fits(true);
-        auto num_headers = GetNumHeaders(_filename, hdu_num);
-
+        std::string error;
+        auto num_headers = GetNumImageHeaders(_filename, hdu_num, error);
         if (num_headers == 0) {
-            throw(casacore::AipsError("Error reading FITS file."));
+            throw(casacore::AipsError(error));
         }
 
+        // Default is casacore::FITSImage; if fails, try CartaFitsImage
+        bool use_casacore_fits(true);
         if (num_headers > 2000) {
             // casacore::FITSImage parses HISTORY
             use_casacore_fits = false;
@@ -135,8 +135,8 @@ void FitsLoader::AllocateImage(const std::string& hdu) {
     }
 }
 
-int FitsLoader::GetNumHeaders(const std::string& filename, int hdu) {
-    // Return number of FITS headers, 0 if error.
+int FitsLoader::GetNumImageHeaders(const std::string& filename, int hdu, std::string& error) {
+    // Return number of FITS headers if image hdu, 0 if error.
     int num_headers(0);
 
     // Open file read-only
@@ -144,13 +144,29 @@ int FitsLoader::GetNumHeaders(const std::string& filename, int hdu) {
     int status(0);
     fits_open_file(&fptr, filename.c_str(), 0, &status);
     if (status) {
+        error = "Error reading FITS file.";
         return num_headers;
     }
 
-    // Advance to hdu (FITS hdu is 1-based)
-    int* hdutype(nullptr);
-    fits_movabs_hdu(fptr, hdu + 1, hdutype, &status);
+    // Advance to hdu (FITS hdu is 1-based) and check if image
+    int hdutype(-1);
+    fits_movabs_hdu(fptr, hdu + 1, &hdutype, &status);
     if (status) {
+        error = "Cannot advance to requested HDU.";
+        return num_headers;
+    }
+    if (hdutype != IMAGE_HDU) {
+        error = "HDU is not an image.";
+        return num_headers;
+    }
+
+    // Check if image exists in HDU
+    std::string key("NAXIS");
+    char* comment(nullptr); // unused
+    int naxis(0);
+    fits_read_key(fptr, TINT, key.c_str(), &naxis, comment, &status);
+    if (naxis == 0) {
+        error = "HDU image is empty.";
         return num_headers;
     }
 

--- a/src/ImageData/FitsLoader.h
+++ b/src/ImageData/FitsLoader.h
@@ -21,7 +21,7 @@ private:
     casacore::uInt _hdu_num;
 
     void AllocateImage(const std::string& hdu) override;
-    int GetNumHeaders(const std::string& filename, int hdu);
+    int GetNumImageHeaders(const std::string& filename, int hdu, std::string& error);
 
     // Image beam headers/table
     bool Is64BitBeamsTable(const std::string& filename);


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
Fixes #1365 
* How does this PR solve the issue? Give a brief summary.
The problem in this issue was that the HDU, which did exist, was not checked to see if it was an image HDU (it was) and that an image exists with naxis > 0 (it did not) before attempting to open it.  This PR adds these checks and improves the error messages to report the failure.
* Are there any companion PRs (frontend, protobuf)?
No
* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
Open a FITS image by URL with a non-existent HDU, a non-image HDU (e.g. binary table), or an image HDU which contains no image.

**Checklist**

- [x] changelog updated / ~no changelog update needed~
- [x] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~protobuf version bumped~ / protobuf version not bumped
- [x] added reviewers and assignee
- [x] added ZenHub estimate, milestone, and release
