### PR TITLE
Fix deleting resumed sessions from OnMessageTask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed NaN values in FITS image with BLANK header keyword ([#1492](https://github.com/CARTAvis/carta-backend/issues/1492)).
 * Don't reallocate memory for image cache unnecessarily ([#1508](https://github.com/CARTAvis/carta-backend/pull/1508)).
 * Fixed crash in ICD channel map test with ASAN enabled ([#1518](https://github.com/CARTAvis/carta-backend/issues/1518)).
+* Fixed deletion of resumed session from message task threads ([#1537](https://github.com/CARTAvis/carta-backend/issues/1537)).
 
 ### Changed
 * Standardized use of float and double NaN (Not a Number) ([#1502](https://github.com/CARTAvis/carta-backend/issues/1502)).

--- a/src/Session/SessionManager.cc
+++ b/src/Session/SessionManager.cc
@@ -62,9 +62,11 @@ SessionManager::SessionManager(ProgramSettings& settings, std::string auth_token
 
 void SessionManager::DeleteSession(uint32_t session_id) {
     std::unique_lock<std::mutex> ulock(_sessions_mutex);
+    uint32_t real_session_id;
     Session* session;
     try {
-        session = _sessions.at(session_id);
+        real_session_id = _real_session_id.at(session_id);
+        session = _sessions.at(real_session_id);
     } catch (const std::out_of_range& e) {
         spdlog::warn("Could not delete session {}: not found!", session_id);
         return;
@@ -82,7 +84,7 @@ void SessionManager::DeleteSession(uint32_t session_id) {
         }
         _real_session_id.erase(session->GetId());
         delete session;
-        _sessions.erase(session_id);
+        _sessions.erase(real_session_id);
     } else {
         spdlog::info("Session {} reference count is not 0 ({}) at this point in DeleteSession", session_id, session->GetRefCount());
     }

--- a/src/Session/SessionManager.cc
+++ b/src/Session/SessionManager.cc
@@ -62,14 +62,19 @@ SessionManager::SessionManager(ProgramSettings& settings, std::string auth_token
 
 void SessionManager::DeleteSession(uint32_t session_id) {
     std::unique_lock<std::mutex> ulock(_sessions_mutex);
-    uint32_t real_session_id;
     Session* session;
+
     try {
-        real_session_id = _real_session_id.at(session_id);
-        session = _sessions.at(real_session_id);
+        session = _sessions.at(session_id);
     } catch (const std::out_of_range& e) {
-        spdlog::warn("Could not delete session {}: not found!", session_id);
-        return;
+        try {
+            auto real_id = _real_session_id.at(session_id);
+            session = _sessions.at(real_id);
+            session_id = real_id;
+        } catch (const std::out_of_range& e) {
+            spdlog::warn("Could not delete session {}: not found!", session_id);
+            return;
+        }
     }
 
     spdlog::info("Session {} [{}] Deleted. Remaining sessions: {}", session->GetId(), session->GetAddress(), Session::NumberOfSessions());
@@ -82,11 +87,13 @@ void SessionManager::DeleteSession(uint32_t session_id) {
             Session* ss = ssp.second;
             spdlog::info("\tMap id {}, session id {}, session ptr {}", ssp.first, ss->GetId(), fmt::ptr(ss));
         }
-        _real_session_id.erase(session->GetId());
+        auto internal_id = session->GetId();
         delete session;
-        _sessions.erase(real_session_id);
+        _sessions.erase(session_id);
+        _real_session_id.erase(internal_id);
+
     } else {
-        spdlog::info("Session {} reference count is not 0 ({}) at this point in DeleteSession", session_id, session->GetRefCount());
+        spdlog::info("Session {} reference count is not 0 ({}) at this point in DeleteSession", session->GetId(), session->GetRefCount());
     }
 }
 


### PR DESCRIPTION
**Description**

This fixes #1537 by looking up the session ID to be deleted in the mapping of internal IDs to real session map IDs.

Still to be tested. Haven't confirmed steps to reproduce, but broadly we need to
1. resume a session
2. do something that spawns a task in a new thread (animation? spectral profile?)
3. end the session (close browser window)
4. whether the session is deleted correctly may depend on which thread calls delete first, but either way the delete called by the OnMessageTask destructor should print a warning about the session not being found in dev, and not in this branch. Log level must be at least 4 (the default).

**Checklist**

- [X] changelog updated
- [x] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [X] no protobuf update needed
- [X] protobuf version not bumped
- [X] added reviewers and assignee
- [ ] GitHub Project estimate added
