### PR TITLE
Retry failure tests once

### DIFF
--- a/.github/actions/run-macos/action.yml
+++ b/.github/actions/run-macos/action.yml
@@ -27,7 +27,7 @@ runs:
         cd $ICD_DIR
         for test_file in $(cat ICD_test_stages/${{ inputs.test_stage_name }}.tests); do
           if CI=true npm test "$test_file"; then
-            echo "$test_file 1st attempt"
+            echo "$test_file 1st attempt: PASS"
           else
             echo "Failed: $test_file - retrying ..."
             sleep 3

--- a/.github/actions/run-macos/action.yml
+++ b/.github/actions/run-macos/action.yml
@@ -26,9 +26,16 @@ runs:
         ICD_DIR=$GITHUB_WORKSPACE/ICD-RxJS
         cd $ICD_DIR
         for test_file in $(cat ICD_test_stages/${{ inputs.test_stage_name }}.tests); do
-          CI=true npm test $test_file
+          if CI=true npm test "$test_file"; then
+            echo "$test_file 1st attempt"
+          else
+            echo "Failed: $test_file - retrying ..."
+            sleep 3
+            CI=true npm test "$test_file"
+          fi
           sleep 3 && pgrep carta_backend
         done
+
       shell: bash
 
     - name: Stop carta-backend

--- a/.github/workflows/icd_tests.yml
+++ b/.github/workflows/icd_tests.yml
@@ -1044,4 +1044,3 @@ jobs:
             - Image-Fitting-ICD-Tests: ${{ needs['Image-Fitting-ICD-Tests'].result }}
             - Vector-Overlay-ICD-Tests: ${{ needs['Vector-Overlay-ICD-Tests'].result }}
             - Resume-ICD-Tests: ${{ needs['Resume-ICD-Tests'].result }}
-


### PR DESCRIPTION
**Description**

* Added a retry mechanism for ICD tests on macOS.

* Each ICD test now runs once, and if it fails, it retries one additional time automatically.  
  This prevents intermittent failures caused by machine or network.

* No companion PR  