### PR TITLE
Backport: Fix deleting resumed sessions from OnMessageTask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1]
+
+### Fixed
+* Fixed deletion of resumed session from message task threads ([#1537](https://github.com/CARTAvis/carta-backend/issues/1537)).
+
 ## [5.0.2]
 
 ### Fixed

--- a/src/Session/SessionManager.cc
+++ b/src/Session/SessionManager.cc
@@ -63,11 +63,18 @@ SessionManager::SessionManager(ProgramSettings& settings, std::string auth_token
 void SessionManager::DeleteSession(uint32_t session_id) {
     std::unique_lock<std::mutex> ulock(_sessions_mutex);
     Session* session;
+
     try {
         session = _sessions.at(session_id);
     } catch (const std::out_of_range& e) {
-        spdlog::warn("Could not delete session {}: not found!", session_id);
-        return;
+        try {
+            auto real_id = _real_session_id.at(session_id);
+            session = _sessions.at(real_id);
+            session_id = real_id;
+        } catch (const std::out_of_range& e) {
+            spdlog::warn("Could not delete session {}: not found!", session_id);
+            return;
+        }
     }
 
     spdlog::info("Session {} [{}] Deleted. Remaining sessions: {}", session->GetId(), session->GetAddress(), Session::NumberOfSessions());
@@ -80,11 +87,13 @@ void SessionManager::DeleteSession(uint32_t session_id) {
             Session* ss = ssp.second;
             spdlog::info("\tMap id {}, session id {}, session ptr {}", ssp.first, ss->GetId(), fmt::ptr(ss));
         }
-        _real_session_id.erase(session->GetId());
+        auto internal_id = session->GetId();
         delete session;
         _sessions.erase(session_id);
+        _real_session_id.erase(internal_id);
+
     } else {
-        spdlog::info("Session {} reference count is not 0 ({}) at this point in DeleteSession", session_id, session->GetRefCount());
+        spdlog::info("Session {} reference count is not 0 ({}) at this point in DeleteSession", session->GetId(), session->GetRefCount());
     }
 }
 


### PR DESCRIPTION
This is a backport of https://github.com/CARTAvis/carta-backend/pull/1546 to the point release.

**Checklist**

- [X] changelog updated
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [X] no protobuf update needed
- [X] protobuf version not bumped
- [X] added reviewers and assignee
- [ ] GitHub Project estimate added
