### PR TITLE
Update OS in the test file: carta-backend/.github/workflows/icd_tests.yml

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,6 +1,6 @@
 
 name: ci
-on: [push, pull_request]
+on: [push]
 jobs:
 
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -312,7 +312,7 @@ jobs:
       - name: Run unit tests
         uses: nick-fields/retry@master
         with:
-          timeout_minutes: 5
+          timeout_minutes: 10
           retry_wait_seconds: 60
           max_attempts: 3
           retry_on_exit_code: 1

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,6 +1,6 @@
 
 name: ci
-on: [push, pull_request]
+on: [push]
 jobs:
 
 
@@ -441,7 +441,7 @@ jobs:
   Notify:
     name: Send notifications
     runs-on: ubuntu-latest
-    needs: [format-check, Ubuntu-Focal, macOS-12, AlmaLinux-8]
+    needs: [format-check, Ubuntu-Focal, Ubuntu-Noble, macOS-12, macOS-15, AlmaLinux-8, AlmaLinux-9]
     if: always()
     steps:
       - name: Notify Slack

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,6 +1,11 @@
 
 name: ci
-on: [push]
+on:
+  push:
+    branches:
+      - dev
+      - release/*
+  pull_request:
 jobs:
 
 
@@ -26,108 +31,6 @@ jobs:
         run: sudo apt-get install doxygen graphviz
       - name: Run doxygen check
         run: stderr=$(doxygen 2>&1 >/dev/null) && [[ ${#stderr} == 0 ]] || ( echo $stderr && exit 1)
-
-
-  Ubuntu-Focal:
-    runs-on: [self-hosted, Linux, X64, Docker]
-    needs: format-check
-    container: carta/backend-builder-ubuntu-focal
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Fix ownership
-        run: |
-          chown -R $(id -u):$(id -g) $PWD
-
-      - name: System information
-        shell: bash
-        run: |
-          uname -a
-          lsb_release -a
-
-      - name: Build backend
-        shell: bash
-        run: |
-          git submodule update --init --recursive
-          mkdir build && cd build
-          cmake .. -Dtest=on -DCMAKE_BUILD_TYPE=Debug \
-                   -DCMAKE_CXX_FLAGS='-O0 -g -fsanitize=address -fno-omit-frame-pointer --coverage' \
-                   -DCMAKE_C_FLAGS='--coverage' \
-                   -DCMAKE_EXE_LINKER_FLAGS='-fsanitize=address'
-          make -j 32
-
-      - name: Check backend runs
-        shell: bash
-        run: |
-          ./build/carta_backend --version
-
-      - name: Run unit tests
-        shell: bash
-        run: |
-          cd build/test
-          ASAN_OPTIONS=suppressions=$GITHUB_WORKSPACE/debug/asan/myasan.supp \
-          LSAN_OPTIONS=suppressions=$GITHUB_WORKSPACE/debug/asan/myasan-leaks.supp \
-          ASAN_SYMBOLIZER_PATH=llvm-symbolizer \
-          ./carta_backend_tests --gtest_output=xml:ubuntu_test_report.xml
-
-      - name: Publish unit test report
-        uses: dorny/test-reporter@v1
-        if: success() || failure()
-        with:
-          name: Ubuntu-Focal Unit Test results
-          path: build/test/ubuntu_test_report.xml
-          reporter: java-junit
-
-      - name: Generate code coverage report
-        shell: bash
-        run: |
-          mkdir coverage
-          gcovr -f src/ --xml-pretty -j 8 -o coverage/coverage.xml
-
-      - name: Create code coverage summary
-        uses: irongut/CodeCoverageSummary@v1.3.0
-        with:
-          filename: coverage/coverage.xml
-          badge: true
-          format: 'markdown'
-          output: both
-          indicators: true
-          thresholds: '38 75'
-          hide_branch_rate: true
-          hide_complexity: true
-
-      - name: Publish code coverage summary
-        uses: LouisBrunner/checks-action@v1.2.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: Code Coverage
-          conclusion: ${{ job.status }}
-          output: "{\"summary\":\"Code Coverage\"}"
-          output_text_description_file: code-coverage-results.md
-
-      - name: Add coverage comment to Pull Request
-        uses: marocchino/sticky-pull-request-comment@v2
-        if: github.event_name == 'pull_request'
-        with:
-          recreate: true
-          skip_unchanged: true
-          path: code-coverage-results.md
-
-      - name: Download and store coverage badge when pushing to dev
-        if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
-        shell: bash
-        run: |
-          head -n1 code-coverage-results.md | grep -Po 'https.*(?=\))' | wget -i - -O badge-coverage.svg
-          git config --global user.email "backend.ci@github.action"
-          git config --global user.name "Backend CI"
-          git add badge-coverage.svg
-          lastcommit=`git log -1 --pretty=format:"%h %s"`
-          git stash
-          git checkout gh-storage
-          git pull
-          git checkout stash@{0} -- badge-coverage.svg
-          git diff --staged --quiet || { git commit -m "Updated coverage @ ${lastcommit}" && git push; }
 
   Ubuntu-Noble:
     runs-on: [self-hosted, Linux, X64, Docker, CI]
@@ -228,58 +131,6 @@ jobs:
           git checkout stash@{0} -- badge-coverage.svg
           git diff --staged --quiet || { git commit -m "Updated coverage @ ${lastcommit}" && git push; }
           
-  macOS-12:
-    runs-on: [self-hosted, macOS-12-M1]
-    needs: format-check
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: System information
-        shell: bash
-        run: |
-          uname -a
-          sw_vers
-
-      - name: Build backend  
-        shell: bash
-        run: |
-          git submodule update --init --recursive
-          mkdir build && cd build
-          cmake .. -Dtest=on -DCMAKE_BUILD_TYPE=Debug \
-                   -DDevSuppressExternalWarnings=ON \
-                   -DCMAKE_CXX_FLAGS='-O0 -g -fsanitize=address -fno-omit-frame-pointer' \
-                   -DCMAKE_EXE_LINKER_FLAGS='-fsanitize=address'
-          make -j 8
-
-      - name: Check backend runs
-        shell: bash
-        run: |
-          ./build/carta_backend --version
-
-      - name: Run unit tests
-        uses: nick-fields/retry@master
-        with:
-          timeout_minutes: 2
-          retry_wait_seconds: 60
-          max_attempts: 3
-          retry_on_exit_code: 1
-          shell: bash
-          command: |
-            cd build/test
-            ASAN_OPTIONS=suppressions=$GITHUB_WORKSPACE/debug/asan/myasan.supp:detect_container_overflow=0 \
-            ASAN_SYMBOLIZER_PATH=/opt/homebrew/opt/llvm/bin/llvm-symbolizer \
-            ./carta_backend_tests --gtest_output=xml:macos_test_report.xml
-            head -1 macos_test_report.xml
-
-      - name: Publish unit test report
-        uses: dorny/test-reporter@v1
-        if: success() || failure()
-        with:
-          name: macOS-12 Unit Test results
-          path: build/test/macos_test_report.xml
-          reporter: java-junit
-
   macOS-15:
     runs-on: [self-hosted, macOS-15-M1, CI]
     needs: format-check
@@ -385,7 +236,7 @@ jobs:
   Notify:
     name: Send notifications
     runs-on: ubuntu-latest
-    needs: [format-check, Ubuntu-Focal, Ubuntu-Noble, macOS-12, macOS-15, AlmaLinux-9]
+    needs: [format-check, Ubuntu-Noble, macOS-15, AlmaLinux-9]
     if: always()
     steps:
       - name: Notify Slack

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -129,10 +129,10 @@ jobs:
           git checkout stash@{0} -- badge-coverage.svg
           git diff --staged --quiet || { git commit -m "Updated coverage @ ${lastcommit}" && git push; }
 
-  Ubuntu-24.04:
+  Ubuntu-Noble:
     runs-on: [self-hosted, Linux, X64, Docker, CI]
     needs: format-check
-    container: carta/backend-builder-ubuntu-24.04
+    container: carta/backend-builder-ubuntu-noble
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -176,7 +176,7 @@ jobs:
         uses: dorny/test-reporter@v1
         if: success() || failure()
         with:
-          name: Ubuntu-24.04 Unit Test results
+          name: Ubuntu-Noble Unit Test results
           path: build/test/ubuntu24_test_report.xml
           reporter: java-junit
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,6 +1,6 @@
 
 name: ci
-on: [push]
+on: [push, pull_request]
 jobs:
 
 
@@ -308,17 +308,11 @@ jobs:
         shell: bash
         run: |
           ./build/carta_backend --version
-
-      - name: List contents of mix test folder
-        shell: bash
-        run: |
-          echo "[DEBUG] Listing test/data/images/mix..."
-          ls -lR test/data/images/mix || echo "Folder not found"
           
       - name: Run unit tests
         uses: nick-fields/retry@master
         with:
-          timeout_minutes: 2
+          timeout_minutes: 5
           retry_wait_seconds: 60
           max_attempts: 3
           retry_on_exit_code: 1
@@ -336,56 +330,6 @@ jobs:
         with:
           name: macOS-15 Unit Test results
           path: build/test/macos_test_report.xml
-          reporter: java-junit
-
-  AlmaLinux-8:
-    runs-on: [self-hosted, Linux, X64, Docker]
-    needs: format-check
-    container: carta/backend-builder-almalinux-8
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Fix ownership
-        run: |
-          chown -R $(id -u):$(id -g) $PWD
-
-      - name: System information
-        shell: bash
-        run: |
-          uname -a
-          cat /etc/redhat-release
-
-      - name: Build backend
-        shell: bash
-        run: |
-          git submodule update --init --recursive
-          mkdir build && cd build
-          cmake .. -Dtest=on -DCMAKE_BUILD_TYPE=Debug \
-                   -DCMAKE_CXX_FLAGS='-O0 -g -fsanitize=address -fno-omit-frame-pointer' \
-                   -DCMAKE_EXE_LINKER_FLAGS='-fsanitize=address'
-          make -j 32
-
-      - name: Check backend runs
-        shell: bash
-        run: |
-          ./build/carta_backend --version
-
-      - name: Run unit tests
-        shell: bash
-        run: |
-          cd build/test
-          ASAN_OPTIONS=suppressions=$GITHUB_WORKSPACE/debug/asan/myasan.supp \
-          LSAN_OPTIONS=suppressions=$GITHUB_WORKSPACE/debug/asan/myasan-leaks.supp \
-          ASAN_SYMBOLIZER_PATH=llvm-symbolizer \
-          ./carta_backend_tests --gtest_output=xml:almalinux_test_report.xml
-
-      - name: Publish unit test report
-        uses: dorny/test-reporter@v1
-        if: success() || failure()
-        with:
-          name: AlmaLinux-8 Unit Test results
-          path: build/test/almalinux_test_report.xml
           reporter: java-junit
 
   AlmaLinux-9:
@@ -441,7 +385,7 @@ jobs:
   Notify:
     name: Send notifications
     runs-on: ubuntu-latest
-    needs: [format-check, Ubuntu-Focal, Ubuntu-Noble, macOS-12, macOS-15, AlmaLinux-8, AlmaLinux-9]
+    needs: [format-check, Ubuntu-Focal, Ubuntu-Noble, macOS-12, macOS-15, AlmaLinux-9]
     if: always()
     steps:
       - name: Notify Slack

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -128,6 +128,53 @@ jobs:
           git checkout stash@{0} -- badge-coverage.svg
           git diff --staged --quiet || { git commit -m "Updated coverage @ ${lastcommit}" && git push; }
 
+  Ubuntu-24.04:
+    runs-on: [self-hosted, Linux, X64, Docker, CI]
+    needs: format-check
+    container: carta/backend-builder-ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Fix ownership
+        run: |
+          chown -R $(id -u):$(id -g) $PWD
+
+      - name: System information
+        shell: bash
+        run: |
+          uname -a
+          lsb_release -a
+
+      - name: Build backend
+        shell: bash
+        run: |
+          git submodule update --init --recursive
+          mkdir build && cd build
+          cmake .. -Dtest=on -DCMAKE_BUILD_TYPE=Debug \
+                   -DCMAKE_CXX_FLAGS='-O0 -g -fsanitize=address -fno-omit-frame-pointer' \
+                   -DCMAKE_EXE_LINKER_FLAGS='-fsanitize=address'
+          make -j 32
+
+      - name: Check backend runs
+        shell: bash
+        run: |
+          ./build/carta_backend --version
+
+      - name: Run unit tests
+        shell: bash
+        run: |
+          cd build/test
+          ASAN_OPTIONS=suppressions=$GITHUB_WORKSPACE/debug/asan/myasan.supp \
+          LSAN_OPTIONS=suppressions=$GITHUB_WORKSPACE/debug/asan/myasan-leaks.supp \
+          ASAN_SYMBOLIZER_PATH=llvm-symbolizer \
+          ./carta_backend_tests --gtest_output=xml:ubuntu_test_report.xml
+
+      - name: Publish unit test report
+        uses: dorny/test-reporter@v1
+        if: success() || failure()
+        with:
+          name: Ubuntu-24.04 Unit Test results
 
   macOS-12:
     runs-on: [self-hosted, macOS-12-M1]
@@ -181,6 +228,55 @@ jobs:
           path: build/test/macos_test_report.xml
           reporter: java-junit
 
+  macOS-15:
+    runs-on: [self-hosted, macOS-15-M1, C1]
+    needs: format-check
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: System information
+        shell: bash
+        run: |
+          uname -a
+          sw_vers
+
+      - name: Build backend  
+        shell: bash
+        run: |
+          git submodule update --init --recursive
+          mkdir build && cd build
+          cmake .. -Dtest=on -DCMAKE_BUILD_TYPE=Debug \
+                   -DDevSuppressExternalWarnings=ON \
+                   -DCMAKE_CXX_FLAGS='-O0 -g -fsanitize=address -fno-omit-frame-pointer' \
+                   -DCMAKE_EXE_LINKER_FLAGS='-fsanitize=address'
+          make -j 8
+
+      - name: Check backend runs
+        shell: bash
+        run: |
+          ./build/carta_backend --version
+
+      - name: Run unit tests
+        uses: nick-fields/retry@master
+        with:
+          timeout_minutes: 2
+          retry_wait_seconds: 60
+          max_attempts: 3
+          retry_on_exit_code: 1
+          shell: bash
+          command: |
+            cd build/test
+            ASAN_OPTIONS=suppressions=$GITHUB_WORKSPACE/debug/asan/myasan.supp:detect_container_overflow=0 \
+            ASAN_SYMBOLIZER_PATH=/opt/homebrew/opt/llvm/bin/llvm-symbolizer \
+            ./carta_backend_tests --gtest_output=xml:macos_test_report.xml
+            head -1 macos_test_report.xml
+
+      - name: Publish unit test report
+        uses: dorny/test-reporter@v1
+        if: success() || failure()
+        with:
+          name: macOS-15 Unit Test results
 
   AlmaLinux-8:
     runs-on: [self-hosted, Linux, X64, Docker]
@@ -232,6 +328,54 @@ jobs:
           path: build/test/almalinux_test_report.xml
           reporter: java-junit
 
+  AlmaLinux-9:
+    runs-on: [self-hosted, Linux, X64, Docker, CI]
+    needs: format-check
+    container: carta/backend-builder-almalinux-9
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Fix ownership
+        run: |
+          chown -R $(id -u):$(id -g) $PWD
+
+      - name: System information
+        shell: bash
+        run: |
+          uname -a
+          cat /etc/redhat-release
+
+      - name: Build backend
+        shell: bash
+        run: |
+          git submodule update --init --recursive
+          mkdir build && cd build
+          cmake .. -Dtest=on -DCMAKE_BUILD_TYPE=Debug \
+                   -DCMAKE_CXX_FLAGS='-O0 -g -fsanitize=address -fno-omit-frame-pointer' \
+                   -DCMAKE_EXE_LINKER_FLAGS='-fsanitize=address'
+          make -j 32
+
+      - name: Check backend runs
+        shell: bash
+        run: |
+          ./build/carta_backend --version
+
+      - name: Run unit tests
+        shell: bash
+        run: |
+          cd build/test
+          ASAN_OPTIONS=suppressions=$GITHUB_WORKSPACE/debug/asan/myasan.supp \
+          LSAN_OPTIONS=suppressions=$GITHUB_WORKSPACE/debug/asan/myasan-leaks.supp \
+          ASAN_SYMBOLIZER_PATH=llvm-symbolizer \
+          ./carta_backend_tests --gtest_output=xml:almalinux_test_report.xml
+
+      - name: Publish unit test report
+        uses: dorny/test-reporter@v1
+        if: success() || failure()
+        with:
+          name: AlmaLinux-9 Unit Test results
+          
   Notify:
     name: Send notifications
     runs-on: ubuntu-latest

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -309,6 +309,12 @@ jobs:
         run: |
           ./build/carta_backend --version
 
+      - name: List contents of mix test folder
+        shell: bash
+        run: |
+          echo "[DEBUG] Listing test/data/images/mix..."
+          ls -lR test/data/images/mix || echo "Folder not found"
+          
       - name: Run unit tests
         uses: nick-fields/retry@master
         with:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,3 +1,4 @@
+
 name: ci
 on: [push, pull_request]
 jobs:
@@ -444,3 +445,4 @@ jobs:
           slack_channel_id: actions-build-status
           slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           github_context: ${{ toJson(github) }}
+

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -177,7 +177,7 @@ jobs:
         if: success() || failure()
         with:
           name: Ubuntu-Noble Unit Test results
-          path: build/test/ubuntu24_test_report.xml
+          path: build/test/ubuntu_test_report.xml
           reporter: java-junit
 
       - name: Generate code coverage report
@@ -281,7 +281,7 @@ jobs:
           reporter: java-junit
 
   macOS-15:
-    runs-on: [self-hosted, macOS-15-M1, C1]
+    runs-on: [self-hosted, macOS-15-M1, CI]
     needs: format-check
     steps:
       - name: Checkout
@@ -329,7 +329,7 @@ jobs:
         if: success() || failure()
         with:
           name: macOS-15 Unit Test results
-          path: build/test/macos15_test_report.xml
+          path: build/test/macos_test_report.xml
           reporter: java-junit
 
   AlmaLinux-8:
@@ -429,7 +429,7 @@ jobs:
         if: success() || failure()
         with:
           name: AlmaLinux-9 Unit Test results
-          path: build/test/almalinux9_test_report.xml
+          path: build/test/almalinux_test_report.xml
           reporter: java-junit
 
   Notify:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -312,7 +312,7 @@ jobs:
       - name: Run unit tests
         uses: nick-fields/retry@master
         with:
-          timeout_minutes: 10
+          timeout_minutes: 2
           retry_wait_seconds: 60
           max_attempts: 3
           retry_on_exit_code: 1

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -152,7 +152,8 @@ jobs:
           git submodule update --init --recursive
           mkdir build && cd build
           cmake .. -Dtest=on -DCMAKE_BUILD_TYPE=Debug \
-                   -DCMAKE_CXX_FLAGS='-O0 -g -fsanitize=address -fno-omit-frame-pointer' \
+                   -DCMAKE_CXX_FLAGS='-O0 -g -fsanitize=address -fno-omit-frame-pointer --coverage' \
+                   -DCMAKE_C_FLAGS='--coverage' \
                    -DCMAKE_EXE_LINKER_FLAGS='-fsanitize=address'
           make -j 32
 
@@ -175,7 +176,57 @@ jobs:
         if: success() || failure()
         with:
           name: Ubuntu-24.04 Unit Test results
+          path: build/test/ubuntu24_test_report.xml
+          reporter: java-junit
 
+      - name: Generate code coverage report
+        shell: bash
+        run: |
+          mkdir coverage
+          gcovr -f src/ --xml-pretty -j 8 -o coverage/coverage.xml
+      - name: Create code coverage summary
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: coverage/coverage.xml
+          badge: true
+          format: 'markdown'
+          output: both
+          indicators: true
+          thresholds: '38 75'
+          hide_branch_rate: true
+          hide_complexity: true
+      - name: Publish code coverage summary
+        uses: LouisBrunner/checks-action@v1.2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: Code Coverage
+          conclusion: ${{ job.status }}
+          output: "{\"summary\":\"Code Coverage\"}"
+          output_text_description_file: code-coverage-results.md          
+
+      - name: Add coverage comment to Pull Request
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: github.event_name == 'pull_request'
+        with:
+          recreate: true
+          skip_unchanged: true
+          path: code-coverage-results.md
+      
+      - name: Download and store coverage badge when pushing to dev
+        if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+        shell: bash
+        run: |
+          head -n1 code-coverage-results.md | grep -Po 'https.*(?=\))' | wget -i - -O badge-coverage.svg
+          git config --global user.email "backend.ci@github.action"
+          git config --global user.name "Backend CI"
+          git add badge-coverage.svg
+          lastcommit=`git log -1 --pretty=format:"%h %s"`
+          git stash
+          git checkout gh-storage
+          git pull
+          git checkout stash@{0} -- badge-coverage.svg
+          git diff --staged --quiet || { git commit -m "Updated coverage @ ${lastcommit}" && git push; }
+          
   macOS-12:
     runs-on: [self-hosted, macOS-12-M1]
     needs: format-check
@@ -277,6 +328,8 @@ jobs:
         if: success() || failure()
         with:
           name: macOS-15 Unit Test results
+          path: build/test/macos15_test_report.xml
+          reporter: java-junit
 
   AlmaLinux-8:
     runs-on: [self-hosted, Linux, X64, Docker]
@@ -375,7 +428,9 @@ jobs:
         if: success() || failure()
         with:
           name: AlmaLinux-9 Unit Test results
-          
+          path: build/test/almalinux9_test_report.xml
+          reporter: java-junit
+
   Notify:
     name: Send notifications
     runs-on: ubuntu-latest

--- a/.github/workflows/icd_tests.yml
+++ b/.github/workflows/icd_tests.yml
@@ -18,6 +18,9 @@ jobs:
           - os_version: macOS-13
             os: macos
             runner: [macOS-13, ICD]
+          - os_version: macOS-14
+            os: macos
+            runner: [macOS-14, ICD]
           - os_version: macOS-15
             os: macos
             runner: [macOS-15, ICD]
@@ -54,8 +57,32 @@ jobs:
           uname -a
           sw_vers
 
+      - name: Build carta-backend (macOS-14)
+        if: matrix.os_version == 'macOS-14'
+        shell: bash
+        run: |
+          export CC=/usr/local/Cellar/llvm/20.1.3/bin/clang
+          export CXX=/usr/local/Cellar/llvm/20.1.3/bin/clang++
+          export PROTOBUF_ROOT=$(brew --prefix protobuf@21)
+          export PATH="$PROTOBUF_ROOT/bin:$PATH"
+          export LIBRARY_PATH="$PROTOBUF_ROOT/lib:$LIBRARY_PATH"
+          export CMAKE_PREFIX_PATH="$PROTOBUF_ROOT:$CMAKE_PREFIX_PATH"
+          export PKG_CONFIG_PATH="$PROTOBUF_ROOT/lib/pkgconfig:$PKG_CONFIG_PATH"
+          SRC_DIR=$GITHUB_WORKSPACE/source
+          BUILD_DIR=$GITHUB_WORKSPACE/build
+          cd $SRC_DIR && git submodule update --init --recursive
+          rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
+          cd $BUILD_DIR
+          cmake $SRC_DIR \
+            -Dtest=on \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DDevSuppressExternalWarnings=ON \
+            -DCMAKE_CXX_FLAGS="-O0 -g -fsanitize=address -fno-omit-frame-pointer" \
+            -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address"
+          make -j 16
+
       - name: Build carta-backend (macOS)
-        if: matrix.os == 'macos'
+        if: matrix.os == 'macos' && matrix.os_version != 'macOS-14'
         shell: bash
         run: |
           SRC_DIR=$GITHUB_WORKSPACE/source
@@ -113,6 +140,9 @@ jobs:
           - os_version: macOS-13
             os: macos
             runner: [macOS-13, ICD]
+          - os_version: macOS-14
+            os: macos
+            runner: [macOS-14, ICD]
           - os_version: macOS-15
             os: macos
             runner: [macOS-15, ICD]
@@ -183,6 +213,9 @@ jobs:
           - os_version: macOS-13
             os: macos
             runner: [macOS-13, ICD]
+          - os_version: macOS-14
+            os: macos
+            runner: [macOS-14, ICD]
           - os_version: macOS-15
             os: macos
             runner: [macOS-15, ICD]
@@ -236,6 +269,9 @@ jobs:
           - os_version: macOS-13
             os: macos
             runner: [macOS-13, ICD]
+          - os_version: macOS-14
+            os: macos
+            runner: [macOS-14, ICD]
           - os_version: macOS-15
             os: macos
             runner: [macOS-15, ICD]
@@ -289,6 +325,9 @@ jobs:
           - os_version: macOS-13
             os: macos
             runner: [macOS-13, ICD]
+          - os_version: macOS-14
+            os: macos
+            runner: [macOS-14, ICD]
           - os_version: macOS-15
             os: macos
             runner: [macOS-15, ICD]
@@ -342,6 +381,9 @@ jobs:
           - os_version: macOS-13
             os: macos
             runner: [macOS-13, ICD]
+          - os_version: macOS-14
+            os: macos
+            runner: [macOS-14, ICD]
           - os_version: macOS-15
             os: macos
             runner: [macOS-15, ICD]
@@ -395,6 +437,9 @@ jobs:
           - os_version: macOS-13
             os: macos
             runner: [macOS-13, ICD]
+          - os_version: macOS-14
+            os: macos
+            runner: [macOS-14, ICD]
           - os_version: macOS-15
             os: macos
             runner: [macOS-15, ICD]
@@ -448,6 +493,9 @@ jobs:
           - os_version: macOS-13
             os: macos
             runner: [macOS-13, ICD]
+          - os_version: macOS-14
+            os: macos
+            runner: [macOS-14, ICD]
           - os_version: macOS-15
             os: macos
             runner: [macOS-15, ICD]
@@ -501,6 +549,9 @@ jobs:
           - os_version: macOS-13
             os: macos
             runner: [macOS-13, ICD]
+          - os_version: macOS-14
+            os: macos
+            runner: [macOS-14, ICD]
           - os_version: macOS-15
             os: macos
             runner: [macOS-15, ICD]
@@ -554,6 +605,9 @@ jobs:
           - os_version: macOS-13
             os: macos
             runner: [macOS-13, ICD]
+          - os_version: macOS-14
+            os: macos
+            runner: [macOS-14, ICD]
           - os_version: macOS-15
             os: macos
             runner: [macOS-15, ICD]
@@ -607,6 +661,9 @@ jobs:
           - os_version: macOS-13
             os: macos
             runner: [macOS-13, ICD]
+          - os_version: macOS-14
+            os: macos
+            runner: [macOS-14, ICD]
           - os_version: macOS-15
             os: macos
             runner: [macOS-15, ICD]
@@ -660,6 +717,9 @@ jobs:
           - os_version: macOS-13
             os: macos
             runner: [macOS-13, ICD]
+          - os_version: macOS-14
+            os: macos
+            runner: [macOS-14, ICD]
           - os_version: macOS-15
             os: macos
             runner: [macOS-15, ICD]
@@ -713,6 +773,9 @@ jobs:
           - os_version: macOS-13
             os: macos
             runner: [macOS-13, ICD]
+          - os_version: macOS-14
+            os: macos
+            runner: [macOS-14, ICD]
           - os_version: macOS-15
             os: macos
             runner: [macOS-15, ICD]
@@ -766,6 +829,9 @@ jobs:
           - os_version: macOS-13
             os: macos
             runner: [macOS-13, ICD]
+          - os_version: macOS-14
+            os: macos
+            runner: [macOS-14, ICD]
           - os_version: macOS-15
             os: macos
             runner: [macOS-15, ICD]
@@ -819,6 +885,9 @@ jobs:
           - os_version: macOS-13
             os: macos
             runner: [macOS-13, ICD]
+          - os_version: macOS-14
+            os: macos
+            runner: [macOS-14, ICD]
           - os_version: macOS-15
             os: macos
             runner: [macOS-15, ICD]
@@ -872,6 +941,9 @@ jobs:
           - os_version: macOS-13
             os: macos
             runner: [macOS-13, ICD]
+          - os_version: macOS-14
+            os: macos
+            runner: [macOS-14, ICD]
           - os_version: macOS-15
             os: macos
             runner: [macOS-15, ICD]

--- a/.github/workflows/icd_tests.yml
+++ b/.github/workflows/icd_tests.yml
@@ -15,30 +15,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os_version: macOS-11
-            os: macos
-            runner: macOS-11
-          - os_version: macOS-12
-            os: macos
-            runner: [macOS-12, ICD]
           - os_version: macOS-13
             os: macos
-            runner: macOS-13
-          - os_version: ubuntu-20.04
-            os: linux
-            runner: [self-hosted, Linux, Apptainer, ICD1]
-            image: /opt/apptainer/ubuntu-2004-dec2023.sif
-            port: 9001
+            runner: [macOS-13, ICD]
+          - os_version: macOS-15
+            os: macos
+            runner: [macOS-15, ICD]
           - os_version: ubuntu-22.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
             image: /opt/apptainer/ubuntu-2204-dec2023.sif
             port: 9002
-          - os_version: rhel-7
+          - os_version: ubuntu-24.04
             os: linux
-            runner: [self-hosted, Linux, Apptainer, ICD3]
-            image: /opt/apptainer/centos7-dec2023.sif
-            port: 9003
+            runner: [self-hosted, Linux, Apptainer, ICD6]
+            image: /opt/apptainer/ubuntu-2404-apr2025.sif
+            port: 9006
           - os_version: rhel-8
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD4]
@@ -118,30 +110,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os_version: macOS-11
-            os: macos
-            runner: macOS-11
-          - os_version: macOS-12
-            os: macos
-            runner: [macOS-12, ICD]
           - os_version: macOS-13
             os: macos
-            runner: macOS-13
-          - os_version: ubuntu-20.04
-            os: linux
-            runner: [self-hosted, Linux, Apptainer, ICD1]
-            image: /opt/apptainer/ubuntu-2004-dec2023.sif
-            port: 9001
+            runner: [macOS-13, ICD]
+          - os_version: macOS-15
+            os: macos
+            runner: [macOS-15, ICD]
           - os_version: ubuntu-22.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
             image: /opt/apptainer/ubuntu-2204-dec2023.sif
             port: 9002
-          - os_version: rhel-7
+          - os_version: ubuntu-24.04
             os: linux
-            runner: [self-hosted, Linux, Apptainer, ICD3]
-            image: /opt/apptainer/centos7-dec2023.sif
-            port: 9003
+            runner: [self-hosted, Linux, Apptainer, ICD6]
+            image: /opt/apptainer/ubuntu-2404-apr2025.sif
+            port: 9006
           - os_version: rhel-8
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD4]
@@ -196,30 +180,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os_version: macOS-11
-            os: macos
-            runner: macOS-11
-          - os_version: macOS-12
-            os: macos
-            runner: [macOS-12, ICD]
           - os_version: macOS-13
             os: macos
-            runner: macOS-13          
-          - os_version: ubuntu-20.04
-            os: linux
-            runner: [self-hosted, Linux, Apptainer, ICD1]
-            image: /opt/apptainer/ubuntu-2004-dec2023.sif
-            port: 9001
+            runner: [macOS-13, ICD]
+          - os_version: macOS-15
+            os: macos
+            runner: [macOS-15, ICD]
           - os_version: ubuntu-22.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
             image: /opt/apptainer/ubuntu-2204-dec2023.sif
             port: 9002
-          - os_version: rhel-7
+          - os_version: ubuntu-24.04
             os: linux
-            runner: [self-hosted, Linux, Apptainer, ICD3]
-            image: /opt/apptainer/centos7-dec2023.sif
-            port: 9003
+            runner: [self-hosted, Linux, Apptainer, ICD6]
+            image: /opt/apptainer/ubuntu-2404-apr2025.sif
+            port: 9006
           - os_version: rhel-8
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD4]
@@ -257,30 +233,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os_version: macOS-11
-            os: macos
-            runner: macOS-11
-          - os_version: macOS-12
-            os: macos
-            runner: [macOS-12, ICD]
           - os_version: macOS-13
             os: macos
-            runner: macOS-13
-          - os_version: ubuntu-20.04
-            os: linux
-            runner: [self-hosted, Linux, Apptainer, ICD1]
-            image: /opt/apptainer/ubuntu-2004-dec2023.sif
-            port: 9001
+            runner: [macOS-13, ICD]
+          - os_version: macOS-15
+            os: macos
+            runner: [macOS-15, ICD]
           - os_version: ubuntu-22.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
             image: /opt/apptainer/ubuntu-2204-dec2023.sif
             port: 9002
-          - os_version: rhel-7
+          - os_version: ubuntu-24.04
             os: linux
-            runner: [self-hosted, Linux, Apptainer, ICD3]
-            image: /opt/apptainer/centos7-dec2023.sif
-            port: 9003
+            runner: [self-hosted, Linux, Apptainer, ICD6]
+            image: /opt/apptainer/ubuntu-2404-apr2025.sif
+            port: 9006
           - os_version: rhel-8
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD4]
@@ -318,30 +286,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os_version: macOS-11
-            os: macos
-            runner: macOS-11
-          - os_version: macOS-12
-            os: macos
-            runner: [macOS-12, ICD]
           - os_version: macOS-13
             os: macos
-            runner: macOS-13
-          - os_version: ubuntu-20.04
-            os: linux
-            runner: [self-hosted, Linux, Apptainer, ICD1]
-            image: /opt/apptainer/ubuntu-2004-dec2023.sif
-            port: 9001
+            runner: [macOS-13, ICD]
+          - os_version: macOS-15
+            os: macos
+            runner: [macOS-15, ICD]
           - os_version: ubuntu-22.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
             image: /opt/apptainer/ubuntu-2204-dec2023.sif
             port: 9002
-          - os_version: rhel-7
+          - os_version: ubuntu-24.04
             os: linux
-            runner: [self-hosted, Linux, Apptainer, ICD3]
-            image: /opt/apptainer/centos7-dec2023.sif
-            port: 9003
+            runner: [self-hosted, Linux, Apptainer, ICD6]
+            image: /opt/apptainer/ubuntu-2404-apr2025.sif
+            port: 9006
           - os_version: rhel-8
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD4]
@@ -379,30 +339,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os_version: macOS-11
-            os: macos
-            runner: macOS-11
-          - os_version: macOS-12
-            os: macos
-            runner: [macOS-12, ICD]
           - os_version: macOS-13
             os: macos
-            runner: macOS-13
-          - os_version: ubuntu-20.04
-            os: linux
-            runner: [self-hosted, Linux, Apptainer, ICD1]
-            image: /opt/apptainer/ubuntu-2004-dec2023.sif
-            port: 9001
+            runner: [macOS-13, ICD]
+          - os_version: macOS-15
+            os: macos
+            runner: [macOS-15, ICD]
           - os_version: ubuntu-22.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
             image: /opt/apptainer/ubuntu-2204-dec2023.sif
             port: 9002
-          - os_version: rhel-7
+          - os_version: ubuntu-24.04
             os: linux
-            runner: [self-hosted, Linux, Apptainer, ICD3]
-            image: /opt/apptainer/centos7-dec2023.sif
-            port: 9003
+            runner: [self-hosted, Linux, Apptainer, ICD6]
+            image: /opt/apptainer/ubuntu-2404-apr2025.sif
+            port: 9006
           - os_version: rhel-8
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD4]
@@ -440,30 +392,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os_version: macOS-11
-            os: macos
-            runner: macOS-11
-          - os_version: macOS-12
-            os: macos
-            runner: [macOS-12, ICD]
           - os_version: macOS-13
             os: macos
-            runner: macOS-13
-          - os_version: ubuntu-20.04
-            os: linux
-            runner: [self-hosted, Linux, Apptainer, ICD1]
-            image: /opt/apptainer/ubuntu-2004-dec2023.sif
-            port: 9001
+            runner: [macOS-13, ICD]
+          - os_version: macOS-15
+            os: macos
+            runner: [macOS-15, ICD]
           - os_version: ubuntu-22.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
             image: /opt/apptainer/ubuntu-2204-dec2023.sif
             port: 9002
-          - os_version: rhel-7
+          - os_version: ubuntu-24.04
             os: linux
-            runner: [self-hosted, Linux, Apptainer, ICD3]
-            image: /opt/apptainer/centos7-dec2023.sif
-            port: 9003
+            runner: [self-hosted, Linux, Apptainer, ICD6]
+            image: /opt/apptainer/ubuntu-2404-apr2025.sif
+            port: 9006
           - os_version: rhel-8
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD4]
@@ -501,30 +445,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os_version: macOS-11
-            os: macos
-            runner: macOS-11
-          - os_version: macOS-12
-            os: macos
-            runner: [macOS-12, ICD]
           - os_version: macOS-13
             os: macos
-            runner: macOS-13
-          - os_version: ubuntu-20.04
-            os: linux
-            runner: [self-hosted, Linux, Apptainer, ICD1]
-            image: /opt/apptainer/ubuntu-2004-dec2023.sif
-            port: 9001
+            runner: [macOS-13, ICD]
+          - os_version: macOS-15
+            os: macos
+            runner: [macOS-15, ICD]
           - os_version: ubuntu-22.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
             image: /opt/apptainer/ubuntu-2204-dec2023.sif
             port: 9002
-          - os_version: rhel-7
+          - os_version: ubuntu-24.04
             os: linux
-            runner: [self-hosted, Linux, Apptainer, ICD3]
-            image: /opt/apptainer/centos7-dec2023.sif
-            port: 9003
+            runner: [self-hosted, Linux, Apptainer, ICD6]
+            image: /opt/apptainer/ubuntu-2404-apr2025.sif
+            port: 9006
           - os_version: rhel-8
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD4]
@@ -562,30 +498,22 @@ jobs:
       fail-fast: false
       matrix:  
         include:
-          - os_version: macOS-11
-            os: macos
-            runner: macOS-11
-          - os_version: macOS-12
-            os: macos  
-            runner: [macOS-12, ICD]
           - os_version: macOS-13
             os: macos
-            runner: macOS-13
-          - os_version: ubuntu-20.04
-            os: linux
-            runner: [self-hosted, Linux, Apptainer, ICD1]
-            image: /opt/apptainer/ubuntu-2004-dec2023.sif
-            port: 9001
+            runner: [macOS-13, ICD]
+          - os_version: macOS-15
+            os: macos
+            runner: [macOS-15, ICD]
           - os_version: ubuntu-22.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
             image: /opt/apptainer/ubuntu-2204-dec2023.sif
             port: 9002
-          - os_version: rhel-7
+          - os_version: ubuntu-24.04
             os: linux
-            runner: [self-hosted, Linux, Apptainer, ICD3]
-            image: /opt/apptainer/centos7-dec2023.sif
-            port: 9003
+            runner: [self-hosted, Linux, Apptainer, ICD6]
+            image: /opt/apptainer/ubuntu-2404-apr2025.sif
+            port: 9006
           - os_version: rhel-8
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD4]
@@ -623,30 +551,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os_version: macOS-11
-            os: macos
-            runner: macOS-11
-          - os_version: macOS-12
-            os: macos
-            runner: [macOS-12, ICD]
           - os_version: macOS-13
             os: macos
-            runner: macOS-13
-          - os_version: ubuntu-20.04
-            os: linux
-            runner: [self-hosted, Linux, Apptainer, ICD1]
-            image: /opt/apptainer/ubuntu-2004-dec2023.sif
-            port: 9001
+            runner: [macOS-13, ICD]
+          - os_version: macOS-15
+            os: macos
+            runner: [macOS-15, ICD]
           - os_version: ubuntu-22.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
             image: /opt/apptainer/ubuntu-2204-dec2023.sif
             port: 9002
-          - os_version: rhel-7
+          - os_version: ubuntu-24.04
             os: linux
-            runner: [self-hosted, Linux, Apptainer, ICD3]
-            image: /opt/apptainer/centos7-dec2023.sif
-            port: 9003
+            runner: [self-hosted, Linux, Apptainer, ICD6]
+            image: /opt/apptainer/ubuntu-2404-apr2025.sif
+            port: 9006
           - os_version: rhel-8
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD4]
@@ -684,30 +604,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os_version: macOS-11
-            os: macos
-            runner: macOS-11
-          - os_version: macOS-12
-            os: macos
-            runner: [macOS-12, ICD]
           - os_version: macOS-13
             os: macos
-            runner: macOS-13
-          - os_version: ubuntu-20.04   
-            os: linux
-            runner: [self-hosted, Linux, Apptainer, ICD1]
-            image: /opt/apptainer/ubuntu-2004-dec2023.sif
-            port: 9001
+            runner: [macOS-13, ICD]
+          - os_version: macOS-15
+            os: macos
+            runner: [macOS-15, ICD]
           - os_version: ubuntu-22.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
             image: /opt/apptainer/ubuntu-2204-dec2023.sif
             port: 9002
-          - os_version: rhel-7
+          - os_version: ubuntu-24.04
             os: linux
-            runner: [self-hosted, Linux, Apptainer, ICD3]
-            image: /opt/apptainer/centos7-dec2023.sif
-            port: 9003
+            runner: [self-hosted, Linux, Apptainer, ICD6]
+            image: /opt/apptainer/ubuntu-2404-apr2025.sif
+            port: 9006
           - os_version: rhel-8
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD4]
@@ -745,30 +657,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os_version: macOS-11
-            os: macos   
-            runner: macOS-11
-          - os_version: macOS-12
-            os: macos
-            runner: [macOS-12, ICD]
           - os_version: macOS-13
             os: macos
-            runner: macOS-13
-          - os_version: ubuntu-20.04
-            os: linux
-            runner: [self-hosted, Linux, Apptainer, ICD1]
-            image: /opt/apptainer/ubuntu-2004-dec2023.sif
-            port: 9001
+            runner: [macOS-13, ICD]
+          - os_version: macOS-15
+            os: macos
+            runner: [macOS-15, ICD]
           - os_version: ubuntu-22.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
             image: /opt/apptainer/ubuntu-2204-dec2023.sif
             port: 9002
-          - os_version: rhel-7  
+          - os_version: ubuntu-24.04
             os: linux
-            runner: [self-hosted, Linux, Apptainer, ICD3]
-            image: /opt/apptainer/centos7-dec2023.sif
-            port: 9003
+            runner: [self-hosted, Linux, Apptainer, ICD6]
+            image: /opt/apptainer/ubuntu-2404-apr2025.sif
+            port: 9006
           - os_version: rhel-8
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD4]
@@ -806,30 +710,22 @@ jobs:
       fail-fast: false
       matrix:
         include:  
-          - os_version: macOS-11
-            os: macos     
-            runner: macOS-11
-          - os_version: macOS-12
-            os: macos
-            runner: [macOS-12, ICD]
           - os_version: macOS-13
             os: macos
-            runner: macOS-13
-          - os_version: ubuntu-20.04
-            os: linux
-            runner: [self-hosted, Linux, Apptainer, ICD1]
-            image: /opt/apptainer/ubuntu-2004-dec2023.sif
-            port: 9001
+            runner: [macOS-13, ICD]
+          - os_version: macOS-15
+            os: macos
+            runner: [macOS-15, ICD]
           - os_version: ubuntu-22.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
             image: /opt/apptainer/ubuntu-2204-dec2023.sif
             port: 9002
-          - os_version: rhel-7      
+          - os_version: ubuntu-24.04
             os: linux
-            runner: [self-hosted, Linux, Apptainer, ICD3]
-            image: /opt/apptainer/centos7-dec2023.sif
-            port: 9003
+            runner: [self-hosted, Linux, Apptainer, ICD6]
+            image: /opt/apptainer/ubuntu-2404-apr2025.sif
+            port: 9006
           - os_version: rhel-8
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD4]
@@ -867,30 +763,22 @@ jobs:
       fail-fast: false
       matrix:
         include:  
-          - os_version: macOS-11
-            os: macos     
-            runner: macOS-11
-          - os_version: macOS-12
-            os: macos
-            runner: [macOS-12, ICD]
           - os_version: macOS-13
             os: macos
-            runner: macOS-13
-          - os_version: ubuntu-20.04
-            os: linux
-            runner: [self-hosted, Linux, Apptainer, ICD1]
-            image: /opt/apptainer/ubuntu-2004-dec2023.sif
-            port: 9001
+            runner: [macOS-13, ICD]
+          - os_version: macOS-15
+            os: macos
+            runner: [macOS-15, ICD]
           - os_version: ubuntu-22.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
             image: /opt/apptainer/ubuntu-2204-dec2023.sif
             port: 9002
-          - os_version: rhel-7      
+          - os_version: ubuntu-24.04
             os: linux
-            runner: [self-hosted, Linux, Apptainer, ICD3]
-            image: /opt/apptainer/centos7-dec2023.sif
-            port: 9003
+            runner: [self-hosted, Linux, Apptainer, ICD6]
+            image: /opt/apptainer/ubuntu-2404-apr2025.sif
+            port: 9006
           - os_version: rhel-8
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD4]
@@ -928,30 +816,22 @@ jobs:
       fail-fast: false
       matrix:
         include:  
-          - os_version: macOS-11
-            os: macos     
-            runner: macOS-11
-          - os_version: macOS-12
-            os: macos
-            runner: [macOS-12, ICD]
           - os_version: macOS-13
             os: macos
-            runner: macOS-13
-          - os_version: ubuntu-20.04
-            os: linux
-            runner: [self-hosted, Linux, Apptainer, ICD1]
-            image: /opt/apptainer/ubuntu-2004-dec2023.sif
-            port: 9001
+            runner: [macOS-13, ICD]
+          - os_version: macOS-15
+            os: macos
+            runner: [macOS-15, ICD]
           - os_version: ubuntu-22.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
             image: /opt/apptainer/ubuntu-2204-dec2023.sif
             port: 9002
-          - os_version: rhel-7      
+          - os_version: ubuntu-24.04
             os: linux
-            runner: [self-hosted, Linux, Apptainer, ICD3]
-            image: /opt/apptainer/centos7-dec2023.sif
-            port: 9003
+            runner: [self-hosted, Linux, Apptainer, ICD6]
+            image: /opt/apptainer/ubuntu-2404-apr2025.sif
+            port: 9006
           - os_version: rhel-8
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD4]
@@ -989,30 +869,22 @@ jobs:
       fail-fast: false
       matrix:
         include:  
-          - os_version: macOS-11
-            os: macos     
-            runner: macOS-11
-          - os_version: macOS-12
-            os: macos
-            runner: [macOS-12, ICD]
           - os_version: macOS-13
             os: macos
-            runner: macOS-13
-          - os_version: ubuntu-20.04
-            os: linux
-            runner: [self-hosted, Linux, Apptainer, ICD1]
-            image: /opt/apptainer/ubuntu-2004-dec2023.sif
-            port: 9001
+            runner: [macOS-13, ICD]
+          - os_version: macOS-15
+            os: macos
+            runner: [macOS-15, ICD]
           - os_version: ubuntu-22.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
             image: /opt/apptainer/ubuntu-2204-dec2023.sif
             port: 9002
-          - os_version: rhel-7      
+          - os_version: ubuntu-24.04
             os: linux
-            runner: [self-hosted, Linux, Apptainer, ICD3]
-            image: /opt/apptainer/centos7-dec2023.sif
-            port: 9003
+            runner: [self-hosted, Linux, Apptainer, ICD6]
+            image: /opt/apptainer/ubuntu-2404-apr2025.sif
+            port: 9006
           - os_version: rhel-8
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD4]

--- a/test/TestFileList.cc
+++ b/test/TestFileList.cc
@@ -83,8 +83,8 @@ TEST_F(FileListTest, SetTopLevelFolder) {
 
     // Request file list for default top folder "/"
     // 0 image files, > 0 subdirectories
-    // auto request5 = Message::FileListRequest("");
-    // TestFileListSubdirectories("/", "", request5);
+    auto request5 = Message::FileListRequest("");
+    TestFileListSubdirectories("/", "", request5);
 }
 
 TEST_F(FileListTest, SetStartingFolder) {

--- a/test/TestFileList.cc
+++ b/test/TestFileList.cc
@@ -83,8 +83,8 @@ TEST_F(FileListTest, SetTopLevelFolder) {
 
     // Request file list for default top folder "/"
     // 0 image files, > 0 subdirectories
-    //auto request5 = Message::FileListRequest("");
-    //TestFileListSubdirectories("/", "", request5);
+    // auto request5 = Message::FileListRequest("");
+    // TestFileListSubdirectories("/", "", request5);
 }
 
 TEST_F(FileListTest, SetStartingFolder) {

--- a/test/TestFileList.cc
+++ b/test/TestFileList.cc
@@ -67,6 +67,11 @@ public:
 
 TEST_F(FileListTest, SetTopLevelFolder) {
     std::string abs_path = (TestRoot() / "data" / "images" / "mix").string();
+    std::cout << "[DEBUG] abs_path = " << abs_path << std::endl;
+
+    for (const auto& entry : std::filesystem::directory_iterator(abs_path)) {
+        std::cout << "[DEBUG] entry = " << entry.path().string() << std::endl;
+    }
 
     auto request1 = Message::FileListRequest(abs_path);
     TestFileList("/", "", request1);

--- a/test/TestFileList.cc
+++ b/test/TestFileList.cc
@@ -67,40 +67,24 @@ public:
 
 TEST_F(FileListTest, SetTopLevelFolder) {
     std::string abs_path = (TestRoot() / "data" / "images" / "mix").string();
-    std::cout << "[DEBUG] abs_path = " << abs_path << std::endl;
-
-    for (const auto& entry : std::filesystem::directory_iterator(abs_path)) {
-        std::cout << "[DEBUG] entry = " << entry.path().string() << std::endl;
-    }
 
     auto request1 = Message::FileListRequest(abs_path);
-    std::cout << "[DEBUG] Running TestFileList with / and request1" << std::endl;
     TestFileList("/", "", request1);
-    std::cout << "[DEBUG] Running TestFileList with empty and request1, recursive = false" << std::endl;
     TestFileList("", "", request1, false);
 
-    std::cout << "[DEBUG] Creating request2 with 'data/images/mix'" << std::endl;
     auto request2 = Message::FileListRequest("data/images/mix");
-    std::cout << "[DEBUG] Running TestFileList with TestRoot and request2" << std::endl;
     TestFileList(TestRoot().string(), "", request2);
 
-    std::cout << "[DEBUG] Creating request3 with empty string" << std::endl;
     auto request3 = Message::FileListRequest("");
-    std::cout << "[DEBUG] Running TestFileList with abs_path and request3" << std::endl;
     TestFileList(abs_path, "", request3);
 
-    std::cout << "[DEBUG] Creating request4 with '.'" << std::endl;
     auto request4 = Message::FileListRequest(".");
-    std::cout << "[DEBUG] Running TestFileList with abs_path and request4" << std::endl;
     TestFileList(abs_path, "", request4);
 
     // Request file list for default top folder "/"
     // 0 image files, > 0 subdirectories
-    std::cout << "[DEBUG] Creating request5 with empty string" << std::endl;
-    auto request5 = Message::FileListRequest("");
-    std::cout << "[DEBUG] Running TestFileListSubdirectories with / and request5" << std::endl;
-    TestFileListSubdirectories("/", "", request5);
-    std::cout << "[DEBUG] End of TestFileListSubdirectories with / and request5" << std::endl;
+    //auto request5 = Message::FileListRequest("");
+    //TestFileListSubdirectories("/", "", request5);
 }
 
 TEST_F(FileListTest, SetStartingFolder) {

--- a/test/TestFileList.cc
+++ b/test/TestFileList.cc
@@ -83,8 +83,8 @@ TEST_F(FileListTest, SetTopLevelFolder) {
 
     // Request file list for default top folder "/"
     // 0 image files, > 0 subdirectories
-    auto request5 = Message::FileListRequest("");
-    TestFileListSubdirectories("/", "", request5);
+    // auto request5 = Message::FileListRequest("");
+    // TestFileListSubdirectories("/", "", request5);
 }
 
 TEST_F(FileListTest, SetStartingFolder) {

--- a/test/TestFileList.cc
+++ b/test/TestFileList.cc
@@ -74,21 +74,31 @@ TEST_F(FileListTest, SetTopLevelFolder) {
     }
 
     auto request1 = Message::FileListRequest(abs_path);
+    std::cout << "[DEBUG] Running TestFileList with / and request1" << std::endl;
     TestFileList("/", "", request1);
+    std::cout << "[DEBUG] Running TestFileList with empty and request1, recursive = false" << std::endl;
     TestFileList("", "", request1, false);
 
+    std::cout << "[DEBUG] Creating request2 with 'data/images/mix'" << std::endl;
     auto request2 = Message::FileListRequest("data/images/mix");
+    std::cout << "[DEBUG] Running TestFileList with TestRoot and request2" << std::endl;
     TestFileList(TestRoot().string(), "", request2);
 
+    std::cout << "[DEBUG] Creating request3 with empty string" << std::endl;
     auto request3 = Message::FileListRequest("");
+    std::cout << "[DEBUG] Running TestFileList with abs_path and request3" << std::endl;
     TestFileList(abs_path, "", request3);
 
+    std::cout << "[DEBUG] Creating request4 with '.'" << std::endl;
     auto request4 = Message::FileListRequest(".");
+    std::cout << "[DEBUG] Running TestFileList with abs_path and request4" << std::endl;
     TestFileList(abs_path, "", request4);
 
     // Request file list for default top folder "/"
     // 0 image files, > 0 subdirectories
+    std::cout << "[DEBUG] Creating request5 with empty string" << std::endl;
     auto request5 = Message::FileListRequest("");
+    std::cout << "[DEBUG] Running TestFileListSubdirectories with / and request5" << std::endl;
     TestFileListSubdirectories("/", "", request5);
 }
 

--- a/test/TestFileList.cc
+++ b/test/TestFileList.cc
@@ -68,6 +68,11 @@ public:
 TEST_F(FileListTest, SetTopLevelFolder) {
     std::string abs_path = (TestRoot() / "data" / "images" / "mix").string();
 
+    // Request file list for default top folder "/"
+    // 0 image files, > 0 subdirectories
+    auto request5 = Message::FileListRequest("");
+    TestFileListSubdirectories("/", "", request5);
+
     auto request1 = Message::FileListRequest(abs_path);
     TestFileList("/", "", request1);
     TestFileList("", "", request1, false);
@@ -80,11 +85,6 @@ TEST_F(FileListTest, SetTopLevelFolder) {
 
     auto request4 = Message::FileListRequest(".");
     TestFileList(abs_path, "", request4);
-
-    // Request file list for default top folder "/"
-    // 0 image files, > 0 subdirectories
-    // auto request5 = Message::FileListRequest("");
-    // TestFileListSubdirectories("/", "", request5);
 }
 
 TEST_F(FileListTest, SetStartingFolder) {

--- a/test/TestFileList.cc
+++ b/test/TestFileList.cc
@@ -68,11 +68,6 @@ public:
 TEST_F(FileListTest, SetTopLevelFolder) {
     std::string abs_path = (TestRoot() / "data" / "images" / "mix").string();
 
-    // Request file list for default top folder "/"
-    // 0 image files, > 0 subdirectories
-    auto request5 = Message::FileListRequest("");
-    TestFileListSubdirectories("/", "", request5);
-
     auto request1 = Message::FileListRequest(abs_path);
     TestFileList("/", "", request1);
     TestFileList("", "", request1, false);
@@ -85,6 +80,11 @@ TEST_F(FileListTest, SetTopLevelFolder) {
 
     auto request4 = Message::FileListRequest(".");
     TestFileList(abs_path, "", request4);
+
+    // Request file list for default top folder "/"
+    // 0 image files, > 0 subdirectories
+    auto request5 = Message::FileListRequest("");
+    TestFileListSubdirectories("/", "", request5);
 }
 
 TEST_F(FileListTest, SetStartingFolder) {

--- a/test/TestFileList.cc
+++ b/test/TestFileList.cc
@@ -100,6 +100,7 @@ TEST_F(FileListTest, SetTopLevelFolder) {
     auto request5 = Message::FileListRequest("");
     std::cout << "[DEBUG] Running TestFileListSubdirectories with / and request5" << std::endl;
     TestFileListSubdirectories("/", "", request5);
+    std::cout << "[DEBUG] End of TestFileListSubdirectories with / and request5" << std::endl;
 }
 
 TEST_F(FileListTest, SetStartingFolder) {


### PR DESCRIPTION
**Description**

* Update os_version, with ICD tests passed: 
macOS-13, macOS-15
ubuntu-22.04, ubuntu-24.04
rhel-8, rhel-9
(macOS-14-Intel has an issue on fitting, update later)

* The runner with a label macOS-13 can't build backend, which try to access an non-exist folder: /Users/runner/, replaced by [macOS-13, ICD]