### PR TITLE
Fix the coverage badge and dependencies in README.md

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -107,15 +107,15 @@ jobs:
       - name: Store coverage badge in gh-storage branch
         shell: bash
         run: |
-          set -x
           git config --global user.email "backend.ci@github.action"
           git config --global user.name "Backend CI"
           git add badge-coverage.svg
           git stash
           git fetch origin gh-storage
           git checkout gh-storage
+          git pull
           git checkout stash@{0} -- badge-coverage.svg
-          git diff --staged --quiet || { git commit -m "Updated coverage" && git pull && git push; }
+          git diff --staged --quiet || { git commit -m "Updated coverage" && git push; }
 
 
   macOS-12:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -111,6 +111,7 @@ jobs:
           git config --global user.name "Backend CI"
           git add badge-coverage.svg
           git stash
+          git fetch origin gh-storage
           git checkout gh-storage
           git checkout stash@{0} -- badge-coverage.svg
           git diff --staged --quiet || { git commit -m "Updated coverage" && git pull && git push }

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -107,8 +107,12 @@ jobs:
       - name: Store coverage badge in gh-storage branch
         shell: bash
         run: |
-          pwd
-          ls
+          git add badge-coverage.svg
+          git stash
+          git switch --orphan gh-storage || git checkout gh-storage
+          git checkout stash@{0} -- badge-coverage.svg
+          git diff --staged --quiet || { git commit -m "Updated coverage" && { git push || git push --set-upstream origin gh-storage; } }
+
 
   macOS-12:
     runs-on: [self-hosted, macOS-12-M1]

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -111,9 +111,9 @@ jobs:
           git config --global user.name "Backend CI"
           git add badge-coverage.svg
           git stash
-          git switch --orphan gh-storage || git checkout gh-storage
+          git checkout gh-storage
           git checkout stash@{0} -- badge-coverage.svg
-          git diff --staged --quiet || { git commit -m "Updated coverage" && { git push || git push --set-upstream origin gh-storage; } }
+          git diff --staged --quiet || { git commit -m "Updated coverage" && git pull && git push }
 
 
   macOS-12:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -100,7 +100,7 @@ jobs:
           path: code-coverage-results.md
 
       - name: Download and store coverage badge when pushing to dev
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
         shell: bash
         run: |
           head -n1 code-coverage-results.md | grep -Po 'https.*(?=\))' | wget -i - -O badge-coverage.svg
@@ -108,7 +108,6 @@ jobs:
           git config --global user.name "Backend CI"
           git add badge-coverage.svg
           lastcommit=`git log -1 --pretty=format:"%h %s"`
-          echo "DEBUG: ${lastcommit}"
           git stash
           git checkout gh-storage
           git pull

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -107,6 +107,8 @@ jobs:
       - name: Store coverage badge in gh-storage branch
         shell: bash
         run: |
+          git config --global user.email "backend.ci@github.action"
+          git config --global user.name "Backend CI"
           git add badge-coverage.svg
           git stash
           git switch --orphan gh-storage || git checkout gh-storage

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -107,6 +107,7 @@ jobs:
       - name: Store coverage badge in gh-storage branch
         shell: bash
         run: |
+          set -x
           git config --global user.email "backend.ci@github.action"
           git config --global user.name "Backend CI"
           git add badge-coverage.svg

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -105,10 +105,10 @@ jobs:
           head -n1 code-coverage-results.md | grep -Po 'https.*(?=\))' | wget -i - -O badge-coverage.svg
 
       - name: Store coverage badge in gh-storage branch
-        uses: sylvanld/action-storage@v1
-        with:
-          src: badge-coverage.svg
-          dst: badge-coverage.svg
+        shell: bash
+        run: |
+          pwd
+          ls
 
   macOS-12:
     runs-on: [self-hosted, macOS-12-M1]

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -97,6 +97,7 @@ jobs:
         if: github.event_name == 'pull_request'
         with:
           recreate: true
+          skip_unchanged: true
           path: code-coverage-results.md
 
       - name: Download and store coverage badge when pushing to dev

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -100,18 +100,20 @@ jobs:
           path: code-coverage-results.md
 
       - name: Download and store coverage badge when pushing to dev
-        if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+        if: github.event_name == 'push'
         shell: bash
         run: |
           head -n1 code-coverage-results.md | grep -Po 'https.*(?=\))' | wget -i - -O badge-coverage.svg
           git config --global user.email "backend.ci@github.action"
           git config --global user.name "Backend CI"
           git add badge-coverage.svg
+          lastcommit=`git log -1 --pretty=format:"%h %s"`
+          echo "DEBUG: ${lastcommit}"
           git stash
           git checkout gh-storage
           git pull
           git checkout stash@{0} -- badge-coverage.svg
-          git diff --staged --quiet || { git commit -m "Updated coverage" && git push; }
+          git diff --staged --quiet || { git commit -m "Updated coverage @ ${lastcommit}" && git push; }
 
 
   macOS-12:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -99,19 +99,14 @@ jobs:
           recreate: true
           path: code-coverage-results.md
 
-      - name: Download coverage badge
+      - name: Download and store coverage badge when pushing to dev
         shell: bash
         run: |
           head -n1 code-coverage-results.md | grep -Po 'https.*(?=\))' | wget -i - -O badge-coverage.svg
-
-      - name: Store coverage badge in gh-storage branch
-        shell: bash
-        run: |
           git config --global user.email "backend.ci@github.action"
           git config --global user.name "Backend CI"
           git add badge-coverage.svg
           git stash
-          git fetch origin gh-storage
           git checkout gh-storage
           git pull
           git checkout stash@{0} -- badge-coverage.svg

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -100,6 +100,7 @@ jobs:
           path: code-coverage-results.md
 
       - name: Download and store coverage badge when pushing to dev
+        if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
         shell: bash
         run: |
           head -n1 code-coverage-results.md | grep -Po 'https.*(?=\))' | wget -i - -O badge-coverage.svg

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Download coverage badge
         shell: bash
         run: |
-          head -n1 test.md | grep -Po 'https.*(?=\))' | wget -i - -O badge-coverage.svg
+          head -n1 code-coverage-results.md | grep -Po 'https.*(?=\))' | wget -i - -O badge-coverage.svg
 
       - name: Store coverage badge in gh-storage branch
         uses: sylvanld/action-storage@v1

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -99,6 +99,17 @@ jobs:
           recreate: true
           path: code-coverage-results.md
 
+      - name: Download coverage badge
+        shell: bash
+        run: |
+          head -n1 test.md | grep -Po 'https.*(?=\))' | wget -i - -O badge-coverage.svg
+
+      - name: Store coverage badge in gh-storage branch
+        uses: sylvanld/action-storage@v1
+        with:
+          src: badge-coverage.svg
+          dst: badge-coverage.svg
+
   macOS-12:
     runs-on: [self-hosted, macOS-12-M1]
     needs: format-check

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -115,7 +115,7 @@ jobs:
           git fetch origin gh-storage
           git checkout gh-storage
           git checkout stash@{0} -- badge-coverage.svg
-          git diff --staged --quiet || { git commit -m "Updated coverage" && git pull && git push }
+          git diff --staged --quiet || { git commit -m "Updated coverage" && git pull && git push; }
 
 
   macOS-12:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@
 
 This is the backend component of the [Cube Analysis and Rendering Tool for Astronomy](https://cartavis.org/), a web-based application for viewing radio astronomy images in CASA, FITS, MIRIAD, and HDF5[^1] formats.
 
-In contrast to the conventional approach of rendering an image on the backend and sending a rendered image to the frontend client, the backend sends a compressed subset of the data, and the frontend renders the image efficiently on the GPU using WebGL and GLSL shaders. While the data is compressed using the lossy ZFP algorithm, the compression artefacts are generally much less noticeable than those cropping up from full-colour JPEG compression. While data sizes depend on the compression quality used, sizes are [comparable](https://docs.google.com/spreadsheets/d/1lp1687TL0bYmbM3jGyjuPd9dYZnrAYGnLIQXWVpnmS0/edit?usp=sharing) with sizes of compressed JPEG images with a 95% quality setting, depending on the colour map used to generate the JPEG image. PNG compression is generally a factor of 2 larger than the ZFP compressed data.
+Rather than rendering each image and sending it to the frontend client (which is the conventional approach), the backend sends a compressed subset of the data, and the frontend renders the image efficiently on the GPU using WebGL and GLSL shaders.
+
+Although the data is compressed with the lossy ZFP algorithm, the compression artefacts are generally much less noticeable than those produced by full-colour JPEG compression.
+
+While data sizes depend on compression quality, sizes are [comparable](https://docs.google.com/spreadsheets/d/1lp1687TL0bYmbM3jGyjuPd9dYZnrAYGnLIQXWVpnmS0/edit?usp=sharing) with sizes of compressed JPEG images with a 95% quality setting (depending on the colour map used to generate the JPEG image). PNG compression is generally a factor of 2 larger than the ZFP-compressed data.
 
 [^1] using the [custom IDIA schema](https://github.com/CARTAvis/fits2idia).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CARTA Image Viewer (Backend)
 
-![code coverage](https://img.shields.io/endpoint?style=plastic&url=https%3A%2F%2Fgist.githubusercontent.com%2Fajm-asiaa%2Fecad490776d42844903aeebf5e6d2173%2Fraw)
+![code coverage](https://raw.githubusercontent.com/CARTAvis/carta-backend/refs/heads/gh-storage/badge-coverage.svg)
 
 Backend process for simple web-based interface for viewing radio astronomy images in CASA, FITS, MIRIAD, and HDF5 formats (using the IDIA custom schema for HDF5). Unlike the conventional approach of rendering an image on the backend and sending a rendered image to the frontend client, the backend sends a compressed subset of the data, and the frontend renders the image efficiently on the GPU using WebGL and GLSL shaders. While the data is compressed using the lossy ZFP algorithm, the compression artefacts are generally much less noticeable than those cropping up from full-colour JPEG compression. While data sizes depend on compression quality used, sizes are [comparable](https://docs.google.com/spreadsheets/d/1lp1687TL0bYmbM3jGyjuPd9dYZnrAYGnLIQXWVpnmS0/edit?usp=sharing) with sizes of compressed JPEG images with a 95% quality setting, depending on the colour map used to generate the JPEG image. PNG compression is generally a factor of 2 larger than the ZFP compressed data.
 

--- a/README.md
+++ b/README.md
@@ -2,73 +2,113 @@
 
 ![code coverage](https://raw.githubusercontent.com/CARTAvis/carta-backend/refs/heads/gh-storage/badge-coverage.svg)
 
-Backend process for simple web-based interface for viewing radio astronomy images in CASA, FITS, MIRIAD, and HDF5 formats (using the IDIA custom schema for HDF5). Unlike the conventional approach of rendering an image on the backend and sending a rendered image to the frontend client, the backend sends a compressed subset of the data, and the frontend renders the image efficiently on the GPU using WebGL and GLSL shaders. While the data is compressed using the lossy ZFP algorithm, the compression artefacts are generally much less noticeable than those cropping up from full-colour JPEG compression. While data sizes depend on compression quality used, sizes are [comparable](https://docs.google.com/spreadsheets/d/1lp1687TL0bYmbM3jGyjuPd9dYZnrAYGnLIQXWVpnmS0/edit?usp=sharing) with sizes of compressed JPEG images with a 95% quality setting, depending on the colour map used to generate the JPEG image. PNG compression is generally a factor of 2 larger than the ZFP compressed data.
+This is the backend component of the [Cube Analysis and Rendering Tool for Astronomy](https://cartavis.org/), a web-based application for viewing radio astronomy images in CASA, FITS, MIRIAD, and HDF5[^1] formats.
 
-## Ubuntu packages
+In contrast to the conventional approach of rendering an image on the backend and sending a rendered image to the frontend client, the backend sends a compressed subset of the data, and the frontend renders the image efficiently on the GPU using WebGL and GLSL shaders. While the data is compressed using the lossy ZFP algorithm, the compression artefacts are generally much less noticeable than those cropping up from full-colour JPEG compression. While data sizes depend on the compression quality used, sizes are [comparable](https://docs.google.com/spreadsheets/d/1lp1687TL0bYmbM3jGyjuPd9dYZnrAYGnLIQXWVpnmS0/edit?usp=sharing) with sizes of compressed JPEG images with a 95% quality setting, depending on the colour map used to generate the JPEG image. PNG compression is generally a factor of 2 larger than the ZFP compressed data.
 
-We provide packages for Ubuntu 20.04 (Focal Fossa) and 18.04 (Bionic Beaver) in [a PPA](https://launchpad.net/~cartavis-team/+archive/ubuntu/carta) on Launchpad. All required dependencies are included in the PPA.
+[^1] using the [custom IDIA schema](https://github.com/CARTAvis/fits2idia).
 
-To add the PPA:
+# Installation
+
+## Linux packages
+
+We provide packages of the backend and all required dependencies for recent Ubuntu LTS releases and recent AlmaLinux releases. They should also work on equivalent distributions closely based on Ubuntu and on RHEL.
+
+If you would like to set up CARTA in a multi-user environment, we recommend installing the [CARTA controller](https://carta-controller.readthedocs.io).
+
+### Ubuntu
 
 ```shell
 sudo add-apt-repository ppa:cartavis-team/carta
 sudo apt-get update
-```
 
-To install the development version of the backend only (suitable for use with the CARTA controller):
-
-```shell
+# install the latest beta version of the backend only
+# (suitable for use with the CARTA controller)
 sudo apt-get install carta-backend-beta
-```
 
-To install the development version of the backend and frontend (suitable for a desktop install):
-
-```shell
+# OR install the latest beta version of the backend and frontend
+# (suitable for a desktop install)
 sudo apt-get install carta-beta
 ```
 
-The development package installs a launcher which allows CARTA to be started from the desktop environment's menu.
+The package installs a launcher which allows CARTA to be started from the desktop environment's menu.
 
-## Building from source
+### AlmaLinux (and equivalents)
+
+```shell
+sudo dnf install epel-release
+sudo dnf install 'dnf-command(copr)'
+sudo dnf copr enable cartavis/carta
+
+# install the latest beta version of the backend only
+# (suitable for use with the CARTA controller)
+sudo dnf install carta-backend-beta
+
+# OR install the latest beta version of the backend and frontend
+# (suitable for a desktop install)
+sudo dnf install carta-beta
+```
+
+## Building the development version from source
 
 ### Submodules
 
-The protocol buffer definitions for communication between the backend and frontend, and for communication between the scripting interface and the backend. [µWebSockets](https://github.com/uNetworking/uWebSockets), which builds on [µSockets](https://github.com/uNetworking/uSockets), is used to communicate with the frontend. In order to get the right version of µWebSockets and its dependency µSockets, together with the other two submodules, a git initialisation command must be applied as follows:
-```shell
-git submodule update --init --recursive
-```
+This repository includes several dependencies as submodules:
+* [The protocol buffer definitions](carta-protobuf) for communication between the backend and frontend.
+* [cxxopts](https://github.com/jarro2783/cxxopts) for parsing commandline options
+* [nlohmann/json](https://github.com/nlohmann/json) for parsing JSON
+* [pugixml](https://github.com/zeux/pugixml) for parsing XML
+* [spdlog](https://github.com/gabime/spdlog) for logging
+* [sse2neon](https://github.com/DLTcollab/sse2neon) for ARM support
+
+Two submodules are not required for building the main source:
+* [image-generator](https://github.com/idia-astro/image-generator) for creating FITS images (from the unit tests; soon to be deprecated)
+* [Doxygen Awesome](https://github.com/jothepro/doxygen-awesome-css), a Doxygen stylesheet (for generating the developer documentation)
+
+You can fetch the submodule contents when you clone the repository (`git clone --recurse-submodules https://github.com/CARTAvis/carta-backend.git`), or after cloning (`git submodule update --init --recursive` inside the directory).
 
 If you use `git pull` to update an existing checkout of this repository, make sure that you also use `git submodule update` to fetch the appropriate versions of the submodule code.
 
 ### External dependencies
 
-The backend build depends on the following libraries: 
-* [casacore and casa imageanalysis](https://github.com/CARTAvis/carta-casacore); follow the build instructions.
-* [zfp](https://github.com/LLNL/zfp) for data compression. The same library is used on the client, after being compiled to WebAssembly. Build and install from git repo. For best performance, build with AVX extensions.
-* [Zstd](https://github.com/facebook/zstd) for data compression. Debian package `libzstd-dev`.
-* [protobuf](https://developers.google.com/protocol-buffers) for client-side communication using specific message formats. Debian package `libprotobuf-dev` (> 3.0 required. Can use [PPA](https://launchpad.net/~maarten-fonville/+archive/ubuntu/protobuf) for earlier versions of Ubuntu). The Debian package `protobuf-compiler` may also be required.
-* [HDF5](https://support.hdfgroup.org/HDF5/) C++ library for HDF5 support. Debian packages `libhdf5-dev` and `libhdf5-cpp-100`. By default, the serial version of the HDF5 library is targeted.
-* [libuuid](https://linux.die.net/man/3/libuuid) for generating auth tokens (if not using external authentication). Debian package `uuid-dev`.
-* [cfitsio](https://heasarc.gsfc.nasa.gov/fitsio/) library for I/O with FITS format data files. Debian package: `libcfitsio-dev`.
-* [wcslib](https://www.gnu.org/software/gnuastro/manual/html_node/WCSLIB.html) library to handle world coordinate system. Debian package: `wcslib-dev`.
+The backend build depends on the following libraries (this is not an exhaustive list): 
+* [casacore + casa imageanalysis](https://github.com/CARTAvis/carta-casacore). We maintain a custom version of this library.
+* [zfp](https://github.com/LLNL/zfp) for data compression. The same library is used on the client, after being compiled to WebAssembly.[^1]
+* [Zstd](https://github.com/facebook/zstd) for data compression.
+* [protobuf](https://developers.google.com/protocol-buffers) for client-side communication using specific message formats.
+* [HDF5](https://support.hdfgroup.org/HDF5/) C++ library for HDF5 support.
+* [libuuid](https://linux.die.net/man/3/libuuid) for generating auth tokens (if not using external authentication).
+* [cfitsio](https://heasarc.gsfc.nasa.gov/fitsio/) library for I/O with FITS format data files.
+* [wcslib](https://www.gnu.org/software/gnuastro/manual/html_node/WCSLIB.html) library to handle world coordinate system.
+
+We recommend using our [Dockerfiles](Dockerfiles) as a guideline for installing these dependencies on RPM-based and Debian-based distributions. We provide packaged versions of dependencies missing from officially supported distributions.
+
+[^1]: If you build `zfp` from source, enable AVX extensions for the best performance.
 
 ### Build
 
-Use cmake to build:
+We use `cmake` to configure the build.
+
 ```shell
 mkdir build
 cd build
 cmake ..
-make
+make -j8
+```
+# Running the backend process
+
+Command-line arguments are in the format `--arg=value` or `--arg value`. By default, the backend will attempt to host frontend files from `../share/carta/frontend` (relative to the executable path). This can be changed with the `--frontend_folder` argument. Run `carta_backend --help` for a full list of options.
+
+Most options can also be set permanently in a user configuration file (`~/.carta/backend.json`, or `~/.carta-beta/backend.json` for our beta packages) or a global configuration file (`/etc/carta/backend.json`). For example:
+```json
+{
+    "$schema": "https://cartavis.github.io/schemas/preference_backend_schema_2.json",
+    "verbosity": 5,
+    "exit_timeout" : 0
+}
 ```
 
-For more detailed example commands for installing the dependencies and performing the build on specific Linux distributions, please refer to the provided [Dockerfiles](https://github.com/CARTAvis/carta-backend/tree/dev/Dockerfiles).
-
-## Running the backend process
-
-Command-line arguments are in the format `--arg=value` or `--arg value`. Run `carta_backend --help` for a list of options. By default, the backend will attempt to host frontend files from `../share/carta/frontend` (relative to the executable path). This can be changed with the `--frontend_folder` argument. Hosting of the frontend can be disabled with the `--no_http` argument. Token-based authentication can be disabled for debugging or development purposes with the `--debug_no_auth` argument.
-
-## Developer documentation
+# Developer documentation
 
 Automatically generated Doxygen documentation can be found at [cartavis.org/carta-backend](https://cartavis.org/carta-backend/).
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Two submodules are not required for building the main source:
 You can fetch the submodule contents when you clone the repository:
 ```shell
 git clone --recurse-submodules https://github.com/CARTAvis/carta-backend.git
-carta-backend
+cd carta-backend
 ```
 
 Alternatively, you can update them after cloning:

--- a/README.md
+++ b/README.md
@@ -10,11 +10,19 @@ In contrast to the conventional approach of rendering an image on the backend an
 
 # Installation
 
+If you are looking for releases of the CARTA application for desktop users, please refer to the [main website](https://cartavis.org/#download).
+
+If you would like to set up CARTA in a multi-user environment, we recommend installing the [CARTA controller](https://carta-controller.readthedocs.io). We provide detailed instructions for a complete deployment of all components on supported platforms.
+
+The rest of this document describes installation of **the backend component only** (for use with a separately installed frontend, or with the controller).
+
 ## Linux packages
 
 We provide packages of the backend and all required dependencies for recent Ubuntu LTS releases and recent AlmaLinux releases. They should also work on equivalent distributions closely based on Ubuntu and on RHEL.
 
-If you would like to set up CARTA in a multi-user environment, we recommend installing the [CARTA controller](https://carta-controller.readthedocs.io).
+The packages install a launcher which allows CARTA to be started from the desktop environment's menu.
+
+The beta package saves user configuration to `.carta-beta` rather than `.carta`.
 
 ### Ubuntu
 
@@ -23,15 +31,13 @@ sudo add-apt-repository ppa:cartavis-team/carta
 sudo apt-get update
 
 # install the latest beta version of the backend only
-# (suitable for use with the CARTA controller)
 sudo apt-get install carta-backend-beta
 
-# OR install the latest beta version of the backend and frontend
-# (suitable for a desktop install)
-sudo apt-get install carta-beta
+# OR install the latest stable release version of the backend only
+sudo apt-get install carta-backend
 ```
 
-The package installs a launcher which allows CARTA to be started from the desktop environment's menu.
+The beta and stable Ubuntu packages use the same install locations, and only one can be installed at a time.
 
 ### AlmaLinux (and equivalents)
 
@@ -41,17 +47,17 @@ sudo dnf install 'dnf-command(copr)'
 sudo dnf copr enable cartavis/carta
 
 # install the latest beta version of the backend only
-# (suitable for use with the CARTA controller)
 sudo dnf install carta-backend-beta
 
-# OR install the latest beta version of the backend and frontend
-# (suitable for a desktop install)
-sudo dnf install carta-beta
+# install the latest stable release version of the backend only
+sudo dnf install carta-backend
 ```
+
+The RPM beta package uses a custom install location in `/opt`, and can be installed in parallel with the stable package.
 
 ## Building the development version from source
 
-### Submodules
+### Obtaining the source
 
 This repository includes several dependencies as submodules:
 * [The protocol buffer definitions](carta-protobuf) for communication between the backend and frontend.
@@ -65,7 +71,18 @@ Two submodules are not required for building the main source:
 * [image-generator](https://github.com/idia-astro/image-generator) for creating FITS images (from the unit tests; soon to be deprecated)
 * [Doxygen Awesome](https://github.com/jothepro/doxygen-awesome-css), a Doxygen stylesheet (for generating the developer documentation)
 
-You can fetch the submodule contents when you clone the repository (`git clone --recurse-submodules https://github.com/CARTAvis/carta-backend.git`), or after cloning (`git submodule update --init --recursive` inside the directory).
+You can fetch the submodule contents when you clone the repository:
+```shell
+git clone --recurse-submodules https://github.com/CARTAvis/carta-backend.git
+carta-backend
+```
+
+Alternatively, you can update them after cloning:
+```shell
+git clone https://github.com/CARTAvis/carta-backend.git
+cd carta-backend
+git submodule update --init --recursive
+```
 
 If you use `git pull` to update an existing checkout of this repository, make sure that you also use `git submodule update` to fetch the appropriate versions of the submodule code.
 
@@ -95,7 +112,10 @@ cd build
 cmake ..
 make -j8
 ```
+
 # Running the backend process
+
+The packages provide a `carta` script which wraps the `carta_backend` executable. Both are available on the path. In the source build, the `carta_backend` executable can be found in the `build` directory.
 
 Command-line arguments are in the format `--arg=value` or `--arg value`. By default, the backend will attempt to host frontend files from `../share/carta/frontend` (relative to the executable path). This can be changed with the `--frontend_folder` argument. Run `carta_backend --help` for a full list of options.
 


### PR DESCRIPTION
**Description**

This PR fixes #1400.

1. The badge URL which we already have in the generated coverage report is parsed out of the report and downloaded, and the generated SVG file is stored in a dedicated `gh-storage` branch. The persistent path to this file can then be used in the README. This may be slightly overengineered for a single file, but we could potentially use this branch for persistent versioned storage of other assets.
2. It's unnecessary to mention `libhdf5-cpp-*` at all, because the `-dev` package will install it. But in any case we should not mention package names here, and link to the dockerfiles instead. I'm rewriting most of this README; a lot of it is incomplete or very outdated.

TODO:

- [X] Once the `gh-storage` branch exists, the fallback commands can be removed.
- [X] Badge update should only be triggered on pushes to dev, not on pull requests.
- [X] General README rewrite for accuracy and clarity

**Checklist**

- [X] ~changelog updated~ / no changelog update needed
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [X] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [X] ~protobuf version bumped~ / protobuf version not bumped
- [X] added reviewers and assignee
- [ ] GitHub Project estimate added
