### PR TITLE
Minor refactoring of polarization values and defaults in the slicer function 

### DIFF
--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -2320,8 +2320,8 @@ casacore::Slicer Frame::GetExportRegionSlicer(const CARTA::SaveFile& save_file_m
 bool Frame::GetStokesTypeIndex(const string& coordinate, int& stokes_index) {
     // Coordinate could be profile (x, y, z), stokes string (I, Q, U), or combination (Ix, Qy)
 
-    if (coordinate == 'x' || coordinate == 'y' || coordinate == 'z') {
-        // Profile only; use current Stokes
+    if (coordinate.empty() || coordinate == 'x' || coordinate == 'y' || coordinate == 'z') {
+        // Profile only or blank; use current Stokes
         stokes_index = CurrentStokes();
         return true;
     }

--- a/src/Frame/Frame.h
+++ b/src/Frame/Frame.h
@@ -75,12 +75,6 @@ static std::unordered_map<CARTA::FileType, string> FileTypeString{{CARTA::FileTy
     {CARTA::FileType::DS9_REG, "DS9"}, {CARTA::FileType::FITS, "FITS"}, {CARTA::FileType::HDF5, "HDF5"},
     {CARTA::FileType::MIRIAD, "MIRIAD"}, {CARTA::FileType::UNKNOWN, "Unknown"}};
 
-static std::unordered_map<CARTA::PolarizationType, std::string> ComputedStokesName{
-    {CARTA::PolarizationType::Ptotal, "Total polarization intensity"}, {CARTA::PolarizationType::Plinear, "Linear polarization intensity"},
-    {CARTA::PolarizationType::PFtotal, "Fractional total polarization intensity"},
-    {CARTA::PolarizationType::PFlinear, "Fractional linear polarization intensity"},
-    {CARTA::PolarizationType::Pangle, "Polarization angle"}};
-
 class Frame {
 public:
     // Load image cache for default_z, except for PV preview image which needs cube
@@ -286,6 +280,7 @@ protected:
     int _spectral_axis, _stokes_axis;
     int _z_index, _stokes_index; // current index
     size_t _width, _height, _depth, _num_stokes;
+    AxisRange _all_x, _all_y, _all_z;
 
     // Image settings
     CARTA::AddRequiredTiles _required_animation_tiles;

--- a/src/ImageData/FileInfo.h
+++ b/src/ImageData/FileInfo.h
@@ -14,7 +14,6 @@
 #include <casacore/images/Images/SubImage.h>
 
 #include <carta-protobuf/defs.pb.h>
-//#include <carta-protobuf/enums.pb.h>
 
 namespace carta {
 namespace FileInfo {
@@ -120,19 +119,6 @@ inline casacore::uInt GetFitsHdu(const std::string& hdu) {
         cc_hdu.fromString(hdu_num, true);
     }
     return hdu_num;
-}
-
-// convert between CARTA::PolarizationType values and FITS standard stokes values
-static bool ConvertFitsStokesValue(const int& in_stokes_value, int& out_stokes_value) {
-    if (in_stokes_value >= 1 && in_stokes_value <= 4) {
-        out_stokes_value = in_stokes_value;
-        return true;
-    } else if ((in_stokes_value >= 4 && in_stokes_value <= 12) || (in_stokes_value <= -1 && in_stokes_value >= -8)) {
-        // convert between [5, 6, ..., 12] and [-1, -2, ..., -8]
-        out_stokes_value = -in_stokes_value + 4;
-        return true;
-    }
-    return false;
 }
 
 } // namespace FileInfo

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -310,7 +310,7 @@ bool FileLoader::FindCoordinateAxes(casacore::IPosition& shape, std::vector<int>
         for (int i = 0; i < _num_stokes; ++i) {
             int stokes_fits_value = _stokes_crval + (i + 1 - _stokes_crpix) * _stokes_cdelt;
             int stokes_value;
-            if (FileInfo::ConvertFitsStokesValue(stokes_fits_value, stokes_value)) {
+            if (Stokes::ConvertFits(stokes_fits_value, stokes_value)) {
                 auto stokes_type = static_cast<CARTA::PolarizationType>(stokes_value);
                 _stokes_indices[stokes_type] = i;
                 _stokes_types[i] = stokes_type;

--- a/src/ImageData/FileLoader.h
+++ b/src/ImageData/FileLoader.h
@@ -121,6 +121,7 @@ public:
     virtual void SetStokesCrpix(float stokes_crpix);
     virtual void SetStokesCdelt(int stokes_cdelt);
     virtual bool GetStokesTypeIndex(const CARTA::PolarizationType& stokes_type, int& stokes_index);
+    virtual bool GetStokesType(const int& stokes_index, CARTA::PolarizationType& stokes_type);
     std::unordered_map<CARTA::PolarizationType, int> GetStokesIndices() {
         return _stokes_indices;
     };
@@ -180,6 +181,7 @@ protected:
 
     // Storage for the stokes type vs. stokes index
     std::unordered_map<CARTA::PolarizationType, int> _stokes_indices;
+    std::unordered_map<int, CARTA::PolarizationType> _stokes_types;
     float _stokes_crval;
     float _stokes_crpix;
     int _stokes_cdelt;

--- a/src/ImageData/StokesFilesConnector.cc
+++ b/src/ImageData/StokesFilesConnector.cc
@@ -252,7 +252,7 @@ bool StokesFilesConnector::OpenStokesFiles(const CARTA::ConcatStokesFiles& messa
         for (int i = 0; i < message.stokes_files_size(); ++i) {
             int new_stokes_value = message.stokes_files(i).polarization_type();
             int new_stokes_fits_value;
-            if (FileInfo::ConvertFitsStokesValue(new_stokes_value, new_stokes_fits_value)) {
+            if (Stokes::ConvertFits(new_stokes_value, new_stokes_fits_value)) {
                 if (stokes_fits_value != 0) {
                     if (delt == 0) {
                         delt = new_stokes_fits_value - stokes_fits_value;
@@ -311,7 +311,7 @@ bool StokesFilesConnector::StokesFilesValid(std::string& err, int& stokes_axis) 
 bool StokesFilesConnector::GetCasaStokesType(
     const CARTA::PolarizationType& in_stokes_type, casacore::Stokes::StokesTypes& out_stokes_type) {
     if (!Stokes::IsComputed(in_stokes_type)) {
-        out_stokes_type = Stokes::ToCasacore(in_stokes_type);
+        out_stokes_type = Stokes::ToCasa(in_stokes_type);
         return true;
     }
     return false;

--- a/src/ImageData/StokesFilesConnector.h
+++ b/src/ImageData/StokesFilesConnector.h
@@ -31,7 +31,7 @@ private:
 
     std::string _top_level_folder;
     std::string _concatenated_name;
-    std::unordered_map<CARTA::PolarizationType, std::unique_ptr<FileLoader>> _loaders;
+    std::map<CARTA::PolarizationType, std::unique_ptr<FileLoader>> _loaders;
 };
 
 } // namespace carta

--- a/src/ImageGenerators/PvGenerator.cc
+++ b/src/ImageGenerators/PvGenerator.cc
@@ -151,7 +151,7 @@ casacore::CoordinateSystem PvGenerator::GetPvCoordinateSystem(const std::shared_
 
     // Add stokes coordinate if input image has one
     if (input_csys->hasPolarizationCoordinate()) {
-        auto casacore_stokes_type = Stokes::ToCasacore(Stokes::Get(stokes));
+        auto casacore_stokes_type = Stokes::ToCasa(Stokes::Get(stokes));
         casacore::Vector<casacore::Int> types(1, casacore_stokes_type);
         casacore::StokesCoordinate stokes_coord(types);
         pv_csys.addCoordinate(stokes_coord);

--- a/src/ImageGenerators/PvGenerator.cc
+++ b/src/ImageGenerators/PvGenerator.cc
@@ -151,7 +151,7 @@ casacore::CoordinateSystem PvGenerator::GetPvCoordinateSystem(const std::shared_
 
     // Add stokes coordinate if input image has one
     if (input_csys->hasPolarizationCoordinate()) {
-        auto casacore_stokes_type = StokesTypesToCasacore[stokes];
+        auto casacore_stokes_type = Stokes::ToCasacore(Stokes::Get(stokes));
         casacore::Vector<casacore::Int> types(1, casacore_stokes_type);
         casacore::StokesCoordinate stokes_coord(types);
         pv_csys.addCoordinate(stokes_coord);

--- a/src/Region/RegionHandler.cc
+++ b/src/Region/RegionHandler.cc
@@ -1918,7 +1918,7 @@ bool RegionHandler::GetRegionSpectralData(int region_id, int file_id, const Axis
                         get_stokes_profiles_data(tmp_results, tmp_stokes));
             };
 
-            if (IsComputedStokes(stokes_index)) { // For computed stokes
+            if (Stokes::IsComputed(stokes_index)) { // For computed stokes
                 if (!GetComputedStokesProfiles(results, stokes_index, get_profiles_data)) {
                     return false;
                 }
@@ -1970,7 +1970,7 @@ bool RegionHandler::GetRegionSpectralData(int region_id, int file_id, const Axis
                 };
 
                 ProfilesMap partial_profiles;
-                if (IsComputedStokes(stokes_index)) { // For computed stokes
+                if (Stokes::IsComputed(stokes_index)) { // For computed stokes
                     if (!GetComputedStokesProfiles(partial_profiles, stokes_index, get_profiles_data)) {
                         return false;
                     }
@@ -2019,7 +2019,7 @@ bool RegionHandler::GetRegionSpectralData(int region_id, int file_id, const Axis
     int dt_target = TARGET_DELTA_TIME; // the target time elapse for each step, in the unit of milliseconds
     auto t_partial_profile_start = std::chrono::high_resolution_clock::now();
 
-    if (IsComputedStokes(stokes_index)) { // Need to re-calculate the lattice coordinate region for computed stokes index
+    if (Stokes::IsComputed(stokes_index)) { // Need to re-calculate the lattice coordinate region for computed stokes index
         lc_region = nullptr;
     }
 
@@ -2048,7 +2048,7 @@ bool RegionHandler::GetRegionSpectralData(int region_id, int file_id, const Axis
         };
 
         ProfilesMap partial_profiles;
-        if (IsComputedStokes(stokes_index)) { // For computed stokes
+        if (Stokes::IsComputed(stokes_index)) { // For computed stokes
             if (!GetComputedStokesProfiles(partial_profiles, stokes_index, get_profiles_data)) {
                 return false;
             }
@@ -2732,28 +2732,28 @@ bool RegionHandler::IsValid(double a, double b) {
 bool RegionHandler::GetComputedStokesProfiles(
     ProfilesMap& profiles, int stokes, const std::function<bool(ProfilesMap&, std::string)>& get_profiles_data) {
     ProfilesMap profile_i, profile_q, profile_u, profile_v;
-    if (stokes == COMPUTE_STOKES_PTOTAL) {
+    if (stokes == CARTA::PolarizationType::Ptotal) {
         if (!get_profiles_data(profile_q, "Qz") || !get_profiles_data(profile_u, "Uz") || !get_profiles_data(profile_v, "Vz")) {
             return false;
         }
         GetStokesPtotal(profile_q, profile_u, profile_v, profiles);
-    } else if (stokes == COMPUTE_STOKES_PFTOTAL) {
+    } else if (stokes == CARTA::PolarizationType::PFtotal) {
         if (!get_profiles_data(profile_i, "Iz") || !get_profiles_data(profile_q, "Qz") || !get_profiles_data(profile_u, "Uz") ||
             !get_profiles_data(profile_v, "Vz")) {
             return false;
         }
         GetStokesPftotal(profile_i, profile_q, profile_u, profile_v, profiles);
-    } else if (stokes == COMPUTE_STOKES_PLINEAR) {
+    } else if (stokes == CARTA::PolarizationType::Plinear) {
         if (!get_profiles_data(profile_q, "Qz") || !get_profiles_data(profile_u, "Uz")) {
             return false;
         }
         GetStokesPlinear(profile_q, profile_u, profiles);
-    } else if (stokes == COMPUTE_STOKES_PFLINEAR) {
+    } else if (stokes == CARTA::PolarizationType::PFlinear) {
         if (!get_profiles_data(profile_i, "Iz") || !get_profiles_data(profile_q, "Qz") || !get_profiles_data(profile_u, "Uz")) {
             return false;
         }
         GetStokesPflinear(profile_i, profile_q, profile_u, profiles);
-    } else if (stokes == COMPUTE_STOKES_PANGLE) {
+    } else if (stokes == CARTA::PolarizationType::Pangle) {
         if (!get_profiles_data(profile_q, "Qz") || !get_profiles_data(profile_u, "Uz")) {
             return false;
         }

--- a/src/Util/Stokes.cc
+++ b/src/Util/Stokes.cc
@@ -6,26 +6,59 @@
 
 #include "Stokes.h"
 
-int GetStokesValue(const CARTA::PolarizationType& stokes_type) {
-    int stokes_value(-1);
-    if (StokesValues.count(stokes_type)) {
-        stokes_value = StokesValues[stokes_type];
+using namespace carta;
+
+std::unordered_map<CARTA::PolarizationType, casacore::Stokes::StokesTypes> Stokes::_to_casacore{
+    {CARTA::PolarizationType::POLARIZATION_TYPE_NONE, casacore::Stokes::StokesTypes::Undefined},
+    {CARTA::PolarizationType::I, casacore::Stokes::StokesTypes::I}, {CARTA::PolarizationType::Q, casacore::Stokes::StokesTypes::Q},
+    {CARTA::PolarizationType::U, casacore::Stokes::StokesTypes::U}, {CARTA::PolarizationType::V, casacore::Stokes::StokesTypes::V},
+    {CARTA::PolarizationType::RR, casacore::Stokes::StokesTypes::RR}, {CARTA::PolarizationType::LL, casacore::Stokes::StokesTypes::LL},
+    {CARTA::PolarizationType::RL, casacore::Stokes::StokesTypes::RL}, {CARTA::PolarizationType::LR, casacore::Stokes::StokesTypes::LR},
+    {CARTA::PolarizationType::XX, casacore::Stokes::StokesTypes::XX}, {CARTA::PolarizationType::YY, casacore::Stokes::StokesTypes::YY},
+    {CARTA::PolarizationType::XY, casacore::Stokes::StokesTypes::XY}, {CARTA::PolarizationType::YX, casacore::Stokes::StokesTypes::YX},
+    {CARTA::PolarizationType::Ptotal, casacore::Stokes::StokesTypes::Ptotal},
+    {CARTA::PolarizationType::Plinear, casacore::Stokes::StokesTypes::Plinear},
+    {CARTA::PolarizationType::PFtotal, casacore::Stokes::StokesTypes::PFtotal},
+    {CARTA::PolarizationType::PFlinear, casacore::Stokes::StokesTypes::PFlinear},
+    {CARTA::PolarizationType::Pangle, casacore::Stokes::StokesTypes::Pangle}};
+
+std::unordered_map<CARTA::PolarizationType, std::string> Stokes::_description{{CARTA::PolarizationType::POLARIZATION_TYPE_NONE, "Unknown"},
+    {CARTA::PolarizationType::I, "Stokes I"}, {CARTA::PolarizationType::Q, "Stokes Q"}, {CARTA::PolarizationType::U, "Stokes U"},
+    {CARTA::PolarizationType::V, "Stokes V"}, {CARTA::PolarizationType::Ptotal, "Total polarization intensity"},
+    {CARTA::PolarizationType::Plinear, "Linear polarization intensity"},
+    {CARTA::PolarizationType::PFtotal, "Fractional total polarization intensity"},
+    {CARTA::PolarizationType::PFlinear, "Fractional linear polarization intensity"},
+    {CARTA::PolarizationType::Pangle, "Polarization angle"}};
+
+CARTA::PolarizationType Stokes::Get(int value) {
+    if (CARTA::PolarizationType_IsValid(value)) {
+        return static_cast<CARTA::PolarizationType>(value);
     }
-    return stokes_value;
+    return CARTA::PolarizationType::POLARIZATION_TYPE_NONE;
 }
 
-CARTA::PolarizationType GetStokesType(int stokes_value) {
-    CARTA::PolarizationType stokes_type = CARTA::PolarizationType::POLARIZATION_TYPE_NONE;
-    if (StokesTypes.count(stokes_value)) {
-        stokes_type = StokesTypes[stokes_value];
+CARTA::PolarizationType Stokes::Get(std::string name) {
+    auto type = CARTA::PolarizationType::POLARIZATION_TYPE_NONE;
+    CARTA::PolarizationType_Parse(name, &type);
+    return type;
+}
+
+casacore::Stokes::StokesTypes Stokes::ToCasacore(CARTA::PolarizationType type) {
+    return _to_casacore.at(type);
+}
+
+std::string Stokes::Name(CARTA::PolarizationType type) {
+    return CARTA::PolarizationType_Name(type);
+}
+
+std::string Stokes::Description(CARTA::PolarizationType type) {
+    try {
+        return _description.at(type);
+    } catch (const std::out_of_range& e) {
+        return CARTA::PolarizationType_Name(type);
     }
-    return stokes_type;
 }
 
-bool IsComputedStokes(int stokes) {
-    return ((stokes >= COMPUTE_STOKES_PTOTAL) && (stokes <= COMPUTE_STOKES_PANGLE));
-}
-
-bool IsComputedStokes(const std::string& stokes) {
-    return IsComputedStokes(StokesValues[StokesStringTypes[stokes]]);
+bool Stokes::IsComputed(int value) {
+    return (value >= CARTA::PolarizationType::Ptotal) && (value <= CARTA::PolarizationType::Pangle);
 }

--- a/src/Util/Stokes.cc
+++ b/src/Util/Stokes.cc
@@ -8,7 +8,7 @@
 
 using namespace carta;
 
-std::unordered_map<CARTA::PolarizationType, casacore::Stokes::StokesTypes> Stokes::_to_casacore{
+std::unordered_map<CARTA::PolarizationType, casacore::Stokes::StokesTypes> Stokes::_to_casa{
     {CARTA::PolarizationType::POLARIZATION_TYPE_NONE, casacore::Stokes::StokesTypes::Undefined},
     {CARTA::PolarizationType::I, casacore::Stokes::StokesTypes::I}, {CARTA::PolarizationType::Q, casacore::Stokes::StokesTypes::Q},
     {CARTA::PolarizationType::U, casacore::Stokes::StokesTypes::U}, {CARTA::PolarizationType::V, casacore::Stokes::StokesTypes::V},
@@ -43,8 +43,20 @@ CARTA::PolarizationType Stokes::Get(std::string name) {
     return type;
 }
 
-casacore::Stokes::StokesTypes Stokes::ToCasacore(CARTA::PolarizationType type) {
-    return _to_casacore.at(type);
+casacore::Stokes::StokesTypes Stokes::ToCasa(CARTA::PolarizationType type) {
+    return _to_casa.at(type);
+}
+
+bool Stokes::ConvertFits(const int& in_stokes_value, int& out_stokes_value) {
+    if (in_stokes_value >= 1 && in_stokes_value <= 4) {
+        out_stokes_value = in_stokes_value;
+        return true;
+    } else if ((in_stokes_value >= 4 && in_stokes_value <= 12) || (in_stokes_value <= -1 && in_stokes_value >= -8)) {
+        // convert between [5, 6, ..., 12] and [-1, -2, ..., -8]
+        out_stokes_value = -in_stokes_value + 4;
+        return true;
+    }
+    return false;
 }
 
 std::string Stokes::Name(CARTA::PolarizationType type) {

--- a/src/Util/Stokes.h
+++ b/src/Util/Stokes.h
@@ -21,14 +21,15 @@ class Stokes {
 public:
     static CARTA::PolarizationType Get(int value);
     static CARTA::PolarizationType Get(std::string name);
-    static casacore::Stokes::StokesTypes ToCasacore(CARTA::PolarizationType type);
+    static casacore::Stokes::StokesTypes ToCasa(CARTA::PolarizationType type);
+    static bool ConvertFits(const int& in_stokes_value, int& out_stokes_value);
     static std::string Name(CARTA::PolarizationType type);
     static std::string Description(CARTA::PolarizationType type);
     static bool IsComputed(int value);
 
     // TODO move FITS mappings here too
 protected:
-    static std::unordered_map<CARTA::PolarizationType, casacore::Stokes::StokesTypes> _to_casacore;
+    static std::unordered_map<CARTA::PolarizationType, casacore::Stokes::StokesTypes> _to_casa;
     static std::unordered_map<CARTA::PolarizationType, std::string> _description;
 };
 

--- a/test/TestExprImage.cc
+++ b/test/TestExprImage.cc
@@ -11,6 +11,8 @@
 #include "ImageData/FileLoader.h"
 #include "Logger/Logger.h"
 
+using namespace carta;
+
 class ImageExprTest : public ::testing::Test {
 public:
     void GenerateImageExprTimesTwo(const std::string& file_name, const std::string& hdu, CARTA::FileType file_type, bool invalid = false) {


### PR DESCRIPTION
**Description**

This is a set of refactoring changes:

* Removing redundant lookups of integers with same integer enums
* Using correct protobuf function to cast integers to integer enums
* General cleanup of polarization values (descriptions; CASA and FITS conversion...)
* Replacing unnecessarily complex and inefficient ordering of small unordered maps with polarization keys (these can just be ordered maps)
* Precalculating fixed ranges for full X, Y and Z and using the X and Y ranges as defaults to GetImageSlicer instead of using a placeholder default which has to be checked and possibly replaced whenever the function is called
* Reimplementing functions for mapping polarization index to polarization value and vice versa

**Checklist**

- [X] ~changelog updated~ / no changelog update needed
- [x] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [X] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [X] ~protobuf version bumped~ / protobuf version not bumped
- [X] added reviewers and assignee
- [ ] GitHub Project estimate added
