### PR TITLE
Small dockerfiles fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,0 @@
-Dockerfiles/Dockerfile-ubuntu-20.04

--- a/Dockerfiles/Dockerfile-ubuntu-22.04
+++ b/Dockerfiles/Dockerfile-ubuntu-22.04
@@ -16,7 +16,7 @@ RUN \
 
 # Get carta dependencies carta-casacore, fits2idia, and zfp from the cartavis-team PPA
 RUN \
-  add-apt-repository -y ppa:cartavis-team/carta-testing && \
+  add-apt-repository -y ppa:cartavis-team/carta && \
   apt-get update && \
   apt-get -y install carta-casacore-dev fits2idia libzfp-dev
 

--- a/Dockerfiles/Dockerfile-ubuntu-22.04
+++ b/Dockerfiles/Dockerfile-ubuntu-22.04
@@ -1,6 +1,4 @@
 FROM ubuntu:22.04
-# Note: kern PPA has been temporarily disabled until kernsuite provide 'jammy' packages. 
-# Until then, the 'casacore-data' package may not be fully up-to-date.
 
 # Install the basic packages
 RUN \

--- a/Dockerfiles/Dockerfile-ubuntu-24.04
+++ b/Dockerfiles/Dockerfile-ubuntu-24.04
@@ -16,7 +16,7 @@ RUN \
 
 # Get carta dependencies carta-casacore, fits2idia, and zfp from the cartavis-team PPA
 RUN \
-  add-apt-repository -y ppa:cartavis-team/carta-testing && \
+  add-apt-repository -y ppa:cartavis-team/carta && \
   apt-get update && \
   apt-get -y install carta-casacore-dev fits2idia libzfp-dev
 

--- a/Dockerfiles/Dockerfile-ubuntu-24.04
+++ b/Dockerfiles/Dockerfile-ubuntu-24.04
@@ -1,6 +1,4 @@
 FROM ubuntu:24.04
-# Note: kern PPA has been temporarily disabled until kernsuite provide 'jammy' packages. 
-# Until then, the 'casacore-data' package may not be fully up-to-date.
 
 # Install the basic packages
 RUN \


### PR DESCRIPTION
This is a small fix to the Dockerfiles (mostly Ubuntu):
1. The PPA has been corrected from `carta-testing` (an internal staging PPA) to `carta` the public PPA which should be used instead.
2. The old `Dockerfile` symlink in the top-level directory was removed.
3. Comment about kernsuite removed from Ubuntu dockerfiles. It wasn't strictly accurate: the main Ubuntu repo `casacore-data` package should update frequently changing data dynamically; it's just annoying to install as a dependency because it has a lot of other casacore dependencies. We can fix this by packaging the cron script we use on our servers in the carta-casacore package, and using it as an alternative dependency of the backend package.

The Ubuntu docker containers we use for CI should be rebuilt so that they use the correct PPA.