### PR TITLE
Fix bug in region spectral profile with flux density statistic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.2]
+
+### Fixed
+* Fixed bug in region spectral profile with flux density statistic ([#1493](https://github.com/CARTAvis/carta-backend/issues/1493)).
+
 ## [5.0.1]
 
 ### Fixed

--- a/src/ImageStats/StatsCalculator.cc
+++ b/src/ImageStats/StatsCalculator.cc
@@ -190,7 +190,7 @@ bool ComputeFluxDensity(
         return false;
     }
     auto npts = stats_result.tovector();
-    stats_result.resize(); 
+    stats_result.resize();
     if (!image_stats.getStatistic(stats_result, casacore::LatticeStatsBase::SUM)) {
         return false;
     }
@@ -208,7 +208,6 @@ bool ComputeFluxDensity(
         spdlog::warn("Cannot compute flux density for image unit not in Jy or K.");
         return false;
     }
-
 
     // Casacore supports "unit-1" and "/unit" syntax so check for both
     bool per_pixel = flux_unit.contains("pixel-1") || (per_unit == "pixel") || (flux_unit.contains("Jy") && per_unit.empty());

--- a/src/ImageStats/StatsCalculator.cc
+++ b/src/ImageStats/StatsCalculator.cc
@@ -256,8 +256,8 @@ bool ComputeFluxDensity(
     return true;
 }
 
-bool GetBeamArea(const casacore::ImageInterface<float>& image, int z, const casacore::String unit, double& beam_area) {
-    // Return restoring beam area in solid angle unit `unit` in `angle`.
+bool GetBeamArea(const casacore::ImageInterface<float>& image, int channel, const casacore::String unit, double& beam_area) {
+    // Return beam area in solid angle unit `unit` in `angle` for requested channel.
     // Returns false if image has no restoring beam  or unit is not a solid angle unit.
     if (!image.imageInfo().hasBeam()) {
         spdlog::warn("Image has no beam for flux density");

--- a/src/ImageStats/StatsCalculator.cc
+++ b/src/ImageStats/StatsCalculator.cc
@@ -189,16 +189,12 @@ bool ComputeFluxDensity(
     if (!image_stats.getStatistic(stats_result, casacore::LatticeStatsBase::NPTS)) {
         return false;
     }
-    double npixels = stats_result(casacore::IPosition(1, 0));
-    if (npixels == 0.0) {
-        return false;
-    }
-
-    stats_result.resize();
+    auto npts = stats_result.tovector();
+    stats_result.resize(); 
     if (!image_stats.getStatistic(stats_result, casacore::LatticeStatsBase::SUM)) {
         return false;
     }
-    double sum = stats_result(casacore::IPosition(1, 0));
+    auto sums = stats_result.tovector();
 
     // Separate unit parts
     casacore::String flux_unit(bunit);
@@ -213,43 +209,55 @@ bool ComputeFluxDensity(
         return false;
     }
 
-    double flux_density;
-    try {
-        // Casacore supports "unit-1" and "/unit" syntax so check for both
-        if (flux_unit.contains("pixel-1") || (per_unit == "pixel") || (flux_unit.contains("Jy") && per_unit.empty())) {
-            flux_density = sum;
-        } else {
-            // Get area for one pixel
-            auto increments = image.coordinates().increment();
-            auto units = image.coordinates().worldAxisUnits();
-            casacore::Quantity area_unit = casacore::Quantity(1.0, units[0]) * casacore::Quantity(1.0, units[1]);
-            casacore::Quantity pixel_area(std::fabs(increments[0] * increments[1]), area_unit.getUnit());
 
-            // Convert pixel area to per_unit
-            if (flux_unit.contains("beam-1") || per_unit.contains("beam")) {
-                double pixel_area_sr = pixel_area.get("sr").getValue();
-                double beam_area_sr;
-                if (!GetBeamArea(image, "sr", beam_area_sr)) {
-                    return false;
-                }
-                flux_density = sum * pixel_area_sr / beam_area_sr;
-            } else if (flux_unit.contains("sr-1") || per_unit == "sr") {
-                double pixel_area_sr = pixel_area.get("sr").getValue();
-                flux_density = sum * pixel_area_sr;
-            } else if (flux_unit.contains("arcsec-2") || per_unit == "arcsec2" || (flux_unit == "K" && per_unit.empty())) {
-                double pixel_area_arcsec2 = pixel_area.get("arcsec2").getValue();
-                flux_density = sum * pixel_area_arcsec2;
-            }
-        }
-    } catch (const casacore::AipsError& err) {
-        return false;
+    // Casacore supports "unit-1" and "/unit" syntax so check for both
+    bool per_pixel = flux_unit.contains("pixel-1") || (per_unit == "pixel") || (flux_unit.contains("Jy") && per_unit.empty());
+
+    // Get area for one pixel
+    casacore::Quantity area_unit, pixel_area;
+    if (!per_pixel) {
+        auto increments = image.coordinates().increment();
+        auto units = image.coordinates().worldAxisUnits();
+        area_unit = casacore::Quantity(1.0, units[0]) * casacore::Quantity(1.0, units[1]);
+        pixel_area = casacore::Quantity(std::fabs(increments[0] * increments[1]), area_unit.getUnit());
     }
 
-    result.push_back(flux_density);
+    for (size_t i = 0; i < npts.size(); ++i) {
+        if (npts[i] == 0) {
+            result.push_back(nan(""));
+        } else {
+            double sum = sums[i];
+
+            try {
+                if (per_pixel) {
+                    result.push_back(sum);
+                } else {
+                    // Convert pixel area to per_unit
+                    if (flux_unit.contains("beam-1") || per_unit.contains("beam")) {
+                        double pixel_area_sr = pixel_area.get("sr").getValue();
+                        double beam_area_sr;
+                        if (!GetBeamArea(image, i, "sr", beam_area_sr)) {
+                            return false;
+                        }
+                        result.push_back(sum * pixel_area_sr / beam_area_sr);
+                    } else if (flux_unit.contains("sr-1") || per_unit == "sr") {
+                        double pixel_area_sr = pixel_area.get("sr").getValue();
+                        result.push_back(sum * pixel_area_sr);
+                    } else if (flux_unit.contains("arcsec-2") || per_unit == "arcsec2" || (flux_unit == "K" && per_unit.empty())) {
+                        double pixel_area_arcsec2 = pixel_area.get("arcsec2").getValue();
+                        result.push_back(sum * pixel_area_arcsec2);
+                    }
+                }
+            } catch (const casacore::AipsError& err) {
+                return false;
+            }
+        }
+    }
+
     return true;
 }
 
-bool GetBeamArea(const casacore::ImageInterface<float>& image, const casacore::String unit, double& beam_area) {
+bool GetBeamArea(const casacore::ImageInterface<float>& image, int z, const casacore::String unit, double& beam_area) {
     // Return restoring beam area in solid angle unit `unit` in `angle`.
     // Returns false if image has no restoring beam  or unit is not a solid angle unit.
     if (!image.imageInfo().hasBeam()) {
@@ -257,7 +265,7 @@ bool GetBeamArea(const casacore::ImageInterface<float>& image, const casacore::S
         return false;
     }
 
-    beam_area = image.imageInfo().restoringBeam().getArea(unit);
+    beam_area = image.imageInfo().restoringBeam(z).getArea(unit);
     return true;
 }
 

--- a/src/ImageStats/StatsCalculator.cc
+++ b/src/ImageStats/StatsCalculator.cc
@@ -264,7 +264,7 @@ bool GetBeamArea(const casacore::ImageInterface<float>& image, int channel, cons
         return false;
     }
 
-    beam_area = image.imageInfo().restoringBeam(z).getArea(unit);
+    beam_area = image.imageInfo().restoringBeam(channel).getArea(unit);
     return true;
 }
 

--- a/src/ImageStats/StatsCalculator.h
+++ b/src/ImageStats/StatsCalculator.h
@@ -90,6 +90,7 @@ bool ComputeFluxDensity(
 
 /** @brief Get the area of the beam in the given unit for an image or a region applied to an image
  *  @param image The image or region applied to an image (casacore::SubImage)
+ *  @param channel The channel index for the beam in the image beam set
  *  @param unit The unit to use for the area calculation, based on the image unit
  *  @param beam_area The result of the calculation
  *  @return Whether the calculation succeeded
@@ -97,7 +98,7 @@ bool ComputeFluxDensity(
  *  casacore::ImageInfo is used to get the area of the beam.
  *  @see ComputeFluxDensity
  */
-bool GetBeamArea(const casacore::ImageInterface<float>& image, int z, const casacore::String unit, double& beam_area);
+bool GetBeamArea(const casacore::ImageInterface<float>& image, int channel, const casacore::String unit, double& beam_area);
 
 } // namespace carta
 

--- a/src/ImageStats/StatsCalculator.h
+++ b/src/ImageStats/StatsCalculator.h
@@ -97,7 +97,7 @@ bool ComputeFluxDensity(
  *  casacore::ImageInfo is used to get the area of the beam.
  *  @see ComputeFluxDensity
  */
-bool GetBeamArea(const casacore::ImageInterface<float>& image, const casacore::String unit, double& beam_area);
+bool GetBeamArea(const casacore::ImageInterface<float>& image, int z, const casacore::String unit, double& beam_area);
 
 } // namespace carta
 


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
Fixes #1493 

* How does this PR solve the issue? Give a brief summary.
Supports per-z flux density in addition to current z.  Verified that spectral profile flux density (per z) values match the image statistics flux density (current z) for each channel.

* Are there any companion PRs (frontend, protobuf)?
No

* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
Create region and request flux density for the region in spectral profiler, check that spectral profile exists.

**Checklist**

- [x] changelog updated / ~no changelog update needed~
- [x] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~protobuf version bumped~ / protobuf version not bumped
- [x] added reviewers and assignee
- [ ] GitHub Project estimate added
