### PR TITLE
Bumped version of image generator to fix tests on Jammy

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -28,11 +28,6 @@ jobs:
           uname -a
           lsb_release -a
 
-      # TODO temporary workaround for https://github.com/actions/runner-images/issues/9491
-      - name: Reduce ASLR entropy
-        run: |
-          sysctl -w vm.mmap_rnd_bits=28
-
       - name: Build backend
         shell: bash
         run: |

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -28,6 +28,11 @@ jobs:
           uname -a
           lsb_release -a
 
+      # TODO temporary workaround for https://github.com/actions/runner-images/issues/9491
+      - name: Reduce ASLR entropy
+        run: |
+          sysctl -w vm.mmap_rnd_bits=28
+
       - name: Build backend
         shell: bash
         run: |


### PR DESCRIPTION
**Description**

This PR bumps the version of the external image generator to the latest version, which fixes a deprecation issue that breaks unit tests on Ubuntu 22.04. Only unit tests are affected.

**Checklist**

- [X] ~changelog updated~ / no changelog update needed
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [X] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [X] ~protobuf version bumped~ / protobuf version not bumped
- [ ] added reviewers and assignee
- [ ] ~GitHub Project estimate added~
