### PR TITLE
Don't start an animation if the animation object cannot be built.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix empty response to HTTP request with underscores in header names ([#1406](https://github.com/CARTAvis/carta-backend/issues/1406))
 * Fix spatial profile for point region in matched image ([#1405](https://github.com/CARTAvis/carta-backend/issues/1405))
 * Fix casacore reformatting GILDAS unit ([#1423](https://github.com/CARTAvis/carta-backend/issues/1423))
+* Fix crash when animator is started while PV preview is active ([#1441](https://github.com/CARTAvis/carta-backend/issues/1441))
 
 ## [5.0.0-beta.1]
 

--- a/src/Session/OnMessageTask.cc
+++ b/src/Session/OnMessageTask.cc
@@ -48,16 +48,16 @@ OnMessageTask* AnimationTask::execute() {
 }
 
 OnMessageTask* StartAnimationTask::execute() {
-    OnMessageTask* tsk;
     if (_session->AnimationActive()) {
-        tsk = new StartAnimationTask(_session, _msg, _msg_id);
+        ThreadManager::QueueTask(new StartAnimationTask(_session, _msg, _msg_id));
     } else {
         _session->SetAnimationActive(true);
-        _session->BuildAnimationObject(_msg, _msg_id);
-        tsk = new AnimationTask(_session);
+        if (_session->BuildAnimationObject(_msg, _msg_id)) {
+            ThreadManager::QueueTask(new AnimationTask(_session));
+        } else {
+            _session->SetAnimationActive(false);
+        }
     }
-    ThreadManager::QueueTask(tsk);
-
     return nullptr;
 }
 

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -2172,7 +2172,7 @@ void Session::SendLogEvent(const std::string& message, std::vector<std::string> 
 // *********************************************************************************
 // ANIMATION
 
-void Session::BuildAnimationObject(CARTA::StartAnimation& msg, uint32_t request_id) {
+bool Session::BuildAnimationObject(CARTA::StartAnimation& msg, uint32_t request_id) {
     CARTA::AnimationFrame start_frame, first_frame, last_frame, delta_frame;
     int file_id;
     uint32_t frame_rate;
@@ -2202,7 +2202,9 @@ void Session::BuildAnimationObject(CARTA::StartAnimation& msg, uint32_t request_
     } else {
         auto ack_message = Message::StartAnimationAck(false, _animation_id, "Incorrect file ID");
         SendEvent(CARTA::EventType::START_ANIMATION_ACK, request_id, ack_message);
+        return false;
     }
+    return true;
 }
 
 void Session::ExecuteAnimationFrameInner(int animation_id) {

--- a/src/Session/Session.h
+++ b/src/Session/Session.h
@@ -121,7 +121,7 @@ public:
     void CancelAnimation() {
         _animation_object->CancelExecution();
     }
-    void BuildAnimationObject(CARTA::StartAnimation& msg, uint32_t request_id);
+    bool BuildAnimationObject(CARTA::StartAnimation& msg, uint32_t request_id);
     bool ExecuteAnimationFrame();
     void ExecuteAnimationFrameInner(int animation_id);
     void StopAnimation(int file_id, const ::CARTA::AnimationFrame& frame);


### PR DESCRIPTION
This fixes #1441.

It should be tested independently of the frontend fix (otherwise the bug will not be triggered in the backend), and vice versa.

**Checklist**

- [X] changelog updated
- [x] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [X] no protobuf update needed
- [X] protobuf version not bumped
- [X] added reviewers and assignee
- [ ] GitHub Project estimate added
