### PR TITLE
Fix animation spatial profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed deletion of resumed session from message task threads ([#1537](https://github.com/CARTAvis/carta-backend/issues/1537)).
 * Fixed region histogram for image Stokes after computed Stokes ([#1522](https://github.com/CARTAvis/carta-backend/issues/1522)).
 * Fixed vector overlay not updating after session resume ([#1543](https://github.com/CARTAvis/carta-backend/issues/1543)).
+* Fixed cursor spatial profiles during animation ([#1558](https://github.com/CARTAvis/carta-backend/issues/1558)).
 
 ### Changed
 * Standardized use of float and double NaN (Not a Number) ([#1502](https://github.com/CARTAvis/carta-backend/issues/1502)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed deletion of resumed session from message task threads ([#1537](https://github.com/CARTAvis/carta-backend/issues/1537)).
 * Fixed region histogram for image Stokes after computed Stokes ([#1522](https://github.com/CARTAvis/carta-backend/issues/1522)).
 * Fixed vector overlay not updating after session resume ([#1543](https://github.com/CARTAvis/carta-backend/issues/1543)).
-* Fixed cursor spatial profiles during animation ([#1558](https://github.com/CARTAvis/carta-backend/issues/1558)).
+* Fixed cursor/region spatial profiles during animation ([#1558](https://github.com/CARTAvis/carta-backend/issues/1558)).
 
 ### Changed
 * Standardized use of float and double NaN (Not a Number) ([#1502](https://github.com/CARTAvis/carta-backend/issues/1502)).

--- a/src/Region/RegionHandler.cc
+++ b/src/Region/RegionHandler.cc
@@ -1910,12 +1910,17 @@ bool RegionHandler::FillSpatialProfileData(std::function<void(CARTA::SpatialProf
         ulock.unlock();
 
         // Get file ids in spatial profile configurations
-        auto config_file_ids = spatial_profile->GetConfigFileIds(file_id);
-        if (config_file_ids.empty()) {
-            continue;
+        std::vector<int> spatial_file_ids;
+        if (file_id > ALL_FILES) {
+            spatial_file_ids.push_back(file_id);
+        } else {
+            spatial_file_ids = spatial_profile->GetConfigFileIds(file_id);
+            if (spatial_file_ids.empty()) {
+                continue;
+            }
         }
 
-        for (int spatial_file_id : config_file_ids) {
+        for (int spatial_file_id : spatial_file_ids) {
             // Get statistics for specific region and file ids (input ids may be ALL)
             if (!RegionFileIdsValid(spatial_region_id, spatial_file_id)) {
                 continue;

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -828,7 +828,7 @@ void Session::OnSetImageChannels(const CARTA::SetImageChannels& message) {
                 }
             }
         } else {
-            // Set new channel
+            // Set new channel and/or stokes
             auto z_target = message.channel();
             auto stokes_target = message.stokes();
             bool z_changed(z_target != frame->CurrentZ());
@@ -1789,16 +1789,21 @@ bool Session::SendSpatialProfileData(int file_id, int region_id) {
     bool data_sent(false);
     std::vector<CARTA::SpatialProfileData> spatial_profile_messages;
 
-    if (_region_handler && (region_id > CURSOR_REGION_ID || region_id == ALL_REGIONS || file_id == ALL_FILES)) {
-        data_sent = _region_handler->FillSpatialProfileData(
-            [&](CARTA::SpatialProfileData spatial_profile_message) {
-                if (spatial_profile_message.profiles_size() > 0) {
-                    auto spatial_file_id = spatial_profile_message.file_id();
-                    SendFileEvent(spatial_file_id, CARTA::EventType::SPATIAL_PROFILE_DATA, 0, spatial_profile_message);
-                    data_sent = true;
-                }
-            },
-            file_id, region_id);
+    if (region_id > CURSOR_REGION_ID || region_id == ALL_REGIONS || file_id == ALL_FILES) {
+        if (region_id == ALL_REGIONS || region_id == CURSOR_REGION_ID) {
+            data_sent = SendSpatialProfileData(file_id, CURSOR_REGION_ID);
+        }
+        if (_region_handler) {
+            data_sent |= _region_handler->FillSpatialProfileData(
+                [&](CARTA::SpatialProfileData spatial_profile_message) {
+                    if (spatial_profile_message.profiles_size() > 0) {
+                        auto spatial_file_id = spatial_profile_message.file_id();
+                        SendFileEvent(spatial_file_id, CARTA::EventType::SPATIAL_PROFILE_DATA, 0, spatial_profile_message);
+                        data_sent = true;
+                    }
+                },
+                file_id, region_id);
+        }
     } else if (region_id == CURSOR_REGION_ID) {
         // Cursor spatial profile
         if (_frames.find(file_id) != _frames.end()) {
@@ -2049,18 +2054,15 @@ void Session::UpdateImageData(int file_id, bool send_image_histogram, bool z_cha
 
 void Session::UpdateRegionData(int file_id, int region_id, bool z_changed, bool stokes_changed) {
     // Send updated data for user-set regions with requirements when z, stokes, or region changes.
-    if (stokes_changed) {
+    bool image_frame_changed(z_changed || stokes_changed);
+    if (stokes_changed || !image_frame_changed) { // stokes or region changed
         SendSpectralProfileData(file_id, region_id, stokes_changed);
     }
 
-    bool channel_changed(z_changed || stokes_changed);
-    SendRegionHistogramData(file_id, region_id, channel_changed);
+    // Send histogram, stats, and spatial profile if z, stokes, or region changes
+    SendRegionHistogramData(file_id, region_id, image_frame_changed);
     SendRegionStatsData(file_id, region_id);
-
-    if (!channel_changed) { // Region changed, update all
-        SendSpatialProfileData(file_id, region_id);
-        SendSpectralProfileData(file_id, region_id, stokes_changed);
-    }
+    SendSpatialProfileData(file_id, region_id);
 }
 
 void Session::RegionDataStreams(int file_id, int region_id) {


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
Fixes #1558 
* How does this PR solve the issue? Give a brief summary.
  * Spatial profiles were only updated when the region changed.  Now updated when z, stokes, or region changes.
  * When region id is ALL_REGIONS, updated spatial profiles only for region handler regions.  Now updates cursor as well.

* Are there any companion PRs (frontend, protobuf)?
No

* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
Open image cube, start animation with cursor/point/line in image.  Spatial profiles should update with each channel or stokes.

**Checklist**

- [ ] changelog updated
- [x] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [ ] no protobuf update needed
- [ ] protobuf version not bumped
- [ ] added reviewers and assignee
- [ ] GitHub Project estimate added
