### PR TITLE
Prevent segfault in casacore log sink destructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix save image/export regions bug which could cause directory overwrite or deletion ([#1377](https://github.com/CARTAvis/carta-backend/issues/1377)).
 * Fix bug in cache slicer transformation which affects some images with rotated axes ([#1389](https://github.com/CARTAvis/carta-backend/pull/1389)).
 * Fix bug accessing top (root) folder of file browser ([#2354](https://github.com/CARTAvis/carta-frontend/issues/2354)).
+* Fix segfault after early exit ([#1382](https://github.com/CARTAvis/carta-backend/issues/1382)).
 
 ### Changed
 * Move the loader cache to separate files ([#1021](https://github.com/CARTAvis/carta-backend/issues/1021)).

--- a/src/Main/Main.cc
+++ b/src/Main/Main.cc
@@ -74,9 +74,8 @@ int main(int argc, char* argv[]) {
             default:
                 carta_log_sink = new CartaLogSink(casacore::LogMessage::NORMAL);
         }
-        casacore::LogSink log_sink(carta_log_sink->filter(), std::shared_ptr<casacore::LogSinkInterface>(carta_log_sink));
         casacore::LogSink::globalSink(carta_log_sink);
-        casacore::LogIO casacore_log(log_sink);
+        casacore::LogIO casacore_log;
 
         if (settings.wait_time >= 0) {
             Session::SetExitTimeout(settings.wait_time);

--- a/src/Main/Main.cc
+++ b/src/Main/Main.cc
@@ -75,7 +75,6 @@ int main(int argc, char* argv[]) {
                 carta_log_sink = new CartaLogSink(casacore::LogMessage::NORMAL);
         }
         casacore::LogSink::globalSink(carta_log_sink);
-        casacore::LogIO casacore_log;
 
         if (settings.wait_time >= 0) {
             Session::SetExitTimeout(settings.wait_time);


### PR DESCRIPTION
**Description**

This fixes #1382. Testing is required to check if this is still doing the correct thing with casacore logs.

The segfault happens in the shared pointer destructor called from the `casacore::LogSink` destructor. I believe that this is because the shared pointer's underlying pointer is zeroed by `casacore::LogSink::globalSink` when it is used to set the global sink. This PR bypasses this issue by not reusing the same raw pointer both to set the global sink and to create a `LogSink` object which the `LogIO` object is then attached to. Instead, it uses the default `LogIO` constructor, which should attach the object to the global sink, which should be set to the correct sink.

I tested this locally and it appears that the casacore messages are still being formatted correctly in the output, but I'm not 100% familiar with the way that this logging model is supposed to work.

If there is no regression, I think that this PR is low-risk enough to be included in the freeze, but I'm creating it as a draft first just in case.

**Checklist**

- [X] changelog updated / ~no changelog update needed~
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [X] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [X] ~protobuf version bumped~ / protobuf version not bumped
- [X] added reviewers and assignee
- [ ] GitHub Project estimate added
