### PR TITLE
Keep degenerate Stokes axis in CoordinateSystem for HDF5 images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+* Fixed coordinate axes error opening HDF5 image ([#1594](https://github.com/CARTAvis/carta-backend/issues/1594)).
+
 ## [6.0.0-beta.1]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-* Fixed coordinate axes error opening HDF5 image ([#1594](https://github.com/CARTAvis/carta-backend/issues/1594)).
+* Fixed error opening HDF5 image with degenerate undefined Stokes axis ([#1594](https://github.com/CARTAvis/carta-backend/issues/1594)).
 
 ## [6.0.0-beta.1]
 

--- a/src/ImageData/CartaHdf5Image.cc
+++ b/src/ImageData/CartaHdf5Image.cc
@@ -78,8 +78,7 @@ casacore::Bool CartaHdf5Image::ok() const {
 }
 
 casacore::Bool CartaHdf5Image::doGetSlice(casacore::Array<float>& buffer, const casacore::Slicer& section) {
-    bool ok = _lattice.doGetSlice(buffer, section);
-    return ok;
+    return _lattice.doGetSlice(buffer, section);
 }
 
 void CartaHdf5Image::doPutSlice(const casacore::Array<float>& buffer, const casacore::IPosition& where, const casacore::IPosition& stride) {

--- a/src/ImageData/CartaHdf5Image.cc
+++ b/src/ImageData/CartaHdf5Image.cc
@@ -78,7 +78,8 @@ casacore::Bool CartaHdf5Image::ok() const {
 }
 
 casacore::Bool CartaHdf5Image::doGetSlice(casacore::Array<float>& buffer, const casacore::Slicer& section) {
-    return _lattice.doGetSlice(buffer, section);
+    bool ok = _lattice.doGetSlice(buffer, section);
+    return ok;
 }
 
 void CartaHdf5Image::doPutSlice(const casacore::Array<float>& buffer, const casacore::IPosition& where, const casacore::IPosition& stride) {
@@ -207,7 +208,7 @@ void CartaHdf5Image::SetUpImage() {
             casacore::LogIO log(sink);
             unsigned int which_rep(0);
             casacore::IPosition image_shape(shape());
-            bool drop_stokes(true);
+            bool drop_stokes(false); // need csys shape to match lattice shape
             casacore::CoordinateSystem coordinate_system = casacore::ImageFITSConverter::getCoordinateSystem(
                 stokes_fits_value, unused_headers_rec, _fits_header_strings, log, which_rep, image_shape, drop_stokes);
             setCoordinateInfo(coordinate_system);

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -216,7 +216,7 @@ bool FileLoader::FindCoordinateAxes(std::string& message) {
     }
 
     if (_coord_sys->nPixelAxes() != _num_dims) {
-        message = "Problem loading image: cannot determine coordinate axes from incomplete header.";
+        message = "Error loading image: number of coordinate pixel axes does not match image shape.";
         return false;
     }
 


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
Fixes #1594 

* How does this PR solve the issue? Give a brief summary.
  - It was actually the degenerate, undefined (value=0) **Stokes** axis which was removed in the casacore::CoordinateSystem, causing it to have 3 pixel axes but the image shape is 4D. casacore::FITSImage sets the image shape to 3D and can load data, but doing this in the CartaHdf5Image fails in H5Sselect_hyperslab in casacore::HDF5DataSet::get. Instead, the Stokes axis is not dropped when creating the CoordinateSystem, the dimensions are the same, and the image loads.
  - I also improved the error message to indicate that the number of csys pixel axes does not match the image shape.

* Are there any companion PRs (frontend, protobuf)?
No

* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
Test image in issue #1594 should be shown in the file browser and loaded.

**Checklist**

- [x] changelog updated
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [x] no protobuf update needed
- [x] protobuf version not bumped
- [x] added reviewers and assignee
- [ ] GitHub Project estimate added
