### PR TITLE
Fix save image critical bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed crash when loading non-image HDU by URL ([#1365](https://github.com/CARTAvis/carta-backend/issues/1365)).
 * Fix crash when parsing FITS header long value ([#1366](https://github.com/CARTAvis/carta-backend/issues/1366)).
 * Fix hdf5 image distortion after animation stops ([#1368](https://github.com/CARTAvis/carta-backend/issues/1368)).
+* Fix save image bug which could cause directory deletion ([#1377](https://github.com/CARTAvis/carta-backend/issues/1377)).
 
 ### Changed
 * Move the loader cache to separate files ([#1021](https://github.com/CARTAvis/carta-backend/issues/1021)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed crash when loading non-image HDU by URL ([#1365](https://github.com/CARTAvis/carta-backend/issues/1365)).
 * Fix crash when parsing FITS header long value ([#1366](https://github.com/CARTAvis/carta-backend/issues/1366)).
 * Fix hdf5 image distortion after animation stops ([#1368](https://github.com/CARTAvis/carta-backend/issues/1368)).
-* Fix save image bug which could cause directory deletion ([#1377](https://github.com/CARTAvis/carta-backend/issues/1377)).
+* Fix save image bug which could cause directory overwrite or deletion ([#1377](https://github.com/CARTAvis/carta-backend/issues/1377)).
 
 ### Changed
 * Move the loader cache to separate files ([#1021](https://github.com/CARTAvis/carta-backend/issues/1021)).

--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -1956,13 +1956,6 @@ void Frame::SaveFile(const std::string& root_folder, const CARTA::SaveFile& save
         }
     }
 
-    if (output_filename.string() == in_file) {
-        message = "The source file can not be overwritten!";
-        save_file_ack.set_success(success);
-        save_file_ack.set_message(message);
-        return;
-    }
-
     double rest_freq(save_file_msg.rest_freq());
     bool change_rest_freq = !std::isnan(rest_freq);
 

--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -1923,10 +1923,25 @@ void Frame::SaveFile(const std::string& root_folder, const CARTA::SaveFile& save
     bool success(false);
     casacore::String message;
 
+    if (output_filename.empty()) {
+        message = "Cannot save image with no filename.";
+        save_file_ack.set_success(success);
+        save_file_ack.set_message(message);
+        return;
+    }
+
     // Get the full resolved name of the output image
     fs::path temp_path = fs::path(root_folder) / directory;
     fs::path abs_path = fs::absolute(temp_path);
     output_filename = abs_path / output_filename;
+
+    if (fs::exists(output_filename) && fs::is_directory(output_filename) &&
+        (CasacoreImageType(output_filename.string()) == casacore::ImageOpener::UNKNOWN)) {
+        message = "Cannot overwrite existing directory.";
+        save_file_ack.set_success(success);
+        save_file_ack.set_message(message);
+        return;
+    }
 
     if (output_filename.string() == in_file) {
         message = "The source file can not be overwritten!";

--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -1939,9 +1939,9 @@ void Frame::SaveFile(const std::string& root_folder, const CARTA::SaveFile& save
     if (fs::exists(output_filename)) {
         if (output_filename.string() == in_file) {
             message = "Cannot overwrite the source image.";
-	} else if (CasacoreImageType(output_filename.string()) == casacore::ImageOpener::UNKNOWN) {
+        } else if (CasacoreImageType(output_filename.string()) == casacore::ImageOpener::UNKNOWN) {
             // Not an image
-	    if (fs::is_directory(output_filename)) {
+            if (fs::is_directory(output_filename)) {
                 message = "Cannot overwrite existing directory.";
             }
         } else if (!overwrite) {

--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -1949,10 +1949,12 @@ void Frame::SaveFile(const std::string& root_folder, const CARTA::SaveFile& save
             } else if (!overwrite) {
                 // Only overwrite file or symlink with confirmation
                 message = "Cannot overwrite existing file or symlink.";
+                save_file_ack.set_overwrite_confirmation_required(true);
             }
         } else if (!overwrite) {
             // Only overwrite image with confirmation
             message = "Cannot overwrite existing image.";
+            save_file_ack.set_overwrite_confirmation_required(true);
         }
 
         if (!message.empty()) {

--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -1921,12 +1921,11 @@ void Frame::SaveFile(const std::string& root_folder, const CARTA::SaveFile& save
     // Set response message
     int file_id(save_file_msg.file_id());
     save_file_ack.set_file_id(file_id);
-    bool success(false);
-    casacore::String message;
+    std::string message;
 
     if (output_filename.empty()) {
         message = "Cannot save image with no filename.";
-        save_file_ack.set_success(success);
+        save_file_ack.set_success(false);
         save_file_ack.set_message(message);
         return;
     }
@@ -1939,18 +1938,25 @@ void Frame::SaveFile(const std::string& root_folder, const CARTA::SaveFile& save
     if (fs::exists(output_filename)) {
         if (output_filename.string() == in_file) {
             message = "Cannot overwrite the source image.";
+        } else if (fs::is_other(output_filename)) {
+            // Not a file, directory, or symlink
+            message = "Cannot overwrite existing path: not a file or directory.";
         } else if (CasacoreImageType(output_filename.string()) == casacore::ImageOpener::UNKNOWN) {
             // Not an image
             if (fs::is_directory(output_filename)) {
+                // Never overwrite directory
                 message = "Cannot overwrite existing directory.";
+            } else if (!overwrite) {
+                // Only overwrite file or symlink with confirmation
+                message = "Cannot overwrite existing file or symlink.";
             }
         } else if (!overwrite) {
-            // Image requires overwrite
+            // Only overwrite image with confirmation
             message = "Cannot overwrite existing image.";
         }
 
         if (!message.empty()) {
-            save_file_ack.set_success(success);
+            save_file_ack.set_success(false);
             save_file_ack.set_message(message);
             return;
         }
@@ -2012,7 +2018,7 @@ void Frame::SaveFile(const std::string& root_folder, const CARTA::SaveFile& save
             } else {
                 image = casacore::SubImage<float>(sub_image, casacore::AxesSpecifier(false), true).cloneII();
             }
-        } catch (casacore::AipsError error) {
+        } catch (const casacore::AipsError& error) {
             message = error.getMesg();
             save_file_ack.set_success(false);
             save_file_ack.set_message(message);
@@ -2025,16 +2031,15 @@ void Frame::SaveFile(const std::string& root_folder, const CARTA::SaveFile& save
     if (change_rest_freq) {
         casacore::CoordinateSystem coord_sys = image->coordinates();
         casacore::String error_msg("");
-        bool success = coord_sys.setRestFrequency(error_msg, casacore::Quantity(rest_freq, casacore::Unit("Hz")));
-        if (success) {
-            success = image->setCoordinateInfo(coord_sys);
-        }
-        if (!success) {
-            spdlog::warn("Failed to set new rest freq; use header rest freq instead: {}", error_msg);
+        if (coord_sys.setRestFrequency(error_msg, casacore::Quantity(rest_freq, casacore::Unit("Hz")))) {
+            if (!image->setCoordinateInfo(coord_sys)) {
+                spdlog::warn("Failed to set new rest freq; using header rest freq instead: {}", error_msg);
+            }
         }
     }
 
     // Export image data to file
+    bool success(false);
     try {
         std::unique_lock<std::mutex> ulock(_image_mutex); // Lock the image while saving the file
         {
@@ -2051,14 +2056,15 @@ void Frame::SaveFile(const std::string& root_folder, const CARTA::SaveFile& save
             }
         }
         ulock.unlock(); // Unlock the image
-    } catch (casacore::AipsError error) {
+
+        if (success) {
+            spdlog::info("Exported a {} file \'{}\'.", FileTypeString[output_file_type], output_filename.string());
+        }
+    } catch (const casacore::AipsError& error) {
         message += error.getMesg();
         save_file_ack.set_success(false);
         save_file_ack.set_message(message);
         return;
-    }
-    if (success) {
-        spdlog::info("Exported a {} file \'{}\'.", FileTypeString[output_file_type], output_filename.string());
     }
 
     // Remove the root folder from the ack message
@@ -2078,7 +2084,7 @@ void Frame::SaveFile(const std::string& root_folder, const CARTA::SaveFile& save
 // Input output_filename as file path
 // Input message as a return message, which may contain error message
 // Return a bool if this functionality success
-bool Frame::ExportCASAImage(casacore::ImageInterface<casacore::Float>& image, fs::path output_filename, casacore::String& message) {
+bool Frame::ExportCASAImage(casacore::ImageInterface<casacore::Float>& image, fs::path output_filename, std::string& message) {
     bool success(false);
 
     // Remove the old image file if it has a same file name
@@ -2125,7 +2131,7 @@ bool Frame::ExportCASAImage(casacore::ImageInterface<casacore::Float>& image, fs
 // Input output_filename as file path
 // Input message as a return message, which may contain error message
 // Return a bool if this functionality success
-bool Frame::ExportFITSImage(casacore::ImageInterface<casacore::Float>& image, fs::path output_filename, casacore::String& message) {
+bool Frame::ExportFITSImage(casacore::ImageInterface<casacore::Float>& image, fs::path output_filename, std::string& message) {
     bool success = false;
     bool prefer_velocity;
     bool optical_velocity;

--- a/src/Frame/Frame.h
+++ b/src/Frame/Frame.h
@@ -252,8 +252,8 @@ protected:
     bool HasSpectralConfig(const SpectralConfig& config);
 
     // Export image
-    bool ExportCASAImage(casacore::ImageInterface<casacore::Float>& image, fs::path output_filename, casacore::String& message);
-    bool ExportFITSImage(casacore::ImageInterface<casacore::Float>& image, fs::path output_filename, casacore::String& message);
+    bool ExportCASAImage(casacore::ImageInterface<casacore::Float>& image, fs::path output_filename, std::string& message);
+    bool ExportFITSImage(casacore::ImageInterface<casacore::Float>& image, fs::path output_filename, std::string& message);
     void ValidateChannelStokes(std::vector<int>& channels, std::vector<int>& stokes, const CARTA::SaveFile& save_file_msg);
     casacore::Slicer GetExportImageSlicer(const CARTA::SaveFile& save_file_msg, casacore::IPosition image_shape);
     casacore::Slicer GetExportRegionSlicer(const CARTA::SaveFile& save_file_msg, casacore::IPosition image_shape,

--- a/src/Region/RegionHandler.cc
+++ b/src/Region/RegionHandler.cc
@@ -235,21 +235,15 @@ void RegionHandler::ExportRegion(int file_id, std::shared_ptr<Frame> frame, CART
     std::string message;
     if (!filename.empty()) {
         casacore::File export_file(filename);
-
         if (export_file.exists()) {
-            if (!overwrite) {
-                message = "Cannot overwrite existing file.";
-                export_ack.set_success(false);
-                export_ack.set_message(message);
-                return;
-            }
-
-            if (export_file.isRegular(false)) {
-                if (!export_file.isWritable()) {
-                    message = "Export region failed: cannot overwrite read-only file.";
-                }
-            } else {
-                message = "Export region failed: path is not a file.";
+            if (export_file.isDirectory()) {
+                message = "Export region failed: cannot overwrite existing directory.";
+            } else if (!export_file.isRegular()) {
+                message = "Export region failed: existing path is not a file.";
+            } else if (!overwrite) {
+                message = "Export region failed: cannot overwrite existing file.";
+            } else if (!export_file.isWritable()) {
+                message = "Export region failed: cannot overwrite read-only file.";
             }
         } else if (!export_file.canCreate()) {
             message = "Export region failed: cannot create file.";

--- a/src/Region/RegionHandler.cc
+++ b/src/Region/RegionHandler.cc
@@ -221,7 +221,7 @@ void RegionHandler::ImportRegion(int file_id, std::shared_ptr<Frame> frame, CART
 }
 
 void RegionHandler::ExportRegion(int file_id, std::shared_ptr<Frame> frame, CARTA::FileType region_file_type,
-    CARTA::CoordinateType coord_type, std::map<int, CARTA::RegionStyle>& region_styles, std::string& filename,
+    CARTA::CoordinateType coord_type, std::map<int, CARTA::RegionStyle>& region_styles, std::string& filename, bool overwrite,
     CARTA::ExportRegionAck& export_ack) {
     // Export regions to given filename, or return export file contents in ack
     // Check if any regions to export
@@ -237,6 +237,13 @@ void RegionHandler::ExportRegion(int file_id, std::shared_ptr<Frame> frame, CART
         casacore::File export_file(filename);
 
         if (export_file.exists()) {
+            if (!overwrite) {
+                message = "Cannot overwrite existing file.";
+                export_ack.set_success(false);
+                export_ack.set_message(message);
+                return;
+            }
+
             if (export_file.isRegular(false)) {
                 if (!export_file.isWritable()) {
                     message = "Export region failed: cannot overwrite read-only file.";

--- a/src/Region/RegionHandler.cc
+++ b/src/Region/RegionHandler.cc
@@ -242,6 +242,7 @@ void RegionHandler::ExportRegion(int file_id, std::shared_ptr<Frame> frame, CART
                 message = "Export region failed: existing path is not a file.";
             } else if (!overwrite) {
                 message = "Export region failed: cannot overwrite existing file.";
+                export_ack.set_overwrite_confirmation_required(true);
             } else if (!export_file.isWritable()) {
                 message = "Export region failed: cannot overwrite read-only file.";
             }

--- a/src/Region/RegionHandler.h
+++ b/src/Region/RegionHandler.h
@@ -42,7 +42,7 @@ public:
     void ImportRegion(int file_id, std::shared_ptr<Frame> frame, CARTA::FileType region_file_type, const std::string& region_file,
         bool file_is_filename, CARTA::ImportRegionAck& import_ack);
     void ExportRegion(int file_id, std::shared_ptr<Frame> frame, CARTA::FileType region_file_type, CARTA::CoordinateType coord_type,
-        std::map<int, CARTA::RegionStyle>& region_styles, std::string& filename, CARTA::ExportRegionAck& export_ack);
+        std::map<int, CARTA::RegionStyle>& region_styles, std::string& filename, bool overwrite, CARTA::ExportRegionAck& export_ack);
 
     // Frames
     void RemoveFrame(int file_id);

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -928,8 +928,8 @@ void Session::OnExportRegion(const CARTA::ExportRegion& message, uint32_t reques
 
             std::map<int, CARTA::RegionStyle> region_styles = {message.region_styles().begin(), message.region_styles().end()};
 
-            _region_handler->ExportRegion(
-                file_id, _frames.at(file_id), message.type(), message.coord_type(), region_styles, abs_filename, export_ack);
+            _region_handler->ExportRegion(file_id, _frames.at(file_id), message.type(), message.coord_type(), region_styles, abs_filename,
+                message.overwrite(), export_ack);
         }
         SendFileEvent(file_id, CARTA::EventType::EXPORT_REGION_ACK, request_id, export_ack);
     } else {

--- a/test/TestRegionImportExport.cc
+++ b/test/TestRegionImportExport.cc
@@ -161,10 +161,11 @@ TEST_F(RegionImportExportTest, TestCrtfPixExportImport) {
         region_style_map[region_id] = style;
     }
     std::string filename; // do not export to file
+    bool overwrite(false);
 
     // Export all regions in frame0 (reference image)
     CARTA::ExportRegionAck export_ack0;
-    region_handler.ExportRegion(file_id, frame0, CARTA::CRTF, CARTA::PIXEL, region_style_map, filename, export_ack0);
+    region_handler.ExportRegion(file_id, frame0, CARTA::CRTF, CARTA::PIXEL, region_style_map, filename, overwrite, export_ack0);
     // Check that all regions were exported
     ASSERT_EQ(export_ack0.contents_size(), num_regions + 2); // header, textbox for text
 
@@ -180,7 +181,7 @@ TEST_F(RegionImportExportTest, TestCrtfPixExportImport) {
     // Export all regions in frame1 (matched image)
     file_id = 1;
     CARTA::ExportRegionAck export_ack1;
-    region_handler.ExportRegion(file_id, frame1, CARTA::CRTF, CARTA::PIXEL, region_style_map, filename, export_ack1);
+    region_handler.ExportRegion(file_id, frame1, CARTA::CRTF, CARTA::PIXEL, region_style_map, filename, overwrite, export_ack1);
     // Check that all regions were exported
     ASSERT_EQ(export_ack1.contents_size(), num_regions + 2); // header, textbox for text
 
@@ -219,8 +220,9 @@ TEST_F(RegionImportExportTest, TestCrtfWorldExportImport) {
         region_style_map[region_id] = style;
     }
     std::string filename; // do not export to file
+    bool overwrite(false);
     CARTA::ExportRegionAck export_ack0;
-    region_handler.ExportRegion(file_id, frame0, CARTA::CRTF, CARTA::WORLD, region_style_map, filename, export_ack0);
+    region_handler.ExportRegion(file_id, frame0, CARTA::CRTF, CARTA::WORLD, region_style_map, filename, overwrite, export_ack0);
     // Check that all regions were exported
     ASSERT_EQ(export_ack0.contents_size(), num_regions + 2); // header, textbox for text
 
@@ -236,7 +238,7 @@ TEST_F(RegionImportExportTest, TestCrtfWorldExportImport) {
     // Export all regions in frame1 (matched image)
     file_id = 1;
     CARTA::ExportRegionAck export_ack1;
-    region_handler.ExportRegion(file_id, frame1, CARTA::CRTF, CARTA::WORLD, region_style_map, filename, export_ack1);
+    region_handler.ExportRegion(file_id, frame1, CARTA::CRTF, CARTA::WORLD, region_style_map, filename, overwrite, export_ack1);
     // Check that all regions were exported
     ASSERT_EQ(export_ack1.contents_size(), num_regions + 2); // header, textbox for text
 
@@ -275,8 +277,9 @@ TEST_F(RegionImportExportTest, TestDs9PixExportImport) {
         region_style_map[region_id] = style;
     }
     std::string filename; // do not export to file
+    bool overwrite(false);
     CARTA::ExportRegionAck export_ack0;
-    region_handler.ExportRegion(file_id, frame0, CARTA::DS9_REG, CARTA::PIXEL, region_style_map, filename, export_ack0);
+    region_handler.ExportRegion(file_id, frame0, CARTA::DS9_REG, CARTA::PIXEL, region_style_map, filename, overwrite, export_ack0);
     // Check that all regions were exported
     ASSERT_EQ(export_ack0.contents_size(), num_regions + 3); // header + globals, coord sys, textbox for text
 
@@ -292,7 +295,7 @@ TEST_F(RegionImportExportTest, TestDs9PixExportImport) {
     // Export all regions in frame1 (matched image)
     file_id = 1;
     CARTA::ExportRegionAck export_ack1;
-    region_handler.ExportRegion(file_id, frame1, CARTA::DS9_REG, CARTA::PIXEL, region_style_map, filename, export_ack1);
+    region_handler.ExportRegion(file_id, frame1, CARTA::DS9_REG, CARTA::PIXEL, region_style_map, filename, overwrite, export_ack1);
     // Check that all regions were exported
     ASSERT_EQ(export_ack1.contents_size(), num_regions + 2); // header + globals, coord sys (textbox + text in same string)
 
@@ -331,8 +334,9 @@ TEST_F(RegionImportExportTest, TestDs9WorldExportImport) {
         region_style_map[region_id] = style;
     }
     std::string filename; // do not export to file
+    bool overwrite(false);
     CARTA::ExportRegionAck export_ack0;
-    region_handler.ExportRegion(file_id, frame0, CARTA::DS9_REG, CARTA::WORLD, region_style_map, filename, export_ack0);
+    region_handler.ExportRegion(file_id, frame0, CARTA::DS9_REG, CARTA::WORLD, region_style_map, filename, overwrite, export_ack0);
     // Check that all regions were exported
     ASSERT_EQ(export_ack0.contents_size(), num_regions + 2); // header + globals, coord sys (textbox + text in same string)
 
@@ -348,7 +352,7 @@ TEST_F(RegionImportExportTest, TestDs9WorldExportImport) {
     // Export all regions in frame1 (matched image)
     file_id = 1;
     CARTA::ExportRegionAck export_ack1;
-    region_handler.ExportRegion(file_id, frame1, CARTA::DS9_REG, CARTA::WORLD, region_style_map, filename, export_ack1);
+    region_handler.ExportRegion(file_id, frame1, CARTA::DS9_REG, CARTA::WORLD, region_style_map, filename, overwrite, export_ack1);
     // Check that all regions were exported
     ASSERT_EQ(export_ack1.contents_size(), num_regions + 2); // header + globals, coord sys (textbox + text in same string)
 


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
#1377 

* How does this PR solve the issue? Give a brief summary.
Saving the image fails if:
  - SaveFile filename is empty (always fails)
  - the resolved path is the same as the source image (always fails)
  - the resolved path is a non-image directory, to prevent deletion/overwrite of existing directory (always fails)
  - the resolved path is a non-image file and overwrite is false
  - the resolved path is a symlink and overwrite is false (else overwrites the link itself, not its target)
  - the resolved path is an image file or directory and overwrite is false

  Exporting regions fails if:
    - the resolved path is a directory
    - the resolved path is an existing file and overwrite is false

This should be backported to carta 4.2.0.

* Are there any companion PRs (frontend, protobuf)?
CARTAvis/carta-frontend#2389, CARTAvis/carta-protobuf#97

* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
See issue description.  As stated, use caution!!! Copy test image to new directory.  Create a region and export to an existing file: should fail unless frontend dialog confirms overwrite.

**Checklist**

- [x] changelog updated / no changelog update needed
- [x] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] protobuf version bumped / ~protobuf version not bumped~
- [x] added reviewers and assignee
- [ ] GitHub Project estimate added
- [ ] Backport to 4.2