### PR TITLE
Addition of missing message handlers

### DIFF
--- a/src/Logger/Logger.cc
+++ b/src/Logger/Logger.cc
@@ -118,7 +118,7 @@ void InitLogger() {
 
 void LogReceivedEventType(const CARTA::EventType& event_type) {
     if (log_protocol_messages) {
-        auto event_name = CARTA::EventType_Name(CARTA::EventType(event_type));
+        auto event_name = CARTA::EventType_Name(event_type);
         if (!event_name.empty()) {
             spdlog::debug("[protocol] <== {}", event_name);
         } else {
@@ -129,7 +129,7 @@ void LogReceivedEventType(const CARTA::EventType& event_type) {
 
 void LogSentEventType(const CARTA::EventType& event_type) {
     if (log_protocol_messages) {
-        auto event_name = CARTA::EventType_Name(CARTA::EventType(event_type));
+        auto event_name = CARTA::EventType_Name(event_type);
         if (!event_name.empty()) {
             spdlog::debug("[protocol] ==> {}", event_name);
         } else {

--- a/src/Session/Session.h
+++ b/src/Session/Session.h
@@ -223,6 +223,7 @@ public:
     void SetAnimationActive(bool val) {
         _animation_active = val;
     }
+    void SendLogEvent(const std::string& message, std::vector<std::string> tags, CARTA::ErrorSeverity severity);
 
 protected:
     // File info for file list (extended info for each hdu_name)
@@ -265,7 +266,6 @@ protected:
     void SendEvent(CARTA::EventType event_type, u_int32_t event_id, const google::protobuf::MessageLite& message, bool compress = true);
     void SendFileEvent(
         int file_id, CARTA::EventType event_type, u_int32_t event_id, google::protobuf::MessageLite& message, bool compress = true);
-    void SendLogEvent(const std::string& message, std::vector<std::string> tags, CARTA::ErrorSeverity severity);
 
     // Channel map cancellation
     bool IsInChannelMapRange(int file_id, int channel);

--- a/src/Session/SessionManager.cc
+++ b/src/Session/SessionManager.cc
@@ -210,7 +210,7 @@ void SessionManager::OnMessage(WSType* ws, std::string_view sv_message, uWS::OpC
         try {
             std::invoke(handler, this, session, sv_message, head);
         } catch (const message_parsing_exception& e) {
-            std::string message = fmt::format("Error handling event: {}", CARTA::EventType_Name(event_type));
+            std::string message = fmt::format("Error parsing {} message", CARTA::EventType_Name(event_type));
             spdlog::error(message);
             session->SendLogEvent(message, {"event"}, CARTA::ErrorSeverity::ERROR);
         }

--- a/src/Session/SessionManager.cc
+++ b/src/Session/SessionManager.cc
@@ -212,7 +212,7 @@ void SessionManager::OnMessage(WSType* ws, std::string_view sv_message, uWS::OpC
         } catch (const message_parsing_exception& e) {
             std::string message = fmt::format("Error handling event: {}", CARTA::EventType_Name(event_type));
             spdlog::error(message);
-            session->SendLogEvent(message);
+            session->SendLogEvent(message, {"event"}, CARTA::ErrorSeverity::ERROR);
         }
     } else if (op_code == uWS::OpCode::TEXT) {
         if (sv_message == "PING") {

--- a/src/Session/SessionManager.cc
+++ b/src/Session/SessionManager.cc
@@ -196,16 +196,17 @@ void SessionManager::OnMessage(WSType* ws, std::string_view sv_message, uWS::OpC
 
         logger::LogReceivedEventType(event_type);
 
-        auto handler = _message_handlers.find(event_type);
-        if (handler == _message_handlers.end()) {
+        MessageHandler handler;
+        try {
+            handler = _message_handlers.at(event_type);
+        } catch (const std::out_of_range& e) {
             spdlog::error("Handler not found for event type: {}", CARTA::EventType_Name(event_type));
-            return;
         }
 
         try {
-            std::invoke(handler->second, this, session, sv_message, head);
+            std::invoke(handler, this, session, sv_message, head);
         } catch (const message_parsing_exception& e) {
-            spdlog::error("Error handling event {} in session {}: {}", event_type, session->GetId(), e.what());
+            spdlog::error("Error handling event {} in session {}: {}", CARTA::EventType_Name(event_type), session->GetId(), e.what());
         }
     } else if (op_code == uWS::OpCode::TEXT) {
         if (sv_message == "PING") {

--- a/src/Session/SessionManager.cc
+++ b/src/Session/SessionManager.cc
@@ -191,6 +191,7 @@ void SessionManager::OnMessage(WSType* ws, std::string_view sv_message, uWS::OpC
 
         if (!CARTA::EventType_IsValid(event_type)) {
             spdlog::error("Bad event type: {}", event_type);
+            session->SendLogEvent("Bad event type: " + event_type, {"event"}, CARTA::ErrorSeverity::ERROR);
             return;
         }
 
@@ -201,12 +202,14 @@ void SessionManager::OnMessage(WSType* ws, std::string_view sv_message, uWS::OpC
             handler = _message_handlers.at(event_type);
         } catch (const std::out_of_range& e) {
             spdlog::error("Handler not found for event type: {}", CARTA::EventType_Name(event_type));
+            session->SendLogEvent("Handler not found for event type: " + CARTA::EventType_Name(event_type), {"event"}, CARTA::ErrorSeverity::ERROR);
         }
 
         try {
             std::invoke(handler, this, session, sv_message, head);
-        } catch (const message_parsing_exception& e) {
-            spdlog::error("Error handling event {} in session {}: {}", CARTA::EventType_Name(event_type), session->GetId(), e.what());
+        } catch (const parsing_exception& e) {
+            spdlog::error("Error handling event: {}", CARTA::EventType_Name(event_type));
+            session->SendLogEvent("Error handling event: " + CARTA::EventType_Name(event_type), {"event"}, CARTA::ErrorSeverity::ERROR);
         }
     } else if (op_code == uWS::OpCode::TEXT) {
         if (sv_message == "PING") {
@@ -314,19 +317,19 @@ std::string SessionManager::IPAsText(std::string_view binary) {
 }
 
 void SessionManager::RegisterViewerHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::RegisterViewer message = Message::DecodeMessage<CARTA::RegisterViewer>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::RegisterViewer>(sv_message);
     auto real_session_id = session->GetId();
     session->OnRegisterViewer(message, head.icd_version, head.request_id);
     _real_session_id[session->GetId()] = real_session_id;
 }
 
 void SessionManager::ResumeSessionHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::ResumeSession message = Message::DecodeMessage<CARTA::ResumeSession>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::ResumeSession>(sv_message);
     session->OnResumeSession(message, head.request_id);
 };
 
 void SessionManager::SetImageChannelsHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::SetImageChannels message = Message::DecodeMessage<CARTA::SetImageChannels>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::SetImageChannels>(sv_message);
     session->ImageChannelLock(message.file_id());
     if (!session->ImageChannelTaskTestAndSet(message.file_id())) {
         OnMessageTask* tsk = new SetImageChannelsTask(session, message.file_id());
@@ -338,14 +341,14 @@ void SessionManager::SetImageChannelsHandler(Session* session, std::string_view 
 };
 
 void SessionManager::SetCursorHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::SetCursor message = Message::DecodeMessage<CARTA::SetCursor>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::SetCursor>(sv_message);
     session->AddCursorSetting(message, head.request_id);
     OnMessageTask* tsk = new SetCursorTask(session, message.file_id());
     ThreadManager::QueueTask(tsk);
 };
 
 void SessionManager::SetHistogramRequirementsHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::SetHistogramRequirements message = Message::DecodeMessage<CARTA::SetHistogramRequirements>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::SetHistogramRequirements>(sv_message);
     if (message.histograms_size() == 0) {
         session->CancelSetHistRequirements();
     } else {
@@ -356,34 +359,34 @@ void SessionManager::SetHistogramRequirementsHandler(Session* session, std::stri
 };
 
 void SessionManager::CloseFileHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::CloseFile message = Message::DecodeMessage<CARTA::CloseFile>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::CloseFile>(sv_message);
     session->OnCloseFile(message);
 };
 
 void SessionManager::StartAnimationHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::StartAnimation message = Message::DecodeMessage<CARTA::StartAnimation>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::StartAnimation>(sv_message);
     session->CancelExistingAnimation();
     OnMessageTask* tsk = new StartAnimationTask(session, message, head.request_id);
     ThreadManager::QueueTask(tsk);
 };
 
 void SessionManager::StopAnimationHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::StopAnimation message = Message::DecodeMessage<CARTA::StopAnimation>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::StopAnimation>(sv_message);
     session->StopAnimation(message.file_id(), message.end_frame());
 };
 
 void SessionManager::AnimationFlowControlHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::AnimationFlowControl message = Message::DecodeMessage<CARTA::AnimationFlowControl>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::AnimationFlowControl>(sv_message);
     session->HandleAnimationFlowControlEvt(message);
 };
 
 void SessionManager::FileInfoRequestHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::FileInfoRequest message = Message::DecodeMessage<CARTA::FileInfoRequest>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::FileInfoRequest>(sv_message);
     session->OnFileInfoRequest(message, head.request_id);
 };
 
 void SessionManager::OpenFileHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::OpenFile message = Message::DecodeMessage<CARTA::OpenFile>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::OpenFile>(sv_message);
     if (!message.lel_expr()) {
         for (auto& session_map : this->_sessions) {
             session_map.second->CloseCachedImage(message.directory(), message.file());
@@ -393,89 +396,89 @@ void SessionManager::OpenFileHandler(Session* session, std::string_view sv_messa
 };
 
 void SessionManager::AddRequiredTilesHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::AddRequiredTiles message = Message::DecodeMessage<CARTA::AddRequiredTiles>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::AddRequiredTiles>(sv_message);
     OnMessageTask* tsk = new GeneralMessageTask<CARTA::AddRequiredTiles>(session, message, head.request_id);
     ThreadManager::QueueTask(tsk);
 };
 
 void SessionManager::RegionFileInfoRequestHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::RegionFileInfoRequest message = Message::DecodeMessage<CARTA::RegionFileInfoRequest>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::RegionFileInfoRequest>(sv_message);
     session->OnRegionFileInfoRequest(message, head.request_id);
 };
 
 void SessionManager::ImportRegionHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::ImportRegion message = Message::DecodeMessage<CARTA::ImportRegion>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::ImportRegion>(sv_message);
     session->OnImportRegion(message, head.request_id);
 };
 
 void SessionManager::ExportRegionHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::ExportRegion message = Message::DecodeMessage<CARTA::ExportRegion>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::ExportRegion>(sv_message);
     session->OnExportRegion(message, head.request_id);
 };
 
 void SessionManager::SetContourParametersHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::SetContourParameters message = Message::DecodeMessage<CARTA::SetContourParameters>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::SetContourParameters>(sv_message);
     OnMessageTask* tsk = new GeneralMessageTask<CARTA::SetContourParameters>(session, message, head.request_id);
     ThreadManager::QueueTask(tsk);
 };
 
 void SessionManager::ScriptingResponseHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::ScriptingResponse message = Message::DecodeMessage<CARTA::ScriptingResponse>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::ScriptingResponse>(sv_message);
     session->OnScriptingResponse(message, head.request_id);
 };
 
 void SessionManager::SetRegionHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::SetRegion message = Message::DecodeMessage<CARTA::SetRegion>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::SetRegion>(sv_message);
     session->OnSetRegion(message, head.request_id);
 };
 
 void SessionManager::RemoveRegionHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::RemoveRegion message = Message::DecodeMessage<CARTA::RemoveRegion>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::RemoveRegion>(sv_message);
     session->OnRemoveRegion(message);
 };
 
 void SessionManager::SetSpectralRequirementsHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::SetSpectralRequirements message = Message::DecodeMessage<CARTA::SetSpectralRequirements>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::SetSpectralRequirements>(sv_message);
     session->OnSetSpectralRequirements(message);
 };
 
 void SessionManager::CatalogFileInfoRequestHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::CatalogFileInfoRequest message = Message::DecodeMessage<CARTA::CatalogFileInfoRequest>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::CatalogFileInfoRequest>(sv_message);
     session->OnCatalogFileInfo(message, head.request_id);
 };
 
 void SessionManager::OpenCatalogFileHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::OpenCatalogFile message = Message::DecodeMessage<CARTA::OpenCatalogFile>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::OpenCatalogFile>(sv_message);
     session->OnOpenCatalogFile(message, head.request_id);
 };
 
 void SessionManager::CloseCatalogFileHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::CloseCatalogFile message = Message::DecodeMessage<CARTA::CloseCatalogFile>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::CloseCatalogFile>(sv_message);
     session->OnCloseCatalogFile(message);
 };
 
 void SessionManager::CatalogFilterRequestHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::CatalogFilterRequest message = Message::DecodeMessage<CARTA::CatalogFilterRequest>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::CatalogFilterRequest>(sv_message);
     session->OnCatalogFilter(message, head.request_id);
 };
 
 void SessionManager::StopMomentCalcHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::StopMomentCalc message = Message::DecodeMessage<CARTA::StopMomentCalc>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::StopMomentCalc>(sv_message);
     session->OnStopMomentCalc(message);
 };
 
 void SessionManager::SaveFileHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::SaveFile message = Message::DecodeMessage<CARTA::SaveFile>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::SaveFile>(sv_message);
     session->OnSaveFile(message, head.request_id);
 };
 
 void SessionManager::ConcatStokesFilesHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::ConcatStokesFiles message = Message::DecodeMessage<CARTA::ConcatStokesFiles>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::ConcatStokesFiles>(sv_message);
     session->OnConcatStokesFiles(message, head.request_id);
 };
 
 void SessionManager::StopFileListHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::StopFileList message = Message::DecodeMessage<CARTA::StopFileList>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::StopFileList>(sv_message);
     if (message.file_list_type() == CARTA::Image) {
         session->StopImageFileList();
     } else {
@@ -484,43 +487,43 @@ void SessionManager::StopFileListHandler(Session* session, std::string_view sv_m
 };
 
 void SessionManager::SetSpatialRequirementsHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::SetSpatialRequirements message = Message::DecodeMessage<CARTA::SetSpatialRequirements>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::SetSpatialRequirements>(sv_message);
     OnMessageTask* tsk = new GeneralMessageTask<CARTA::SetSpatialRequirements>(session, message, head.request_id);
     ThreadManager::QueueTask(tsk);
 };
 
 void SessionManager::SetStatsRequirementsHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::SetStatsRequirements message = Message::DecodeMessage<CARTA::SetStatsRequirements>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::SetStatsRequirements>(sv_message);
     OnMessageTask* tsk = new GeneralMessageTask<CARTA::SetStatsRequirements>(session, message, head.request_id);
     ThreadManager::QueueTask(tsk);
 };
 
 void SessionManager::MomentRequestHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::MomentRequest message = Message::DecodeMessage<CARTA::MomentRequest>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::MomentRequest>(sv_message);
     OnMessageTask* tsk = new GeneralMessageTask<CARTA::MomentRequest>(session, message, head.request_id);
     ThreadManager::QueueTask(tsk);
 };
 
 void SessionManager::FileListRequestHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::FileListRequest message = Message::DecodeMessage<CARTA::FileListRequest>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::FileListRequest>(sv_message);
     OnMessageTask* tsk = new GeneralMessageTask<CARTA::FileListRequest>(session, message, head.request_id);
     ThreadManager::QueueTask(tsk);
 };
 
 void SessionManager::RegionListRequestHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::RegionListRequest message = Message::DecodeMessage<CARTA::RegionListRequest>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::RegionListRequest>(sv_message);
     OnMessageTask* tsk = new GeneralMessageTask<CARTA::RegionListRequest>(session, message, head.request_id);
     ThreadManager::QueueTask(tsk);
 };
 
 void SessionManager::CatalogListRequestHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::CatalogListRequest message = Message::DecodeMessage<CARTA::CatalogListRequest>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::CatalogListRequest>(sv_message);
     OnMessageTask* tsk = new GeneralMessageTask<CARTA::CatalogListRequest>(session, message, head.request_id);
     ThreadManager::QueueTask(tsk);
 };
 
 void SessionManager::PvRequestHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::PvRequest message = Message::DecodeMessage<CARTA::PvRequest>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::PvRequest>(sv_message);
     if (message.has_preview_settings()) {
         session->StopPvPreviewUpdates(message.preview_settings().preview_id());
     }
@@ -529,44 +532,44 @@ void SessionManager::PvRequestHandler(Session* session, std::string_view sv_mess
 };
 
 void SessionManager::StopPvCalcHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::StopPvCalc message = Message::DecodeMessage<CARTA::StopPvCalc>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::StopPvCalc>(sv_message);
     session->OnStopPvCalc(message);
 };
 
 void SessionManager::FittingRequestHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::FittingRequest message = Message::DecodeMessage<CARTA::FittingRequest>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::FittingRequest>(sv_message);
     OnMessageTask* tsk = new GeneralMessageTask<CARTA::FittingRequest>(session, message, head.request_id);
     ThreadManager::QueueTask(tsk);
 };
 
 void SessionManager::SetVectorOverlayParametersHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::SetVectorOverlayParameters message = Message::DecodeMessage<CARTA::SetVectorOverlayParameters>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::SetVectorOverlayParameters>(sv_message);
     OnMessageTask* tsk = new GeneralMessageTask<CARTA::SetVectorOverlayParameters>(session, message, head.request_id);
     ThreadManager::QueueTask(tsk);
 };
 
 void SessionManager::StopFittingHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::StopFitting message = Message::DecodeMessage<CARTA::StopFitting>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::StopFitting>(sv_message);
     session->OnStopFitting(message);
 };
 
 void SessionManager::StopPvPreviewHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::StopPvPreview message = Message::DecodeMessage<CARTA::StopPvPreview>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::StopPvPreview>(sv_message);
     session->OnStopPvPreview(message);
 };
 
 void SessionManager::ClosePvPreviewHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::ClosePvPreview message = Message::DecodeMessage<CARTA::ClosePvPreview>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::ClosePvPreview>(sv_message);
     session->OnClosePvPreview(message);
 };
 
 void SessionManager::RemoteFileRequestHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::RemoteFileRequest message = Message::DecodeMessage<CARTA::RemoteFileRequest>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::RemoteFileRequest>(sv_message);
     session->OnRemoteFileRequest(message, head.request_id);
 };
 
 void SessionManager::ChannelMapFlowControlHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::ChannelMapFlowControl message = Message::DecodeMessage<CARTA::ChannelMapFlowControl>(sv_message);
+    auto message = Message::DecodeMessage<CARTA::ChannelMapFlowControl>(sv_message);
     session->HandleChannelMapFlowControlEvt(message);
 };
 

--- a/src/Session/SessionManager.cc
+++ b/src/Session/SessionManager.cc
@@ -187,20 +187,23 @@ void SessionManager::OnMessage(WSType* ws, std::string_view sv_message, uWS::OpC
         session->UpdateLastMessageTimestamp();
 
         EventHeader head = Message::GetEventHeader(sv_message);
-
         CARTA::EventType event_type = head.GetType();
+
+        if (CARTA::EventType_IsValid(event_type) == "") {
+            spdlog::error("Bad event type: {}", event_type);
+            return;
+        }
+
         logger::LogReceivedEventType(event_type);
-        MessageHandler handler;
-        try {
-            handler = _message_handlers.at(event_type);
-        } catch (const std::out_of_range& e) {
-            spdlog::error("Handler not found for event type: {}", event_type);
-            std::cerr << "Out of range error: " << e.what() << std::endl;
+
+        auto handler = _message_handlers.find(event_type);
+        if (handler == _message_handlers.end()) {
+            spdlog::error("Handler not found for event type: {}", CARTA::EventType_Name(event_type));
             return;
         }
 
         try {
-            std::invoke(handler, this, session, sv_message, head);
+            std::invoke(handler->second, this, session, sv_message, head);
         } catch (const message_parsing_exception& e) {
             spdlog::error("Error handling event {} in session {}: {}", event_type, session->GetId(), e.what());
         }

--- a/src/Session/SessionManager.cc
+++ b/src/Session/SessionManager.cc
@@ -21,6 +21,7 @@ std::unordered_map<CARTA::EventType, SessionManager::MessageHandler> SessionMana
     {CARTA::EventType::SET_HISTOGRAM_REQUIREMENTS, &SessionManager::SetHistogramRequirementsHandler},
     {CARTA::EventType::CLOSE_FILE, &SessionManager::CloseFileHandler},
     {CARTA::EventType::START_ANIMATION, &SessionManager::StartAnimationHandler},
+    {CARTA::EventType::STOP_ANIMATION, &SessionManager::StopAnimationHandler},
     {CARTA::EventType::ANIMATION_FLOW_CONTROL, &SessionManager::AnimationFlowControlHandler},
     {CARTA::EventType::FILE_INFO_REQUEST, &SessionManager::FileInfoRequestHandler},
     {CARTA::EventType::OPEN_FILE, &SessionManager::OpenFileHandler},
@@ -47,13 +48,16 @@ std::unordered_map<CARTA::EventType, SessionManager::MessageHandler> SessionMana
     {CARTA::EventType::FILE_LIST_REQUEST, &SessionManager::FileListRequestHandler},
     {CARTA::EventType::REGION_LIST_REQUEST, &SessionManager::RegionListRequestHandler},
     {CARTA::EventType::CATALOG_LIST_REQUEST, &SessionManager::CatalogListRequestHandler},
-    {CARTA::EventType::PV_REQUEST, &SessionManager::PvRequestHandler}, {CARTA::EventType::STOP_PV_CALC, &SessionManager::StopPvCalcHandler},
+    {CARTA::EventType::PV_REQUEST, &SessionManager::PvRequestHandler}, 
+    {CARTA::EventType::STOP_PV_CALC, &SessionManager::StopPvCalcHandler},
     {CARTA::EventType::FITTING_REQUEST, &SessionManager::FittingRequestHandler},
     {CARTA::EventType::SET_VECTOR_OVERLAY_PARAMETERS, &SessionManager::SetVectorOverlayParametersHandler},
     {CARTA::EventType::STOP_FITTING, &SessionManager::StopFittingHandler},
     {CARTA::EventType::STOP_PV_PREVIEW, &SessionManager::StopPvPreviewHandler},
+    {CARTA::EventType::CLOSE_PV_PREVIEW, &SessionManager::ClosePvPreviewHandler},
     {CARTA::EventType::REMOTE_FILE_REQUEST, &SessionManager::RemoteFileRequestHandler},
-    {CARTA::EventType::CHANNEL_MAP_FLOW_CONTROL, &SessionManager::ChannelMapFlowControlHandler}};
+    {CARTA::EventType::CHANNEL_MAP_FLOW_CONTROL, &SessionManager::ChannelMapFlowControlHandler}
+};
 
 SessionManager::SessionManager(ProgramSettings& settings, std::string auth_token, std::shared_ptr<FileListHandler> file_list_handler)
     : _session_number(0), _app(uWS::App()), _settings(settings), _auth_token(auth_token), _file_list_handler(file_list_handler) {}
@@ -361,6 +365,11 @@ void SessionManager::StartAnimationHandler(Session* session, std::string_view sv
     ThreadManager::QueueTask(tsk);
 };
 
+void SessionManager::StopAnimationHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
+    CARTA::StopAnimation message = Message::DecodeMessage<CARTA::StartAnimation>(sv_message);
+    session->StopAnimation(message.file_id(), message.end_frame());
+};
+
 void SessionManager::AnimationFlowControlHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
     CARTA::AnimationFlowControl message = Message::DecodeMessage<CARTA::AnimationFlowControl>(sv_message);
     session->HandleAnimationFlowControlEvt(message);
@@ -544,7 +553,7 @@ void SessionManager::StopPvPreviewHandler(Session* session, std::string_view sv_
     session->OnStopPvPreview(message);
 };
 
-void SessionManager::ClosePvReviewHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
+void SessionManager::ClosePvPreviewHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
     CARTA::ClosePvPreview message = Message::DecodeMessage<CARTA::ClosePvPreview>(sv_message);
     session->OnClosePvPreview(message);
 };

--- a/src/Session/SessionManager.cc
+++ b/src/Session/SessionManager.cc
@@ -189,7 +189,7 @@ void SessionManager::OnMessage(WSType* ws, std::string_view sv_message, uWS::OpC
         EventHeader head = Message::GetEventHeader(sv_message);
         CARTA::EventType event_type = head.GetType();
 
-        if (CARTA::EventType_IsValid(event_type) == "") {
+        if (!CARTA::EventType_IsValid(event_type)) {
             spdlog::error("Bad event type: {}", event_type);
             return;
         }

--- a/src/Session/SessionManager.cc
+++ b/src/Session/SessionManager.cc
@@ -202,7 +202,8 @@ void SessionManager::OnMessage(WSType* ws, std::string_view sv_message, uWS::OpC
             handler = _message_handlers.at(event_type);
         } catch (const std::out_of_range& e) {
             spdlog::error("Handler not found for event type: {}", CARTA::EventType_Name(event_type));
-            session->SendLogEvent("Handler not found for event type: " + CARTA::EventType_Name(event_type), {"event"}, CARTA::ErrorSeverity::ERROR);
+            session->SendLogEvent(
+                "Handler not found for event type: " + CARTA::EventType_Name(event_type), {"event"}, CARTA::ErrorSeverity::ERROR);
         }
 
         try {

--- a/src/Session/SessionManager.cc
+++ b/src/Session/SessionManager.cc
@@ -190,9 +190,9 @@ void SessionManager::OnMessage(WSType* ws, std::string_view sv_message, uWS::OpC
         CARTA::EventType event_type = head.GetType();
 
         if (!CARTA::EventType_IsValid(event_type)) {
-            std::string message = fmt::format("Bad event type: {}", event_type);
-            spdlog::error(message);
-            session->SendLogEvent(message, {"event"}, CARTA::ErrorSeverity::ERROR);
+            std::string error = fmt::format("Bad event type: {}", event_type);
+            spdlog::error(error);
+            session->SendLogEvent(error, {"event"}, CARTA::ErrorSeverity::ERROR);
             return;
         }
 
@@ -202,17 +202,17 @@ void SessionManager::OnMessage(WSType* ws, std::string_view sv_message, uWS::OpC
         try {
             handler = _message_handlers.at(event_type);
         } catch (const std::out_of_range& e) {
-            std::string message = fmt::format("Handler not found for event type: {}", CARTA::EventType_Name(event_type));
-            spdlog::error(message);
-            session->SendLogEvent(message, {"event"}, CARTA::ErrorSeverity::ERROR);
+            std::string error = fmt::format("Handler not found for event type: {}", CARTA::EventType_Name(event_type));
+            spdlog::error(error);
+            session->SendLogEvent(error, {"event"}, CARTA::ErrorSeverity::ERROR);
         }
 
         try {
             std::invoke(handler, this, session, sv_message, head);
         } catch (const message_parsing_exception& e) {
-            std::string message = fmt::format("Error parsing {} message", CARTA::EventType_Name(event_type));
-            spdlog::error(message);
-            session->SendLogEvent(message, {"event"}, CARTA::ErrorSeverity::ERROR);
+            std::string error = fmt::format("Error parsing {} message", CARTA::EventType_Name(event_type));
+            spdlog::error(error);
+            session->SendLogEvent(error, {"event"}, CARTA::ErrorSeverity::ERROR);
         }
     } else if (op_code == uWS::OpCode::TEXT) {
         if (sv_message == "PING") {

--- a/src/Session/SessionManager.cc
+++ b/src/Session/SessionManager.cc
@@ -48,16 +48,14 @@ std::unordered_map<CARTA::EventType, SessionManager::MessageHandler> SessionMana
     {CARTA::EventType::FILE_LIST_REQUEST, &SessionManager::FileListRequestHandler},
     {CARTA::EventType::REGION_LIST_REQUEST, &SessionManager::RegionListRequestHandler},
     {CARTA::EventType::CATALOG_LIST_REQUEST, &SessionManager::CatalogListRequestHandler},
-    {CARTA::EventType::PV_REQUEST, &SessionManager::PvRequestHandler}, 
-    {CARTA::EventType::STOP_PV_CALC, &SessionManager::StopPvCalcHandler},
+    {CARTA::EventType::PV_REQUEST, &SessionManager::PvRequestHandler}, {CARTA::EventType::STOP_PV_CALC, &SessionManager::StopPvCalcHandler},
     {CARTA::EventType::FITTING_REQUEST, &SessionManager::FittingRequestHandler},
     {CARTA::EventType::SET_VECTOR_OVERLAY_PARAMETERS, &SessionManager::SetVectorOverlayParametersHandler},
     {CARTA::EventType::STOP_FITTING, &SessionManager::StopFittingHandler},
     {CARTA::EventType::STOP_PV_PREVIEW, &SessionManager::StopPvPreviewHandler},
     {CARTA::EventType::CLOSE_PV_PREVIEW, &SessionManager::ClosePvPreviewHandler},
     {CARTA::EventType::REMOTE_FILE_REQUEST, &SessionManager::RemoteFileRequestHandler},
-    {CARTA::EventType::CHANNEL_MAP_FLOW_CONTROL, &SessionManager::ChannelMapFlowControlHandler}
-};
+    {CARTA::EventType::CHANNEL_MAP_FLOW_CONTROL, &SessionManager::ChannelMapFlowControlHandler}};
 
 SessionManager::SessionManager(ProgramSettings& settings, std::string auth_token, std::shared_ptr<FileListHandler> file_list_handler)
     : _session_number(0), _app(uWS::App()), _settings(settings), _auth_token(auth_token), _file_list_handler(file_list_handler) {}

--- a/src/Session/SessionManager.cc
+++ b/src/Session/SessionManager.cc
@@ -364,7 +364,7 @@ void SessionManager::StartAnimationHandler(Session* session, std::string_view sv
 };
 
 void SessionManager::StopAnimationHandler(Session* session, std::string_view sv_message, const EventHeader& head) {
-    CARTA::StopAnimation message = Message::DecodeMessage<CARTA::StartAnimation>(sv_message);
+    CARTA::StopAnimation message = Message::DecodeMessage<CARTA::StopAnimation>(sv_message);
     session->StopAnimation(message.file_id(), message.end_frame());
 };
 

--- a/src/Session/SessionManager.cc
+++ b/src/Session/SessionManager.cc
@@ -190,8 +190,9 @@ void SessionManager::OnMessage(WSType* ws, std::string_view sv_message, uWS::OpC
         CARTA::EventType event_type = head.GetType();
 
         if (!CARTA::EventType_IsValid(event_type)) {
-            spdlog::error("Bad event type: {}", event_type);
-            session->SendLogEvent("Bad event type: " + event_type, {"event"}, CARTA::ErrorSeverity::ERROR);
+            std::string message = fmt::format("Bad event type: {}", event_type);
+            spdlog::error(message);
+            session->SendLogEvent(message, {"event"}, CARTA::ErrorSeverity::ERROR);
             return;
         }
 
@@ -201,16 +202,17 @@ void SessionManager::OnMessage(WSType* ws, std::string_view sv_message, uWS::OpC
         try {
             handler = _message_handlers.at(event_type);
         } catch (const std::out_of_range& e) {
-            spdlog::error("Handler not found for event type: {}", CARTA::EventType_Name(event_type));
-            session->SendLogEvent(
-                "Handler not found for event type: " + CARTA::EventType_Name(event_type), {"event"}, CARTA::ErrorSeverity::ERROR);
+            std::string message = fmt::format("Handler not found for event type: {}", CARTA::EventType_Name(event_type));
+            spdlog::error(message);
+            session->SendLogEvent(message, {"event"}, CARTA::ErrorSeverity::ERROR);
         }
 
         try {
             std::invoke(handler, this, session, sv_message, head);
-        } catch (const parsing_exception& e) {
-            spdlog::error("Error handling event: {}", CARTA::EventType_Name(event_type));
-            session->SendLogEvent("Error handling event: " + CARTA::EventType_Name(event_type), {"event"}, CARTA::ErrorSeverity::ERROR);
+        } catch (const message_parsing_exception& e) {
+            std::string message = fmt::format("Error handling event: {}", CARTA::EventType_Name(event_type));
+            spdlog::error(message);
+            session->SendLogEvent(message);
         }
     } else if (op_code == uWS::OpCode::TEXT) {
         if (sv_message == "PING") {

--- a/src/Session/SessionManager.h
+++ b/src/Session/SessionManager.h
@@ -52,6 +52,7 @@ private:
     void SetHistogramRequirementsHandler(Session* session, std::string_view sv_message, const EventHeader& head);
     void CloseFileHandler(Session* session, std::string_view sv_message, const EventHeader& head);
     void StartAnimationHandler(Session* session, std::string_view sv_message, const EventHeader& head);
+    void StopAnimationHandler(Session* session, std::string_view sv_message, const EventHeader& head);
     void AnimationFlowControlHandler(Session* session, std::string_view sv_message, const EventHeader& head);
     void FileInfoRequestHandler(Session* session, std::string_view sv_message, const EventHeader& head);
     void OpenFileHandler(Session* session, std::string_view sv_message, const EventHeader& head);
@@ -84,7 +85,7 @@ private:
     void SetVectorOverlayParametersHandler(Session* session, std::string_view sv_message, const EventHeader& head);
     void StopFittingHandler(Session* session, std::string_view sv_message, const EventHeader& head);
     void StopPvPreviewHandler(Session* session, std::string_view sv_message, const EventHeader& head);
-    void ClosePvReviewHandler(Session* session, std::string_view sv_message, const EventHeader& head);
+    void ClosePvPreviewHandler(Session* session, std::string_view sv_message, const EventHeader& head);
     void RemoteFileRequestHandler(Session* session, std::string_view sv_message, const EventHeader& head);
     void ChannelMapFlowControlHandler(Session* session, std::string_view sv_message, const EventHeader& head);
 

--- a/src/Util/Message.tcc
+++ b/src/Util/Message.tcc
@@ -9,7 +9,7 @@
 
 #include "Message.h"
 
-struct message_parsing_exception : std::runtime_error {
+struct parsing_exception : std::runtime_error {
     using std::runtime_error::runtime_error;
 };
 
@@ -17,8 +17,7 @@ template <typename T>
 /**
  * @note This function uses a static_assert to ensure that T has a member function `ParseFromArray`.
  *       If T does not have this member function, a compilation error will occur.
- *       The function also throws a runtime error if the parsing fails, providing information about
- *       the session ID and the type of the message.
+ *       The function also throws a parsing exception if the parsing fails.
  */
 T Message::DecodeMessage(std::string_view sv_message) {
     const char* event_buf = sv_message.data() + sizeof(carta::EventHeader);
@@ -27,7 +26,7 @@ T Message::DecodeMessage(std::string_view sv_message) {
         "T must have a member function ParseFromArray(const void*, int)");
     T decoded_message;
     if (!decoded_message.ParseFromArray(event_buf, event_length)) {
-        throw message_parsing_exception("Failed to parse message");
+        throw parsing_exception("Failed to parse message");
     }
     return decoded_message;
 }

--- a/src/Util/Message.tcc
+++ b/src/Util/Message.tcc
@@ -9,7 +9,7 @@
 
 #include "Message.h"
 
-struct parsing_exception : std::runtime_error {
+struct message_parsing_exception : std::runtime_error {
     using std::runtime_error::runtime_error;
 };
 
@@ -26,7 +26,7 @@ T Message::DecodeMessage(std::string_view sv_message) {
         "T must have a member function ParseFromArray(const void*, int)");
     T decoded_message;
     if (!decoded_message.ParseFromArray(event_buf, event_length)) {
-        throw parsing_exception("Failed to parse message");
+        throw message_parsing_exception("Failed to parse message");
     }
     return decoded_message;
 }


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
The handlers for the STOP_ANIMATION and STOP_PV_PREVIEW were missing, highlighted in issue #1475 
* How does this PR solve the issue? Give a brief summary.
The missing message handlers are added back into the codebase.
* Are there any companion PRs (frontend, protobuf)?
No
* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
Steps to reproduce the behavior:
1. Open image
2. Start animation
3. Stop animation
4. See error

If there is no error which resembles the following message, then the issue has been resolved.
`[2025-06-18 19:43:31.242Z] [CARTA] [error] Handler not found for event type: 17
Out of range error: unordered_map::at: key not found`


**Checklist**

- [ ] no changelog update needed
- [x] e2e test passing / corresponding fix added 
- [ ] ICD test passing / corresponding fix added
- [ ] no protobuf update needed
- [ ] protobuf version not bumped
- [ ] added reviewers and assignee
- [ ] GitHub Project estimate added
