### PR TITLE
Fix top directory in file browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix matched polygon region approximation crash ([#1383](https://github.com/CARTAvis/carta-backend/issues/1383)).
 * Fix save image/export regions bug which could cause directory overwrite or deletion ([#1377](https://github.com/CARTAvis/carta-backend/issues/1377)).
 * Fix bug in cache slicer transformation which affects some images with rotated axes ([#1389](https://github.com/CARTAvis/carta-backend/pull/1389)).
+* Fix bug accessing top (root) folder of file browser ([#2354](https://github.com/CARTAvis/carta-frontend/issues/2354)).
 
 ### Changed
 * Move the loader cache to separate files ([#1021](https://github.com/CARTAvis/carta-backend/issues/1021)).

--- a/src/Util/Casacore.cc
+++ b/src/Util/Casacore.cc
@@ -103,34 +103,41 @@ casacore::String GetResolvedFilename(const string& root_dir, const string& direc
     // (absolute pathname with symlinks resolved)
     casacore::String resolved_filename;
     casacore::Path path(root_dir);
-    path.append(directory);
-    casacore::File cc_directory(path);
+    if (directory != ".") {
+        path.append(directory);
+    }
+    casacore::File cc_file(path);
 
-    if (!cc_directory.exists()) {
+    // Check directory for error messages
+    if (!cc_file.exists()) {
         message = "Directory " + directory + " does not exist.";
-    } else if (!cc_directory.isReadable()) {
+    } else if (!cc_file.isReadable()) {
         message = "Directory " + directory + " is not readable.";
     } else {
+        // Check file
         path.append(file);
-        casacore::File cc_file(path);
-
+        cc_file = casacore::File(path);
         if (!cc_file.exists()) {
             message = "File " + file + " does not exist.";
         } else if (!cc_file.isReadable()) {
             message = "File " + file + " is not readable.";
         } else {
             try {
-                resolved_filename = cc_file.path().resolvedName();
+                resolved_filename = path.resolvedName();
             } catch (const casacore::AipsError& err) {
                 try {
-                    resolved_filename = cc_file.path().absoluteName();
+                    resolved_filename = path.absoluteName();
+                    // Workaround for casacore parsing bug when path is "/"
+                    if (resolved_filename.empty()) {
+                        resolved_filename = path.originalName();
+                    }
                 } catch (const casacore::AipsError& err) {
-                    // return empty string
                     message = "Cannot resolve file path.";
                 }
             }
         }
     }
+
     return resolved_filename;
 }
 

--- a/src/Util/Casacore.cc
+++ b/src/Util/Casacore.cc
@@ -6,6 +6,7 @@
 
 #include "Casacore.h"
 
+#include <casacore/casa/Arrays/ArrayUtil.h>
 #include <casacore/casa/OS/File.h>
 #include <casacore/casa/Quanta/UnitMap.h>
 
@@ -99,16 +100,14 @@ bool IsSubdirectory(string folder, string top_folder) {
 }
 
 casacore::String GetResolvedFilename(const string& root_dir, const string& directory, const string& file, string& message) {
-    // Given directory (relative to root folder) and file, return resolved path and filename
-    // (absolute pathname with symlinks resolved)
+    // Given directory (relative to root directory) and file, return resolved file path.
+    // Check if file path exists and is readable.
     casacore::String resolved_filename;
     casacore::Path path(root_dir);
-    if (directory != ".") {
-        path.append(directory);
-    }
+    path.append(directory);
     casacore::File cc_file(path);
 
-    // Check directory for error messages
+    // Check directory
     if (!cc_file.exists()) {
         message = "Directory " + directory + " does not exist.";
     } else if (!cc_file.isReadable()) {
@@ -125,14 +124,12 @@ casacore::String GetResolvedFilename(const string& root_dir, const string& direc
             try {
                 resolved_filename = path.resolvedName();
             } catch (const casacore::AipsError& err) {
-                try {
-                    resolved_filename = path.absoluteName();
-                    // Workaround for casacore parsing bug when path is "/"
-                    if (resolved_filename.empty()) {
-                        resolved_filename = path.originalName();
-                    }
-                } catch (const casacore::AipsError& err) {
-                    message = "Cannot resolve file path.";
+                // resolvedName() calls absoluteName(), which returns an empty path due to parsing bug to remove dots (., ..) from path,
+                // resulting in AipsError. Workaround just sets expanded name used for exists() and isReadable().
+                if (path.absoluteName().empty()) {
+                    resolved_filename = path.expandedName();
+                } else {
+                    message = err.getMesg();
                 }
             }
         }

--- a/src/Util/Casacore.cc
+++ b/src/Util/Casacore.cc
@@ -6,7 +6,6 @@
 
 #include "Casacore.h"
 
-#include <casacore/casa/Arrays/ArrayUtil.h>
 #include <casacore/casa/OS/File.h>
 #include <casacore/casa/Quanta/UnitMap.h>
 

--- a/test/TestFileList.cc
+++ b/test/TestFileList.cc
@@ -47,6 +47,22 @@ public:
             }
         }
     }
+
+    void TestFileListSubdirectories(const std::string& top_level_folder, const std::string& starting_folder,
+        const CARTA::FileListRequest& request, bool expected_success = true) {
+        std::shared_ptr<FileListHandler> file_list_handler = std::make_shared<FileListHandler>(top_level_folder, starting_folder);
+        CARTA::FileListResponse response;
+        FileListHandler::ResultMsg result_msg;
+        file_list_handler->OnFileListRequest(request, response, result_msg);
+
+        EXPECT_EQ(response.success(), expected_success);
+        if (!response.success()) {
+            return;
+        }
+        // Expect no image files, non-zero subdirectories
+        EXPECT_EQ(response.files_size(), 0);
+        EXPECT_GT(response.subdirectories_size(), 0);
+    }
 };
 
 TEST_F(FileListTest, SetTopLevelFolder) {
@@ -64,6 +80,11 @@ TEST_F(FileListTest, SetTopLevelFolder) {
 
     auto request4 = Message::FileListRequest(".");
     TestFileList(abs_path, "", request4);
+
+    // Request file list for default top folder "/"
+    // 0 image files, > 0 subdirectories
+    auto request5 = Message::FileListRequest("");
+    TestFileListSubdirectories("/", "", request5);
 }
 
 TEST_F(FileListTest, SetStartingFolder) {


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
Fixes CARTAvis/carta-backend#1394

* How does this PR solve the issue? Give a brief summary.
casacore::Path cannot resolve "/" or "/." to absolute path due to parsing error.  Instead, use casacore::Path::expandedName() which is used for casacore::File::exists() and casacore::File::isReadable().

* Are there any companion PRs (frontend, protobuf)?
No

* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
Open file browser and click the top directory of breadcrumbs, which is the root directory.  A file list should appear instead of an error.

**Checklist**

- [x] changelog updated / ~no changelog update needed~
- [x] e2e test passing / ~corresponding fix added~ / ~new e2e test created~
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~protobuf version bumped~ / protobuf version not bumped
- [x] added reviewers and assignee
- [ ] GitHub Project estimate added
