### PR TITLE
MipToLayer incorrect value

### DIFF
--- a/src/DataStream/VectorField.cc
+++ b/src/DataStream/VectorField.cc
@@ -193,7 +193,7 @@ void GetTiles(int image_width, int image_height, int mip, std::vector<Tile>& til
     int tile_size_original = TILE_SIZE * mip;
     int num_tile_columns = ceil((double)image_width / tile_size_original);
     int num_tile_rows = ceil((double)image_height / tile_size_original);
-    int32_t tile_layer = Tile::MipToLayer(mip, image_width, image_height, TILE_SIZE, TILE_SIZE);
+    int32_t tile_layer = -1;
     tiles.resize(num_tile_rows * num_tile_columns);
 
     for (int j = 0; j < num_tile_rows; ++j) {


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
* A preference value set on the front-end application is causing the calculation of an invalid mip layer
* How does this PR solve the issue? Give a brief summary.
* This PR explicitly sets the mip layer to -1, to indicate failure or obvious default value.
* Are there any companion PRs (frontend, protobuf)?
* No
* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
* No

**Checklist**

- [ ] changelog updated / no changelog update needed
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [ ] protobuf updated to the latest dev commit / no protobuf update needed
- [ ] protobuf version bumped / protobuf version not bumped
- [ ] added reviewers and assignee
- [ ] GitHub Project estimate added
