### PR TITLE
Fix channel map segfault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.4]
+
+### Fixed
+* Fixed bug causing channel map crash ([#1541](https://github.com/CARTAvis/carta-backend/issues/1541)).
+
 ## [5.0.2]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.0.5]
+## [5.1]
 
 ### Fixed
 * Fixed bug causing channel map crash ([#1541](https://github.com/CARTAvis/carta-backend/issues/1541)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.0.4]
+## [5.0.5]
 
 ### Fixed
 * Fixed bug causing channel map crash ([#1541](https://github.com/CARTAvis/carta-backend/issues/1541)).

--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -452,12 +452,12 @@ bool Frame::GetRasterData(int z, std::vector<float>& image_data, CARTA::ImageBou
 
     Timer t;
     float* z_data;
+    std::vector<float> z_matrix;
     if (z == _z_index) {
         // Use image cache for current z
         z_data = _image_cache.get();
     } else {
         // Load data for requested z
-        std::vector<float> z_matrix;
         GetZMatrix(z_matrix, z, _stokes_index);
         z_data = z_matrix.data();
     }


### PR DESCRIPTION
**Description**
Patch to v5.0.3.

* What is implemented or fixed? Mention the linked issue(s), if any.
Fixes #1541 .

* How does this PR solve the issue? Give a brief summary.
Moved std::vector declaration out of if/else block so data does not go out of scope during smoothing. This fix has already been merged to dev branch in #1519 .

* Are there any companion PRs (frontend, protobuf)?
No

* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
See test image in issue. Open image and enable channel map.

**Checklist**

- [x] changelog updated
- [x] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [x] no protobuf update needed
- [x] protobuf version not bumped
- [x] added reviewers and assignee
- [ ] GitHub Project estimate added
