### PR TITLE
Bumped ICD version

### DIFF
--- a/src/Util/Message.h
+++ b/src/Util/Message.h
@@ -47,7 +47,7 @@
 #include "ImageStats/Histogram.h"
 
 namespace carta {
-const uint16_t ICD_VERSION = 28;
+const uint16_t ICD_VERSION = 29;
 struct EventHeader {
     uint16_t type;
     uint16_t icd_version;


### PR DESCRIPTION
**Description**

The ICD version is lagging behind the actual major version in latest carta-protobuf.

**Checklist**

- [X] ~changelog updated~ / no changelog update needed
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [X] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [X] protobuf version bumped / ~protobuf version not bumped~
- [X] added reviewers and assignee
- [ ] GitHub Project estimate added
