### PR TITLE
Map resumed session ID on viewer registration

### DIFF
--- a/src/Session/SessionManager.cc
+++ b/src/Session/SessionManager.cc
@@ -89,7 +89,6 @@ void SessionManager::OnConnect(WSType* ws) {
     // create a Session
     std::unique_lock<std::mutex> ulock(_sessions_mutex);
     _sessions[session_id] = new Session(ws, loop, session_id, address, _file_list_handler);
-    _real_session_id[_sessions[session_id]->GetId()] = session_id;
     _sessions[session_id]->IncreaseRefCount();
 
     spdlog::info("Session {} [{}] Connected. Num sessions: {}", session_id, address, Session::NumberOfSessions());
@@ -160,7 +159,9 @@ void SessionManager::OnMessage(WSType* ws, std::string_view sv_message, uWS::OpC
                 case CARTA::EventType::REGISTER_VIEWER: {
                     CARTA::RegisterViewer message;
                     if (message.ParseFromArray(event_buf, event_length)) {
+                        auto real_session_id = session->GetId();
                         session->OnRegisterViewer(message, head.icd_version, head.request_id);
+                        _real_session_id[session->GetId()] = real_session_id;
                         message_parsed = true;
                     }
                     break;
@@ -170,7 +171,6 @@ void SessionManager::OnMessage(WSType* ws, std::string_view sv_message, uWS::OpC
                     spdlog::debug("({})({}) resuming session", fmt::ptr(session), session->GetId());
                     if (message.ParseFromArray(event_buf, event_length)) {
                         session->OnResumeSession(message, head.request_id);
-                        _real_session_id[session->GetId()] = session_id;
                         message_parsed = true;
                     }
                     break;


### PR DESCRIPTION
**Description**

This is a followup to #1417 which resolves a design conflict with #1440 and also fixes a small bug in the original PR.

Instead of adding the mapping between each newly created session ID and itself on connection, and also adding the mapping between a resumed session ID and the new session ID when a session is resumed, we can do this once when the viewer is registered -- this message triggers the change of the ID in the session object, so we can obtain both values from the session object (before and after), which is available in the handler function in #1440. Additionally, in the original PR, we were creating duplicate mappings for resumed sessions and never removing them (although they would never be accessed).

**Checklist**

- [X] no changelog update needed
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [X] no protobuf update needed
- [X] protobuf version not bumped
- [X] added reviewers and assignee
- [ ] GitHub Project estimate added
