### PR TITLE
Create casacore array correctly when fetching region data for other Stokes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1]
+
+### Fixed
+* Fixed fetching of region data for other Stokes ([#1551](https://github.com/CARTAvis/carta-backend/issues/1551)).
+
 ## [5.0.2]
 
 ### Fixed

--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -1694,13 +1694,13 @@ bool Frame::GetRegionData(const StokesRegion& stokes_region, std::vector<float>&
 
             // Get image data and mask, with image mutex locked
             std::unique_lock<std::mutex> ulock(_image_mutex);
-            casacore::Array<float> tmpdata;
             if (_loader->IsGenerated() || is_computed_stokes) { // For the image in memory
+                casacore::Array<float> tmpdata;
                 sub_image.doGetSlice(tmpdata, slicer);
                 data = tmpdata.tovector();
             } else {
                 data.resize(subimage_shape.product()); // must size correctly before sharing
-                tmpdata = casacore::Array<float>(subimage_shape, data.data(), casacore::StorageInitPolicy::SHARE);
+                casacore::Array<float> tmpdata(subimage_shape, data.data(), casacore::StorageInitPolicy::SHARE);
                 sub_image.doGetSlice(tmpdata, slicer);
             }
 

--- a/src/Region/Region.cc
+++ b/src/Region/Region.cc
@@ -164,10 +164,10 @@ std::shared_ptr<casacore::LCRegion> Region::GetImageRegion(int file_id, std::sha
                 }
 
                 // Cache LCRegion
-                if (lcregion && stokes_source.IsOriginalImage()) {
+                if (stokes_source.IsOriginalImage()) {
                     std::lock_guard<std::mutex> guard(_lcregion_mutex);
                     _lcregion = lcregion;
-                    _lcregion_set = true;
+                    _lcregion_set = true; // attempt was made even if lcregion failed (outside image)
                 }
             }
         } else {

--- a/src/Region/Region.cc
+++ b/src/Region/Region.cc
@@ -163,10 +163,12 @@ std::shared_ptr<casacore::LCRegion> Region::GetImageRegion(int file_id, std::sha
                     // Region is outside image
                 }
 
-                // Cache LCRegion
+                // Cache LCRegion and set flag
                 if (stokes_source.IsOriginalImage()) {
-                    std::lock_guard<std::mutex> guard(_lcregion_mutex);
-                    _lcregion = lcregion;
+                    if (lcregion) {
+                        std::lock_guard<std::mutex> guard(_lcregion_mutex);
+                        _lcregion = lcregion;
+                    }
                     _lcregion_set = true; // attempt was made even if lcregion failed (outside image)
                 }
             }

--- a/src/Region/Region.cc
+++ b/src/Region/Region.cc
@@ -162,12 +162,12 @@ std::shared_ptr<casacore::LCRegion> Region::GetImageRegion(int file_id, std::sha
                 } catch (const casacore::AipsError& err) {
                     // Region is outside image
                 }
-                _lcregion_set = true;
 
                 // Cache LCRegion
                 if (lcregion && stokes_source.IsOriginalImage()) {
                     std::lock_guard<std::mutex> guard(_lcregion_mutex);
                     _lcregion = lcregion;
+                    _lcregion_set = true;
                 }
             }
         } else {

--- a/src/Region/Region.cc
+++ b/src/Region/Region.cc
@@ -147,7 +147,7 @@ std::shared_ptr<casacore::LCRegion> Region::GetImageRegion(int file_id, std::sha
 
     if (!lcregion) {
         if (IsInReferenceImage(file_id)) {
-            if (!_lcregion_set) {
+            if (!_lcregion_set || Stokes::IsComputed(stokes_source.stokes)) {
                 // Create LCRegion from TableRecord
                 casacore::TableRecord region_record;
                 if (GetRegionState().IsRotbox()) {

--- a/src/Region/RegionHandler.cc
+++ b/src/Region/RegionHandler.cc
@@ -1688,6 +1688,7 @@ bool RegionHandler::GetRegionHistogramData(
             auto* default_histogram = histogram_message.mutable_histograms();
             std::vector<int> histogram_bins(1, 0);
             FillHistogram(default_histogram, 1, 0.0, 0.0, histogram_bins, NAN, NAN);
+            histogram_messages.emplace_back(histogram_message);
             continue;
         }
 


### PR DESCRIPTION
Previously the temporary array would be discarded and the data would be empty. This has been isolated for the backport from #1510.

The LCRegion from Region::GetImageRegion was also fixed to return a 2D LCRegion for the reference image for computed stokes, so that it could be used to get the region data as mentioned.

I will also update the changelog in this branch, and retroactively add the entry to the dev changelog.