### PR TITLE
Set rest frequency in moment generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 * Support PV image generation along a polyline region ([#1341](https://github.com/CARTAvis/carta-backend/issues/1341)).
+* Support setting rest frequency for moment image generation ([#1385](https://github.com/CARTAvis/carta-backend/issues/1385)).
 
 ### Fixed
 * Fixed crash when loading non-image HDU by URL ([#1365](https://github.com/CARTAvis/carta-backend/issues/1365)).

--- a/src/ImageGenerators/MomentGenerator.h
+++ b/src/ImageGenerators/MomentGenerator.h
@@ -51,7 +51,9 @@ private:
     void SetMomentAxis(const CARTA::MomentRequest& moment_request);
     void SetMomentTypes(const CARTA::MomentRequest& moment_request);
     void SetPixelRange(const CARTA::MomentRequest& moment_request);
+    void SetRestFrequency(const CARTA::MomentRequest& moment_request);
     void ResetImageMoments(const casacore::ImageRegion& image_region);
+    void SetImageRestFrequency(double rest_frequency);
     int GetMomentMode(CARTA::Moment moment);
     casacore::String GetMomentSuffix(casacore::Int moment);
     casacore::String GetInputFileName();
@@ -72,6 +74,7 @@ private:
     int _axis;                                // Moment axis
     casacore::Vector<float> _include_pix;
     casacore::Vector<float> _exclude_pix;
+    double _rest_frequency; // Hz
     casacore::String _error_msg;
     bool _success;
     bool _cancel;


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
Closes #1385 

* How does this PR solve the issue? Give a brief summary.
Set MomentRequest rest frequency in MomentGenerator image coordinate system, then restore image rest freq after moment images created.

* Are there any companion PRs (frontend, protobuf)?
 CARTAvis/carta-frontend#2404 + CARTAvis/carta-protobuf#98

* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
Rest frequency will be added to Moment dialog in frontend.

**Checklist**

- [x] changelog updated / ~no changelog update needed~
- [x] e2e test passing / corresponding fix added / new e2e test created
- [x] ICD test passing / corresponding fix added / new ICD test created
- [x] protobuf updated to the latest dev commit / ~no protobuf update needed~
- [x] protobuf minor version bumped / ~protobuf version not bumped~
- [x] added reviewers and assignee
- [ ] GitHub Project estimate added
