### PR TITLE
Include full path in error messages about nonexistent files (e.g. when loading a workspace) issue #1354

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Moved region histogram implementation to analysis subdirectory ([#1509](https://github.com/CARTAvis/carta-backend/issues/1509)).
 * Moved region statistics implementation to analysis subdirectory ([#1512](https://github.com/CARTAvis/carta-backend/issues/1512)).
 * Excluded image cache data from core dumps on supported platforms ([#1506](https://github.com/CARTAvis/carta-backend/pull/1506)).
+* Moved region spatial profile implementation to analysis subdirectory ([#1515](https://github.com/CARTAvis/carta-backend/issues/1515)).
 * Full file path was added to the error message due to non-existing/non-readable file ([#1354](https://github.com/CARTAvis/carta-backend/issues/1354)).
 
 ## [5.0.2]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Don't reallocate memory for image cache unnecessarily ([#1508](https://github.com/CARTAvis/carta-backend/pull/1508)).
 * Fixed crash in ICD channel map test with ASAN enabled ([#1518](https://github.com/CARTAvis/carta-backend/issues/1518)).
 * Fixed fetching of region data for other Stokes ([#1551](https://github.com/CARTAvis/carta-backend/issues/1551)).
-* Full file path was added to the error message due to non-existing/non-readable file ([#1354](https://github.com/CARTAvis/carta-backend/issues/1354)).
 
 ### Changed
 * Standardized use of float and double NaN (Not a Number) ([#1502](https://github.com/CARTAvis/carta-backend/issues/1502)).
@@ -20,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Moved region histogram implementation to analysis subdirectory ([#1509](https://github.com/CARTAvis/carta-backend/issues/1509)).
 * Moved region statistics implementation to analysis subdirectory ([#1512](https://github.com/CARTAvis/carta-backend/issues/1512)).
 * Excluded image cache data from core dumps on supported platforms ([#1506](https://github.com/CARTAvis/carta-backend/pull/1506)).
+* Full file path was added to the error message due to non-existing/non-readable file ([#1354](https://github.com/CARTAvis/carta-backend/issues/1354)).
 
 ## [5.0.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Don't reallocate memory for image cache unnecessarily ([#1508](https://github.com/CARTAvis/carta-backend/pull/1508)).
 * Fixed crash in ICD channel map test with ASAN enabled ([#1518](https://github.com/CARTAvis/carta-backend/issues/1518)).
 * Fixed fetching of region data for other Stokes ([#1551](https://github.com/CARTAvis/carta-backend/issues/1551)).
+* Full file path was added to the error message due to non-existing/non-readable file ([#1354](https://github.com/CARTAvis/carta-backend/issues/1354)).
 
 ### Changed
 * Standardized use of float and double NaN (Not a Number) ([#1502](https://github.com/CARTAvis/carta-backend/issues/1502)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Moved region histogram implementation to analysis subdirectory ([#1509](https://github.com/CARTAvis/carta-backend/issues/1509)).
 * Moved region statistics implementation to analysis subdirectory ([#1512](https://github.com/CARTAvis/carta-backend/issues/1512)).
 * Excluded image cache data from core dumps on supported platforms ([#1506](https://github.com/CARTAvis/carta-backend/pull/1506)).
-* Moved region spatial profile implementation to analysis subdirectory ([#1515](https://github.com/CARTAvis/carta-backend/issues/1515)).
 * Full file path was added to the error message due to non-existing/non-readable file ([#1354](https://github.com/CARTAvis/carta-backend/issues/1354)).
 
 ## [5.0.2]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Moved region import/export implementation to new subdirectory ([#1505](https://github.com/CARTAvis/carta-backend/issues/1505)).
 * Moved region histogram implementation to analysis subdirectory ([#1509](https://github.com/CARTAvis/carta-backend/issues/1509)).
 * Moved region statistics implementation to analysis subdirectory ([#1512](https://github.com/CARTAvis/carta-backend/issues/1512)).
-* Excluded image cache data from core dumps on supported platforms ([#1506](https://github.com/CARTAvis/carta-backend/pull/1506)).
 * Full file path was added to the error message due to non-existing/non-readable file ([#1354](https://github.com/CARTAvis/carta-backend/issues/1354)).
 * Moved region spatial profile implementation to analysis subdirectory ([#1515](https://github.com/CARTAvis/carta-backend/issues/1515)).
 

--- a/src/Util/Casacore.cc
+++ b/src/Util/Casacore.cc
@@ -32,17 +32,17 @@ casacore::String GetResolvedFilename(
 
     // Check directory
     if (!cc_file.exists()) {
-        message = "Directory " + path.expandedName() + " does not exist.";
+        message = fmt::format("Directory {} does not exist.", path.expandedName());
     } else if (!cc_file.isReadable()) {
-        message = "Directory " + path.expandedName() + " is not readable.";
+        message = fmt::format("Directory {} is not readable.", path.expandedName());
     } else {
         // Check file
         path.append(file);
         cc_file = casacore::File(path);
         if (!cc_file.exists()) {
-            message = "File " + path.expandedName() + " does not exist.";
+            message = fmt::format("File {} does not exist.", path.expandedName());
         } else if (!cc_file.isReadable()) {
-            message = "File " + path.expandedName() + " is not readable.";
+            message = fmt::format("File {} is not readable.", path.expandedName());
         } else {
             try {
                 resolved_filename = path.resolvedName();
@@ -52,7 +52,7 @@ casacore::String GetResolvedFilename(
                 if (path.absoluteName().empty()) {
                     resolved_filename = path.expandedName();
                 } else {
-                    message = err.getMesg();
+                    fmt::format("Error resolving file {} : {}", path.expandedName(), err.getMesg());
                 }
             }
         }

--- a/src/Util/Casacore.cc
+++ b/src/Util/Casacore.cc
@@ -32,17 +32,17 @@ casacore::String GetResolvedFilename(
 
     // Check directory
     if (!cc_file.exists()) {
-        message = "Directory " + directory + " does not exist (filename = " + file + ").";
+        message = "Directory " + path.expandedName() + " does not exist.";
     } else if (!cc_file.isReadable()) {
-        message = "Directory " + directory + " is not readable (filename = " + file + ").";
+        message = "Directory " + path.expandedName() + " is not readable.";
     } else {
         // Check file
         path.append(file);
         cc_file = casacore::File(path);
         if (!cc_file.exists()) {
-            message = "File " + file + " does not exist in the directory " + directory + ".";
+            message = "File " + path.expandedName() + " does not exist.";
         } else if (!cc_file.isReadable()) {
-            message = "File " + file + " is not readable in the directory " + directory + ".";
+            message = "File " + path.expandedName() + " is not readable.";
         } else {
             try {
                 resolved_filename = path.resolvedName();

--- a/src/Util/Casacore.cc
+++ b/src/Util/Casacore.cc
@@ -32,17 +32,17 @@ casacore::String GetResolvedFilename(
 
     // Check directory
     if (!cc_file.exists()) {
-        message = "Directory " + directory + " does not exist.";
+        message = "Directory " + directory + " does not exist (filename = " + file + ").";
     } else if (!cc_file.isReadable()) {
-        message = "Directory " + directory + " is not readable.";
+        message = "Directory " + directory + " is not readable (filename = " + file + ").";
     } else {
         // Check file
         path.append(file);
         cc_file = casacore::File(path);
         if (!cc_file.exists()) {
-            message = "File " + file + " does not exist.";
+            message = "File " + file + " does not exist in the directory " + directory + ".";
         } else if (!cc_file.isReadable()) {
-            message = "File " + file + " is not readable.";
+            message = "File " + file + " is not readable in the directory " + directory + ".";
         } else {
             try {
                 resolved_filename = path.resolvedName();


### PR DESCRIPTION
**Description**
When error due to non-existing or non-readable file occurs the error message should contain both directory and filename.
This seems a very small on standalone change (Issue #1354). 

Done:
- [x] extended error message with the missing information (file or directory)

To do before moving out of draft:
- [ ] Adrianna to review and also verify if this satisfies any potential security concerns mentioned in the description.
- [ ] verify if this is what was required or anything else should be added
- [ ] what to show in the exception catch code (Casacore.cc : line ~47 } catch (const casacore::AipsError& err) {). Perhaps path.expandedName() should also be added to the error message (around like message = err.getMesg());

To check during code review:

Related work to leave for later PRs:

**Checklist**
- [x] changelog updated
- [x] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [x]  no protobuf update needed
- [ ] protobuf version not bumped
- [ ] added reviewers and assignee
- [ ] GitHub Project estimate added

