### PR TITLE
Fix matched polygon region approximation crash

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -31,7 +31,7 @@ jobs:
       # TODO temporary workaround for https://github.com/actions/runner-images/issues/9491
       - name: Reduce ASLR entropy
         run: |
-          sudo sysctl -w vm.mmap_rnd_bits=28
+          sysctl -w vm.mmap_rnd_bits=28
 
       - name: Build backend
         shell: bash

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -28,11 +28,6 @@ jobs:
           uname -a
           lsb_release -a
 
-      # TODO temporary workaround for https://github.com/actions/runner-images/issues/9491
-      - name: Reduce ASLR entropy
-        run: |
-          sysctl -w vm.mmap_rnd_bits=28
-
       - name: Build backend
         shell: bash
         run: |

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -28,6 +28,11 @@ jobs:
           uname -a
           lsb_release -a
 
+      # TODO temporary workaround for https://github.com/actions/runner-images/issues/9491
+      - name: Reduce ASLR entropy
+        run: |
+          sudo sysctl -w vm.mmap_rnd_bits=28
+
       - name: Build backend
         shell: bash
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix crash when parsing FITS header long value ([#1366](https://github.com/CARTAvis/carta-backend/issues/1366)).
 * Fix incorrect parsing of SPECSYS value for ATCA FITS header ([#1375](https://github.com/CARTAvis/carta-backend/issues/1375)).
 * Fix hdf5 image distortion after animation stops ([#1368](https://github.com/CARTAvis/carta-backend/issues/1368)).
+* Fix matched polygon region approximation crash ([#1383](https://github.com/CARTAvis/carta-backend/issues/1383)).
 
 ### Changed
 * Move the loader cache to separate files ([#1021](https://github.com/CARTAvis/carta-backend/issues/1021)).

--- a/src/Region/RegionConverter.cc
+++ b/src/Region/RegionConverter.cc
@@ -440,8 +440,9 @@ std::shared_ptr<casacore::LCRegion> RegionConverter::GetAppliedPolygonRegion(
                 return lc_region;
             }
 
-            if (has_distortion) {
-                // if ~horizontal then remove intermediate points to fix "kinks" in mask
+            // If short segment with only starting point, do not fix.
+            if (has_distortion && segment_x.size() > 1) {
+                // If ~horizontal segment, remove intermediate points to fix "kinks" in mask.
                 RemoveHorizontalPolygonPoints(segment_x, segment_y);
             }
 

--- a/test/TestRegionMatched.cc
+++ b/test/TestRegionMatched.cc
@@ -169,7 +169,7 @@ TEST_F(RegionMatchedTest, TestMatchedImagePolygonLCRegion) {
     ASSERT_EQ(lc_region->latticeShape(), image_shape);
     ASSERT_EQ(lc_region->shape(), casacore::IPosition(2, 5, 6));
 
-    // Set polygon with very short segment
+    // Set polygon with very short segment which is does not have points added in matched region approximation.
     region_id = -1;
     std::vector<float> points2 = {5.0, 5.0, 4.0, 3.0, 4.0, 3.01, 1.0, 6.0, 3.0, 8.0};
     ok = SetRegion(region_handler, file_id0, region_id, region_type, points2, rotation, csys0);

--- a/test/TestRegionMatched.cc
+++ b/test/TestRegionMatched.cc
@@ -147,27 +147,38 @@ TEST_F(RegionMatchedTest, TestMatchedImagePolygonLCRegion) {
 
     // Set region in frame0
     carta::RegionHandler region_handler;
-    int file_id(0), region_id(-1);
+    int file_id0(0), region_id(-1);
     CARTA::RegionType region_type = CARTA::RegionType::POLYGON;
     std::vector<float> points = {5.0, 5.0, 4.0, 3.0, 1.0, 6.0, 3.0, 8.0};
     float rotation(0.0);
-    auto csys = frame0->CoordinateSystem();
-    bool ok = SetRegion(region_handler, file_id, region_id, region_type, points, rotation, csys);
+    auto csys0 = frame0->CoordinateSystem();
+    bool ok = SetRegion(region_handler, file_id0, region_id, region_type, points, rotation, csys0);
     ASSERT_TRUE(ok);
     auto region = region_handler.GetRegion(region_id);
     ASSERT_TRUE(region); // shared_ptr<Region>
 
     // Get Region as 2D LCRegion in frame1
-    file_id = 1;
-    csys = frame1->CoordinateSystem();
+    int file_id1(1);
+    auto csys1 = frame1->CoordinateSystem();
     auto image_shape = frame1->ImageShape();
-    auto lc_region = region->GetImageRegion(file_id, csys, image_shape);
+    auto lc_region = region->GetImageRegion(file_id1, csys1, image_shape);
 
     // Check LCRegion
     ASSERT_TRUE(lc_region); // shared_ptr<casacore::LCRegion>
     ASSERT_EQ(lc_region->ndim(), image_shape.size());
     ASSERT_EQ(lc_region->latticeShape(), image_shape);
     ASSERT_EQ(lc_region->shape(), casacore::IPosition(2, 5, 6));
+
+    // Set polygon with very short segment
+    region_id = -1;
+    std::vector<float> points2 = {5.0, 5.0, 4.0, 3.0, 4.0, 3.01, 1.0, 6.0, 3.0, 8.0};
+    ok = SetRegion(region_handler, file_id0, region_id, region_type, points2, rotation, csys0);
+    ASSERT_TRUE(ok);
+    region = region_handler.GetRegion(region_id);
+    ASSERT_TRUE(region); // shared_ptr<Region>
+    // Get Region as 2D LCRegion in frame1
+    lc_region = region->GetImageRegion(file_id1, csys1, image_shape);
+    ASSERT_TRUE(lc_region); // shared_ptr<casacore::LCRegion>
 }
 
 TEST_F(RegionMatchedTest, TestMatchedImagePointRecord) {


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
Fixes #1383 and duplicate issue #1384

* How does this PR solve the issue? Give a brief summary.
To approximate a polygon region in a matched region, the polygon is reinvented with many points between the original polygon points to prevent distortion in the conversion.  But when the original polygon has a very short segment, the matched segment may not add any points and consists of  just the starting point.  The segmentation fault resulted due to invalid indexing which assumed at least two points when checking for "kinks" introduced in a matched horizontal segment.  In this fix, these one-point segments are no longer checked.  Added a RegionMatchedTest which causes a seg fault in dev but passes in this branch.
  
* Are there any companion PRs (frontend, protobuf)?
No

* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
Try to get stats or spectral profile for a matched polygon with a very short segment between points,  < 1/1000th of the original polygon length (the new backend test uses a polygon with only 5 points).  The analysis should complete successfully and not crash the backend.

**Checklist**

- [x] changelog updated / ~no changelog update needed~
- [x] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~protobuf version bumped~ / protobuf version not bumped
- [x] added reviewers and assignee
- [ ] GitHub Project estimate added
