### PR TITLE
Set FITS BLANK values to NaN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * Fixed linker error during unit test build on some platforms ([#1481](https://github.com/CARTAvis/carta-backend/issues/1481)).
+* Fixed NaN values in FITS image with BLANK header keyword ([#1492](https://github.com/CARTAvis/carta-backend/issues/1492)).
 
 ## [5.0.2]
 

--- a/src/ImageData/CartaFitsImage.tcc
+++ b/src/ImageData/CartaFitsImage.tcc
@@ -130,7 +130,6 @@ bool CartaFitsImage::GetPixelMask(int datatype, const casacore::IPosition& shape
     }
 
     fits_read_pixnull(fptr, dtype, start.data(), mask_size, data_buffer.data(), mask_buffer.data(), &anynul, &status);
-    std::cerr << "***** GetPixelMask fits_read_pixnull anynul=" << anynul << std::endl;
     ulock.unlock();
 
     if (status > 0) {

--- a/src/ImageData/CartaFitsImage.tcc
+++ b/src/ImageData/CartaFitsImage.tcc
@@ -63,12 +63,12 @@ bool CartaFitsImage::GetDataSubset(int datatype, const casacore::Slicer& section
             break;
         }
         case -32: {
-            float* fnull_val(nullptr);
-            fits_read_subset(fptr, TFLOAT, start.data(), end.data(), inc.data(), fnull_val, tmp_buffer.data(), &anynul, &status);
+            float fnull_val(std::numeric_limits<float>::quiet_NaN());
+            fits_read_subset(fptr, TFLOAT, start.data(), end.data(), inc.data(), &fnull_val, tmp_buffer.data(), &anynul, &status);
             break;
         }
         case -64: {
-            double dnull_val(NAN);
+            double dnull_val(std::numeric_limits<double>::quiet_NaN());
             fits_read_subset(fptr, TDOUBLE, start.data(), end.data(), inc.data(), &dnull_val, tmp_buffer.data(), &anynul, &status);
             break;
         }
@@ -130,6 +130,7 @@ bool CartaFitsImage::GetPixelMask(int datatype, const casacore::IPosition& shape
     }
 
     fits_read_pixnull(fptr, dtype, start.data(), mask_size, data_buffer.data(), mask_buffer.data(), &anynul, &status);
+    std::cerr << "***** GetPixelMask fits_read_pixnull anynul=" << anynul << std::endl;
     ulock.unlock();
 
     if (status > 0) {


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
Fixes #1492

* How does this PR solve the issue? Give a brief summary.
Use a float NaN value for null values returned by the cfitsio function `fits_read_subset`.

* Are there any companion PRs (frontend, protobuf)?
No

* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
Open image in issue, check that values are NaN instead of -8.

**Checklist**

- [x] changelog updated / ~no changelog update needed~
- [x] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [x] ~protobuf updated to the latest dev commit~ / no protobuf update needed
- [x] ~protobuf version bumped~ / protobuf version not bumped
- [x] added reviewers and assignee
- [ ] GitHub Project estimate added
