### PR TITLE
Fix memory leak in closed PV and other images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * Fix empty response to HTTP request with underscores in header names ([#1406](https://github.com/CARTAvis/carta-backend/issues/1406))
+* Fix memory leak in Frame for PV and other images ([#1289](https://github.com/CARTAvis/carta-backend/issues/1289))
 
 ## [5.0.0-beta.1]
 

--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -38,6 +38,7 @@ Frame::Frame(uint32_t session_id, std::shared_ptr<FileLoader> loader, const std:
       _tile_cache(0),
       _z_index(default_z),
       _stokes_index(DEFAULT_STOKES),
+      _image_cache_size(0),
       _image_cache_valid(false),
       _tile_pool(std::make_shared<TilePool>()),
       _use_tile_cache(false),
@@ -388,8 +389,13 @@ bool Frame::FillImageCache() {
 
     Timer t;
     StokesSlicer stokes_slicer = GetImageSlicer(AxisRange(_z_index), _stokes_index);
-    _image_cache_size = stokes_slicer.slicer.length().product();
-    _image_cache = std::make_unique<float[]>(_image_cache_size);
+    auto frame_size = stokes_slicer.slicer.length().product();
+    if (frame_size != _image_cache_size) {
+        _image_cache.reset();
+        _image_cache_size = frame_size;
+        _image_cache = std::make_unique<float[]>(_image_cache_size);
+    }
+
     if (!GetSlicerData(stokes_slicer, _image_cache.get())) {
         spdlog::error("Session {}: {}", _session_id, "Loading image cache failed.");
         return false;

--- a/src/Frame/Frame.h
+++ b/src/Frame/Frame.h
@@ -81,7 +81,7 @@ public:
     // Load image cache for default_z, except for PV preview image which needs cube
     Frame(uint32_t session_id, std::shared_ptr<FileLoader> loader, const std::string& hdu, int default_z = DEFAULT_Z,
         bool load_image_cache = true);
-    ~Frame() {};
+    ~Frame(){};
 
     bool IsValid();
     std::string GetErrorMessage();

--- a/src/Frame/Frame.h
+++ b/src/Frame/Frame.h
@@ -83,7 +83,7 @@ public:
     ~Frame() {
         // unique_ptr deletes managed pointer but we need to delete array
         auto image_cache_ptr = _image_cache.release();
-        delete [] image_cache_ptr;
+        delete[] image_cache_ptr;
     }
 
     bool IsValid();

--- a/src/Frame/Frame.h
+++ b/src/Frame/Frame.h
@@ -28,6 +28,7 @@
 #include "ImageGenerators/MomentGenerator.h"
 #include "ImageStats/BasicStatsCalculator.h"
 #include "ImageStats/Histogram.h"
+#include "Logger/Logger.h"
 #include "Region/Region.h"
 #include "ThreadingManager/Concurrency.h"
 #include "Util/FileSystem.h"
@@ -80,11 +81,7 @@ public:
     // Load image cache for default_z, except for PV preview image which needs cube
     Frame(uint32_t session_id, std::shared_ptr<FileLoader> loader, const std::string& hdu, int default_z = DEFAULT_Z,
         bool load_image_cache = true);
-    ~Frame() {
-        // unique_ptr deletes managed pointer but we need to delete array
-        auto image_cache_ptr = _image_cache.release();
-        delete[] image_cache_ptr;
-    }
+    ~Frame() {};
 
     bool IsValid();
     std::string GetErrorMessage();

--- a/src/Frame/Frame.h
+++ b/src/Frame/Frame.h
@@ -80,7 +80,11 @@ public:
     // Load image cache for default_z, except for PV preview image which needs cube
     Frame(uint32_t session_id, std::shared_ptr<FileLoader> loader, const std::string& hdu, int default_z = DEFAULT_Z,
         bool load_image_cache = true);
-    ~Frame(){};
+    ~Frame() {
+        // unique_ptr deletes managed pointer but we need to delete array
+        auto image_cache_ptr = _image_cache.release();
+        delete [] image_cache_ptr;
+    }
 
     bool IsValid();
     std::string GetErrorMessage();

--- a/src/Frame/Frame.h
+++ b/src/Frame/Frame.h
@@ -28,7 +28,6 @@
 #include "ImageGenerators/MomentGenerator.h"
 #include "ImageStats/BasicStatsCalculator.h"
 #include "ImageStats/Histogram.h"
-#include "Logger/Logger.h"
 #include "Region/Region.h"
 #include "ThreadingManager/Concurrency.h"
 #include "Util/FileSystem.h"


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
Fixes #1289 .

* How does this PR solve the issue? Give a brief summary.
When an image is closed, the Frame holding it is deleted.  I used a debugger in the Frame destructor and noticed that for a unique_ptr it deleted the managed pointer (`delete __ptr;`).  But the _image_cache managed pointer is to an array of a size designated at construction with make_unique.  unique_ptr should delete this array when going out of scope, but deleting it manually (`delete[] image_cache_ptr;`) seems to have fixed the issue on macOS.  Since this fix is in Frame, it will be applied to all images opened in CARTA.

This is the psrecord plot for requesting 4 PV images on macOS 14 Sonoma (M1, clang 15.0.0):
![pv_mem](https://github.com/user-attachments/assets/d2abd7fd-49f8-46c4-8033-8ec660d4168c)

* Are there any companion PRs (frontend, protobuf)?
No

* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
Run psrecord while requesting a PV image multiple times.

**Checklist**

- [ ] changelog updated / ~no changelog update needed~
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [ ] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [ ] ~protobuf version bumped~ / protobuf version not bumped
- [ ] added reviewers and assignee
- [ ] GitHub Project estimate added
