### PR TITLE
Fix Stokes histograms in matched image in dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Don't reallocate memory for image cache unnecessarily ([#1508](https://github.com/CARTAvis/carta-backend/pull/1508)).
 * Fixed crash in ICD channel map test with ASAN enabled ([#1518](https://github.com/CARTAvis/carta-backend/issues/1518)).
 * Fixed fetching of region data for other Stokes ([#1551](https://github.com/CARTAvis/carta-backend/issues/1551)).
+* Fixed region histogram for image Stokes after computed Stokes ([#1522](https://github.com/CARTAvis/carta-backend/issues/1522)).
 
 ### Changed
 * Standardized use of float and double NaN (Not a Number) ([#1502](https://github.com/CARTAvis/carta-backend/issues/1502)).

--- a/src/Region/Region.cc
+++ b/src/Region/Region.cc
@@ -162,12 +162,14 @@ std::shared_ptr<casacore::LCRegion> Region::GetImageRegion(int file_id, std::sha
                 } catch (const casacore::AipsError& err) {
                     // Region is outside image
                 }
-                _lcregion_set = true;
 
-                // Cache LCRegion
-                if (lcregion && stokes_source.IsOriginalImage()) {
-                    std::lock_guard<std::mutex> guard(_lcregion_mutex);
-                    _lcregion = lcregion;
+                // Cache LCRegion and set flag
+                if (stokes_source.IsOriginalImage()) {
+                    if (lcregion) {
+                        std::lock_guard<std::mutex> guard(_lcregion_mutex);
+                        _lcregion = lcregion;
+                    }
+                    _lcregion_set = true; // attempt was made even if lcregion failed (outside image)
                 }
             }
         } else {


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
Fixes #1522 for dev.  Fix has been backported in PR #1550.

* How does this PR solve the issue? Give a brief summary.
A flag is set to indicate an attempt to create an LCRegion was made and, if successful, the LCRegion is cached. This flag was being set for computed Stokes even though the LCRegion is not cached.  Then when the flag is checked for the image Stokes, there is no attempt to create the LCRegion. In this fix, the flag is not set for computed Stokes so that it succeeds for image Stokes.

* Are there any companion PRs (frontend, protobuf)?
No

* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
Match images, create region, request computed Stokes histogram for matched image, then for reference image. Change Stokes from computed to image Stokes for reference image, all histograms should succeed.

**Checklist**

- [x] changelog updated
- [x] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [x] no protobuf update needed
- [x] protobuf version not bumped
- [x] added reviewers and assignee
- [ ] GitHub Project estimate added
