### PR TITLE
Specify older clang-format version in format check

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -9,9 +9,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install clang-format 14
-        run: |
-          sudo apt-get update
-          sudo apt-get install clang-format-14
+        run: sudo apt-get install clang-format-14
       - name: Run format check
         run: ./scripts/style.py --clang-format clang-format-14 all check
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -6,8 +6,14 @@ jobs:
   format-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - run: ./scripts/style.py --clang-format clang-format-14 all check
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install clang-format 14
+        run: |
+          sudo apt-get update
+          sudo apt-get install clang-format-14
+      - name: Run format check
+        run: ./scripts/style.py --clang-format clang-format-14 all check
 
 
   Ubuntu-Focal:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: ./scripts/style.py all check
+      - run: ./scripts/style.py --clang-format clang-format-14 all check
 
 
   Ubuntu-Focal:

--- a/scripts/style.py
+++ b/scripts/style.py
@@ -247,7 +247,7 @@ class HeaderGuards(Test):
                     cls.out("Can't find header guard in", filename)
                     cls.out("Fixing...")
 
-                    data = re.sub("(/\*.*?\*/\n)", rf"\1\n#ifndef {new_guard_name}\n#define {new_guard_name}\n", data, count=1, flags=re.DOTALL)
+                    data = re.sub(r"(/\*.*?\*/\n)", rf"\1\n#ifndef {new_guard_name}\n#define {new_guard_name}\n", data, count=1, flags=re.DOTALL)
                     data = re.sub(r"\n$", rf"\n{new_endif}\n", data)
                     data_changed = True
 


### PR DESCRIPTION
This is a minor change to the CI, to specify a known working clang-format version. It looks like the latest Ubuntu image has changed, and the default clang-format is too new.

I also fixed a syntax warning in newer versions of Python, triggered by the usage of a non-raw string with an invalid escape sequence in one of the regexes.