### PR TITLE
Refactoring: remove never-to-be-used wrappers from Util/Message #1533

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Moved region statistics implementation to analysis subdirectory ([#1512](https://github.com/CARTAvis/carta-backend/issues/1512)).
 * Excluded image cache data from core dumps on supported platforms ([#1506](https://github.com/CARTAvis/carta-backend/pull/1506)).
 * Moved region spatial profile implementation to analysis subdirectory ([#1515](https://github.com/CARTAvis/carta-backend/issues/1515)).
+* Removed unused protobuf message wrappers ([#1533](https://github.com/CARTAvis/carta-backend/issues/1533)).
 
 ## [5.0.2]
 

--- a/src/Util/Message.cc
+++ b/src/Util/Message.cc
@@ -11,13 +11,13 @@
 
 #include <chrono>
 
-CARTA::RegisterViewer Message::RegisterViewer(uint32_t session_id, std::string api_key, uint32_t client_feature_flags) {
+/*CARTA::RegisterViewer Message::RegisterViewer(uint32_t session_id, std::string api_key, uint32_t client_feature_flags) {
     CARTA::RegisterViewer register_viewer;
     register_viewer.set_session_id(session_id);
     register_viewer.set_api_key(api_key);
     register_viewer.set_client_feature_flags(client_feature_flags);
     return register_viewer;
-}
+}*/
 
 CARTA::CloseFile Message::CloseFile(int32_t file_id) {
     CARTA::CloseFile close_file;
@@ -54,16 +54,16 @@ CARTA::SetImageChannels Message::SetImageChannels(
     return set_image_channels;
 }
 
-CARTA::SetCursor Message::SetCursor(int32_t file_id, float x, float y) {
+/*CARTA::SetCursor Message::SetCursor(int32_t file_id, float x, float y) {
     CARTA::SetCursor set_cursor;
     set_cursor.set_file_id(file_id);
     auto* point = set_cursor.mutable_point();
     point->set_x(x);
     point->set_y(y);
     return set_cursor;
-}
+}*/
 
-CARTA::SetSpatialRequirements Message::SetSpatialRequirements(int32_t file_id, int32_t region_id) {
+/*CARTA::SetSpatialRequirements Message::SetSpatialRequirements(int32_t file_id, int32_t region_id) {
     CARTA::SetSpatialRequirements set_spatial_requirements;
     set_spatial_requirements.set_file_id(file_id);
     set_spatial_requirements.set_region_id(region_id);
@@ -72,9 +72,9 @@ CARTA::SetSpatialRequirements Message::SetSpatialRequirements(int32_t file_id, i
     auto* spatial_requirement_y = set_spatial_requirements.add_spatial_profiles();
     spatial_requirement_y->set_coordinate("y");
     return set_spatial_requirements;
-}
+}*/
 
-CARTA::SetStatsRequirements Message::SetStatsRequirements(int32_t file_id, int32_t region_id) {
+/*CARTA::SetStatsRequirements Message::SetStatsRequirements(int32_t file_id, int32_t region_id) {
     CARTA::SetStatsRequirements set_stats_requirements;
     set_stats_requirements.set_file_id(file_id);
     set_stats_requirements.set_region_id(region_id);
@@ -88,9 +88,9 @@ CARTA::SetStatsRequirements Message::SetStatsRequirements(int32_t file_id, int32
     stats_config->add_stats_types(CARTA::StatsType::Min);
     stats_config->add_stats_types(CARTA::StatsType::Max);
     return set_stats_requirements;
-}
+}*/
 
-CARTA::SetHistogramRequirements Message::SetHistogramRequirements(
+/*CARTA::SetHistogramRequirements Message::SetHistogramRequirements(
     int32_t file_id, int32_t region_id, const std::string& coordinate, int32_t channel, int32_t num_bins) {
     CARTA::SetHistogramRequirements set_histogram_requirements;
     set_histogram_requirements.set_file_id(file_id);
@@ -100,7 +100,7 @@ CARTA::SetHistogramRequirements Message::SetHistogramRequirements(
     histograms->set_channel(channel);
     histograms->set_num_bins(num_bins);
     return set_histogram_requirements;
-}
+}*/
 
 CARTA::AddRequiredTiles Message::AddRequiredTiles(
     int32_t file_id, CARTA::CompressionType compression_type, float compression_quality, const std::vector<int32_t>& tiles) {
@@ -149,7 +149,7 @@ CARTA::SetRegion Message::SetRegion(
     return set_region;
 }
 
-CARTA::SetStatsRequirements Message::SetStatsRequirements(int32_t file_id, int32_t region_id, std::string coordinate) {
+/*CARTA::SetStatsRequirements Message::SetStatsRequirements(int32_t file_id, int32_t region_id, std::string coordinate) {
     CARTA::SetStatsRequirements set_stats_requirements;
     set_stats_requirements.set_file_id(file_id);
     set_stats_requirements.set_region_id(region_id);
@@ -166,9 +166,9 @@ CARTA::SetStatsRequirements Message::SetStatsRequirements(int32_t file_id, int32
     stats_configs->add_stats_types(CARTA::StatsType::Max);
     stats_configs->add_stats_types(CARTA::StatsType::Extrema);
     return set_stats_requirements;
-}
+}*/
 
-CARTA::SetSpectralRequirements Message::SetSpectralRequirements(int32_t file_id, int32_t region_id, std::string coordinate) {
+/*CARTA::SetSpectralRequirements Message::SetSpectralRequirements(int32_t file_id, int32_t region_id, std::string coordinate) {
     CARTA::SetSpectralRequirements set_spectral_requirements;
     set_spectral_requirements.set_file_id(file_id);
     set_spectral_requirements.set_region_id(region_id);
@@ -185,9 +185,9 @@ CARTA::SetSpectralRequirements Message::SetSpectralRequirements(int32_t file_id,
     spectral_profiles->add_stats_types(CARTA::StatsType::Max);
     spectral_profiles->add_stats_types(CARTA::StatsType::Extrema);
     return set_spectral_requirements;
-}
+}*/
 
-CARTA::StartAnimation Message::StartAnimation(int32_t file_id, std::pair<int32_t, int32_t> first_frame,
+/*CARTA::StartAnimation Message::StartAnimation(int32_t file_id, std::pair<int32_t, int32_t> first_frame,
     std::pair<int32_t, int32_t> start_frame, std::pair<int32_t, int32_t> last_frame, std::pair<int32_t, int32_t> delta_frame,
     CARTA::CompressionType compression_type, float compression_quality, const std::vector<float>& tiles, int32_t frame_rate) {
     CARTA::StartAnimation start_animation;
@@ -219,9 +219,9 @@ CARTA::StartAnimation Message::StartAnimation(int32_t file_id, std::pair<int32_t
     start_animation.set_frame_rate(frame_rate);
 
     return start_animation;
-}
+}*/
 
-CARTA::AnimationFlowControl Message::AnimationFlowControl(int32_t file_id, std::pair<int32_t, int32_t> received_frame) {
+/*CARTA::AnimationFlowControl Message::AnimationFlowControl(int32_t file_id, std::pair<int32_t, int32_t> received_frame) {
     CARTA::AnimationFlowControl animation_flow_control;
     animation_flow_control.set_file_id(file_id);
     auto* mutable_received_frame = animation_flow_control.mutable_received_frame();
@@ -233,9 +233,9 @@ CARTA::AnimationFlowControl Message::AnimationFlowControl(int32_t file_id, std::
     animation_flow_control.set_timestamp(t_now.time_since_epoch().count());
 
     return animation_flow_control;
-}
+}*/
 
-CARTA::StopAnimation Message::StopAnimation(int32_t file_id, std::pair<int32_t, int32_t> end_frame) {
+/*CARTA::StopAnimation Message::StopAnimation(int32_t file_id, std::pair<int32_t, int32_t> end_frame) {
     CARTA::StopAnimation stop_animation;
     stop_animation.set_file_id(file_id);
     auto* mutable_end_frame = stop_animation.mutable_end_frame();
@@ -243,9 +243,9 @@ CARTA::StopAnimation Message::StopAnimation(int32_t file_id, std::pair<int32_t, 
     mutable_end_frame->set_stokes(end_frame.second);
 
     return stop_animation;
-}
+}*/
 
-CARTA::SetSpatialRequirements_SpatialConfig Message::SpatialConfig(
+/*CARTA::SetSpatialRequirements_SpatialConfig Message::SpatialConfig(
     std::string coordinate, int32_t start, int32_t end, int32_t mip, int32_t width) {
     CARTA::SetSpatialRequirements_SpatialConfig spatial_config;
     spatial_config.set_coordinate(coordinate);
@@ -254,9 +254,9 @@ CARTA::SetSpatialRequirements_SpatialConfig Message::SpatialConfig(
     spatial_config.set_mip(mip);
     spatial_config.set_width(width);
     return spatial_config;
-}
+}*/
 
-CARTA::IntBounds Message::IntBounds(int32_t min, int32_t max) {
+/*CARTA::IntBounds Message::IntBounds(int32_t min, int32_t max) {
     CARTA::IntBounds int_bounds;
     int_bounds.set_min(min);
     int_bounds.set_max(max);
@@ -299,9 +299,9 @@ CARTA::MomentRequest Message::MomentsRequest(int32_t file_id, int32_t region_id,
     moment_request.add_moments(CARTA::Moment::COORD_OF_THE_MIN_OF_THE_SPECTRUM);
     moment_request.set_keep(keep);
     return moment_request;
-}
+}*/
 
-CARTA::ImageProperties Message::ImageProperties(std::string directory, std::string file, std::string hdu, int32_t file_id,
+/*CARTA::ImageProperties Message::ImageProperties(std::string directory, std::string file, std::string hdu, int32_t file_id,
     CARTA::RenderMode render_mode, int32_t channel, int32_t stokes) {
     CARTA::ImageProperties image_properties;
     image_properties.set_directory(directory);
@@ -334,24 +334,24 @@ CARTA::SetSpectralRequirements_SpectralConfig Message::SpectralConfig(const std:
     spectral_config.set_coordinate(coordinate);
     spectral_config.add_stats_types(CARTA::StatsType::Mean);
     return spectral_config;
-}
+}*/
 
-CARTA::FileListRequest Message::FileListRequest(const std::string& directory, const CARTA::FileListFilterMode filter_mode) {
+/*CARTA::FileListRequest Message::FileListRequest(const std::string& directory, const CARTA::FileListFilterMode filter_mode) {
     CARTA::FileListRequest file_list_request;
     file_list_request.set_directory(directory);
     file_list_request.set_filter_mode(filter_mode);
     return file_list_request;
-}
+}*/
 
-CARTA::FileInfoRequest Message::FileInfoRequest(const std::string& directory, const std::string& file, const std::string& hdu) {
+/*CARTA::FileInfoRequest Message::FileInfoRequest(const std::string& directory, const std::string& file, const std::string& hdu) {
     CARTA::FileInfoRequest file_info_request;
     file_info_request.set_directory(directory);
     file_info_request.set_file(file);
     file_info_request.set_hdu(hdu);
     return file_info_request;
-}
+}*/
 
-CARTA::SetContourParameters Message::SetContourParameters(uint32_t file_id, uint32_t ref_file_id, int32_t x_min, int32_t x_max,
+/*CARTA::SetContourParameters Message::SetContourParameters(uint32_t file_id, uint32_t ref_file_id, int32_t x_min, int32_t x_max,
     int32_t y_min, int32_t y_max, const std::vector<double>& levels, CARTA::SmoothingMode smoothing_mode, int32_t smoothing_factor,
     int32_t decimation_factor, int32_t compression_level, int32_t contour_chunk_size) {
     CARTA::SetContourParameters message;
@@ -371,9 +371,9 @@ CARTA::SetContourParameters Message::SetContourParameters(uint32_t file_id, uint
     message.set_compression_level(compression_level);
     message.set_contour_chunk_size(contour_chunk_size);
     return message;
-}
+}*/
 
-CARTA::SetVectorOverlayParameters Message::SetVectorOverlayParameters(uint32_t file_id, uint32_t mip, bool fractional, double threshold,
+/*CARTA::SetVectorOverlayParameters Message::SetVectorOverlayParameters(uint32_t file_id, uint32_t mip, bool fractional, double threshold,
     bool debiasing, double q_error, double u_error, int32_t stokes_intensity, int32_t stokes_angle,
     const CARTA::CompressionType& compression_type, float compression_quality) {
     CARTA::SetVectorOverlayParameters message;
@@ -389,7 +389,7 @@ CARTA::SetVectorOverlayParameters Message::SetVectorOverlayParameters(uint32_t f
     message.set_compression_type(compression_type);
     message.set_compression_quality(compression_quality);
     return message;
-}
+}*/
 
 CARTA::ImageBounds Message::ImageBounds(int32_t x_min, int32_t x_max, int32_t y_min, int32_t y_max) {
     CARTA::ImageBounds message;
@@ -445,12 +445,12 @@ CARTA::ScriptingRequest Message::ScriptingRequest(uint32_t scripting_request_id,
     return message;
 }
 
-CARTA::ChannelMapFlowControl Message::ChannelMapFlowControl(int32_t file_id, int32_t received_channel) {
+/*CARTA::ChannelMapFlowControl Message::ChannelMapFlowControl(int32_t file_id, int32_t received_channel) {
     CARTA::ChannelMapFlowControl message;
     message.set_file_id(file_id);
     message.set_received_channel(received_channel);
     return message;
-}
+}*/
 
 carta::EventHeader Message::GetEventHeader(std::string_view message) {
     return *reinterpret_cast<const carta::EventHeader*>(message.data());
@@ -581,7 +581,7 @@ CARTA::MomentProgress Message::MomentProgress(int32_t file_id, float progress) {
     return message;
 }
 
-CARTA::PvRequest Message::PvRequest(int32_t file_id, int32_t region_id, int32_t width, int z_min, int32_t z_max, bool reverse, bool keep) {
+/*CARTA::PvRequest Message::PvRequest(int32_t file_id, int32_t region_id, int32_t width, int z_min, int32_t z_max, bool reverse, bool keep) {
     CARTA::PvRequest message;
     message.set_file_id(file_id);
     message.set_region_id(region_id);
@@ -596,7 +596,7 @@ CARTA::PvRequest Message::PvRequest(int32_t file_id, int32_t region_id, int32_t 
     message.set_reverse(reverse);
     message.set_keep(keep);
     return message;
-}
+}*/
 
 CARTA::PvProgress Message::PvProgress(int32_t file_id, float progress, int32_t preview_id) {
     CARTA::PvProgress message;
@@ -722,7 +722,7 @@ CARTA::ListProgress Message::ListProgress(
     message.set_percentage(percentage);
     return message;
 }
-CARTA::RemoteFileRequest Message::RemoteFileRequest(int32_t file_id, const string& hips, const string& wcs, int32_t width, int32_t height,
+/*CARTA::RemoteFileRequest Message::RemoteFileRequest(int32_t file_id, const string& hips, const string& wcs, int32_t width, int32_t height,
     const string& projection, float fov, float ra, float dec, const string& coordsys, float rotation_angle, const string& object) {
     CARTA::RemoteFileRequest message;
     message.set_file_id(file_id);
@@ -738,7 +738,7 @@ CARTA::RemoteFileRequest Message::RemoteFileRequest(int32_t file_id, const strin
     message.set_rotation_angle(rotation_angle);
     message.set_object(object);
     return message;
-}
+}*/
 
 void FillHistogram(CARTA::Histogram* histogram, int32_t num_bins, double bin_width, double first_bin_center,
     const std::vector<int32_t>& bins, double mean, double std_dev) {

--- a/src/Util/Message.cc
+++ b/src/Util/Message.cc
@@ -11,14 +11,6 @@
 
 #include <chrono>
 
-/*CARTA::RegisterViewer Message::RegisterViewer(uint32_t session_id, std::string api_key, uint32_t client_feature_flags) {
-    CARTA::RegisterViewer register_viewer;
-    register_viewer.set_session_id(session_id);
-    register_viewer.set_api_key(api_key);
-    register_viewer.set_client_feature_flags(client_feature_flags);
-    return register_viewer;
-}*/
-
 CARTA::CloseFile Message::CloseFile(int32_t file_id) {
     CARTA::CloseFile close_file;
     close_file.set_file_id(file_id);
@@ -53,54 +45,6 @@ CARTA::SetImageChannels Message::SetImageChannels(
     }
     return set_image_channels;
 }
-
-/*CARTA::SetCursor Message::SetCursor(int32_t file_id, float x, float y) {
-    CARTA::SetCursor set_cursor;
-    set_cursor.set_file_id(file_id);
-    auto* point = set_cursor.mutable_point();
-    point->set_x(x);
-    point->set_y(y);
-    return set_cursor;
-}*/
-
-/*CARTA::SetSpatialRequirements Message::SetSpatialRequirements(int32_t file_id, int32_t region_id) {
-    CARTA::SetSpatialRequirements set_spatial_requirements;
-    set_spatial_requirements.set_file_id(file_id);
-    set_spatial_requirements.set_region_id(region_id);
-    auto* spatial_requirement_x = set_spatial_requirements.add_spatial_profiles();
-    spatial_requirement_x->set_coordinate("x");
-    auto* spatial_requirement_y = set_spatial_requirements.add_spatial_profiles();
-    spatial_requirement_y->set_coordinate("y");
-    return set_spatial_requirements;
-}*/
-
-/*CARTA::SetStatsRequirements Message::SetStatsRequirements(int32_t file_id, int32_t region_id) {
-    CARTA::SetStatsRequirements set_stats_requirements;
-    set_stats_requirements.set_file_id(file_id);
-    set_stats_requirements.set_region_id(region_id);
-    auto* stats_config = set_stats_requirements.add_stats_configs();
-    stats_config->add_stats_types(CARTA::StatsType::NumPixels);
-    stats_config->add_stats_types(CARTA::StatsType::Sum);
-    stats_config->add_stats_types(CARTA::StatsType::Mean);
-    stats_config->add_stats_types(CARTA::StatsType::RMS);
-    stats_config->add_stats_types(CARTA::StatsType::Sigma);
-    stats_config->add_stats_types(CARTA::StatsType::SumSq);
-    stats_config->add_stats_types(CARTA::StatsType::Min);
-    stats_config->add_stats_types(CARTA::StatsType::Max);
-    return set_stats_requirements;
-}*/
-
-/*CARTA::SetHistogramRequirements Message::SetHistogramRequirements(
-    int32_t file_id, int32_t region_id, const std::string& coordinate, int32_t channel, int32_t num_bins) {
-    CARTA::SetHistogramRequirements set_histogram_requirements;
-    set_histogram_requirements.set_file_id(file_id);
-    set_histogram_requirements.set_region_id(region_id);
-    auto* histograms = set_histogram_requirements.add_histograms();
-    histograms->set_coordinate(coordinate);
-    histograms->set_channel(channel);
-    histograms->set_num_bins(num_bins);
-    return set_histogram_requirements;
-}*/
 
 CARTA::AddRequiredTiles Message::AddRequiredTiles(
     int32_t file_id, CARTA::CompressionType compression_type, float compression_quality, const std::vector<int32_t>& tiles) {
@@ -148,248 +92,6 @@ CARTA::SetRegion Message::SetRegion(
     }
     return set_region;
 }
-
-/*CARTA::SetStatsRequirements Message::SetStatsRequirements(int32_t file_id, int32_t region_id, std::string coordinate) {
-    CARTA::SetStatsRequirements set_stats_requirements;
-    set_stats_requirements.set_file_id(file_id);
-    set_stats_requirements.set_region_id(region_id);
-    auto* stats_configs = set_stats_requirements.add_stats_configs();
-    stats_configs->set_coordinate(coordinate);
-    stats_configs->add_stats_types(CARTA::StatsType::NumPixels);
-    stats_configs->add_stats_types(CARTA::StatsType::Sum);
-    stats_configs->add_stats_types(CARTA::StatsType::FluxDensity);
-    stats_configs->add_stats_types(CARTA::StatsType::Mean);
-    stats_configs->add_stats_types(CARTA::StatsType::RMS);
-    stats_configs->add_stats_types(CARTA::StatsType::Sigma);
-    stats_configs->add_stats_types(CARTA::StatsType::SumSq);
-    stats_configs->add_stats_types(CARTA::StatsType::Min);
-    stats_configs->add_stats_types(CARTA::StatsType::Max);
-    stats_configs->add_stats_types(CARTA::StatsType::Extrema);
-    return set_stats_requirements;
-}*/
-
-/*CARTA::SetSpectralRequirements Message::SetSpectralRequirements(int32_t file_id, int32_t region_id, std::string coordinate) {
-    CARTA::SetSpectralRequirements set_spectral_requirements;
-    set_spectral_requirements.set_file_id(file_id);
-    set_spectral_requirements.set_region_id(region_id);
-    auto* spectral_profiles = set_spectral_requirements.add_spectral_profiles();
-    spectral_profiles->set_coordinate(coordinate);
-    spectral_profiles->add_stats_types(CARTA::StatsType::NumPixels);
-    spectral_profiles->add_stats_types(CARTA::StatsType::Sum);
-    spectral_profiles->add_stats_types(CARTA::StatsType::FluxDensity);
-    spectral_profiles->add_stats_types(CARTA::StatsType::Mean);
-    spectral_profiles->add_stats_types(CARTA::StatsType::RMS);
-    spectral_profiles->add_stats_types(CARTA::StatsType::Sigma);
-    spectral_profiles->add_stats_types(CARTA::StatsType::SumSq);
-    spectral_profiles->add_stats_types(CARTA::StatsType::Min);
-    spectral_profiles->add_stats_types(CARTA::StatsType::Max);
-    spectral_profiles->add_stats_types(CARTA::StatsType::Extrema);
-    return set_spectral_requirements;
-}*/
-
-/*CARTA::StartAnimation Message::StartAnimation(int32_t file_id, std::pair<int32_t, int32_t> first_frame,
-    std::pair<int32_t, int32_t> start_frame, std::pair<int32_t, int32_t> last_frame, std::pair<int32_t, int32_t> delta_frame,
-    CARTA::CompressionType compression_type, float compression_quality, const std::vector<float>& tiles, int32_t frame_rate) {
-    CARTA::StartAnimation start_animation;
-    auto* mutable_first_frame = start_animation.mutable_first_frame();
-    mutable_first_frame->set_channel(first_frame.first);
-    mutable_first_frame->set_stokes(first_frame.second);
-
-    auto* mutable_start_frame = start_animation.mutable_start_frame();
-    mutable_start_frame->set_channel(start_frame.first);
-    mutable_start_frame->set_stokes(start_frame.second);
-
-    auto* mutable_last_frame = start_animation.mutable_last_frame();
-    mutable_last_frame->set_channel(last_frame.first);
-    mutable_last_frame->set_stokes(last_frame.second);
-
-    auto* mutable_delta_frame = start_animation.mutable_delta_frame();
-    mutable_delta_frame->set_channel(delta_frame.first);
-    mutable_delta_frame->set_stokes(delta_frame.second);
-
-    auto* mutable_required_tiles = start_animation.mutable_required_tiles();
-    mutable_required_tiles->set_file_id(file_id);
-    mutable_required_tiles->set_compression_type(compression_type);
-    mutable_required_tiles->set_compression_quality(compression_quality);
-
-    for (int i = 0; i < tiles.size(); ++i) {
-        mutable_required_tiles->add_tiles(tiles[i]);
-    }
-
-    start_animation.set_frame_rate(frame_rate);
-
-    return start_animation;
-}*/
-
-/*CARTA::AnimationFlowControl Message::AnimationFlowControl(int32_t file_id, std::pair<int32_t, int32_t> received_frame) {
-    CARTA::AnimationFlowControl animation_flow_control;
-    animation_flow_control.set_file_id(file_id);
-    auto* mutable_received_frame = animation_flow_control.mutable_received_frame();
-    mutable_received_frame->set_channel(received_frame.first);
-    mutable_received_frame->set_stokes(received_frame.second);
-    animation_flow_control.set_animation_id(1);
-
-    const auto t_now = std::chrono::system_clock::now();
-    animation_flow_control.set_timestamp(t_now.time_since_epoch().count());
-
-    return animation_flow_control;
-}*/
-
-/*CARTA::StopAnimation Message::StopAnimation(int32_t file_id, std::pair<int32_t, int32_t> end_frame) {
-    CARTA::StopAnimation stop_animation;
-    stop_animation.set_file_id(file_id);
-    auto* mutable_end_frame = stop_animation.mutable_end_frame();
-    mutable_end_frame->set_channel(end_frame.first);
-    mutable_end_frame->set_stokes(end_frame.second);
-
-    return stop_animation;
-}*/
-
-/*CARTA::SetSpatialRequirements_SpatialConfig Message::SpatialConfig(
-    std::string coordinate, int32_t start, int32_t end, int32_t mip, int32_t width) {
-    CARTA::SetSpatialRequirements_SpatialConfig spatial_config;
-    spatial_config.set_coordinate(coordinate);
-    spatial_config.set_start(start);
-    spatial_config.set_end(end);
-    spatial_config.set_mip(mip);
-    spatial_config.set_width(width);
-    return spatial_config;
-}*/
-
-/*CARTA::IntBounds Message::IntBounds(int32_t min, int32_t max) {
-    CARTA::IntBounds int_bounds;
-    int_bounds.set_min(min);
-    int_bounds.set_max(max);
-    return int_bounds;
-}
-
-CARTA::FloatBounds Message::FloatBounds(float min, float max) {
-    CARTA::FloatBounds float_bounds;
-    float_bounds.set_min(min);
-    float_bounds.set_max(max);
-    return float_bounds;
-}
-
-// not used
-CARTA::MomentRequest Message::MomentsRequest(int32_t file_id, int32_t region_id, CARTA::MomentAxis moments_axis,
-    CARTA::MomentMask moment_mask, CARTA::IntBounds spectral_range, CARTA::FloatBounds pixel_range, bool keep) {
-    CARTA::MomentRequest moment_request;
-    moment_request.set_file_id(file_id);
-    moment_request.set_region_id(region_id);
-    moment_request.set_axis(moments_axis);
-    moment_request.set_mask(moment_mask);
-    auto* mutable_spectral_range = moment_request.mutable_spectral_range();
-    mutable_spectral_range->set_min(spectral_range.min());
-    mutable_spectral_range->set_max(spectral_range.max());
-    auto* mutable_pixel_range = moment_request.mutable_pixel_range();
-    mutable_pixel_range->set_min(pixel_range.min());
-    mutable_pixel_range->set_max(pixel_range.max());
-    moment_request.add_moments(CARTA::Moment::MEAN_OF_THE_SPECTRUM);
-    moment_request.add_moments(CARTA::Moment::INTEGRATED_OF_THE_SPECTRUM);
-    moment_request.add_moments(CARTA::Moment::INTENSITY_WEIGHTED_COORD);
-    moment_request.add_moments(CARTA::Moment::INTENSITY_WEIGHTED_DISPERSION_OF_THE_COORD);
-    moment_request.add_moments(CARTA::Moment::MEDIAN_OF_THE_SPECTRUM);
-    moment_request.add_moments(CARTA::Moment::MEDIAN_COORDINATE);
-    moment_request.add_moments(CARTA::Moment::STD_ABOUT_THE_MEAN_OF_THE_SPECTRUM);
-    moment_request.add_moments(CARTA::Moment::RMS_OF_THE_SPECTRUM);
-    moment_request.add_moments(CARTA::Moment::ABS_MEAN_DEVIATION_OF_THE_SPECTRUM);
-    moment_request.add_moments(CARTA::Moment::MAX_OF_THE_SPECTRUM);
-    moment_request.add_moments(CARTA::Moment::COORD_OF_THE_MAX_OF_THE_SPECTRUM);
-    moment_request.add_moments(CARTA::Moment::MIN_OF_THE_SPECTRUM);
-    moment_request.add_moments(CARTA::Moment::COORD_OF_THE_MIN_OF_THE_SPECTRUM);
-    moment_request.set_keep(keep);
-    return moment_request;
-}*/
-
-/*CARTA::ImageProperties Message::ImageProperties(std::string directory, std::string file, std::string hdu, int32_t file_id,
-    CARTA::RenderMode render_mode, int32_t channel, int32_t stokes) {
-    CARTA::ImageProperties image_properties;
-    image_properties.set_directory(directory);
-    image_properties.set_file(file);
-    image_properties.set_hdu(hdu);
-    image_properties.set_file_id(file_id);
-    image_properties.set_render_mode(render_mode);
-    image_properties.set_channel(channel);
-    image_properties.set_stokes(stokes);
-    return image_properties;
-}
-
-CARTA::ResumeSession Message::ResumeSession(std::vector<CARTA::ImageProperties> images) {
-    CARTA::ResumeSession resume_session;
-    for (auto image : images) {
-        auto* tmp_image = resume_session.add_images();
-        tmp_image->set_directory(image.directory());
-        tmp_image->set_file(image.file());
-        tmp_image->set_hdu(image.hdu());
-        tmp_image->set_file_id(image.file_id());
-        tmp_image->set_render_mode(image.render_mode());
-        tmp_image->set_channel(image.channel());
-        tmp_image->set_stokes(image.stokes());
-    }
-    return resume_session;
-}
-
-CARTA::SetSpectralRequirements_SpectralConfig Message::SpectralConfig(const std::string& coordinate) {
-    CARTA::SetSpectralRequirements_SpectralConfig spectral_config;
-    spectral_config.set_coordinate(coordinate);
-    spectral_config.add_stats_types(CARTA::StatsType::Mean);
-    return spectral_config;
-}*/
-
-/*CARTA::FileListRequest Message::FileListRequest(const std::string& directory, const CARTA::FileListFilterMode filter_mode) {
-    CARTA::FileListRequest file_list_request;
-    file_list_request.set_directory(directory);
-    file_list_request.set_filter_mode(filter_mode);
-    return file_list_request;
-}*/
-
-/*CARTA::FileInfoRequest Message::FileInfoRequest(const std::string& directory, const std::string& file, const std::string& hdu) {
-    CARTA::FileInfoRequest file_info_request;
-    file_info_request.set_directory(directory);
-    file_info_request.set_file(file);
-    file_info_request.set_hdu(hdu);
-    return file_info_request;
-}*/
-
-/*CARTA::SetContourParameters Message::SetContourParameters(uint32_t file_id, uint32_t ref_file_id, int32_t x_min, int32_t x_max,
-    int32_t y_min, int32_t y_max, const std::vector<double>& levels, CARTA::SmoothingMode smoothing_mode, int32_t smoothing_factor,
-    int32_t decimation_factor, int32_t compression_level, int32_t contour_chunk_size) {
-    CARTA::SetContourParameters message;
-    message.set_file_id(file_id);
-    message.set_reference_file_id(ref_file_id);
-    auto* image_bounds = message.mutable_image_bounds();
-    image_bounds->set_x_min(x_min);
-    image_bounds->set_x_max(x_max);
-    image_bounds->set_y_min(y_min);
-    image_bounds->set_y_max(y_max);
-    for (auto level : levels) {
-        message.add_levels(level);
-    }
-    message.set_smoothing_mode(smoothing_mode);
-    message.set_smoothing_factor(smoothing_factor);
-    message.set_decimation_factor(decimation_factor);
-    message.set_compression_level(compression_level);
-    message.set_contour_chunk_size(contour_chunk_size);
-    return message;
-}*/
-
-/*CARTA::SetVectorOverlayParameters Message::SetVectorOverlayParameters(uint32_t file_id, uint32_t mip, bool fractional, double threshold,
-    bool debiasing, double q_error, double u_error, int32_t stokes_intensity, int32_t stokes_angle,
-    const CARTA::CompressionType& compression_type, float compression_quality) {
-    CARTA::SetVectorOverlayParameters message;
-    message.set_file_id(file_id);
-    message.set_smoothing_factor(mip);
-    message.set_fractional(fractional);
-    message.set_threshold(threshold);
-    message.set_debiasing(debiasing);
-    message.set_q_error(q_error);
-    message.set_u_error(u_error);
-    message.set_stokes_intensity(stokes_intensity);
-    message.set_stokes_angle(stokes_angle);
-    message.set_compression_type(compression_type);
-    message.set_compression_quality(compression_quality);
-    return message;
-}*/
 
 CARTA::ImageBounds Message::ImageBounds(int32_t x_min, int32_t x_max, int32_t y_min, int32_t y_max) {
     CARTA::ImageBounds message;
@@ -444,13 +146,6 @@ CARTA::ScriptingRequest Message::ScriptingRequest(uint32_t scripting_request_id,
     message.set_return_path(return_path);
     return message;
 }
-
-/*CARTA::ChannelMapFlowControl Message::ChannelMapFlowControl(int32_t file_id, int32_t received_channel) {
-    CARTA::ChannelMapFlowControl message;
-    message.set_file_id(file_id);
-    message.set_received_channel(received_channel);
-    return message;
-}*/
 
 carta::EventHeader Message::GetEventHeader(std::string_view message) {
     return *reinterpret_cast<const carta::EventHeader*>(message.data());
@@ -581,23 +276,6 @@ CARTA::MomentProgress Message::MomentProgress(int32_t file_id, float progress) {
     return message;
 }
 
-/*CARTA::PvRequest Message::PvRequest(int32_t file_id, int32_t region_id, int32_t width, int z_min, int32_t z_max, bool reverse, bool keep) {
-    CARTA::PvRequest message;
-    message.set_file_id(file_id);
-    message.set_region_id(region_id);
-    message.set_width(width);
-
-    if (z_min >= 0 && z_max >= 0) {
-        auto spectral_range = message.mutable_spectral_range();
-        spectral_range->set_min(z_min);
-        spectral_range->set_max(z_max);
-    }
-
-    message.set_reverse(reverse);
-    message.set_keep(keep);
-    return message;
-}*/
-
 CARTA::PvProgress Message::PvProgress(int32_t file_id, float progress, int32_t preview_id) {
     CARTA::PvProgress message;
     message.set_file_id(file_id);
@@ -722,23 +400,6 @@ CARTA::ListProgress Message::ListProgress(
     message.set_percentage(percentage);
     return message;
 }
-/*CARTA::RemoteFileRequest Message::RemoteFileRequest(int32_t file_id, const string& hips, const string& wcs, int32_t width, int32_t height,
-    const string& projection, float fov, float ra, float dec, const string& coordsys, float rotation_angle, const string& object) {
-    CARTA::RemoteFileRequest message;
-    message.set_file_id(file_id);
-    message.set_hips(hips);
-    message.set_wcs(wcs);
-    message.set_width(width);
-    message.set_height(height);
-    message.set_projection(projection);
-    message.set_fov(fov);
-    message.set_ra(ra);
-    message.set_dec(dec);
-    message.set_coordsys(coordsys);
-    message.set_rotation_angle(rotation_angle);
-    message.set_object(object);
-    return message;
-}*/
 
 void FillHistogram(CARTA::Histogram* histogram, int32_t num_bins, double bin_width, double first_bin_center,
     const std::vector<int32_t>& bins, double mean, double std_dev) {

--- a/src/Util/Message.h
+++ b/src/Util/Message.h
@@ -68,17 +68,11 @@ class Message {
 
 public:
     // Request messages
-//    static CARTA::RegisterViewer RegisterViewer(uint32_t session_id, std::string api_key, uint32_t client_feature_flags);
     static CARTA::CloseFile CloseFile(int32_t file_id);
     static CARTA::OpenFile OpenFile(std::string directory, std::string file, bool lel_expr, std::string hdu, int32_t file_id,
         bool support_aips_beam, CARTA::RenderMode render_mode = CARTA::RenderMode::RASTER);
     static CARTA::SetImageChannels SetImageChannels(int32_t file_id, int32_t channel, int32_t stokes,
         CARTA::CompressionType compression_type = CARTA::CompressionType::NONE, float compression_quality = -1);
-//    static CARTA::SetCursor SetCursor(int32_t file_id, float x, float y);
-//    static CARTA::SetSpatialRequirements SetSpatialRequirements(int32_t file_id, int32_t region_id);
-//    static CARTA::SetStatsRequirements SetStatsRequirements(int32_t file_id, int32_t region_id);
-//    static CARTA::SetHistogramRequirements SetHistogramRequirements(int32_t file_id, int32_t region_id, const std::string& coordinate = "z",
-//        int32_t channel = CURRENT_Z, int32_t num_bins = AUTO_BIN_SIZE);
     static CARTA::AddRequiredTiles AddRequiredTiles(
         int32_t file_id, CARTA::CompressionType compression_type, float compression_quality, const std::vector<int32_t>& tiles);
     static CARTA::Point Point(float x, float y);
@@ -87,32 +81,6 @@ public:
     static CARTA::Point Point(const std::vector<double>& input, int x_index = 0, int y_index = 1);
     static CARTA::SetRegion SetRegion(
         int32_t file_id, int32_t region_id, CARTA::RegionType region_type, std::vector<CARTA::Point> control_points, float rotation);
-//    static CARTA::SetStatsRequirements SetStatsRequirements(int32_t file_id, int32_t region_id, std::string coordinate);
-//    static CARTA::SetSpectralRequirements SetSpectralRequirements(int32_t file_id, int32_t region_id, std::string coordinate);
-//    static CARTA::StartAnimation StartAnimation(int32_t file_id, std::pair<int32_t, int32_t> first_frame,
-//        std::pair<int32_t, int32_t> start_frame, std::pair<int32_t, int32_t> last_frame, std::pair<int32_t, int32_t> delta_frame,
-//        CARTA::CompressionType compression_type, float compression_quality, const std::vector<float>& tiles, int32_t frame_rate = 5);
-//    static CARTA::AnimationFlowControl AnimationFlowControl(int32_t file_id, std::pair<int32_t, int32_t> received_frame);
-//    static CARTA::StopAnimation StopAnimation(int32_t file_id, std::pair<int32_t, int32_t> end_frame);
-//    static CARTA::SetSpatialRequirements_SpatialConfig SpatialConfig(
-//        std::string coordinate, int32_t start = 0, int32_t end = 0, int32_t mip = 0, int32_t width = 0);
-//    static CARTA::IntBounds IntBounds(int32_t min, int32_t max);
-//  static CARTA::FloatBounds FloatBounds(float min, float max);
-//    static CARTA::MomentRequest MomentsRequest(int32_t file_id, int32_t region_id, CARTA::MomentAxis moments_axis,
-//        CARTA::MomentMask moment_mask, CARTA::IntBounds spectral_range, CARTA::FloatBounds pixel_range, bool keep = false);
-//    static CARTA::ImageProperties ImageProperties(std::string directory, std::string file, std::string hdu, int32_t file_id,
-//        CARTA::RenderMode render_mode, int32_t channel, int32_t stokes);
-//    static CARTA::ResumeSession ResumeSession(std::vector<CARTA::ImageProperties> images);
-//    static CARTA::SetSpectralRequirements_SpectralConfig SpectralConfig(const std::string& coordinate);
-//    static CARTA::FileListRequest FileListRequest(
-//        const std::string& directory, const CARTA::FileListFilterMode filter_mode = CARTA::FileListFilterMode::Content);
-//    static CARTA::FileInfoRequest FileInfoRequest(const std::string& directory, const std::string& file, const std::string& hdu = "");
-//    static CARTA::SetContourParameters SetContourParameters(uint32_t file_id, uint32_t ref_file_id, int32_t x_min, int32_t x_max,
-//        int32_t y_min, int32_t y_max, const std::vector<double>& levels, CARTA::SmoothingMode smoothing_mode, int32_t smoothing_factor,
-//        int32_t decimation_factor, int32_t compression_level, int32_t contour_chunk_size);
-//    static CARTA::SetVectorOverlayParameters SetVectorOverlayParameters(uint32_t file_id, uint32_t mip, bool fractional, double threshold,
-//        bool debiasing, double q_error, double u_error, int32_t stokes_intensity, int32_t stokes_angle,
-//        const CARTA::CompressionType& compression_type, float compression_quality);
     static CARTA::ImageBounds ImageBounds(int32_t x_min, int32_t x_max, int32_t y_min, int32_t y_max);
     static CARTA::SetRegion SetRegion(int32_t file_id, int32_t region_id, const CARTA::RegionInfo& region_info);
     static CARTA::ConcatStokesFiles ConcatStokesFiles(
@@ -122,7 +90,6 @@ public:
         const CARTA::DoublePoint& center, double amp, const CARTA::DoublePoint& fwhm, double pa);
     static CARTA::ScriptingRequest ScriptingRequest(uint32_t scripting_request_id, const std::string& target, const std::string& action,
         const std::string& parameters, bool async, const std::string& return_path);
-//    static CARTA::ChannelMapFlowControl ChannelMapFlowControl(int32_t file_id, int32_t received_channel);
 
     // Response messages
     static CARTA::SpectralProfileData SpectralProfileData(int32_t file_id, int32_t region_id, int32_t stokes, float progress,
@@ -139,12 +106,7 @@ public:
     static CARTA::RegisterViewerAck RegisterViewerAck(
         uint32_t session_id, bool success, const std::string& status, const CARTA::SessionType& type);
     static CARTA::MomentProgress MomentProgress(int32_t file_id, float progress);
-//    static CARTA::PvRequest PvRequest(
-//        int32_t file_id, int32_t region_id, int32_t width, int z_min = -1, int32_t z_max = -1, bool reverse = false, bool keep = false);
     static CARTA::PvProgress PvProgress(int32_t file_id, float progress, int32_t preview_id = 0);
-//    static CARTA::RemoteFileRequest RemoteFileRequest(int32_t file_id, const std::string& hips, const std::string& wcs, int32_t width,
-//        int32_t height, const std::string& projection, float fov, float ra, float dec, const std::string& coordsys, float rotation_angle,
-//        const std::string& object);
     static CARTA::FittingProgress FittingProgress(int32_t file_id, float progress);
     static CARTA::RegionHistogramData RegionHistogramData(
         int32_t file_id, int32_t region_id, int32_t channel, int32_t stokes, float progress, const carta::HistogramConfig& hist_config);

--- a/src/Util/Message.h
+++ b/src/Util/Message.h
@@ -68,17 +68,17 @@ class Message {
 
 public:
     // Request messages
-    static CARTA::RegisterViewer RegisterViewer(uint32_t session_id, std::string api_key, uint32_t client_feature_flags);
+//    static CARTA::RegisterViewer RegisterViewer(uint32_t session_id, std::string api_key, uint32_t client_feature_flags);
     static CARTA::CloseFile CloseFile(int32_t file_id);
     static CARTA::OpenFile OpenFile(std::string directory, std::string file, bool lel_expr, std::string hdu, int32_t file_id,
         bool support_aips_beam, CARTA::RenderMode render_mode = CARTA::RenderMode::RASTER);
     static CARTA::SetImageChannels SetImageChannels(int32_t file_id, int32_t channel, int32_t stokes,
         CARTA::CompressionType compression_type = CARTA::CompressionType::NONE, float compression_quality = -1);
-    static CARTA::SetCursor SetCursor(int32_t file_id, float x, float y);
-    static CARTA::SetSpatialRequirements SetSpatialRequirements(int32_t file_id, int32_t region_id);
-    static CARTA::SetStatsRequirements SetStatsRequirements(int32_t file_id, int32_t region_id);
-    static CARTA::SetHistogramRequirements SetHistogramRequirements(int32_t file_id, int32_t region_id, const std::string& coordinate = "z",
-        int32_t channel = CURRENT_Z, int32_t num_bins = AUTO_BIN_SIZE);
+//    static CARTA::SetCursor SetCursor(int32_t file_id, float x, float y);
+//    static CARTA::SetSpatialRequirements SetSpatialRequirements(int32_t file_id, int32_t region_id);
+//    static CARTA::SetStatsRequirements SetStatsRequirements(int32_t file_id, int32_t region_id);
+//    static CARTA::SetHistogramRequirements SetHistogramRequirements(int32_t file_id, int32_t region_id, const std::string& coordinate = "z",
+//        int32_t channel = CURRENT_Z, int32_t num_bins = AUTO_BIN_SIZE);
     static CARTA::AddRequiredTiles AddRequiredTiles(
         int32_t file_id, CARTA::CompressionType compression_type, float compression_quality, const std::vector<int32_t>& tiles);
     static CARTA::Point Point(float x, float y);
@@ -87,32 +87,32 @@ public:
     static CARTA::Point Point(const std::vector<double>& input, int x_index = 0, int y_index = 1);
     static CARTA::SetRegion SetRegion(
         int32_t file_id, int32_t region_id, CARTA::RegionType region_type, std::vector<CARTA::Point> control_points, float rotation);
-    static CARTA::SetStatsRequirements SetStatsRequirements(int32_t file_id, int32_t region_id, std::string coordinate);
-    static CARTA::SetSpectralRequirements SetSpectralRequirements(int32_t file_id, int32_t region_id, std::string coordinate);
-    static CARTA::StartAnimation StartAnimation(int32_t file_id, std::pair<int32_t, int32_t> first_frame,
-        std::pair<int32_t, int32_t> start_frame, std::pair<int32_t, int32_t> last_frame, std::pair<int32_t, int32_t> delta_frame,
-        CARTA::CompressionType compression_type, float compression_quality, const std::vector<float>& tiles, int32_t frame_rate = 5);
-    static CARTA::AnimationFlowControl AnimationFlowControl(int32_t file_id, std::pair<int32_t, int32_t> received_frame);
-    static CARTA::StopAnimation StopAnimation(int32_t file_id, std::pair<int32_t, int32_t> end_frame);
-    static CARTA::SetSpatialRequirements_SpatialConfig SpatialConfig(
-        std::string coordinate, int32_t start = 0, int32_t end = 0, int32_t mip = 0, int32_t width = 0);
-    static CARTA::IntBounds IntBounds(int32_t min, int32_t max);
-    static CARTA::FloatBounds FloatBounds(float min, float max);
-    static CARTA::MomentRequest MomentsRequest(int32_t file_id, int32_t region_id, CARTA::MomentAxis moments_axis,
-        CARTA::MomentMask moment_mask, CARTA::IntBounds spectral_range, CARTA::FloatBounds pixel_range, bool keep = false);
-    static CARTA::ImageProperties ImageProperties(std::string directory, std::string file, std::string hdu, int32_t file_id,
-        CARTA::RenderMode render_mode, int32_t channel, int32_t stokes);
-    static CARTA::ResumeSession ResumeSession(std::vector<CARTA::ImageProperties> images);
-    static CARTA::SetSpectralRequirements_SpectralConfig SpectralConfig(const std::string& coordinate);
-    static CARTA::FileListRequest FileListRequest(
-        const std::string& directory, const CARTA::FileListFilterMode filter_mode = CARTA::FileListFilterMode::Content);
-    static CARTA::FileInfoRequest FileInfoRequest(const std::string& directory, const std::string& file, const std::string& hdu = "");
-    static CARTA::SetContourParameters SetContourParameters(uint32_t file_id, uint32_t ref_file_id, int32_t x_min, int32_t x_max,
-        int32_t y_min, int32_t y_max, const std::vector<double>& levels, CARTA::SmoothingMode smoothing_mode, int32_t smoothing_factor,
-        int32_t decimation_factor, int32_t compression_level, int32_t contour_chunk_size);
-    static CARTA::SetVectorOverlayParameters SetVectorOverlayParameters(uint32_t file_id, uint32_t mip, bool fractional, double threshold,
-        bool debiasing, double q_error, double u_error, int32_t stokes_intensity, int32_t stokes_angle,
-        const CARTA::CompressionType& compression_type, float compression_quality);
+//    static CARTA::SetStatsRequirements SetStatsRequirements(int32_t file_id, int32_t region_id, std::string coordinate);
+//    static CARTA::SetSpectralRequirements SetSpectralRequirements(int32_t file_id, int32_t region_id, std::string coordinate);
+//    static CARTA::StartAnimation StartAnimation(int32_t file_id, std::pair<int32_t, int32_t> first_frame,
+//        std::pair<int32_t, int32_t> start_frame, std::pair<int32_t, int32_t> last_frame, std::pair<int32_t, int32_t> delta_frame,
+//        CARTA::CompressionType compression_type, float compression_quality, const std::vector<float>& tiles, int32_t frame_rate = 5);
+//    static CARTA::AnimationFlowControl AnimationFlowControl(int32_t file_id, std::pair<int32_t, int32_t> received_frame);
+//    static CARTA::StopAnimation StopAnimation(int32_t file_id, std::pair<int32_t, int32_t> end_frame);
+//    static CARTA::SetSpatialRequirements_SpatialConfig SpatialConfig(
+//        std::string coordinate, int32_t start = 0, int32_t end = 0, int32_t mip = 0, int32_t width = 0);
+//    static CARTA::IntBounds IntBounds(int32_t min, int32_t max);
+//  static CARTA::FloatBounds FloatBounds(float min, float max);
+//    static CARTA::MomentRequest MomentsRequest(int32_t file_id, int32_t region_id, CARTA::MomentAxis moments_axis,
+//        CARTA::MomentMask moment_mask, CARTA::IntBounds spectral_range, CARTA::FloatBounds pixel_range, bool keep = false);
+//    static CARTA::ImageProperties ImageProperties(std::string directory, std::string file, std::string hdu, int32_t file_id,
+//        CARTA::RenderMode render_mode, int32_t channel, int32_t stokes);
+//    static CARTA::ResumeSession ResumeSession(std::vector<CARTA::ImageProperties> images);
+//    static CARTA::SetSpectralRequirements_SpectralConfig SpectralConfig(const std::string& coordinate);
+//    static CARTA::FileListRequest FileListRequest(
+//        const std::string& directory, const CARTA::FileListFilterMode filter_mode = CARTA::FileListFilterMode::Content);
+//    static CARTA::FileInfoRequest FileInfoRequest(const std::string& directory, const std::string& file, const std::string& hdu = "");
+//    static CARTA::SetContourParameters SetContourParameters(uint32_t file_id, uint32_t ref_file_id, int32_t x_min, int32_t x_max,
+//        int32_t y_min, int32_t y_max, const std::vector<double>& levels, CARTA::SmoothingMode smoothing_mode, int32_t smoothing_factor,
+//        int32_t decimation_factor, int32_t compression_level, int32_t contour_chunk_size);
+//    static CARTA::SetVectorOverlayParameters SetVectorOverlayParameters(uint32_t file_id, uint32_t mip, bool fractional, double threshold,
+//        bool debiasing, double q_error, double u_error, int32_t stokes_intensity, int32_t stokes_angle,
+//        const CARTA::CompressionType& compression_type, float compression_quality);
     static CARTA::ImageBounds ImageBounds(int32_t x_min, int32_t x_max, int32_t y_min, int32_t y_max);
     static CARTA::SetRegion SetRegion(int32_t file_id, int32_t region_id, const CARTA::RegionInfo& region_info);
     static CARTA::ConcatStokesFiles ConcatStokesFiles(
@@ -122,7 +122,7 @@ public:
         const CARTA::DoublePoint& center, double amp, const CARTA::DoublePoint& fwhm, double pa);
     static CARTA::ScriptingRequest ScriptingRequest(uint32_t scripting_request_id, const std::string& target, const std::string& action,
         const std::string& parameters, bool async, const std::string& return_path);
-    static CARTA::ChannelMapFlowControl ChannelMapFlowControl(int32_t file_id, int32_t received_channel);
+//    static CARTA::ChannelMapFlowControl ChannelMapFlowControl(int32_t file_id, int32_t received_channel);
 
     // Response messages
     static CARTA::SpectralProfileData SpectralProfileData(int32_t file_id, int32_t region_id, int32_t stokes, float progress,
@@ -139,12 +139,12 @@ public:
     static CARTA::RegisterViewerAck RegisterViewerAck(
         uint32_t session_id, bool success, const std::string& status, const CARTA::SessionType& type);
     static CARTA::MomentProgress MomentProgress(int32_t file_id, float progress);
-    static CARTA::PvRequest PvRequest(
-        int32_t file_id, int32_t region_id, int32_t width, int z_min = -1, int32_t z_max = -1, bool reverse = false, bool keep = false);
+//    static CARTA::PvRequest PvRequest(
+//        int32_t file_id, int32_t region_id, int32_t width, int z_min = -1, int32_t z_max = -1, bool reverse = false, bool keep = false);
     static CARTA::PvProgress PvProgress(int32_t file_id, float progress, int32_t preview_id = 0);
-    static CARTA::RemoteFileRequest RemoteFileRequest(int32_t file_id, const std::string& hips, const std::string& wcs, int32_t width,
-        int32_t height, const std::string& projection, float fov, float ra, float dec, const std::string& coordsys, float rotation_angle,
-        const std::string& object);
+//    static CARTA::RemoteFileRequest RemoteFileRequest(int32_t file_id, const std::string& hips, const std::string& wcs, int32_t width,
+//        int32_t height, const std::string& projection, float fov, float ra, float dec, const std::string& coordsys, float rotation_angle,
+//        const std::string& object);
     static CARTA::FittingProgress FittingProgress(int32_t file_id, float progress);
     static CARTA::RegionHistogramData RegionHistogramData(
         int32_t file_id, int32_t region_id, int32_t channel, int32_t stokes, float progress, const carta::HistogramConfig& hist_config);

--- a/test/TestContour.cc
+++ b/test/TestContour.cc
@@ -16,6 +16,28 @@ static const std::string IMAGE_OPTS_NAN = "-s 0 -n row column -d 10";
 
 class ContourTest : public ::testing::Test {
 public:
+    static CARTA::SetContourParameters SetContourParameters(uint32_t file_id, uint32_t ref_file_id, int32_t x_min, int32_t x_max,
+        int32_t y_min, int32_t y_max, const std::vector<double>& levels, CARTA::SmoothingMode smoothing_mode, int32_t smoothing_factor,
+        int32_t decimation_factor, int32_t compression_level, int32_t contour_chunk_size) {
+        CARTA::SetContourParameters message;
+        message.set_file_id(file_id);
+        message.set_reference_file_id(ref_file_id);
+        auto* image_bounds = message.mutable_image_bounds();
+        image_bounds->set_x_min(x_min);
+        image_bounds->set_x_max(x_max);
+        image_bounds->set_y_min(y_min);
+        image_bounds->set_y_max(y_max);
+        for (auto level : levels) {
+            message.add_levels(level);
+        }
+        message.set_smoothing_mode(smoothing_mode);
+        message.set_smoothing_factor(smoothing_factor);
+        message.set_decimation_factor(decimation_factor);
+        message.set_compression_level(compression_level);
+        message.set_contour_chunk_size(contour_chunk_size);
+        return message;
+    }
+
     void GenerateContour(
         int width, int height, std::string image_opts, const CARTA::FileType& file_type, const CARTA::SmoothingMode& smoothing_mode) {
         std::string image_shape = std::to_string(width) + " " + std::to_string(height);
@@ -31,7 +53,7 @@ public:
 
         spdlog::info("The generated image contains random pixels values with mean = 0 and STD = 1.");
         std::vector<double> levels{0, -1, 1}; // Contour levels
-        auto set_contour_params = Message::SetContourParameters(0, 0, 0, width, 0, height, levels, smoothing_mode, 4, 4, 8, 100000);
+        auto set_contour_params = ContourTest::SetContourParameters(0, 0, 0, width, 0, height, levels, smoothing_mode, 4, 4, 8, 100000);
 
         EXPECT_TRUE(frame->SetContourParameters(set_contour_params));
 

--- a/test/TestCursorSpatialProfiles.cc
+++ b/test/TestCursorSpatialProfiles.cc
@@ -116,7 +116,8 @@ TEST_F(CursorSpatialProfileTest, SmallFitsProfile) {
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     FitsDataReader reader(path_string);
 
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {CursorSpatialProfileTest::SpatialConfig("x"), CursorSpatialProfileTest::SpatialConfig("y")};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {
+        CursorSpatialProfileTest::SpatialConfig("x"), CursorSpatialProfileTest::SpatialConfig("y")};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(5, 5);
 
@@ -157,7 +158,8 @@ TEST_F(CursorSpatialProfileTest, SmallHdf5Profile) {
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     Hdf5DataReader reader(path_string);
 
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {CursorSpatialProfileTest::SpatialConfig("x"), CursorSpatialProfileTest::SpatialConfig("y")};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {
+        CursorSpatialProfileTest::SpatialConfig("x"), CursorSpatialProfileTest::SpatialConfig("y")};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(5, 5);
 
@@ -492,7 +494,8 @@ TEST_F(CursorSpatialProfileTest, Hdf5MultipleChunkFullRes) {
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     Hdf5DataReader reader(path_string);
 
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {CursorSpatialProfileTest::SpatialConfig("x"), CursorSpatialProfileTest::SpatialConfig("y")};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {
+        CursorSpatialProfileTest::SpatialConfig("x"), CursorSpatialProfileTest::SpatialConfig("y")};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(150, 150);
 
@@ -561,7 +564,8 @@ TEST_F(CursorSpatialProfileTest, FitsChannelChange) {
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     FitsDataReader reader(path_string);
 
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {CursorSpatialProfileTest::SpatialConfig("x"), CursorSpatialProfileTest::SpatialConfig("y")};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {
+        CursorSpatialProfileTest::SpatialConfig("x"), CursorSpatialProfileTest::SpatialConfig("y")};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(5, 5);
     std::string msg;
@@ -610,7 +614,8 @@ TEST_F(CursorSpatialProfileTest, FitsChannelStokesChange) {
     int stokes(0);                // set stokes channel as "I"
     int spatial_config_stokes(1); // set spatial config coordinate = {"Qx", "Qy"}
 
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {CursorSpatialProfileTest::SpatialConfig("Qx"), CursorSpatialProfileTest::SpatialConfig("Qy")};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {
+        CursorSpatialProfileTest::SpatialConfig("Qx"), CursorSpatialProfileTest::SpatialConfig("Qy")};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(x, y);
     std::string msg;
@@ -653,7 +658,8 @@ TEST_F(CursorSpatialProfileTest, ContiguousHDF5ChannelChange) {
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     Hdf5DataReader reader(path_string);
 
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {CursorSpatialProfileTest::SpatialConfig("x"), CursorSpatialProfileTest::SpatialConfig("y")};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {
+        CursorSpatialProfileTest::SpatialConfig("x"), CursorSpatialProfileTest::SpatialConfig("y")};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(5, 5);
     std::string msg;
@@ -696,7 +702,8 @@ TEST_F(CursorSpatialProfileTest, ChunkedHDF5ChannelChange) {
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     Hdf5DataReader reader(path_string);
 
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {CursorSpatialProfileTest::SpatialConfig("x"), CursorSpatialProfileTest::SpatialConfig("y")};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {
+        CursorSpatialProfileTest::SpatialConfig("x"), CursorSpatialProfileTest::SpatialConfig("y")};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(5, 5);
     std::string msg;
@@ -745,7 +752,8 @@ TEST_F(CursorSpatialProfileTest, ChunkedHDF5ChannelStokesChange) {
     int stokes(0);                // set stokes channel as "I"
     int spatial_config_stokes(1); // set spatial config coordinate = {"Qx", "Qy"}
 
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {CursorSpatialProfileTest::SpatialConfig("Qx"), CursorSpatialProfileTest::SpatialConfig("Qy")};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {
+        CursorSpatialProfileTest::SpatialConfig("Qx"), CursorSpatialProfileTest::SpatialConfig("Qy")};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(x, y);
     std::string msg;

--- a/test/TestCursorSpatialProfiles.cc
+++ b/test/TestCursorSpatialProfiles.cc
@@ -21,6 +21,17 @@ static const std::string IMAGE_OPTS = "-s 0 -n row column -d 10";
 
 class CursorSpatialProfileTest : public ::testing::Test, public ImageGenerator {
 public:
+    static CARTA::SetSpatialRequirements_SpatialConfig SpatialConfig(
+        std::string coordinate, int32_t start = 0, int32_t end = 0, int32_t mip = 0, int32_t width = 0) {
+        CARTA::SetSpatialRequirements_SpatialConfig spatial_config;
+        spatial_config.set_coordinate(coordinate);
+        spatial_config.set_start(start);
+        spatial_config.set_end(end);
+        spatial_config.set_mip(mip);
+        spatial_config.set_width(width);
+        return spatial_config;
+    }
+
     static std::tuple<CARTA::SpatialProfile, CARTA::SpatialProfile> GetProfiles(CARTA::SpatialProfileData& data) {
         if (data.profiles(0).coordinate().back() == 'x') {
             return {data.profiles(0), data.profiles(1)};
@@ -105,7 +116,7 @@ TEST_F(CursorSpatialProfileTest, SmallFitsProfile) {
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     FitsDataReader reader(path_string);
 
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {Message::SpatialConfig("x"), Message::SpatialConfig("y")};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {CursorSpatialProfileTest::SpatialConfig("x"), CursorSpatialProfileTest::SpatialConfig("y")};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(5, 5);
 
@@ -146,7 +157,7 @@ TEST_F(CursorSpatialProfileTest, SmallHdf5Profile) {
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     Hdf5DataReader reader(path_string);
 
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {Message::SpatialConfig("x"), Message::SpatialConfig("y")};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {CursorSpatialProfileTest::SpatialConfig("x"), CursorSpatialProfileTest::SpatialConfig("y")};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(5, 5);
 
@@ -188,7 +199,7 @@ TEST_F(CursorSpatialProfileTest, LowResFitsProfile) {
     FitsDataReader reader(path_string);
 
     std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {
-        Message::SpatialConfig("x", 0, 0, 2), Message::SpatialConfig("y", 0, 0, 2)};
+        CursorSpatialProfileTest::SpatialConfig("x", 0, 0, 2), CursorSpatialProfileTest::SpatialConfig("y", 0, 0, 2)};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(50, 50);
 
@@ -223,7 +234,7 @@ TEST_F(CursorSpatialProfileTest, LowResHdf5ProfileExactMipAvailable) {
     Hdf5DataReader reader(path_string);
 
     std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {
-        Message::SpatialConfig("x", 0, 0, 2), Message::SpatialConfig("y", 0, 0, 2)};
+        CursorSpatialProfileTest::SpatialConfig("x", 0, 0, 2), CursorSpatialProfileTest::SpatialConfig("y", 0, 0, 2)};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(50, 50);
 
@@ -259,7 +270,7 @@ TEST_F(CursorSpatialProfileTest, LowResHdf5ProfileLowerMipAvailable) {
 
     // mip 4 is requested, but the file only has a dataset for mip 2
     std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {
-        Message::SpatialConfig("x", 0, 0, 4), Message::SpatialConfig("y", 0, 0, 4)};
+        CursorSpatialProfileTest::SpatialConfig("x", 0, 0, 4), CursorSpatialProfileTest::SpatialConfig("y", 0, 0, 4)};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(50, 50);
 
@@ -296,7 +307,7 @@ TEST_F(CursorSpatialProfileTest, LowResHdf5ProfileNoMipAvailable) {
 
     // mip 2 is requested, but this file is too small to have mipmaps
     std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {
-        Message::SpatialConfig("x", 0, 0, 2), Message::SpatialConfig("y", 0, 0, 2)};
+        CursorSpatialProfileTest::SpatialConfig("x", 0, 0, 2), CursorSpatialProfileTest::SpatialConfig("y", 0, 0, 2)};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(50, 50);
 
@@ -332,7 +343,7 @@ TEST_F(CursorSpatialProfileTest, FullResFitsStartEnd) {
     FitsDataReader reader(path_string);
 
     std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {
-        Message::SpatialConfig("x", 100, 200, 0), Message::SpatialConfig("y", 100, 200, 0)};
+        CursorSpatialProfileTest::SpatialConfig("x", 100, 200, 0), CursorSpatialProfileTest::SpatialConfig("y", 100, 200, 0)};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(150, 150);
 
@@ -367,7 +378,7 @@ TEST_F(CursorSpatialProfileTest, FullResHdf5StartEnd) {
     Hdf5DataReader reader(path_string);
 
     std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {
-        Message::SpatialConfig("x", 100, 200, 0), Message::SpatialConfig("y", 100, 200, 0)};
+        CursorSpatialProfileTest::SpatialConfig("x", 100, 200, 0), CursorSpatialProfileTest::SpatialConfig("y", 100, 200, 0)};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(150, 150);
 
@@ -402,7 +413,7 @@ TEST_F(CursorSpatialProfileTest, LowResFitsStartEnd) {
     FitsDataReader reader(path_string);
 
     std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {
-        Message::SpatialConfig("x", 100, 200, 4), Message::SpatialConfig("y", 100, 200, 4)};
+        CursorSpatialProfileTest::SpatialConfig("x", 100, 200, 4), CursorSpatialProfileTest::SpatialConfig("y", 100, 200, 4)};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(150, 150);
 
@@ -439,7 +450,7 @@ TEST_F(CursorSpatialProfileTest, LowResHdf5StartEnd) {
     Hdf5DataReader reader(path_string);
 
     std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {
-        Message::SpatialConfig("x", 100, 200, 4), Message::SpatialConfig("y", 100, 200, 4)};
+        CursorSpatialProfileTest::SpatialConfig("x", 100, 200, 4), CursorSpatialProfileTest::SpatialConfig("y", 100, 200, 4)};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(150, 150);
 
@@ -481,7 +492,7 @@ TEST_F(CursorSpatialProfileTest, Hdf5MultipleChunkFullRes) {
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     Hdf5DataReader reader(path_string);
 
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {Message::SpatialConfig("x"), Message::SpatialConfig("y")};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {CursorSpatialProfileTest::SpatialConfig("x"), CursorSpatialProfileTest::SpatialConfig("y")};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(150, 150);
 
@@ -516,7 +527,7 @@ TEST_F(CursorSpatialProfileTest, Hdf5MultipleChunkFullResStartEnd) {
     Hdf5DataReader reader(path_string);
 
     std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {
-        Message::SpatialConfig("x", 1000, 1500), Message::SpatialConfig("y", 1000, 1500)};
+        CursorSpatialProfileTest::SpatialConfig("x", 1000, 1500), CursorSpatialProfileTest::SpatialConfig("y", 1000, 1500)};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(1250, 1250);
 
@@ -550,7 +561,7 @@ TEST_F(CursorSpatialProfileTest, FitsChannelChange) {
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     FitsDataReader reader(path_string);
 
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {Message::SpatialConfig("x"), Message::SpatialConfig("y")};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {CursorSpatialProfileTest::SpatialConfig("x"), CursorSpatialProfileTest::SpatialConfig("y")};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(5, 5);
     std::string msg;
@@ -599,7 +610,7 @@ TEST_F(CursorSpatialProfileTest, FitsChannelStokesChange) {
     int stokes(0);                // set stokes channel as "I"
     int spatial_config_stokes(1); // set spatial config coordinate = {"Qx", "Qy"}
 
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {Message::SpatialConfig("Qx"), Message::SpatialConfig("Qy")};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {CursorSpatialProfileTest::SpatialConfig("Qx"), CursorSpatialProfileTest::SpatialConfig("Qy")};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(x, y);
     std::string msg;
@@ -642,7 +653,7 @@ TEST_F(CursorSpatialProfileTest, ContiguousHDF5ChannelChange) {
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     Hdf5DataReader reader(path_string);
 
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {Message::SpatialConfig("x"), Message::SpatialConfig("y")};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {CursorSpatialProfileTest::SpatialConfig("x"), CursorSpatialProfileTest::SpatialConfig("y")};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(5, 5);
     std::string msg;
@@ -685,7 +696,7 @@ TEST_F(CursorSpatialProfileTest, ChunkedHDF5ChannelChange) {
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     Hdf5DataReader reader(path_string);
 
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {Message::SpatialConfig("x"), Message::SpatialConfig("y")};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {CursorSpatialProfileTest::SpatialConfig("x"), CursorSpatialProfileTest::SpatialConfig("y")};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(5, 5);
     std::string msg;
@@ -734,7 +745,7 @@ TEST_F(CursorSpatialProfileTest, ChunkedHDF5ChannelStokesChange) {
     int stokes(0);                // set stokes channel as "I"
     int spatial_config_stokes(1); // set spatial config coordinate = {"Qx", "Qy"}
 
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {Message::SpatialConfig("Qx"), Message::SpatialConfig("Qy")};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> profiles = {CursorSpatialProfileTest::SpatialConfig("Qx"), CursorSpatialProfileTest::SpatialConfig("Qy")};
     frame->SetSpatialRequirements(profiles);
     frame->SetCursor(x, y);
     std::string msg;

--- a/test/TestFileInfo.cc
+++ b/test/TestFileInfo.cc
@@ -18,6 +18,14 @@ static const std::string SAMPLE_FILES_PATH = (TestRoot() / "data" / "images" / "
 
 class FileInfoLoaderTest : public ::testing::Test {
 public:
+    static CARTA::FileInfoRequest FileInfoRequest(const std::string& directory, const std::string& file, const std::string& hdu = "") {
+        CARTA::FileInfoRequest file_info_request;
+        file_info_request.set_directory(directory);
+        file_info_request.set_file(file);
+        file_info_request.set_hdu(hdu);
+        return file_info_request;
+    }
+
     static void CheckFileInfoLoader(
         const std::string& request_filename, const CARTA::FileType& request_file_type, const std::string& request_hdu = "") {
         std::string fullname = SAMPLE_FILES_PATH + "/" + request_filename;
@@ -182,7 +190,7 @@ public:
     TestSession() : Session(nullptr, nullptr, 0, "", nullptr) {}
 
     void TestFileInfo(const std::string& request_filename, const CARTA::FileType& request_file_type, const std::string& request_hdu = "") {
-        auto request = Message::FileInfoRequest(SAMPLE_FILES_PATH, request_filename, request_hdu);
+        auto request = FileInfoLoaderTest::FileInfoRequest(SAMPLE_FILES_PATH, request_filename, request_hdu);
         CARTA::FileInfoResponse response;
         auto& file_info = *response.mutable_file_info();
         std::map<std::string, CARTA::FileInfoExtended> extended_info_map;

--- a/test/TestFileList.cc
+++ b/test/TestFileList.cc
@@ -14,6 +14,13 @@ using namespace carta;
 
 class FileListTest : public ::testing::Test {
 public:
+    static CARTA::FileListRequest FileListRequest(const std::string& directory, const CARTA::FileListFilterMode filter_mode = CARTA::FileListFilterMode::Content) {
+        CARTA::FileListRequest file_list_request;
+        file_list_request.set_directory(directory);
+        file_list_request.set_filter_mode(filter_mode);
+        return file_list_request;
+    }
+
     CARTA::FileListResponse RequestFileList(
         const std::string& top_level_folder, const std::string& starting_folder, const CARTA::FileListRequest& request) {
         std::shared_ptr<FileListHandler> file_list_handler = std::make_shared<FileListHandler>(top_level_folder, starting_folder);
@@ -119,47 +126,47 @@ public:
 TEST_F(FileListTest, SetTopLevelFolder) {
     std::string abs_path = (TestRoot() / "data" / "images" / "mix").string();
 
-    auto request1 = Message::FileListRequest(abs_path);
+    auto request1 = FileListTest::FileListRequest(abs_path);
     TestFileList("/", "", request1);
     TestFileList("", "", request1, false);
 
-    auto request2 = Message::FileListRequest("data/images/mix");
+    auto request2 = FileListTest::FileListRequest("data/images/mix");
     TestFileList(TestRoot().string(), "", request2);
 
-    auto request3 = Message::FileListRequest("");
+    auto request3 = FileListTest::FileListRequest("");
     TestFileList(abs_path, "", request3);
 
-    auto request4 = Message::FileListRequest(".");
+    auto request4 = FileListTest::FileListRequest(".");
     TestFileList(abs_path, "", request4);
 
     // Request file list for default top folder "/"
     // 0 image files, > 0 subdirectories
-    auto request5 = Message::FileListRequest("");
+    auto request5 = FileListTest::FileListRequest("");
     TestFileListSubdirectories("/", "", request5);
 }
 
 TEST_F(FileListTest, SetStartingFolder) {
     std::string abs_path = (TestRoot() / "data" / "images" / "mix").string();
 
-    auto request1 = Message::FileListRequest("$BASE/data/images/mix");
+    auto request1 = FileListTest::FileListRequest("$BASE/data/images/mix");
     TestFileList("/", TestRoot().string(), request1);
 
-    auto request2 = Message::FileListRequest("$BASE");
+    auto request2 = FileListTest::FileListRequest("$BASE");
     TestFileList(TestRoot().string(), "data/images/mix", request2);
     TestFileList("/", abs_path, request2);
     TestFileList("", abs_path, request2, false);
 }
 
 TEST_F(FileListTest, AccessFalseFolder) {
-    auto request = Message::FileListRequest("$BASE/folder_not_existed");
+    auto request = FileListTest::FileListRequest("$BASE/folder_not_existed");
     TestFileList(TestRoot().string(), "data/images/mix", request, false);
 }
 
 TEST_F(FileListTest, AccessForbiddenFolder) {
-    auto request1 = Message::FileListRequest("..");
+    auto request1 = FileListTest::FileListRequest("..");
     TestFileList(TestRoot().string(), "", request1, false);
 
-    auto request2 = Message::FileListRequest("../../..");
+    auto request2 = FileListTest::FileListRequest("../../..");
     TestFileList(TestRoot().string(), "", request2, false);
 }
 
@@ -174,24 +181,24 @@ TEST_F(FileListTest, TestFilterModes) {
 
     // Filter mode Content
     // Empty dirs are dirs, ignores empty files and txt file.
-    auto request1 = Message::FileListRequest("data/images/mix");
+    auto request1 = FileListTest::FileListRequest("data/images/mix");
     auto response = RequestFileList(TestRoot().string(), "", request1);
     TestFileListResponse(response, 4, 5);
 
     // Filter mode Extension
     // Empty fits/hdf5 files are images, empty dirs are dirs, ignores other empty files and txt.
-    auto request2 = Message::FileListRequest("data/images/mix", CARTA::FileListFilterMode::Extension);
+    auto request2 = FileListTest::FileListRequest("data/images/mix", CARTA::FileListFilterMode::Extension);
     response = RequestFileList(TestRoot().string(), "", request2);
     TestFileListResponse(response, 6, 5);
 
     // Filter mode AllFiles
     // All are files or dirs
-    auto request3 = Message::FileListRequest("data/images/mix", CARTA::FileListFilterMode::AllFiles);
+    auto request3 = FileListTest::FileListRequest("data/images/mix", CARTA::FileListFilterMode::AllFiles);
     response = RequestFileList(TestRoot().string(), "", request3);
     TestFileListResponse(response, 7, 7, false);
 
     // Filter mode AllFiles with image as directory should have one FileInfo for the image
-    auto request4 = Message::FileListRequest("data/images/mix/M17_SWex_unit.image", CARTA::FileListFilterMode::AllFiles);
+    auto request4 = FileListTest::FileListRequest("data/images/mix/M17_SWex_unit.image", CARTA::FileListFilterMode::AllFiles);
     response = RequestFileList(TestRoot().string(), "", request4);
     TestFileListResponse(response, 1, 0);
 }

--- a/test/TestFileList.cc
+++ b/test/TestFileList.cc
@@ -14,7 +14,8 @@ using namespace carta;
 
 class FileListTest : public ::testing::Test {
 public:
-    static CARTA::FileListRequest FileListRequest(const std::string& directory, const CARTA::FileListFilterMode filter_mode = CARTA::FileListFilterMode::Content) {
+    static CARTA::FileListRequest FileListRequest(
+        const std::string& directory, const CARTA::FileListFilterMode filter_mode = CARTA::FileListFilterMode::Content) {
         CARTA::FileListRequest file_list_request;
         file_list_request.set_directory(directory);
         file_list_request.set_filter_mode(filter_mode);

--- a/test/TestPvGenerator.cc
+++ b/test/TestPvGenerator.cc
@@ -555,7 +555,7 @@ TEST_F(PvGeneratorTest, PvPreview) {
     // Request PV preview
     int width(3), z_min(0), z_max(9); // all channels
     bool reverse(false);
-    auto pv_request = Message::PvRequest(file_id, region_id, width, z_min, z_max, reverse);
+    auto pv_request = PvGeneratorTest::PvRequest(file_id, region_id, width, z_min, z_max, reverse);
     auto preview_settings = pv_request.mutable_preview_settings();
     preview_settings->set_preview_id(0);
     preview_settings->set_region_id(-1); // box region for SubImage to fit in memory, not needed

--- a/test/TestPvGenerator.cc
+++ b/test/TestPvGenerator.cc
@@ -21,7 +21,8 @@ using ::testing::Pointwise;
 
 class PvGeneratorTest : public ::testing::Test, public ImageGenerator {
 public:
-    static CARTA::PvRequest PvRequest(int32_t file_id, int32_t region_id, int32_t width, int z_min = -1, int32_t z_max = -1, bool reverse = false, bool keep = false) {
+    static CARTA::PvRequest PvRequest(
+        int32_t file_id, int32_t region_id, int32_t width, int z_min = -1, int32_t z_max = -1, bool reverse = false, bool keep = false) {
         CARTA::PvRequest message;
         message.set_file_id(file_id);
         message.set_region_id(region_id);

--- a/test/TestPvGenerator.cc
+++ b/test/TestPvGenerator.cc
@@ -21,6 +21,23 @@ using ::testing::Pointwise;
 
 class PvGeneratorTest : public ::testing::Test, public ImageGenerator {
 public:
+    static CARTA::PvRequest PvRequest(int32_t file_id, int32_t region_id, int32_t width, int z_min = -1, int32_t z_max = -1, bool reverse = false, bool keep = false) {
+        CARTA::PvRequest message;
+        message.set_file_id(file_id);
+        message.set_region_id(region_id);
+        message.set_width(width);
+
+        if (z_min >= 0 && z_max >= 0) {
+            auto spectral_range = message.mutable_spectral_range();
+            spectral_range->set_min(z_min);
+            spectral_range->set_max(z_max);
+        }
+
+        message.set_reverse(reverse);
+        message.set_keep(keep);
+        return message;
+    }
+
     static void SetPvCut(carta::RegionHandler& region_handler, int file_id, int& region_id, std::vector<float>& endpoints,
         std::shared_ptr<casacore::CoordinateSystem> csys, bool is_annotation = false) {
         // Define RegionState for line region
@@ -56,7 +73,7 @@ public:
         SetPvCut(region_handler, file_id, region_id, endpoints, frame->CoordinateSystem());
 
         // Request PV image
-        auto pv_request = Message::PvRequest(file_id, region_id, width);
+        auto pv_request = PvGeneratorTest::PvRequest(file_id, region_id, width);
         auto progress_callback = [&](float progress) {};
         CARTA::PvResponse pv_response;
         carta::GeneratedImage pv_image;
@@ -98,7 +115,7 @@ TEST_F(PvGeneratorTest, FitsPvImage) {
 
     // Request PV image
     int width(3);
-    auto pv_request = Message::PvRequest(file_id, region_id, width);
+    auto pv_request = PvGeneratorTest::PvRequest(file_id, region_id, width);
     auto progress_callback = [&](float progress) {};
     CARTA::PvResponse pv_response;
     carta::GeneratedImage pv_image;
@@ -168,7 +185,7 @@ TEST_F(PvGeneratorTest, FitsPvImageHorizontalCut) {
 
     // Request PV image
     int width(1);
-    auto pv_request = Message::PvRequest(file_id, region_id, width);
+    auto pv_request = PvGeneratorTest::PvRequest(file_id, region_id, width);
     auto progress_callback = [&](float progress) {};
     CARTA::PvResponse pv_response;
     carta::GeneratedImage pv_image;
@@ -245,7 +262,7 @@ TEST_F(PvGeneratorTest, FitsPvImageVerticalCut) {
 
     // Request PV image
     int width(1);
-    auto pv_request = Message::PvRequest(file_id, region_id, width);
+    auto pv_request = PvGeneratorTest::PvRequest(file_id, region_id, width);
     auto progress_callback = [&](float progress) {};
     CARTA::PvResponse pv_response;
     carta::GeneratedImage pv_image;
@@ -314,7 +331,7 @@ TEST_F(PvGeneratorTest, TestNoSpectralAxis) {
 
     // Request PV image
     int width(3);
-    auto pv_request = Message::PvRequest(file_id, region_id, width);
+    auto pv_request = PvGeneratorTest::PvRequest(file_id, region_id, width);
     auto progress_callback = [&](float progress) {};
     CARTA::PvResponse pv_response;
     carta::GeneratedImage pv_image;
@@ -346,7 +363,7 @@ TEST_F(PvGeneratorTest, PvImageSpectralRange) {
 
     // Request PV image
     int width(3), z_min(0), z_max(5); // first 6 channels
-    auto pv_request = Message::PvRequest(file_id, region_id, width, z_min, z_max);
+    auto pv_request = PvGeneratorTest::PvRequest(file_id, region_id, width, z_min, z_max);
     auto progress_callback = [&](float progress) {};
     CARTA::PvResponse pv_response;
     carta::GeneratedImage pv_image;
@@ -377,7 +394,7 @@ TEST_F(PvGeneratorTest, PvImageReversedAxes) {
     // Request PV image
     int width(3), z_min(0), z_max(9); // all channels
     bool reverse(false);
-    auto pv_request = Message::PvRequest(file_id, region_id, width, z_min, z_max, reverse);
+    auto pv_request = PvGeneratorTest::PvRequest(file_id, region_id, width, z_min, z_max, reverse);
     auto progress_callback = [&](float progress) {};
     CARTA::PvResponse pv_response;
     carta::GeneratedImage pv_image;
@@ -388,7 +405,7 @@ TEST_F(PvGeneratorTest, PvImageReversedAxes) {
 
     // Request reverse PV image with same cut
     reverse = true;
-    pv_request = Message::PvRequest(file_id, region_id, width, z_min, z_max, reverse);
+    pv_request = PvGeneratorTest::PvRequest(file_id, region_id, width, z_min, z_max, reverse);
     CARTA::PvResponse rev_pv_response;
     carta::GeneratedImage rev_pv_image;
     region_handler.CalculatePvImage(pv_request, frame, progress_callback, rev_pv_response, rev_pv_image);
@@ -417,7 +434,7 @@ TEST_F(PvGeneratorTest, PvImageKeep) {
     // Request PV image
     int width(3), z_min(0), z_max(9); // all channels
     bool reverse(false), keep(false);
-    auto pv_request = Message::PvRequest(file_id, region_id, width, z_min, z_max, reverse, keep);
+    auto pv_request = PvGeneratorTest::PvRequest(file_id, region_id, width, z_min, z_max, reverse, keep);
     auto progress_callback = [&](float progress) {};
     CARTA::PvResponse pv_response;
     carta::GeneratedImage pv_image;
@@ -429,7 +446,7 @@ TEST_F(PvGeneratorTest, PvImageKeep) {
 
     // Request PV image, keeping the first
     keep = true;
-    pv_request = Message::PvRequest(file_id, region_id, width, z_min, z_max, reverse, keep);
+    pv_request = PvGeneratorTest::PvRequest(file_id, region_id, width, z_min, z_max, reverse, keep);
     CARTA::PvResponse pv_response2;
     carta::GeneratedImage pv_image2;
     region_handler.CalculatePvImage(pv_request, frame, progress_callback, pv_response2, pv_image2);
@@ -440,7 +457,7 @@ TEST_F(PvGeneratorTest, PvImageKeep) {
 
     // Request PV image, replace all and reset index
     keep = false;
-    pv_request = Message::PvRequest(file_id, region_id, width, z_min, z_max, reverse, keep);
+    pv_request = PvGeneratorTest::PvRequest(file_id, region_id, width, z_min, z_max, reverse, keep);
     CARTA::PvResponse pv_response3;
     carta::GeneratedImage pv_image3;
     region_handler.CalculatePvImage(pv_request, frame, progress_callback, pv_response3, pv_image3);
@@ -466,7 +483,7 @@ TEST_F(PvGeneratorTest, FitsPvAnnotationLine) {
     // Request PV image - should fail
     int width(3), z_min(0), z_max(9); // all channels
     bool reverse(false), keep(false);
-    auto pv_request = Message::PvRequest(file_id, region_id, width, z_min, z_max, reverse, keep);
+    auto pv_request = PvGeneratorTest::PvRequest(file_id, region_id, width, z_min, z_max, reverse, keep);
     auto progress_callback = [&](float progress) {};
     CARTA::PvResponse pv_response;
     carta::GeneratedImage pv_image;
@@ -492,7 +509,7 @@ TEST_F(PvGeneratorTest, FitsPvPolyLine) {
     // Request PV image
     int width(3), z_min(0), z_max(9); // all channels
     bool reverse(false), keep(false);
-    auto pv_request = Message::PvRequest(file_id, region_id, width, z_min, z_max, reverse, keep);
+    auto pv_request = PvGeneratorTest::PvRequest(file_id, region_id, width, z_min, z_max, reverse, keep);
     auto progress_callback = [&](float progress) {};
     CARTA::PvResponse pv_response;
     carta::GeneratedImage pv_image;
@@ -512,7 +529,7 @@ TEST_F(PvGeneratorTest, FitsPvPolyLine) {
     region_id = -1;
     is_annotation = true;
     SetPvCut(region_handler, file_id, region_id, endpoints, csys, is_annotation);
-    pv_request = Message::PvRequest(file_id, region_id, width, z_min, z_max, reverse, keep);
+    pv_request = PvGeneratorTest::PvRequest(file_id, region_id, width, z_min, z_max, reverse, keep);
     CARTA::PvResponse pv_response2;
     carta::GeneratedImage pv_image2;
     region_handler.CalculatePvImage(pv_request, frame, progress_callback, pv_response2, pv_image2);

--- a/test/TestRegionHistogram.cc
+++ b/test/TestRegionHistogram.cc
@@ -18,8 +18,8 @@ using namespace carta;
 
 class RegionHistogramTest : public ::testing::Test {
 public:
-    static CARTA::SetHistogramRequirements SetHistogramRequirements(
-        int32_t file_id, int32_t region_id, const std::string& coordinate = "z", int32_t channel = CURRENT_Z, int32_t num_bins = AUTO_BIN_SIZE) {
+    static CARTA::SetHistogramRequirements SetHistogramRequirements(int32_t file_id, int32_t region_id, const std::string& coordinate = "z",
+        int32_t channel = CURRENT_Z, int32_t num_bins = AUTO_BIN_SIZE) {
         CARTA::SetHistogramRequirements set_histogram_requirements;
         set_histogram_requirements.set_file_id(file_id);
         set_histogram_requirements.set_region_id(region_id);

--- a/test/TestRegionHistogram.cc
+++ b/test/TestRegionHistogram.cc
@@ -18,6 +18,18 @@ using namespace carta;
 
 class RegionHistogramTest : public ::testing::Test {
 public:
+    static CARTA::SetHistogramRequirements SetHistogramRequirements(
+        int32_t file_id, int32_t region_id, const std::string& coordinate = "z", int32_t channel = CURRENT_Z, int32_t num_bins = AUTO_BIN_SIZE) {
+        CARTA::SetHistogramRequirements set_histogram_requirements;
+        set_histogram_requirements.set_file_id(file_id);
+        set_histogram_requirements.set_region_id(region_id);
+        auto* histograms = set_histogram_requirements.add_histograms();
+        histograms->set_coordinate(coordinate);
+        histograms->set_channel(channel);
+        histograms->set_num_bins(num_bins);
+        return set_histogram_requirements;
+    }
+
     static bool SetRegion(carta::RegionHandler& region_handler, int file_id, int& region_id, const std::vector<float>& points,
         std::shared_ptr<casacore::CoordinateSystem> csys, bool is_annotation) {
         std::vector<CARTA::Point> control_points;
@@ -49,7 +61,7 @@ public:
         }
 
         // Set histogram requirements
-        auto histogram_req_message = Message::SetHistogramRequirements(file_id, region_id, coordinate);
+        auto histogram_req_message = SetHistogramRequirements(file_id, region_id, coordinate);
         std::vector<CARTA::HistogramConfig> histogram_configs = {
             histogram_req_message.histograms().begin(), histogram_req_message.histograms().end()};
         if (!region_handler.SetHistogramRequirements(region_id, file_id, frame, histogram_configs)) {
@@ -77,7 +89,7 @@ public:
         }
         // Set histogram requirements for region in image1
         file_id = 1;
-        auto histogram_req_message = Message::SetHistogramRequirements(file_id, region_id);
+        auto histogram_req_message = SetHistogramRequirements(file_id, region_id);
         std::vector<CARTA::HistogramConfig> histogram_configs = {
             histogram_req_message.histograms().begin(), histogram_req_message.histograms().end()};
         if (!region_handler.SetHistogramRequirements(region_id, file_id, frame1, histogram_configs)) {

--- a/test/TestRegionSpatialProfiles.cc
+++ b/test/TestRegionSpatialProfiles.cc
@@ -385,7 +385,8 @@ TEST_F(RegionSpatialProfileTest, FitsMovePointProfile) {
 
     // Set spatial requirements
     int start(0), end(0), mip(0), width(3);
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {
+        RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
     ok = region_handler.SetSpatialRequirements(region_id, file_id, frame, spatial_reqs);
     ASSERT_TRUE(ok);
 

--- a/test/TestRegionSpatialProfiles.cc
+++ b/test/TestRegionSpatialProfiles.cc
@@ -116,7 +116,8 @@ public:
         int file_id(0), region_id(-1);
         std::vector<float> endpoints = {0.0, 0.0, 9.0, 9.0};
         int start(0), end(0), mip(0);
-        std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
+        std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {
+            RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
         CARTA::SpatialProfileData spatial_profile_message;
 
         if (expected_width_range) {
@@ -243,7 +244,8 @@ TEST_F(RegionSpatialProfileTest, FitsPolylineProfile) {
     std::string image_path = FileFinder::FitsImagePath("noise_3d.fits");
     std::vector<float> endpoints = {1.0, 1.0, 9.0, 1.0, 9.0, 5.0};
     int start(0), end(0), mip(0), width(1);
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {
+        RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
 
     CARTA::SpatialProfileData spatial_profile_message;
     bool ok = RegionSpatialProfile(image_path, endpoints, spatial_reqs, spatial_profile_message);
@@ -294,7 +296,8 @@ TEST_F(RegionSpatialProfileTest, FitsPointProfile) {
     std::vector<float> endpoints = {0.0, 0.0};
     int start(0), end(0), mip(0), width(1);
     std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {
-        RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width), RegionSpatialProfileTest::SpatialConfig("y", start, end, mip, width)};
+        RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width),
+        RegionSpatialProfileTest::SpatialConfig("y", start, end, mip, width)};
 
     CARTA::SpatialProfileData spatial_profile_message;
     bool ok = RegionSpatialProfile(image_path, endpoints, spatial_reqs, spatial_profile_message);

--- a/test/TestRegionSpatialProfiles.cc
+++ b/test/TestRegionSpatialProfiles.cc
@@ -112,7 +112,8 @@ public:
         std::string image_path = FileFinder::FitsImagePath("noise_3d.fits");
         std::vector<float> endpoints = {0.0, 0.0, 9.0, 9.0};
         int start(0), end(0), mip(0);
-        std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
+        std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {
+            RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
         CARTA::SpatialProfileData spatial_profile;
 
         if (expected_width_range) {
@@ -141,7 +142,8 @@ TEST_F(RegionSpatialProfileTest, TestSpatialRequirements) {
 
     // Set spatial requirements
     int start(0), end(0), mip(0), width(3);
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {
+        RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
     ok = region_handler.SetSpatialRequirements(region_id, file_id, frame, spatial_reqs);
     ASSERT_TRUE(ok);
 
@@ -160,7 +162,8 @@ TEST_F(RegionSpatialProfileTest, FitsLineProfile) {
     std::string image_path = FileFinder::FitsImagePath("noise_3d.fits");
     std::vector<float> endpoints = {0.0, 0.0, 9.0, 9.0};
     int start(0), end(0), mip(0), width(3);
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {
+        RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
 
     CARTA::SpatialProfileData spatial_profile;
     bool ok = RegionSpatialProfile(image_path, endpoints, spatial_reqs, spatial_profile);
@@ -175,7 +178,8 @@ TEST_F(RegionSpatialProfileTest, Hdf5LineProfile) {
     std::string image_path = FileFinder::Hdf5ImagePath("noise_10px_10px.hdf5");
     std::vector<float> endpoints = {0.0, 0.0, 9.0, 9.0};
     int start(0), end(0), mip(0), width(3);
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {
+        RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
 
     CARTA::SpatialProfileData spatial_profile;
     bool ok = RegionSpatialProfile(image_path, endpoints, spatial_reqs, spatial_profile);
@@ -188,7 +192,8 @@ TEST_F(RegionSpatialProfileTest, FitsHorizontalCutProfile) {
     std::string image_path = FileFinder::FitsImagePath("noise_3d.fits");
     std::vector<float> endpoints = {9.0, 5.0, 1.0, 5.0}; // Set line region at y=5
     int start(0), end(0), mip(0), width(1);
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {
+        RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
 
     CARTA::SpatialProfileData spatial_profile;
     bool ok = RegionSpatialProfile(image_path, endpoints, spatial_reqs, spatial_profile);
@@ -212,7 +217,8 @@ TEST_F(RegionSpatialProfileTest, FitsVerticalCutProfile) {
     std::string image_path = FileFinder::FitsImagePath("noise_3d.fits");
     std::vector<float> endpoints = {5.0, 9.0, 5.0, 1.0}; // Set line region at x=5
     int start(0), end(0), mip(0), width(1);
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {RegionSpatialProfileTest::SpatialConfig("y", start, end, mip, width)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {
+        RegionSpatialProfileTest::SpatialConfig("y", start, end, mip, width)};
 
     CARTA::SpatialProfileData spatial_profile;
     bool ok = RegionSpatialProfile(image_path, endpoints, spatial_reqs, spatial_profile);
@@ -236,7 +242,8 @@ TEST_F(RegionSpatialProfileTest, FitsPolylineProfile) {
     std::string image_path = FileFinder::FitsImagePath("noise_3d.fits");
     std::vector<float> endpoints = {1.0, 1.0, 9.0, 1.0, 9.0, 5.0};
     int start(0), end(0), mip(0), width(1);
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {
+        RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
     std::vector<CARTA::SpatialProfileData> spatial_profiles;
 
     CARTA::SpatialProfileData spatial_profile;
@@ -274,7 +281,8 @@ TEST_F(RegionSpatialProfileTest, FitsAnnotationLineProfile) {
     std::string image_path = FileFinder::FitsImagePath("noise_3d.fits");
     std::vector<float> endpoints = {0.0, 0.0, 9.0, 9.0};
     int start(0), end(0), mip(0), width(3);
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {
+        RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
 
     CARTA::SpatialProfileData spatial_profile;
     bool is_annotation(true);
@@ -287,7 +295,8 @@ TEST_F(RegionSpatialProfileTest, FitsPointProfile) {
     std::string image_path = FileFinder::FitsImagePath("noise_3d.fits");
     std::vector<float> endpoints = {0.0, 0.0};
     int start(0), end(0), mip(0), width(1);
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {
+        RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
 
     CARTA::SpatialProfileData spatial_profile;
     bool ok = RegionSpatialProfile(image_path, endpoints, spatial_reqs, spatial_profile);
@@ -311,7 +320,8 @@ TEST_F(RegionSpatialProfileTest, Hdf5PointProfile) {
     std::string image_path = FileFinder::Hdf5ImagePath("noise_10px_10px.hdf5");
     std::vector<float> points = {0.0, 0.0};
     int start(0), end(0), mip(0), width(1);
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {
+        RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
 
     CARTA::SpatialProfileData spatial_profile;
     bool ok = RegionSpatialProfile(image_path, points, spatial_reqs, spatial_profile);
@@ -335,7 +345,8 @@ TEST_F(RegionSpatialProfileTest, FitsPointProfileOutsideImage) {
     std::string image_path = FileFinder::FitsImagePath("noise_3d.fits");
     std::vector<float> endpoints = {-2.0, -2.0};
     int start(0), end(0), mip(0), width(1);
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {
+        RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
 
     CARTA::SpatialProfileData spatial_profile;
     bool ok = RegionSpatialProfile(image_path, endpoints, spatial_reqs, spatial_profile);
@@ -347,7 +358,8 @@ TEST_F(RegionSpatialProfileTest, FitsAnnotationPointProfile) {
     std::string image_path = FileFinder::FitsImagePath("noise_3d.fits");
     std::vector<float> point = {0.0, 0.0};
     int start(0), end(0), mip(0), width(3);
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {
+        RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
 
     CARTA::SpatialProfileData spatial_profile;
     bool is_annotation(true);

--- a/test/TestRegionSpatialProfiles.cc
+++ b/test/TestRegionSpatialProfiles.cc
@@ -385,7 +385,7 @@ TEST_F(RegionSpatialProfileTest, FitsMovePointProfile) {
 
     // Set spatial requirements
     int start(0), end(0), mip(0), width(3);
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {Message::SpatialConfig("x", start, end, mip, width)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
     ok = region_handler.SetSpatialRequirements(region_id, file_id, frame, spatial_reqs);
     ASSERT_TRUE(ok);
 

--- a/test/TestRegionSpatialProfiles.cc
+++ b/test/TestRegionSpatialProfiles.cc
@@ -17,6 +17,17 @@ using namespace carta;
 
 class RegionSpatialProfileTest : public ::testing::Test {
 public:
+    static CARTA::SetSpatialRequirements_SpatialConfig SpatialConfig(
+        std::string coordinate, int32_t start = 0, int32_t end = 0, int32_t mip = 0, int32_t width = 0) {
+        CARTA::SetSpatialRequirements_SpatialConfig spatial_config;
+        spatial_config.set_coordinate(coordinate);
+        spatial_config.set_start(start);
+        spatial_config.set_end(end);
+        spatial_config.set_mip(mip);
+        spatial_config.set_width(width);
+        return spatial_config;
+    }
+
     static bool SetRegion(carta::RegionHandler& region_handler, int file_id, int& region_id, const std::vector<float>& points,
         std::shared_ptr<casacore::CoordinateSystem> csys, bool is_annotation) {
         std::vector<CARTA::Point> control_points;
@@ -101,7 +112,7 @@ public:
         std::string image_path = FileFinder::FitsImagePath("noise_3d.fits");
         std::vector<float> endpoints = {0.0, 0.0, 9.0, 9.0};
         int start(0), end(0), mip(0);
-        std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {Message::SpatialConfig("x", start, end, mip, width)};
+        std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
         CARTA::SpatialProfileData spatial_profile;
 
         if (expected_width_range) {
@@ -130,7 +141,7 @@ TEST_F(RegionSpatialProfileTest, TestSpatialRequirements) {
 
     // Set spatial requirements
     int start(0), end(0), mip(0), width(3);
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {Message::SpatialConfig("x", start, end, mip, width)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
     ok = region_handler.SetSpatialRequirements(region_id, file_id, frame, spatial_reqs);
     ASSERT_TRUE(ok);
 
@@ -149,7 +160,7 @@ TEST_F(RegionSpatialProfileTest, FitsLineProfile) {
     std::string image_path = FileFinder::FitsImagePath("noise_3d.fits");
     std::vector<float> endpoints = {0.0, 0.0, 9.0, 9.0};
     int start(0), end(0), mip(0), width(3);
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {Message::SpatialConfig("x", start, end, mip, width)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
 
     CARTA::SpatialProfileData spatial_profile;
     bool ok = RegionSpatialProfile(image_path, endpoints, spatial_reqs, spatial_profile);
@@ -164,7 +175,7 @@ TEST_F(RegionSpatialProfileTest, Hdf5LineProfile) {
     std::string image_path = FileFinder::Hdf5ImagePath("noise_10px_10px.hdf5");
     std::vector<float> endpoints = {0.0, 0.0, 9.0, 9.0};
     int start(0), end(0), mip(0), width(3);
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {Message::SpatialConfig("x", start, end, mip, width)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
 
     CARTA::SpatialProfileData spatial_profile;
     bool ok = RegionSpatialProfile(image_path, endpoints, spatial_reqs, spatial_profile);
@@ -177,7 +188,7 @@ TEST_F(RegionSpatialProfileTest, FitsHorizontalCutProfile) {
     std::string image_path = FileFinder::FitsImagePath("noise_3d.fits");
     std::vector<float> endpoints = {9.0, 5.0, 1.0, 5.0}; // Set line region at y=5
     int start(0), end(0), mip(0), width(1);
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {Message::SpatialConfig("x", start, end, mip, width)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
 
     CARTA::SpatialProfileData spatial_profile;
     bool ok = RegionSpatialProfile(image_path, endpoints, spatial_reqs, spatial_profile);
@@ -201,7 +212,7 @@ TEST_F(RegionSpatialProfileTest, FitsVerticalCutProfile) {
     std::string image_path = FileFinder::FitsImagePath("noise_3d.fits");
     std::vector<float> endpoints = {5.0, 9.0, 5.0, 1.0}; // Set line region at x=5
     int start(0), end(0), mip(0), width(1);
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {Message::SpatialConfig("y", start, end, mip, width)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {RegionSpatialProfileTest::SpatialConfig("y", start, end, mip, width)};
 
     CARTA::SpatialProfileData spatial_profile;
     bool ok = RegionSpatialProfile(image_path, endpoints, spatial_reqs, spatial_profile);
@@ -225,7 +236,7 @@ TEST_F(RegionSpatialProfileTest, FitsPolylineProfile) {
     std::string image_path = FileFinder::FitsImagePath("noise_3d.fits");
     std::vector<float> endpoints = {1.0, 1.0, 9.0, 1.0, 9.0, 5.0};
     int start(0), end(0), mip(0), width(1);
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {Message::SpatialConfig("x", start, end, mip, width)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
     std::vector<CARTA::SpatialProfileData> spatial_profiles;
 
     CARTA::SpatialProfileData spatial_profile;
@@ -263,7 +274,7 @@ TEST_F(RegionSpatialProfileTest, FitsAnnotationLineProfile) {
     std::string image_path = FileFinder::FitsImagePath("noise_3d.fits");
     std::vector<float> endpoints = {0.0, 0.0, 9.0, 9.0};
     int start(0), end(0), mip(0), width(3);
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {Message::SpatialConfig("x", start, end, mip, width)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
 
     CARTA::SpatialProfileData spatial_profile;
     bool is_annotation(true);
@@ -276,7 +287,7 @@ TEST_F(RegionSpatialProfileTest, FitsPointProfile) {
     std::string image_path = FileFinder::FitsImagePath("noise_3d.fits");
     std::vector<float> endpoints = {0.0, 0.0};
     int start(0), end(0), mip(0), width(1);
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {Message::SpatialConfig("x", start, end, mip, width)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
 
     CARTA::SpatialProfileData spatial_profile;
     bool ok = RegionSpatialProfile(image_path, endpoints, spatial_reqs, spatial_profile);
@@ -300,7 +311,7 @@ TEST_F(RegionSpatialProfileTest, Hdf5PointProfile) {
     std::string image_path = FileFinder::Hdf5ImagePath("noise_10px_10px.hdf5");
     std::vector<float> points = {0.0, 0.0};
     int start(0), end(0), mip(0), width(1);
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {Message::SpatialConfig("x", start, end, mip, width)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
 
     CARTA::SpatialProfileData spatial_profile;
     bool ok = RegionSpatialProfile(image_path, points, spatial_reqs, spatial_profile);
@@ -324,7 +335,7 @@ TEST_F(RegionSpatialProfileTest, FitsPointProfileOutsideImage) {
     std::string image_path = FileFinder::FitsImagePath("noise_3d.fits");
     std::vector<float> endpoints = {-2.0, -2.0};
     int start(0), end(0), mip(0), width(1);
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {Message::SpatialConfig("x", start, end, mip, width)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
 
     CARTA::SpatialProfileData spatial_profile;
     bool ok = RegionSpatialProfile(image_path, endpoints, spatial_reqs, spatial_profile);
@@ -336,7 +347,7 @@ TEST_F(RegionSpatialProfileTest, FitsAnnotationPointProfile) {
     std::string image_path = FileFinder::FitsImagePath("noise_3d.fits");
     std::vector<float> point = {0.0, 0.0};
     int start(0), end(0), mip(0), width(3);
-    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {Message::SpatialConfig("x", start, end, mip, width)};
+    std::vector<CARTA::SetSpatialRequirements_SpatialConfig> spatial_reqs = {RegionSpatialProfileTest::SpatialConfig("x", start, end, mip, width)};
 
     CARTA::SpatialProfileData spatial_profile;
     bool is_annotation(true);

--- a/test/TestRegionSpectralProfiles.cc
+++ b/test/TestRegionSpectralProfiles.cc
@@ -17,6 +17,25 @@ using namespace carta;
 
 class RegionSpectralProfileTest : public ::testing::Test {
 public:
+    static CARTA::SetSpectralRequirements SetSpectralRequirements(int32_t file_id, int32_t region_id, std::string coordinate) {
+        CARTA::SetSpectralRequirements set_spectral_requirements;
+        set_spectral_requirements.set_file_id(file_id);
+        set_spectral_requirements.set_region_id(region_id);
+        auto* spectral_profiles = set_spectral_requirements.add_spectral_profiles();
+        spectral_profiles->set_coordinate(coordinate);
+        spectral_profiles->add_stats_types(CARTA::StatsType::NumPixels);
+        spectral_profiles->add_stats_types(CARTA::StatsType::Sum);
+        spectral_profiles->add_stats_types(CARTA::StatsType::FluxDensity);
+        spectral_profiles->add_stats_types(CARTA::StatsType::Mean);
+        spectral_profiles->add_stats_types(CARTA::StatsType::RMS);
+        spectral_profiles->add_stats_types(CARTA::StatsType::Sigma);
+        spectral_profiles->add_stats_types(CARTA::StatsType::SumSq);
+        spectral_profiles->add_stats_types(CARTA::StatsType::Min);
+        spectral_profiles->add_stats_types(CARTA::StatsType::Max);
+        spectral_profiles->add_stats_types(CARTA::StatsType::Extrema);
+        return set_spectral_requirements;
+    }
+
     static bool SetRegion(carta::RegionHandler& region_handler, int file_id, int& region_id, const std::vector<float>& points,
         std::shared_ptr<casacore::CoordinateSystem> csys, bool is_annotation) {
         std::vector<CARTA::Point> control_points;
@@ -49,7 +68,7 @@ public:
         }
 
         // Set spectral requirements (Message requests 10 stats types)
-        auto spectral_req_message = Message::SetSpectralRequirements(file_id, region_id, "z");
+        auto spectral_req_message = SetSpectralRequirements(file_id, region_id, "z");
         std::vector<CARTA::SetSpectralRequirements_SpectralConfig> spectral_requirements = {
             spectral_req_message.spectral_profiles().begin(), spectral_req_message.spectral_profiles().end()};
         if (!region_handler.SetSpectralRequirements(region_id, file_id, frame, spectral_requirements)) {

--- a/test/TestRegionStats.cc
+++ b/test/TestRegionStats.cc
@@ -32,7 +32,7 @@ public:
         stats_config->add_stats_types(CARTA::StatsType::Max);
         return set_stats_requirements;
     }
-    
+
     static bool SetRegion(carta::RegionHandler& region_handler, int file_id, int& region_id, const std::vector<float>& points,
         std::shared_ptr<casacore::CoordinateSystem> csys, bool is_annotation) {
         std::vector<CARTA::Point> control_points;

--- a/test/TestRegionStats.cc
+++ b/test/TestRegionStats.cc
@@ -17,6 +17,22 @@ using namespace carta;
 
 class RegionStatsTest : public ::testing::Test {
 public:
+    static CARTA::SetStatsRequirements SetStatsRequirements(int32_t file_id, int32_t region_id) {
+        CARTA::SetStatsRequirements set_stats_requirements;
+        set_stats_requirements.set_file_id(file_id);
+        set_stats_requirements.set_region_id(region_id);
+        auto* stats_config = set_stats_requirements.add_stats_configs();
+        stats_config->add_stats_types(CARTA::StatsType::NumPixels);
+        stats_config->add_stats_types(CARTA::StatsType::Sum);
+        stats_config->add_stats_types(CARTA::StatsType::Mean);
+        stats_config->add_stats_types(CARTA::StatsType::RMS);
+        stats_config->add_stats_types(CARTA::StatsType::Sigma);
+        stats_config->add_stats_types(CARTA::StatsType::SumSq);
+        stats_config->add_stats_types(CARTA::StatsType::Min);
+        stats_config->add_stats_types(CARTA::StatsType::Max);
+        return set_stats_requirements;
+    }
+    
     static bool SetRegion(carta::RegionHandler& region_handler, int file_id, int& region_id, const std::vector<float>& points,
         std::shared_ptr<casacore::CoordinateSystem> csys, bool is_annotation) {
         std::vector<CARTA::Point> control_points;
@@ -48,7 +64,7 @@ public:
         }
 
         // Set stats requirements
-        auto stats_req_message = Message::SetStatsRequirements(file_id, region_id);
+        auto stats_req_message = SetStatsRequirements(file_id, region_id);
         std::vector<CARTA::SetStatsRequirements_StatsConfig> stats_configs = {
             stats_req_message.stats_configs().begin(), stats_req_message.stats_configs().end()};
         if (!region_handler.SetStatsRequirements(region_id, file_id, frame, stats_configs)) {


### PR DESCRIPTION
**Description**

Moving wrapper functions which are only used in tests from from Message.cc to specific tests - as described in Issue [#1533](https://github.com/CARTAvis/carta-backend/issues/1533) 

**Done:**
- [x] the bulk of the wrappers were already moved from Message.cc to specific tests
- [x] fix style and make the CI/CD pass.

**To do before moving out of draft:**
- [X] consult/review by Adrianna
- [X] In the process, I've noticed that in Message.cc there are global functions ::FillHistogram and ::FillStatistics which seem to implement some common/general functionality used in a couple of places (e.g. Frame.cc). However, they do not seem to be message related. So, should they really be here, or rather moved elsewhere? To be discussed and decided. *addressed in comment*
- [X] Anything else I've missed?

**Checklist**

- [X] changelog updated
- [x] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [x] no protobuf update needed
- [X] protobuf version not bumped
- [X] added reviewers and assignee
- [ ] GitHub Project estimate added
