### PR TITLE
Fix converting point region to matched image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * Fix empty response to HTTP request with underscores in header names ([#1406](https://github.com/CARTAvis/carta-backend/issues/1406))
+* Fix spatial profile for point region in matched image ([#1405](https://github.com/CARTAvis/carta-backend/issues/1405))
 
 ## [5.0.0-beta.1]
 

--- a/src/Region/RegionConverter.cc
+++ b/src/Region/RegionConverter.cc
@@ -494,16 +494,20 @@ std::vector<std::vector<CARTA::Point>> RegionConverter::GetReferencePolygonPoint
     switch (_region_state.type) {
         case CARTA::POINT: {
             points.push_back(_region_state.control_points);
+            break;
         }
         case CARTA::RECTANGLE:
         case CARTA::POLYGON: {
-            return GetApproximatePolygonPoints(num_vertices, has_distortion);
+            points = GetApproximatePolygonPoints(num_vertices, has_distortion);
+            break;
         }
         case CARTA::ELLIPSE: {
             points.push_back(GetApproximateEllipsePoints(num_vertices));
+            break;
         }
-        default:
-            return points;
+        default: {
+            // Return empty vector
+        }
     }
     return points;
 }


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
Fixes #1405 
* How does this PR solve the issue? Give a brief summary.
Add breaks to switch statement and make consistent (remove return statement).
* Are there any companion PRs (frontend, protobuf)?
No
* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
With two matched images, create a point region then request spatial profile for this region in the matched image.

**Checklist**

- [x] changelog updated / ~no changelog update needed~
- [x] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~protobuf version bumped~ / protobuf version not bumped
- [x] added reviewers and assignee
- [ ] GitHub Project estimate added
