### PR TITLE
Optimisation of directory type checking in file list

### DIFF
--- a/src/FileList/FileListHandler.cc
+++ b/src/FileList/FileListHandler.cc
@@ -165,7 +165,7 @@ void FileListHandler::GetFileList(CARTA::FileListResponse& file_list_response, c
                                 add_directory = true;
                             } else {
                                 // Determine if image or directory
-                                auto file_type = GuessImageDirectoryType(full_path, filter_mode == CARTA::Content);
+                                auto file_type = GuessImageDirectoryType(full_path);
                                 // This is a normal directory
                                 if (file_type == CARTA::UNKNOWN) {
                                     add_directory = true;
@@ -187,7 +187,7 @@ void FileListHandler::GetFileList(CARTA::FileListResponse& file_list_response, c
 
                         if (cc_file.isDirectory(true) && cc_file.isExecutable()) {
                             // Determine if image or directory for image list
-                            file_type = GuessImageDirectoryType(full_path, filter_mode == CARTA::Content);
+                            file_type = GuessImageDirectoryType(full_path);
 
                             if (file_type == CARTA::UNKNOWN) {
                                 // This is a normal directory

--- a/src/Main/ProgramSettings.cc
+++ b/src/Main/ProgramSettings.cc
@@ -12,16 +12,15 @@
 #include <spdlog/fmt/fmt.h>
 #include <cxxopts/cxxopts.hpp>
 
-#include <casacore/images/Images/ImageOpener.h>
-
 #include "Util/App.h"
+#include "Util/File.h"
 
 using json = nlohmann::json;
 
 namespace carta {
 
 template <class T>
-void applyOptionalArgument(T& val, const string& argument_name, const cxxopts::ParseResult& results) {
+void applyOptionalArgument(T& val, const std::string& argument_name, const cxxopts::ParseResult& results) {
     if (results.count(argument_name)) {
         val = results[argument_name].as<T>();
     }
@@ -163,7 +162,7 @@ void ProgramSettings::SetSettingsFromJSON(const json& j) {
 }
 
 void ProgramSettings::ApplyCommandLineSettings(int argc, char** argv) {
-    std::vector<string> positional_arguments;
+    std::vector<std::string> positional_arguments;
 
     cxxopts::Options options("carta", "Cube Analysis and Rendering Tool for Astronomy");
     // clang-format off
@@ -178,20 +177,20 @@ void ProgramSettings::ApplyCommandLineSettings(int argc, char** argv) {
         ("log_protocol_messages", "enable protocol message debug logs", cxxopts::value<bool>())
         ("no_frontend", "disable built-in HTTP frontend interface", cxxopts::value<bool>())
         ("no_database", "disable built-in HTTP database interface", cxxopts::value<bool>())
-        ("http_url_prefix", "custom URL prefix for HTTP server", cxxopts::value<string>(), "")
+        ("http_url_prefix", "custom URL prefix for HTTP server", cxxopts::value<std::string>(), "")
         ("no_browser", "don't open the frontend URL in a browser on startup", cxxopts::value<bool>())
-        ("browser", "custom browser command", cxxopts::value<string>(), "<browser>")
-        ("host", "only listen on the specified interface (IP address or hostname)", cxxopts::value<string>(), "<interface>")
+        ("browser", "custom browser command", cxxopts::value<std::string>(), "<browser>")
+        ("host", "only listen on the specified interface (IP address or hostname)", cxxopts::value<std::string>(), "<interface>")
         ("p,port", fmt::format("manually set the HTTP and WebSocket port (default: {} or nearest available port)", DEFAULT_SOCKET_PORT), cxxopts::value<std::vector<int>>(), "<port>")
         ("t,omp_threads", "manually set OpenMP thread pool count", cxxopts::value<int>(), "<threads>")
-        ("top_level_folder", "set top-level folder for data files", cxxopts::value<string>(), "<dir>")
-        ("frontend_folder", "set folder from which frontend files are served", cxxopts::value<string>(), "<dir>")
+        ("top_level_folder", "set top-level folder for data files", cxxopts::value<std::string>(), "<dir>")
+        ("frontend_folder", "set folder from which frontend files are served", cxxopts::value<std::string>(), "<dir>")
         ("exit_timeout", "number of seconds to stay alive after last session exits", cxxopts::value<int>(), "<sec>")
         ("initial_timeout", "number of seconds to stay alive at start if no clients connect", cxxopts::value<int>(), "<sec>")
         ("idle_timeout", "number of seconds to keep idle sessions alive", cxxopts::value<int>(), "<sec>")
         ("read_only_mode", "disable write requests", cxxopts::value<bool>())
         ("enable_scripting", "enable HTTP scripting interface", cxxopts::value<bool>())
-        ("files", "files to load", cxxopts::value<std::vector<string>>(positional_arguments))
+        ("files", "files to load", cxxopts::value<std::vector<std::string>>(positional_arguments))
         ("no_user_config", "ignore user configuration file", cxxopts::value<bool>())
         ("no_system_config", "ignore system configuration file", cxxopts::value<bool>());
 
@@ -200,8 +199,8 @@ void ProgramSettings::ApplyCommandLineSettings(int argc, char** argv) {
         ("no_runtime_config", "do not send a runtime config object to frontend clients", cxxopts::value<bool>())
         ("controller_deployment", "used when the backend is launched by carta-controller", cxxopts::value<bool>())
         ("threads", "[deprecated] manually set number of event processing threads (no longer supported)", cxxopts::value<int>(), "<threads>")
-        ("base", "[deprecated] set starting folder for data files (use the positional parameter instead)", cxxopts::value<string>(), "<dir>")
-        ("root", "[deprecated] use 'top_level_folder' instead", cxxopts::value<string>(), "<dir>")
+        ("base", "[deprecated] set starting folder for data files (use the positional parameter instead)", cxxopts::value<std::string>(), "<dir>")
+        ("root", "[deprecated] use 'top_level_folder' instead", cxxopts::value<std::string>(), "<dir>")
         ("no_http", "[deprecated] disable built-in HTTP frontend and database interfaces (use 'no_frontend' and/or 'no_database' instead)", cxxopts::value<bool>());
     // clang-format on
 
@@ -335,10 +334,8 @@ global configuration files, respectively.
         std::error_code error_code;
         if (fs::exists(p, error_code)) {
             if (fs::is_directory(p, error_code)) {
-                auto image_type = casacore::ImageOpener::imageType(p.string());
-                if (image_type == casacore::ImageOpener::AIPSPP || image_type == casacore::ImageOpener::MIRIAD ||
-                    image_type == casacore::ImageOpener::IMAGECONCAT || image_type == casacore::ImageOpener::IMAGEEXPR ||
-                    image_type == casacore::ImageOpener::COMPLISTIMAGE) {
+                auto image_type = GuessImageDirectoryType(p.string());
+                if (image_type != CARTA::UNKNOWN) {
                     file_paths.push_back(p);
                 } else {
                     starting_folder = p.string();

--- a/src/Util/File.cc
+++ b/src/Util/File.cc
@@ -9,6 +9,7 @@
 #include <spdlog/fmt/fmt.h>
 #include <fstream>
 
+#include "Casacore.h"
 #include "String.h"
 
 uint32_t GetMagicNumber(const std::string& filename) {
@@ -95,6 +96,38 @@ CARTA::FileType GuessImageType(const std::string& path_string, bool check_conten
             return CARTA::FITS;
         } else if (HasSuffix(filename, ".hdf5")) {
             return CARTA::HDF5;
+        }
+    }
+
+    return CARTA::UNKNOWN;
+}
+
+CARTA::FileType GuessImageDirectoryType(const std::string& path_string, bool check_content) {
+    if (check_content) {
+        // Guess file type using casacore::ImageOpener
+        auto image_type = CasacoreImageType(path_string);
+
+        switch (image_type) {
+            case casacore::ImageOpener::AIPSPP:
+            case casacore::ImageOpener::IMAGECONCAT:
+            case casacore::ImageOpener::IMAGEEXPR:
+            case casacore::ImageOpener::COMPLISTIMAGE:
+                return CARTA::CASA;
+            case casacore::ImageOpener::MIRIAD:
+                return CARTA::MIRIAD;
+            default:
+                return CARTA::UNKNOWN;
+        }
+    } else {
+        // Guess file type by checking for files inside directory
+        fs::path dir(path_string);
+
+        if (fs::exists(dir / "table.info") || fs::exists(dir / "imageconcat.json") || fs::exists(dir / "imageexpr.json")) {
+            return CARTA::CASA;
+        }
+
+        if (fs::exists(dir / "image") && fs::exists(dir / "header")) {
+            return CARTA::MIRIAD;
         }
     }
 

--- a/src/Util/File.cc
+++ b/src/Util/File.cc
@@ -10,7 +10,6 @@
 #include <fstream>
 #include <regex>
 
-#include "Casacore.h"
 #include "String.h"
 
 uint32_t GetMagicNumber(const std::string& filename) {

--- a/src/Util/File.cc
+++ b/src/Util/File.cc
@@ -108,33 +108,16 @@ CARTA::FileType GuessImageType(const std::string& path_string, bool check_conten
     return CARTA::UNKNOWN;
 }
 
-CARTA::FileType GuessImageDirectoryType(const std::string& path_string, bool check_content) {
-    if (check_content) {
-        // Guess file type using casacore::ImageOpener
-        auto image_type = CasacoreImageType(path_string);
+CARTA::FileType GuessImageDirectoryType(const std::string& path_string) {
+    // Guess file type by checking for files inside directory
+    fs::path dir(path_string);
 
-        switch (image_type) {
-            case casacore::ImageOpener::AIPSPP:
-            case casacore::ImageOpener::IMAGECONCAT:
-            case casacore::ImageOpener::IMAGEEXPR:
-            case casacore::ImageOpener::COMPLISTIMAGE:
-                return CARTA::CASA;
-            case casacore::ImageOpener::MIRIAD:
-                return CARTA::MIRIAD;
-            default:
-                return CARTA::UNKNOWN;
-        }
-    } else {
-        // Guess file type by checking for files inside directory
-        fs::path dir(path_string);
+    if (fs::exists(dir / "table.info") || fs::exists(dir / "imageconcat.json") || fs::exists(dir / "imageexpr.json")) {
+        return CARTA::CASA;
+    }
 
-        if (fs::exists(dir / "table.info") || fs::exists(dir / "imageconcat.json") || fs::exists(dir / "imageexpr.json")) {
-            return CARTA::CASA;
-        }
-
-        if (fs::exists(dir / "image") && fs::exists(dir / "header")) {
-            return CARTA::MIRIAD;
-        }
+    if (fs::exists(dir / "image") && fs::exists(dir / "header")) {
+        return CARTA::MIRIAD;
     }
 
     return CARTA::UNKNOWN;

--- a/src/Util/File.h
+++ b/src/Util/File.h
@@ -25,6 +25,7 @@
 #define TEMP_FILE_ID -100
 
 CARTA::FileType GuessImageType(const std::string& path_string, bool check_content);
+CARTA::FileType GuessImageDirectoryType(const std::string& path_string, bool check_content);
 CARTA::FileType GuessRegionType(const std::string& path_string, bool check_content);
 CARTA::CatalogFileType GuessTableType(const std::string& path_string, bool check_content);
 

--- a/src/Util/File.h
+++ b/src/Util/File.h
@@ -25,7 +25,7 @@
 #define TEMP_FILE_ID -100
 
 CARTA::FileType GuessImageType(const std::string& path_string, bool check_content);
-CARTA::FileType GuessImageDirectoryType(const std::string& path_string, bool check_content);
+CARTA::FileType GuessImageDirectoryType(const std::string& path_string);
 CARTA::FileType GuessRegionType(const std::string& path_string, bool check_content);
 CARTA::CatalogFileType GuessTableType(const std::string& path_string, bool check_content);
 


### PR DESCRIPTION
This is an attempt to improve the performance of generating a file list for directories with lots of subdirectories. The main performance bottlenecks in the current code are:

1. Checking whether a directory is a known image format, and should be treated as a file,
2. Counting the children of a subdirectory.

There are three options for displaying file lists: filtering by content, filtering by file extension, and no filtering. Filtering by content additionally slows down the file list generation because it reads the signature of each ordinary file to determine the type. Guessing the type from the file extension speeds up the processing of ordinary files, but not subdirectories, which are always checked with casacore's `ImageOpener`. Turning off filtering entirely has no additional performance impact on the image file list (because detection of directory-based images is still required), but speeds up the region file list (because if no filtering is required, all directories can be shown without additional checks).

This PR is an attempt to add a less expensive heuristic for directory-based images, to be used when the option to filter by content is not selected. It performs almost the same checks as `ImageOpener`, but only for directories, by looking for files inside the directory with `fs::exists`, and without distinguishing between different CASA image subtypes.

The existing code assumes that there are directory image formats which we do not support, and handles them differently. However, it's clear from the `ImageOpener` code that the GIPSY format is a pair of files, not a directory (so `ImageOpener` would never return that type for a directory), and the `CAIPS` and `NEWSTAR` types are obsolete and never returned by `ImageOpener` (at all). So I have removed this option from the code, and not implemented it in the alternative code.

The result: the alternative code appears to be slightly faster, but I don't know if it's faster enough for it to make sense to add it as an alternative to the casacore code. If this implementation is sufficient for our purposes (e.g. we don't need to read the `table.info` file because we don't need do distinguish between CASA sub-types here), then perhaps we should *replace* the casacore check with this (for a modest speed improvement in all cases).

Other optimizations we discussed:

* Not counting subdirectory children
* Disabling directory type-checking entirely (if not filtering by content?), and changing the frontend UI to fetch the type information when a directory is clicked on
* Progressively requesting info for batches of directories as the user scrolls (this would require a more substantial redesign, with ICD changes)

I think we're planning to use the last option as our long-term solution, and I would suggest applying that strategy to all files: instead of loading file information up-front when generating the file list, we could initially return *just* a bare list of files and directories, and then return information for lists of files *and* directories as the frontend requests them.

**Checklist**

- [ ] changelog updated / no changelog update needed
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [X] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [X] ~protobuf version bumped~ / protobuf version not bumped
- [X] added reviewers and assignee
- [ ] GitHub Project estimate added
