### PR TITLE
Backport cache vector allocation and core dump fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1]
+
+### Fixed
+* Don't reallocate memory for image cache unnecessarily ([#1508](https://github.com/CARTAvis/carta-backend/pull/1508)).
+
 ## [5.0.2]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Don't reallocate memory for image cache unnecessarily ([#1508](https://github.com/CARTAvis/carta-backend/pull/1508)).
 
+### Changed
+* Excluded image cache data from core dumps on supported platforms ([#1506](https://github.com/CARTAvis/carta-backend/pull/1506)).
+
 ## [5.0.2]
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,6 +278,7 @@ set(SOURCE_FILES
         src/Util/Casacore.cc
         src/Util/File.cc
         src/Util/Json.cc
+        src/Util/Memory.cc
         src/Util/Message.cc
         src/Util/Stokes.cc
         src/Util/String.cc

--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -79,7 +79,7 @@ Frame::Frame(uint32_t session_id, std::shared_ptr<FileLoader> loader, const std:
 
     _use_tile_cache = _loader->UseTileCache();
 
-    // load full image cache for loaders that don't use the tile cache and mipmaps
+    // load full single-channel image cache for loaders that don't use the tile cache and mipmaps
     if (load_image_cache && !(_use_tile_cache && _loader->HasMip(2)) && !FillImageCache()) {
         _open_image_error = fmt::format("Cannot load image data. Check log.");
         _valid = false;
@@ -385,17 +385,22 @@ bool Frame::FillImageCache() {
     }
 
     Timer t;
+
+    if (_image_cache == nullptr) {
+        // allocate memory for full image cache
+        _image_cache_size = _dims.width * _dims.height;
+        _image_cache = std::make_unique<float[]>(_image_cache_size);
+    }
+
     StokesSlicer stokes_slicer = GetImageSlicer(AxisRange(_z_index), _stokes_index);
-    _image_cache_size = stokes_slicer.slicer.length().product();
-    _image_cache = std::make_unique<float[]>(_image_cache_size);
     if (!GetSlicerData(stokes_slicer, _image_cache.get())) {
         spdlog::error("Session {}: {}", _session_id, "Loading image cache failed.");
         return false;
     }
 
     auto dt = t.Elapsed();
-    spdlog::performance("Load {}x{} image to cache in {:.3f} ms at {:.3f} MPix/s", _dims.width, _dims.height, dt.ms(),
-        (float)(_dims.width * _dims.height) / dt.us());
+    spdlog::performance("Load {}x{} image Z {} pol. {} to cache in {:.3f} ms at {:.3f} MPix/s", _dims.width, _dims.height, _z_index,
+        _stokes_index, dt.ms(), (float)(_dims.width * _dims.height) / dt.us());
 
     _image_cache_valid = true;
     return true;
@@ -888,7 +893,7 @@ bool Frame::GetBasicStats(int z, int stokes, BasicStats<float>& stats) {
 
         if ((z == CurrentZ()) && (stokes == CurrentStokes())) {
             // calculate histogram from image cache
-            if ((_image_cache_size == 0) && !FillImageCache()) {
+            if ((!_image_cache_valid) && !FillImageCache()) {
                 // cannot calculate
                 return false;
             }
@@ -956,7 +961,7 @@ bool Frame::CalculateHistogram(int region_id, int z, int stokes, int num_bins, c
 
     if ((z == CurrentZ()) && (stokes == CurrentStokes())) {
         // calculate histogram from current image cache
-        if ((_image_cache_size == 0) && !FillImageCache()) {
+        if ((!_image_cache_valid) && !FillImageCache()) {
             return false;
         }
         bool write_lock(false);

--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -389,10 +389,11 @@ bool Frame::FillImageCache() {
     if (_image_cache == nullptr) {
         // allocate memory for full image cache
         _image_cache_size = _dims.width * _dims.height;
-        _image_cache = std::make_unique<float[]>(_image_cache_size);
+        _image_cache = MakeUniqueAlignedDataPtr<float>(_image_cache_size);
     }
 
     StokesSlicer stokes_slicer = GetImageSlicer(AxisRange(_z_index), _stokes_index);
+
     if (!GetSlicerData(stokes_slicer, _image_cache.get())) {
         spdlog::error("Session {}: {}", _session_id, "Loading image cache failed.");
         return false;

--- a/src/Frame/Frame.h
+++ b/src/Frame/Frame.h
@@ -296,7 +296,7 @@ protected:
     ContourSettings _contour_settings;
 
     // Image data cache and mutex
-    long long int _image_cache_size;
+    size_t _image_cache_size;
     std::unique_ptr<float[]> _image_cache;
     bool _image_cache_valid;       // cached image data is valid for current z and stokes
     queuing_rw_mutex _cache_mutex; // allow concurrent reads but lock for write

--- a/src/Frame/Frame.h
+++ b/src/Frame/Frame.h
@@ -32,6 +32,7 @@
 #include "ThreadingManager/Concurrency.h"
 #include "Util/FileSystem.h"
 #include "Util/Image.h"
+#include "Util/Memory.h"
 #include "Util/Message.h"
 
 namespace carta {
@@ -297,7 +298,7 @@ protected:
 
     // Image data cache and mutex
     size_t _image_cache_size;
-    std::unique_ptr<float[]> _image_cache;
+    UniqueAlignedDataPtr<float> _image_cache;
     bool _image_cache_valid;       // cached image data is valid for current z and stokes
     queuing_rw_mutex _cache_mutex; // allow concurrent reads but lock for write
     std::mutex _image_mutex;       // only one disk access at a time

--- a/src/Util/Memory.cc
+++ b/src/Util/Memory.cc
@@ -1,0 +1,33 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018- Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+#include "Memory.h"
+
+#include <cerrno>
+
+#include <spdlog/fmt/fmt.h>
+#include <spdlog/spdlog.h>
+
+/**
+ * @details Mark the memory address range provided to be excluded from core dumps, using the madvise system function, if this is supported
+ * by the platform (either MADV_DONTDUMP nor MADV_NOCORE must be defined). The address range must be page-aligned.
+ *
+ * @note If the functionality is unsupported or the address range is invalid, this function prints a warning message.
+ */
+bool ExcludeFromCoreDump(void* address, size_t size) {
+#ifdef NO_CORE_DUMP_ADVICE
+    if (madvise(address, size, NO_CORE_DUMP_ADVICE)) {
+        auto e(errno);
+        auto out = fmt::memory_buffer();
+        fmt::format_system_error(out, e, "Failed to exclude data from core dump");
+        spdlog::warn(fmt::to_string(out));
+        return false;
+    }
+    return true;
+#endif
+    spdlog::warn("Could not exclude data from core dump: unsupported platform.");
+    return false;
+}

--- a/src/Util/Memory.h
+++ b/src/Util/Memory.h
@@ -1,0 +1,78 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018- Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+#ifndef CARTA_SRC_UTIL_MEMORY_H_
+#define CARTA_SRC_UTIL_MEMORY_H_
+
+#include <sys/mman.h>
+#include <unistd.h>
+#include <memory>
+#include <string>
+
+// If either of these madvise flags is defined, we can support excluding memory addresses from core dumps.
+#if defined(MADV_DONTDUMP)
+// Available on Linux
+#define NO_CORE_DUMP_ADVICE MADV_DONTDUMP
+#elif defined(MADV_NOCORE)
+// Available on FreeBSD
+#define NO_CORE_DUMP_ADVICE MADV_NOCORE
+#endif
+
+/**
+ * @brief Mark the memory address range provided to be excluded from core dumps, if this is supported by the platform. The range must be
+ * page-aligned.
+ * @param address The starting address of the memory range, which must be page-aligned.
+ * @param size The size of the memory range, which must be an exact multiple of the page size.
+ *
+ * @return Whether the address range was successfully marked.
+ */
+bool ExcludeFromCoreDump(void* address, size_t size);
+
+/**
+ * @brief Custom deleter for page-aligned data.
+ * @see UniqueAlignedDataPtr
+ * @note This is a wrapper around std::free which allows UniqueAlignedDataPtr to be constructed without the need for an explicit deleter
+ * parameter.
+ */
+struct AlignedDataDeleter {
+    void operator()(void* ptr) {
+        std::free(ptr);
+    }
+};
+
+/**
+ * @brief Alias for a std::unique_ptr that manages a page-aligned dynamic array and has a custom deleter.
+ * @tparam T The type of the data in the array managed by the pointer.
+ */
+template <typename T>
+using UniqueAlignedDataPtr = std::unique_ptr<T[], AlignedDataDeleter>;
+
+/**
+ * @brief Create a UniqueAlignedDataPtr and optionally mark its data to be excluded from core dumps.
+ *
+ * @details This function allocates page-aligned memory using std::aligned_alloc. The array size is automatically converted to the raw
+ * memory size for the given data type and padded to a multiple of the page size. The custom deleter of the returned pointer automatically
+ * handles deallocation correctly when the pointer is destroyed.
+ * @note This function calls ExcludeFromCoreDump internally if exclude_from_core_dump is true, but ignores a failure result.
+ *
+ * @tparam T The type of the data in the array managed by the pointer.
+ * @param size The size of the array.
+ * @param exclude_from_core_dump Whether the data should be excluded from core dumps.
+ *
+ * @return The constructed UniqueAlignedDataPtr.
+ */
+template <typename T>
+UniqueAlignedDataPtr<T> MakeUniqueAlignedDataPtr(size_t size, bool exclude_from_core_dump = true) {
+    size_t page_size = sysconf(_SC_PAGE_SIZE);
+    size_t padded_size = (size * sizeof(T) + page_size - 1) & -page_size;
+    auto ptr = UniqueAlignedDataPtr<T>(static_cast<T*>(std::aligned_alloc(page_size, padded_size)));
+    if (exclude_from_core_dump) {
+        ExcludeFromCoreDump(ptr.get(), padded_size);
+    }
+    return ptr;
+}
+
+#endif // CARTA_SRC_UTIL_MEMORY_H_

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -64,11 +64,12 @@ set(TEST_SOURCES
         TestRegionStats.cc
         TestRestApi.cc
         TestTileEncoding.cc
+	TestVoTable.cc
         Util/TestUtilCasacore.cc
         Util/TestUtilFile.cc
         Util/TestUtilImage.cc
-        Util/TestUtilString.cc
-        TestVoTable.cc)
+        Util/TestUtilMemory.cc
+        Util/TestUtilString.cc)
 
 # Add all the sources in the main project and remove Main.cc
 foreach(src_file ${SOURCE_FILES})

--- a/test/Util/TestUtilMemory.cc
+++ b/test/Util/TestUtilMemory.cc
@@ -1,0 +1,16 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018- Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+#include "Util/Memory.h"
+
+class MemoryUtilTest : public ::testing::Test {};
+
+TEST_F(MemoryUtilTest, TestPageAlignedFloatArray) {
+    auto data = MakeUniqueAlignedDataPtr<float>(10);
+    EXPECT_EQ(reinterpret_cast<uintptr_t>(data.get()) % sysconf(_SC_PAGE_SIZE), 0);
+}


### PR DESCRIPTION
This is a backport of the fix to stop unnecessarily deallocating and reallocating the image cache memory every time the channel changes, and the feature to exclude the image cache data from core dumps.