### PR TITLE
Add generated schemas header library as explicit dependency of backend to ensure correct build order

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,6 +288,9 @@ set(SOURCE_FILES
 
 add_definitions(-DHAVE_HDF5 -DPUGIXML_COMPACT)
 add_executable(carta_backend ${SOURCE_FILES})
+
+add_dependencies(carta_backend carta-schemas)
+
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     list(REMOVE_ITEM LINK_LIBS uuid)
     target_link_libraries(carta_backend uv ${LINK_LIBS})


### PR DESCRIPTION
**Description**

Fixes #1472. This ensures that the schema headers are built before the backend is built.

**Checklist**

- [X] no changelog update needed
- [x] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [X] no protobuf update needed
- [X] protobuf version not bumped
- [X] added reviewers and assignee
- [ ] GitHub Project estimate added
