### PR TITLE
vector overlay after session resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed NaN values in FITS image with BLANK header keyword ([#1492](https://github.com/CARTAvis/carta-backend/issues/1492)).
 * Don't reallocate memory for image cache unnecessarily ([#1508](https://github.com/CARTAvis/carta-backend/pull/1508)).
 * Fixed crash in ICD channel map test with ASAN enabled ([#1518](https://github.com/CARTAvis/carta-backend/issues/1518)).
+* Fixed vector overlay not updating after session resume ([#1543](https://github.com/CARTAvis/carta-backend/issues/1543)).
 
 ### Changed
 * Standardized use of float and double NaN (Not a Number) ([#1502](https://github.com/CARTAvis/carta-backend/issues/1502)).

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -1280,6 +1280,11 @@ void Session::OnResumeSession(const CARTA::ResumeSession& message, uint32_t requ
             if (image.contour_settings().levels_size()) {
                 OnSetContourParameters(image.contour_settings(), true);
             }
+
+            // Set vector overlay
+            if (image.vector_overlay_settings().file_id()) {
+                OnSetVectorOverlayParameters(image.vector_overlay_settings(), true);
+            }
         }
     }
 
@@ -1589,8 +1594,8 @@ void Session::OnStopFitting(const CARTA::StopFitting& stop_fitting) {
     }
 }
 
-void Session::OnSetVectorOverlayParameters(const CARTA::SetVectorOverlayParameters& message) {
-    if (_frames.count(message.file_id()) && _frames.at(message.file_id())->SetVectorOverlayParameters(message)) {
+void Session::OnSetVectorOverlayParameters(const CARTA::SetVectorOverlayParameters& message, bool silent) {
+    if (_frames.count(message.file_id()) && _frames.at(message.file_id())->SetVectorOverlayParameters(message) && !silent) {
         SendVectorFieldData(message.file_id());
     }
 }

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -1282,7 +1282,7 @@ void Session::OnResumeSession(const CARTA::ResumeSession& message, uint32_t requ
             }
 
             // Set vector overlay
-            if (image.vector_overlay_settings().file_id()) {
+            if (image.vector_overlay_settings().stokes_intensity() >= 0 || image.vector_overlay_settings().stokes_angle() >= 0) {
                 OnSetVectorOverlayParameters(image.vector_overlay_settings(), true);
             }
         }

--- a/src/Session/Session.h
+++ b/src/Session/Session.h
@@ -93,7 +93,7 @@ public:
     void OnStopPvCalc(const CARTA::StopPvCalc& stop_pv_calc);
     void OnFittingRequest(const CARTA::FittingRequest& fitting_request, uint32_t request_id);
     void OnStopFitting(const CARTA::StopFitting& stop_fitting);
-    void OnSetVectorOverlayParameters(const CARTA::SetVectorOverlayParameters& message);
+    void OnSetVectorOverlayParameters(const CARTA::SetVectorOverlayParameters& message, bool silent = false);
     void OnStopPvPreview(const CARTA::StopPvPreview& stop_pv_preview);
     void OnClosePvPreview(const CARTA::ClosePvPreview& close_pv_preview);
     void OnRemoteFileRequest(const CARTA::RemoteFileRequest& message, uint32_t request_id);


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
Closes #1543.  
* How does this PR solve the issue? Give a brief summary.
  - Adding vector overlay setting in the `Session::OnResumeSession`.
  - Adding `vector_overlay_settings` to the protobuf message `ImageProperties`.
* Are there any companion PRs (frontend, protobuf)?
  - Frontend [PR2636](https://github.com/CARTAvis/carta-frontend/pull/2636)
  - Protobuf [PR105](https://github.com/CARTAvis/carta-protobuf/pull/105)
* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
No

**Checklist**

- [x] changelog updated / ~no changelog update needed~
- [x] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [ ] protobuf updated to the latest dev commit / ~no protobuf update needed~
- [ ] protobuf version bumped / ~protobuf version not bumped~
- [ ] added reviewers and assignee
- [ ] GitHub Project estimate added
