### PR TITLE
log message removal

### DIFF
--- a/src/Session/SessionManager.cc
+++ b/src/Session/SessionManager.cc
@@ -197,15 +197,11 @@ void SessionManager::OnMessage(WSType* ws, std::string_view sv_message, uWS::OpC
             return;
         }
 
-        auto start_time = std::chrono::high_resolution_clock::now();
         try {
             std::invoke(handler, this, session, sv_message, head);
         } catch (const message_parsing_exception& e) {
             spdlog::error("Error handling event {} in session {}: {}", event_type, session->GetId(), e.what());
         }
-        auto end_time = std::chrono::high_resolution_clock::now();
-        spdlog::info("Processed event {} in {} ms", event_type,
-            std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count());
     } else if (op_code == uWS::OpCode::TEXT) {
         if (sv_message == "PING") {
             auto t_session = session->GetLastMessageTimestamp();


### PR DESCRIPTION
A poorly placed log message in the SessionManager class is flooding the logs with unhelpful log messages.
`[2025-06-16 16:41:31.830Z] [CARTA] [info] Processed event 7 in 0 ms
[2025-06-16 16:41:32.055Z] [CARTA] [info] Processed event 7 in 0 ms
[2025-06-16 16:41:32.135Z] [CARTA] [info] Processed event 8 in 0 ms`

* What is implemented or fixed? Mention the linked issue(s), if any.
  * A log message in in the SessionManager class is being removed.
* How does this PR solve the issue? Give a brief summary.
  * It will remove the unhelpful log messages.
* Are there any companion PRs (frontend, protobuf)?
  * No
* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
  * No

**Checklist**

- [X] no changelog update needed
- [x] e2e test passing / corresponding fix added
- [ ] ICD test passing / corresponding fix added
- [X] no protobuf update needed
- [X] protobuf version not bumped
- [X] added reviewers and assignee
- [ ] GitHub Project estimate added
