### PR TITLE
Clip rounded profile start to end after clipping rounded end to width / height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix save image/export regions bug which could cause directory overwrite or deletion ([#1377](https://github.com/CARTAvis/carta-backend/issues/1377)).
 * Fix bug in cache slicer transformation which affects some images with rotated axes ([#1389](https://github.com/CARTAvis/carta-backend/pull/1389)).
 * Fix bug accessing top (root) folder of file browser ([#2354](https://github.com/CARTAvis/carta-frontend/issues/2354)).
+* Fix crash when spatially matching two images ([#1395](https://github.com/CARTAvis/carta-backend/issues/1395)).
 
 ### Changed
 * Move the loader cache to separate files ([#1021](https://github.com/CARTAvis/carta-backend/issues/1021)).

--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -1194,6 +1194,7 @@ bool Frame::FillSpatialProfileData(PointXy point, std::vector<CARTA::SetSpatialR
                     start = decimated_start * mip;
                     end = decimated_end * mip;
                     end = config.coordinate().back() == 'x' ? std::min(end, _width) : std::min(end, _height);
+                    start = std::min(start, end);
                 }
 
                 if (is_current_stokes) {


### PR DESCRIPTION
**Description**

This should fix #1395.

I believe that this bug is triggered by the spatially matched images being non-overlapping, which leads to a profile sometimes being requested from the large image with both endpoints being the largest y value (i.e. 999 to 999). When the image is zoomed out and a large mip is used, the endpoints are rounded for decimation (from 999 to 1000). The _end_ is then restricted to the height of the image (999), but we did not consider the possibility that the _start_ value could be equal to the end and thus _also_ need to be adjusted in the same way here.

This PR adds a line to restrict the start so that it does not exceed the end.

In my local test (on Ubuntu), the crash was happening in `profile.reserve(end - start);`. I'm not 100% sure if @crocka's crash on the Mac (a value being too large to fit in a `size_t`) was happening in exactly the same place, but it's likely to have had the same root cause (a negative number being incorrectly converted to an unsigned type).

If you cannot reproduce the crash in `dev`, try reducing the area available for the image viewer component (e.g. by opening the browser console in the window). It's only triggered when the mip is high enough (and I believe when your cursor is in the appropriate area of the image).

If there is no regression, I think this is a low-risk addition.

**Checklist**

- [X] changelog updated / ~no changelog update needed~
- [x] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [X] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [X] ~protobuf version bumped~ / protobuf version not bumped
- [X] added reviewers and assignee
- [ ] GitHub Project estimate added
