### PR TITLE
Fix incorrect parsing of the ATCA FITS header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Fixed crash when loading non-image HDU by URL ([#1365](https://github.com/CARTAvis/carta-backend/issues/1365)).
 * Fix crash when parsing FITS header long value ([#1366](https://github.com/CARTAvis/carta-backend/issues/1366)).
+* Fix incorrect parsing of SPECSYS value for ATCA FITS header ([#1375](https://github.com/CARTAvis/carta-backend/issues/1375)).
 
 ### Changed
 * Move the loader cache to separate files ([#1021](https://github.com/CARTAvis/carta-backend/issues/1021)).

--- a/src/FileList/FileExtInfoLoader.cc
+++ b/src/FileList/FileExtInfoLoader.cc
@@ -247,6 +247,7 @@ void FileExtInfoLoader::AddEntriesFromHeaderStrings(
     // CartaHdf5Image shortens keywords to FITS length 8
     std::unordered_map<std::string, std::string> hdf5_keys = {
         {"H5SCHEMA", "SCHEMA_VERSION"}, {"H5CNVRTR", "HDF5_CONVERTER"}, {"H5CONVSN", "HDF5_CONVERTER_VERSION"}, {"H5DATE", "HDF5_DATE"}};
+    bool has_specsys(false);
 
     for (auto& header : headers) {
         // Parse header into name, value, comment
@@ -335,6 +336,8 @@ void FileExtInfoLoader::AddEntriesFromHeaderStrings(
                 // not numeric
             }
             is_string_value = true;
+        } else if (name == "SPECSYS") {
+            has_specsys = true;
         }
 
         // Set name
@@ -365,7 +368,7 @@ void FileExtInfoLoader::AddEntriesFromHeaderStrings(
         }
     }
 
-    if (!specsys.empty()) {
+    if (!has_specsys && !specsys.empty()) {
         // separated from VELO CTYPE
         auto entry = extended_info.add_header_entries();
         entry->set_name("SPECSYS");

--- a/src/FileList/FileExtInfoLoader.cc
+++ b/src/FileList/FileExtInfoLoader.cc
@@ -313,11 +313,18 @@ void FileExtInfoLoader::AddEntriesFromHeaderStrings(
             name = hdf5_keys[name];
         }
 
+        if (name == "SPECSYS") {
+            has_specsys = true;
+            specsys = value;
+        }
+
         if (name.startsWith("CTYPE")) {
             if ((value == "STOKES") || (value == "Stokes") || (value == "stokes")) {
                 stokes_ctype_num = name.back();
             } else if (value.startsWith("VELO-")) {
-                specsys = value.after('-');
+                if (specsys.empty()) {
+                    specsys = value.after('-');
+                }
                 value = "VELO";
             }
             is_string_value = true;
@@ -336,8 +343,6 @@ void FileExtInfoLoader::AddEntriesFromHeaderStrings(
                 // not numeric
             }
             is_string_value = true;
-        } else if (name == "SPECSYS") {
-            has_specsys = true;
         }
 
         // Set name


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
Closes #1375.  

* How does this PR solve the issue? Give a brief summary.
The value of SPECSYS from the ATCA FITS header is already provided. So we don't need to parse it from the suffix of VELO-XXX (the string after '-'), which would also result in the failure rendering of the coordinate system.

* Are there any companion PRs (frontend, protobuf)?
No.

* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
The coordinate system for ATCA FITS images can be successfully rendered on the frontend.

**Checklist**

- [x] changelog updated ~/ no changelog update needed~
- [x] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [x] ~protobuf updated to the latest dev commit /~ no protobuf update needed
- [x] ~protobuf version bumped /~ protobuf version not bumped
- [ ] added reviewers and assignee
- [ ] GitHub Project estimate added
