### PR TITLE
Fix handling of HTTP headers with underscores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+* Fix empty response to HTTP request with underscores in header names ([#1406](https://github.com/CARTAvis/carta-backend/issues/1406))
+
 ## [5.0.0-beta.1]
 
 ### Added

--- a/third-party/install/uWebSockets.cmake
+++ b/third-party/install/uWebSockets.cmake
@@ -42,7 +42,7 @@ macro(install_uWebSockets)
 
     FetchContent_Declare(
             uWebSockets-build
-            URL https://github.com/uNetworking/uWebSockets/archive/refs/tags/v20.46.0.zip
+            URL https://github.com/uNetworking/uWebSockets/archive/refs/tags/v20.74.0.zip
             SOURCE_DIR ${UWEBSOCKETS_SOURCE_DIR}
     )
 


### PR DESCRIPTION
**Description**

This fixes #1406 by updating the uWebSockets dependency to the latest version.

**Checklist**

- [X] changelog updated / ~no changelog update needed~
- [x] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [X] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [X] ~protobuf version bumped~ / protobuf version not bumped
- [X] added reviewers and assignee
- [ ] GitHub Project estimate added
