### PR TITLE
Fixed the current building issue of centOS7 in the CI/CD

### DIFF
--- a/.github/workflows/icd_tests.yml
+++ b/.github/workflows/icd_tests.yml
@@ -86,8 +86,8 @@ jobs:
           SRC_DIR=$GITHUB_WORKSPACE/source
           BUILD_DIR=$GITHUB_WORKSPACE/build-${{ matrix.os_version }}
           rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
+          cd source ; git submodule update --init --recursive
           apptainer exec --bind $GITHUB_WORKSPACE:$GITHUB_WORKSPACE --pwd $SRC_DIR ${{ matrix.image }} /bin/bash -c "\
-            git submodule update --init --recursive && \
             cd $BUILD_DIR && \
             cmake $SRC_DIR \
               -Dtest=on \
@@ -178,9 +178,11 @@ jobs:
           BUILD_DIR=$GITHUB_WORKSPACE/build-${{ matrix.os_version }}
           ICD_DIR=$GITHUB_WORKSPACE/ICD-RxJS
           cp -r $ICD_DIR $BUILD_DIR
+          cd $BUILD_DIR/ICD-RxJS
+          git submodule update --init --recursive
           apptainer exec --bind $GITHUB_WORKSPACE:$GITHUB_WORKSPACE --pwd $BUILD_DIR ${{ matrix.image }} /bin/bash -c "\
             cd ICD-RxJS && \
-            git submodule init && git submodule update && npm install && \
+            npm install && \
             cd protobuf && \
             ./build_proto.sh && \
             cd ../src/test && \


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
Because the daily ICD tests in the github action runner failed from the last week, this PR fixed the github action runner failure that happened in the linux platform, especially the centOS7 platform.

* How does this PR solve the issue? Give a brief summary.
I found the git version does not work in the github action runner (from 2.315.0 -> 2.316.0 in the last week) folder for CentOS7 apptainer, the git version version works well in other folder (without github action runner) inside the same apptainer. So I choose the workaround solution, put `git submodule update --init --recursive` into the previous step, then start the apptainer.

* Are there any related PRs (frontend, protobuf)?
No, this PR only changes the `carta-backend/.github/workflows/icd_tests.yml`
This PR will not affect the carta-backend codebase at all.

* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
Because the ICD-RxJS github action runner faces the same failure, we have used the same solution and applied the ICD-RxJS repository, then the github action runners are all passed ([link](https://github.com/CARTAvis/ICD-RxJS/actions/runs/8880766292)), the ICD-RxJS PR has been merged to the dev branch.

However, I found there is no 

```
  # Allows you to run this workflow manually from the Actions tab
  workflow_dispatch:
```

in the `carta-backend/.github/workflows/icd_tests.yml`, so I have no idea how to trigger this specific branch to run the icd_tests.yml... (unlike icd_tests.yml in the ICD-RxJS/.github/workflows)
The old [PR](https://github.com/CARTAvis/carta-backend/pull/1348), that adding all ICD tests into the github action runner looks like merged into the dev branch because the PR was not the an usual PR...

Note: the **potential** review method I can imagine so far is visual checking of these two files:
`ICD-RxJS/.github/workflows/icd_tests.yml`
`carta-backend/.github/workflows/icd_tests.yml`

Check 
(1) name: Build carta-backend (Linux) - run: 
the `cd source ; git submodule update --init --recursive` should be before the apptainer

(2)name: Prepare ICD-RxJS (Linux) - run:
the 
```
          cd $BUILD_DIR/ICD-RxJS
          git submodule update --init --recursive
```
should be before the apptainer too.


**Checklist**

- [ ] changelog updated / no changelog update needed
- [x] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~protobuf version bumped~ / protobuf version not bumped
- [x] added reviewers and assignee
- [ ] GitHub Project estimate added
