### PR TITLE
Handle invalid database objects correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+* Fixed bugs in database validation error handling which caused preferences to be wiped, and corrected preferences schema ([#1485](https://github.com/CARTAvis/carta-backend/issues/1485)).
+
 ## [5.0.0]
 
 ### Added

--- a/src/HttpServer/HttpServer.cc
+++ b/src/HttpServer/HttpServer.cc
@@ -261,14 +261,19 @@ bool HttpServer::WritePreferencesFile(nlohmann::json& obj) {
     auto preferences_path = _config_folder / "preferences.json";
 
     try {
-        fs::create_directories(preferences_path.parent_path().string());
-        std::ofstream file(preferences_path.string());
         // Ensure correct schema and version values are written
         obj["$schema"] = Json::Schema("preferences")["$id"];
         obj["version"] = 2;
+
+        // Validate the preferences
         Json::Validator("preferences").validate(obj);
+
+        // Write out the preferences to file
         auto json_string = obj.dump(4);
+        fs::create_directories(preferences_path.parent_path().string());
+        std::ofstream file(preferences_path.string());
         file << json_string;
+
         return true;
     } catch (json::type_error e) {
         spdlog::warn(e.what());
@@ -624,8 +629,6 @@ bool HttpServer::WriteObjectFile(const std::string& object_type, const std::stri
     auto object_path = _config_folder / (object_type + "s") / (object_name + ".json");
 
     try {
-        fs::create_directories(object_path.parent_path());
-        std::ofstream file(object_path.string());
         // Ensure correct schema value is written
         if (OBJECT_TYPES.count(object_type)) {
             obj["$schema"] = Json::Schema(object_type)["$id"];
@@ -634,10 +637,15 @@ bool HttpServer::WriteObjectFile(const std::string& object_type, const std::stri
             return false;
         }
 
+        // Validate the object
         Json::Validator(object_type).validate(obj);
 
+        // Write out the object to file
         auto json_string = obj.dump(4);
+        fs::create_directories(object_path.parent_path());
+        std::ofstream file(object_path.string());
         file << json_string;
+
         return true;
     } catch (json::type_error e) {
         spdlog::warn(e.what());

--- a/src/HttpServer/HttpServer.cc
+++ b/src/HttpServer/HttpServer.cc
@@ -223,12 +223,44 @@ void HttpServer::AddCorsHeaders(Res* res) {
     res->writeHeader("Access-Control-Max-Age", "3600");
 }
 
+void HttpServer::NormalisePreferences(nlohmann::json& obj) {
+    // Ensure correct schema and version values are written
+    obj["$schema"] = Json::Schema("preferences")["$id"];
+    obj["version"] = 2;
+}
+
+bool HttpServer::ValidatePreferences(nlohmann::json& obj) {
+    bool valid(true);
+    auto error_callback = [&](const json::json_pointer& pointer, const json& instance, const std::string& message) {
+        spdlog::debug("Error validating preferences at {} with value {}: {}", pointer.to_string(), instance.dump(), message);
+        valid = false;
+    };
+
+    JsonCustomErrorHandler error_handler(error_callback);
+    Json::Validator("preferences").validate(obj, error_handler);
+
+    return valid;
+}
+
+bool HttpServer::ValidateObject(const std::string& object_type, nlohmann::json& obj) {
+    bool valid(true);
+    auto error_callback = [&](const json::json_pointer& pointer, const json& instance, const std::string& message) {
+        spdlog::debug("Error validating {} at {} with value {}: {}", object_type, pointer.to_string(), instance.dump(), message);
+        valid = false;
+    };
+
+    JsonCustomErrorHandler error_handler(error_callback);
+    Json::Validator(object_type).validate(obj, error_handler);
+
+    return valid;
+}
+
 json HttpServer::GetExistingPreferences() {
     auto preferences_path = _config_folder / "preferences.json";
     json obj = {};
 
-    if (!fs::exists(preferences_path)) {
-        return {{"version", 1}};
+    if (!fs::exists(preferences_path) || !fs::file_size(preferences_path)) {
+        return {{"version", 2}};
     }
 
     std::ifstream file(preferences_path.string());
@@ -241,47 +273,27 @@ json HttpServer::GetExistingPreferences() {
         return {};
     }
 
-    bool valid(true);
-    auto error_callback = [&](const json::json_pointer& pointer, const json& instance, const std::string& message) {
-        spdlog::debug("Error validating preferences at {} with value {}: {}", pointer.to_string(), instance.dump(), message);
-        valid = false;
-    };
-
-    JsonCustomErrorHandler error_handler(error_callback);
-    Json::Validator("preferences").validate(obj, error_handler);
-
-    if (!valid) {
-        spdlog::warn("Returning invalid preferences.");
-    }
-
     return obj;
 }
 
 bool HttpServer::WritePreferencesFile(nlohmann::json& obj) {
     auto preferences_path = _config_folder / "preferences.json";
 
+    // Dump the preferences to string
+    std::string json_string;
     try {
-        // Ensure correct schema and version values are written
-        obj["$schema"] = Json::Schema("preferences")["$id"];
-        obj["version"] = 2;
-
-        // Validate the preferences
-        Json::Validator("preferences").validate(obj);
-
-        // Write out the preferences to file
-        auto json_string = obj.dump(4);
-        fs::create_directories(preferences_path.parent_path().string());
-        std::ofstream file(preferences_path.string());
-        file << json_string;
-
-        return true;
+        json_string = obj.dump(4);
     } catch (json::type_error e) {
         spdlog::warn(e.what());
         return false;
-    } catch (std::exception e) {
-        spdlog::warn(e.what());
-        return false;
     }
+
+    // Write out the preferences to file
+    fs::create_directories(preferences_path.parent_path().string());
+    std::ofstream file(preferences_path.string());
+    file << json_string;
+
+    return true;
 }
 
 void HttpServer::WaitForData(Res* res, Req* req, const std::function<void(const std::string&)>& callback) {
@@ -306,6 +318,10 @@ void HttpServer::HandleGetPreferences(Res* res, Req* req) {
     // Read preferences JSON file
     json existing_preferences = GetExistingPreferences();
     if (!existing_preferences.empty()) {
+        if (!ValidatePreferences(existing_preferences)) {
+            spdlog::warn("Returning invalid preferences.");
+        }
+
         res->writeStatus(HTTP_200);
         AddNoCacheHeaders(res);
         res->writeHeader("Content-Type", "application/json");
@@ -326,13 +342,26 @@ std::string_view HttpServer::UpdatePreferencesFromString(const std::string& buff
 
     try {
         json update_data = json::parse(buffer);
-        json existing_data = GetExistingPreferences();
 
-        // Update each preference key-value pair
+        // Validate the new preferences *before* merging with existing preferences
+        // First we need to ensure the version is included
+        NormalisePreferences(update_data);
+        if (!ValidatePreferences(update_data)) {
+            spdlog::warn("Rejecting invalid preference update.");
+            return HTTP_400;
+        }
+
+        json existing_data = GetExistingPreferences();
+        // Apply here too to avoid counting these as changed prefs
+        NormalisePreferences(existing_data);
+
+        // Update each preference key-value pair, and count changes
         int modified_key_count = 0;
         for (auto& [key, value] : update_data.items()) {
-            existing_data[key] = value;
-            modified_key_count++;
+            if (!existing_data.count(key) || existing_data[key] != value) {
+                existing_data[key] = value;
+                modified_key_count++;
+            }
         }
 
         if (modified_key_count) {
@@ -394,6 +423,7 @@ std::string_view HttpServer::ClearPreferencesFromString(const std::string& buffe
                     }
                 }
                 if (modified_key_count) {
+                    NormalisePreferences(existing_data);
                     if (WritePreferencesFile(existing_data)) {
                         spdlog::debug("Cleared {} preferences", modified_key_count);
                         return HTTP_200;
@@ -575,16 +605,7 @@ nlohmann::json HttpServer::GetObjectFromPath(const fs::path& path, const std::st
         return obj;
     }
 
-    bool valid(true);
-    auto error_callback = [&](const json::json_pointer& pointer, const json& instance, const std::string& message) {
-        spdlog::debug("Error validating {} at {} with value {}: {}", object_type, pointer.to_string(), instance.dump(), message);
-        valid = false;
-    };
-
-    JsonCustomErrorHandler error_handler(error_callback);
-    Json::Validator(object_type).validate(obj, error_handler);
-
-    if (!valid) {
+    if (!ValidateObject(object_type, obj)) {
         spdlog::warn("Returning invalid {}.", object_type);
     }
 
@@ -628,32 +649,33 @@ nlohmann::json HttpServer::GetExistingObjects(const std::string& object_type) {
 bool HttpServer::WriteObjectFile(const std::string& object_type, const std::string& object_name, nlohmann::json& obj) {
     auto object_path = _config_folder / (object_type + "s") / (object_name + ".json");
 
+    // Ensure correct schema value is written
+    if (OBJECT_TYPES.count(object_type)) {
+        obj["$schema"] = Json::Schema(object_type)["$id"];
+    } else {
+        spdlog::error("Unknown object types: {}.", object_type);
+        return false;
+    }
+
+    // Validate the object
+    if (!ValidateObject(object_type, obj)) {
+        spdlog::warn("Rejecting invalid {} update.", object_type);
+        return false;
+    }
+
+    // Write out the object to file
+    std::string json_string;
     try {
-        // Ensure correct schema value is written
-        if (OBJECT_TYPES.count(object_type)) {
-            obj["$schema"] = Json::Schema(object_type)["$id"];
-        } else {
-            spdlog::error("Unknown object types: {}.", object_type);
-            return false;
-        }
-
-        // Validate the object
-        Json::Validator(object_type).validate(obj);
-
-        // Write out the object to file
-        auto json_string = obj.dump(4);
-        fs::create_directories(object_path.parent_path());
-        std::ofstream file(object_path.string());
-        file << json_string;
-
-        return true;
+        json_string = obj.dump(4);
     } catch (json::type_error e) {
         spdlog::warn(e.what());
         return false;
-    } catch (std::exception e) {
-        spdlog::warn(e.what());
-        return false;
     }
+    fs::create_directories(object_path.parent_path());
+    std::ofstream file(object_path.string());
+    file << json_string;
+
+    return true;
 }
 
 std::string_view HttpServer::SetObjectFromString(const std::string& object_type, const std::string& buffer) {

--- a/src/HttpServer/HttpServer.cc
+++ b/src/HttpServer/HttpServer.cc
@@ -255,6 +255,19 @@ bool HttpServer::ValidateObject(const std::string& object_type, nlohmann::json& 
     return valid;
 }
 
+void HttpServer::WritePreferencesBackup() {
+    auto preferences_path = _config_folder / "preferences.json";
+    auto backup_path = _config_folder / "preferences.json.bak";
+    std::error_code error_code;
+
+    fs::copy_file(preferences_path, backup_path, fs::copy_options::update_existing, error_code);
+    if (error_code) {
+        spdlog::warn("Could not back up preferences: {}", error_code.message());
+    } else {
+        spdlog::info("Backed up preferences to {}.", backup_path.string());
+    }
+}
+
 json HttpServer::GetExistingPreferences() {
     auto preferences_path = _config_folder / "preferences.json";
     json obj = {};
@@ -269,7 +282,7 @@ json HttpServer::GetExistingPreferences() {
     try {
         obj = json::parse(json_string);
     } catch (json::parse_error e) {
-        spdlog::warn(e.what());
+        spdlog::warn("Existing preferences are malformed: {}", e.what());
         return {};
     }
 
@@ -352,6 +365,13 @@ std::string_view HttpServer::UpdatePreferencesFromString(const std::string& buff
         }
 
         json existing_data = GetExistingPreferences();
+        bool write_backup(false);
+
+        // If returned object is completely empty, the prefs are malformed. Back up before writing.
+        if (existing_data.empty()) {
+            write_backup = true;
+        }
+
         // Apply here too to avoid counting these as changed prefs
         NormalisePreferences(existing_data);
 
@@ -365,6 +385,9 @@ std::string_view HttpServer::UpdatePreferencesFromString(const std::string& buff
         }
 
         if (modified_key_count) {
+            if (write_backup) {
+                WritePreferencesBackup();
+            }
             if (WritePreferencesFile(existing_data)) {
                 spdlog::debug("Updated {} preferences", modified_key_count);
                 return HTTP_200;
@@ -601,7 +624,7 @@ nlohmann::json HttpServer::GetObjectFromPath(const fs::path& path, const std::st
     try {
         obj = json::parse(json_string);
     } catch (json::exception e) {
-        spdlog::warn(e.what());
+        spdlog::warn("Existing {} is malformed: {}", object_type, e.what());
         return obj;
     }
 

--- a/src/HttpServer/HttpServer.cc
+++ b/src/HttpServer/HttpServer.cc
@@ -262,9 +262,9 @@ void HttpServer::WritePreferencesBackup() {
 
     fs::copy_file(preferences_path, backup_path, fs::copy_options::update_existing, error_code);
     if (error_code) {
-        spdlog::warn("Could not back up preferences: {}", error_code.message());
+        spdlog::warn("Could not back up preferences file: {}", error_code.message());
     } else {
-        spdlog::info("Backed up preferences to {}.", backup_path.string());
+        spdlog::info("Backed up preferences file to {}.", backup_path.string());
     }
 }
 
@@ -282,7 +282,7 @@ json HttpServer::GetExistingPreferences() {
     try {
         obj = json::parse(json_string);
     } catch (json::parse_error e) {
-        spdlog::warn("Existing preferences are malformed: {}", e.what());
+        spdlog::warn("Preferences file is malformed: {}", e.what());
         return {};
     }
 
@@ -365,12 +365,9 @@ std::string_view HttpServer::UpdatePreferencesFromString(const std::string& buff
         }
 
         json existing_data = GetExistingPreferences();
-        bool write_backup(false);
 
         // If returned object is completely empty, the prefs are malformed. Back up before writing.
-        if (existing_data.empty()) {
-            write_backup = true;
-        }
+        bool malformed(existing_data.empty());
 
         // Apply here too to avoid counting these as changed prefs
         NormalisePreferences(existing_data);
@@ -385,7 +382,10 @@ std::string_view HttpServer::UpdatePreferencesFromString(const std::string& buff
         }
 
         if (modified_key_count) {
-            if (write_backup) {
+            if (malformed) {
+                spdlog::warn(
+                    "Preferences file is malformed. All preferences will be reset to defaults before update. Attempting to back up "
+                    "preferences file.");
                 WritePreferencesBackup();
             }
             if (WritePreferencesFile(existing_data)) {
@@ -624,7 +624,9 @@ nlohmann::json HttpServer::GetObjectFromPath(const fs::path& path, const std::st
     try {
         obj = json::parse(json_string);
     } catch (json::exception e) {
-        spdlog::warn("Existing {} is malformed: {}", object_type, e.what());
+        std::string type_str(object_type);
+        type_str[0] = std::toupper(type_str[0]);
+        spdlog::warn("{} file {} is malformed: {}", type_str, path.string(), e.what());
         return obj;
     }
 

--- a/src/HttpServer/HttpServer.h
+++ b/src/HttpServer/HttpServer.h
@@ -69,6 +69,7 @@ private:
     bool ValidateObject(const std::string& object_type, nlohmann::json& obj);
 
     bool WritePreferencesFile(nlohmann::json& obj);
+    void WritePreferencesBackup();
     bool WriteObjectFile(const std::string& object_type, const std::string& object_name, nlohmann::json& obj);
     void WaitForData(Res* res, Req* req, const std::function<void(const std::string&)>& callback);
 

--- a/src/HttpServer/HttpServer.h
+++ b/src/HttpServer/HttpServer.h
@@ -64,6 +64,10 @@ private:
     void AddNoCacheHeaders(Res* res);
     void AddCorsHeaders(Res* res);
 
+    void NormalisePreferences(nlohmann::json& obj);
+    bool ValidatePreferences(nlohmann::json& obj);
+    bool ValidateObject(const std::string& object_type, nlohmann::json& obj);
+
     bool WritePreferencesFile(nlohmann::json& obj);
     bool WriteObjectFile(const std::string& object_type, const std::string& object_name, nlohmann::json& obj);
     void WaitForData(Res* res, Req* req, const std::function<void(const std::string&)>& callback);

--- a/test/TestRestApi.cc
+++ b/test/TestRestApi.cc
@@ -24,7 +24,9 @@ class TestHttpServer : public carta::HttpServer {
 public:
     TestHttpServer(std::shared_ptr<SessionManager> session_manager, fs::path root_folder, std::string auth_token, bool read_only_mode)
         : carta::HttpServer(session_manager, root_folder, UserDirectory(), auth_token, read_only_mode) {}
+    FRIEND_TEST(RestApiTest, MissingStartingPrefs);
     FRIEND_TEST(RestApiTest, EmptyStartingPrefs);
+    FRIEND_TEST(RestApiTest, MalformedStartingPrefs);
     FRIEND_TEST(RestApiTest, GetExistingPrefs);
     FRIEND_TEST(RestApiTest, UpdatePrefsEmpty);
     FRIEND_TEST(RestApiTest, UpdatePrefsNotJson);
@@ -183,6 +185,16 @@ public:
         std::ofstream(preferences_path.string()) << example_options.dump(4);
     }
 
+    void WriteEmptyPrefs() {
+        fs::create_directories(preferences_path.parent_path());
+        std::ofstream(preferences_path.string()) << "";
+    }
+
+    void WriteMalformedPrefs() {
+        fs::create_directories(preferences_path.parent_path());
+        std::ofstream(preferences_path.string()) << "this is not a json file!";
+    }
+
     void WriteDefaultLayouts() {
         fs::create_directories(layouts_path);
         std::ofstream((layouts_path / "test_layout.json").string()) << example_layout.dump(4);
@@ -221,9 +233,21 @@ private:
     fs::path working_directory;
 };
 
-TEST_F(RestApiTest, EmptyStartingPrefs) {
+TEST_F(RestApiTest, MissingStartingPrefs) {
     auto existing_preferences = _frontend_server->GetExistingPreferences();
-    EXPECT_EQ(existing_preferences, json({{"version", 1}}));
+    EXPECT_EQ(existing_preferences, json({{"version", 2}}));
+}
+
+TEST_F(RestApiTest, EmptyStartingPrefs) {
+    WriteEmptyPrefs();
+    auto existing_preferences = _frontend_server->GetExistingPreferences();
+    EXPECT_EQ(existing_preferences, json({{"version", 2}}));
+}
+
+TEST_F(RestApiTest, MalformedStartingPrefs) {
+    WriteMalformedPrefs();
+    auto existing_preferences = _frontend_server->GetExistingPreferences();
+    EXPECT_EQ(existing_preferences, json());
 }
 
 TEST_F(RestApiTest, GetExistingPrefs) {

--- a/test/TestRestApi.cc
+++ b/test/TestRestApi.cc
@@ -33,6 +33,8 @@ public:
     FRIEND_TEST(RestApiTest, UpdatePrefsInvalidResult);
     FRIEND_TEST(RestApiTest, UpdatePrefsSingleKey);
     FRIEND_TEST(RestApiTest, UpdatePrefsKeyList);
+    FRIEND_TEST(RestApiTest, UpdatePrefsExistingMalformed);
+    FRIEND_TEST(RestApiTest, UpdatePrefsExistingMalformedNoChange);
     FRIEND_TEST(RestApiTest, DeletePrefsEmpty);
     FRIEND_TEST(RestApiTest, DeletePrefsNotJson);
     FRIEND_TEST(RestApiTest, DeletePrefsIgnoresInvalidKeys);
@@ -92,20 +94,23 @@ class RestApiTest : public ::testing::Test {
 public:
     std::unique_ptr<TestHttpServer> _frontend_server;
     std::unique_ptr<TestHttpServer> _frontend_server_read_only_mode;
+    fs::path test_user_folder;
     fs::path preferences_path;
     fs::path layouts_path;
     fs::path snippets_path;
     fs::path workspaces_path;
     json example_options;
+    json new_options;
     json example_layout;
     json example_snippet;
     json example_workspace;
 
     RestApiTest() {
-        preferences_path = fs::path(getenv("HOME")) / CARTA_USER_FOLDER_PREFIX / "config/preferences.json";
-        layouts_path = fs::path(getenv("HOME")) / CARTA_USER_FOLDER_PREFIX / "config/layouts";
-        snippets_path = fs::path(getenv("HOME")) / CARTA_USER_FOLDER_PREFIX / "config/snippets";
-        workspaces_path = fs::path(getenv("HOME")) / CARTA_USER_FOLDER_PREFIX / "config/workspaces";
+        test_user_folder = fs::path(getenv("HOME")) / CARTA_USER_FOLDER_PREFIX;
+        preferences_path = test_user_folder / "config/preferences.json";
+        layouts_path = test_user_folder / "config/layouts";
+        snippets_path = test_user_folder / "config/snippets";
+        workspaces_path = test_user_folder / "config/workspaces";
 
         example_options = R"({
             "$schema": "https://cartavis.org/schemas/preferences_schema_2.json",
@@ -115,6 +120,11 @@ public:
             "beamType": "open",
             "beamVisible": true,
             "beamWidth": 1
+        })"_json;
+
+        new_options = R"({
+            "$schema": "https://cartavis.org/schemas/preferences_schema_2.json",
+            "version": 2
         })"_json;
 
         example_layout = R"({
@@ -174,10 +184,12 @@ public:
     void SetUp() {
         _frontend_server.reset(new TestHttpServer(nullptr, "/", "my_test_key", false));
         _frontend_server_read_only_mode.reset(new TestHttpServer(nullptr, "/", "my_test_key", true));
-        fs::remove(preferences_path);
-        fs::remove_all(layouts_path);
-        fs::remove_all(snippets_path);
-        fs::remove_all(workspaces_path);
+
+        // Guard to avoid deleting a real user directory
+        ASSERT_NE(CARTA_USER_FOLDER_PREFIX, ".carta");
+        ASSERT_NE(CARTA_USER_FOLDER_PREFIX, ".carta-beta");
+        // Remove .carta-unit-tests
+        fs::remove_all(test_user_folder);
     }
 
     void WriteDefaultPrefs() {
@@ -220,13 +232,11 @@ public:
     }
 
     void TearDown() {
-        // Remove .carta-unit-tests/config/preferences (and empty dirs)
-        fs::remove(preferences_path);
-        fs::remove_all(layouts_path);
-        fs::remove_all(snippets_path);
-        fs::remove_all(workspaces_path);
-        fs::remove(preferences_path.parent_path());
-        fs::remove(preferences_path.parent_path().parent_path());
+        // Guard to avoid deleting a real user directory
+        ASSERT_NE(CARTA_USER_FOLDER_PREFIX, ".carta");
+        ASSERT_NE(CARTA_USER_FOLDER_PREFIX, ".carta-beta");
+        // Remove .carta-unit-tests
+        fs::remove_all(test_user_folder);
     }
 
 private:
@@ -285,6 +295,8 @@ TEST_F(RestApiTest, UpdatePrefsSingleKey) {
     // Check that only the beamType key has been modified
     existing_preferences["beamType"] = "open";
     EXPECT_EQ(existing_preferences, example_options);
+    // Check that the original prefs were not backed up
+    EXPECT_FALSE(fs::exists(preferences_path.string() + ".bak"));
 }
 
 TEST_F(RestApiTest, UpdatePrefsKeyList) {
@@ -299,6 +311,34 @@ TEST_F(RestApiTest, UpdatePrefsKeyList) {
     existing_preferences["beamType"] = "open";
     existing_preferences["beamColor"] = "#8A9BA8";
     EXPECT_EQ(existing_preferences, example_options);
+    // Check that the original prefs were not backed up
+    EXPECT_FALSE(fs::exists(preferences_path.string() + ".bak"));
+}
+
+TEST_F(RestApiTest, UpdatePrefsExistingMalformed) {
+    WriteMalformedPrefs();
+    json prefs = {{"beamType", "solid"}};
+    auto status = _frontend_server->UpdatePreferencesFromString(prefs.dump());
+    EXPECT_EQ(status, HTTP_200);
+    auto existing_preferences = _frontend_server->GetExistingPreferences();
+    EXPECT_TRUE(existing_preferences["beamType"] == "solid");
+    // Check that the other preferences were reset
+    existing_preferences.erase("beamType");
+    EXPECT_EQ(existing_preferences, new_options);
+    // Check that the original prefs were backed up
+    EXPECT_TRUE(fs::exists(preferences_path.string() + ".bak"));
+}
+
+TEST_F(RestApiTest, UpdatePrefsExistingMalformedNoChange) {
+    WriteMalformedPrefs();
+    json prefs = {{"version", "2"}};
+    auto status = _frontend_server->UpdatePreferencesFromString(prefs.dump());
+    EXPECT_EQ(status, HTTP_200);
+    // Check that the preferences are blank (still malformed)
+    auto existing_preferences = _frontend_server->GetExistingPreferences();
+    EXPECT_EQ(existing_preferences, json());
+    // Check that the original prefs were not backed up
+    EXPECT_FALSE(fs::exists(preferences_path.string() + ".bak"));
 }
 
 TEST_F(RestApiTest, DeletePrefsEmpty) {


### PR DESCRIPTION
**Description**

Fixes #1485.

The functions which save database objects to disk open the file for writing before performing validation. This means that if validation fails, the file is left blank. This PR moves the opening of the file to just before it is needed for writing, after the validation step. The invalid update is just ignored (which is what currently happens in the controller).

The actual invalid preferences which triggered this issue need separate fixes in these companion PRs:

1. In the [schema definition](https://github.com/CARTAvis/schemas/pull/10) (which is incorrect)
2. In the [frontend](https://github.com/CARTAvis/carta-frontend/pull/2563) (which needs a shim in the upgrade function to correct existing preferences which previous versions of the backend would have allowed to be saved).
3. In the [controller](https://github.com/CARTAvis/carta-controller/pull/239) (which needs the schema update)

This also needs to be merged into the 5.0 branch.

Still to be done:

- [X] The validator library documentation suggests that the default exception thrown by the validator includes a detailed description of the validation error(s), but it's actually just reported as a generic exception. This can be fixed with a custom validator (we already have one that we can reuse with a custom exception).
- [ ] ~The controller sends data in failure responses which contains the error status and a specific error message. The backend does not do this. For parity with the controller, it should send back the same data with the same message under the same circumstances.~ This is not critical, and I would like to adjust the controller's messages. I will make separate issues for this.
- [X] This PR should also include the schemas fix.
- [X] Updated prefs should be validated *before*, not *after* merge with existing prefs before write to file. Otherwise an existing invalid preference will block writes forever.
- [X] Assorted other small issues found and fixed.

**Checklist**

- [X] changelog updated
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [X] no protobuf update needed
- [X] protobuf version not bumped
- [X] added reviewers and assignee
- [ ] GitHub Project estimate added
