### PR TITLE
Refactoring: use smart pointers for loaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+* Refactored loader factory to return smart pointers to loaders ([#1597](https://github.com/CARTAvis/carta-backend/pull/1597)).
+
 ## [6.0.0-beta.1]
 
 ### Fixed

--- a/src/Cache/LoaderCache.cc
+++ b/src/Cache/LoaderCache.cc
@@ -27,7 +27,7 @@ std::shared_ptr<FileLoader> LoaderCache::Get(const std::string& filename, const 
         // Create the loader -- don't block while doing this
         std::shared_ptr<FileLoader> loader_ptr;
         guard.unlock();
-        loader_ptr = std::shared_ptr<FileLoader>(FileLoader::GetLoader(filename, directory));
+        loader_ptr = FileLoader::GetLoader(filename, directory);
         guard.lock();
 
         // Check if the loader was added in the meantime

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -27,23 +27,23 @@
 
 using namespace carta;
 
-FileLoader* FileLoader::GetLoader(const std::string& filename, const std::string& directory) {
+std::shared_ptr<FileLoader> FileLoader::GetLoader(const std::string& filename, const std::string& directory) {
     if (!directory.empty()) {
         // filename is LEL expression for image(s) in directory
-        return new ExprLoader(filename, directory);
+        return std::make_shared<ExprLoader>(filename, directory);
     } else if (IsCompressedFits(filename)) {
-        return new FitsLoader(filename, true);
+        return std::make_shared<FitsLoader>(filename, true);
     } else if (IsRemoteHttpFile(filename)) {
-        return new FitsLoader(filename, false, true);
+        return std::make_shared<FitsLoader>(filename, false, true);
     }
 
     switch (CasacoreImageType(filename)) {
         case casacore::ImageOpener::AIPSPP:
-            return new CasaLoader(filename);
+            return std::make_shared<CasaLoader>(filename);
         case casacore::ImageOpener::FITS:
-            return new FitsLoader(filename);
+            return std::make_shared<FitsLoader>(filename);
         case casacore::ImageOpener::MIRIAD:
-            return new MiriadLoader(filename);
+            return std::make_shared<MiriadLoader>(filename);
         case casacore::ImageOpener::GIPSY:
             break;
         case casacore::ImageOpener::CAIPS:
@@ -51,22 +51,22 @@ FileLoader* FileLoader::GetLoader(const std::string& filename, const std::string
         case casacore::ImageOpener::NEWSTAR:
             break;
         case casacore::ImageOpener::HDF5:
-            return new Hdf5Loader(filename);
+            return std::make_shared<Hdf5Loader>(filename);
         case casacore::ImageOpener::IMAGECONCAT:
-            return new ConcatLoader(filename);
+            return std::make_shared<ConcatLoader>(filename);
         case casacore::ImageOpener::IMAGEEXPR:
-            return new ExprLoader(filename);
+            return std::make_shared<ExprLoader>(filename);
         case casacore::ImageOpener::COMPLISTIMAGE:
-            return new CompListLoader(filename);
+            return std::make_shared<CompListLoader>(filename);
         default:
             break;
     }
     return nullptr;
 }
 
-FileLoader* FileLoader::GetLoader(std::shared_ptr<casacore::ImageInterface<float>> image, const std::string& filename) {
+std::shared_ptr<FileLoader> FileLoader::GetLoader(std::shared_ptr<casacore::ImageInterface<float>> image, const std::string& filename) {
     if (image) {
-        return new ImagePtrLoader(image, filename);
+        return std::make_shared<ImagePtrLoader>(image, filename);
     } else {
         spdlog::error("Fail to assign an image pointer!");
         return nullptr;

--- a/src/ImageData/FileLoader.h
+++ b/src/ImageData/FileLoader.h
@@ -48,9 +48,9 @@ public:
     FileLoader(const std::string& filename, const std::string& directory = "", bool is_gz = false, bool is_generated = false);
     virtual ~FileLoader() = default;
 
-    static FileLoader* GetLoader(const std::string& filename, const std::string& directory = "");
+    static std::shared_ptr<FileLoader> GetLoader(const std::string& filename, const std::string& directory = "");
     // Access an image from the memory, not from the disk
-    static FileLoader* GetLoader(std::shared_ptr<casacore::ImageInterface<float>> image, const std::string& filename);
+    static std::shared_ptr<FileLoader> GetLoader(std::shared_ptr<casacore::ImageInterface<float>> image, const std::string& filename);
 
     // check for mirlib (MIRIAD) error; returns true for other image types
     virtual bool CanOpenFile(std::string& error);

--- a/src/ImageData/StokesFilesConnector.cc
+++ b/src/ImageData/StokesFilesConnector.cc
@@ -202,7 +202,7 @@ bool StokesFilesConnector::OpenStokesFiles(const CARTA::ConcatStokesFiles& messa
             if (hdu.empty()) { // use first when required
                 hdu = "0";
             }
-            _loaders[stokes_type].reset(FileLoader::GetLoader(full_name));
+            _loaders[stokes_type] = FileLoader::GetLoader(full_name);
             _loaders[stokes_type]->OpenFile(hdu);
         } catch (casacore::AipsError& ex) {
             err = fmt::format("Failed to open the file: {}", ex.getMesg());
@@ -317,9 +317,6 @@ bool StokesFilesConnector::GetCasaStokesType(
 }
 
 void StokesFilesConnector::ClearCache() {
-    for (auto& loader : _loaders) {
-        loader.second.reset();
-    }
     _loaders.clear();
     _concatenated_name = "";
 }

--- a/src/ImageData/StokesFilesConnector.h
+++ b/src/ImageData/StokesFilesConnector.h
@@ -31,7 +31,7 @@ private:
 
     std::string _top_level_folder;
     std::string _concatenated_name;
-    std::map<CARTA::PolarizationType, std::unique_ptr<FileLoader>> _loaders;
+    std::map<CARTA::PolarizationType, std::shared_ptr<FileLoader>> _loaders;
 };
 
 } // namespace carta

--- a/src/Region/RegionHandler.cc
+++ b/src/Region/RegionHandler.cc
@@ -940,7 +940,7 @@ bool RegionHandler::CalculatePvPreviewImage(int file_id, int region_id, int line
         }
 
         // Preview image is now set, make frame to access it.
-        auto preview_loader = std::shared_ptr<FileLoader>(FileLoader::GetLoader(preview_image, ""));
+        auto preview_loader = FileLoader::GetLoader(preview_image, "");
         auto preview_session_id(-1);
         auto preview_frame = std::make_shared<Frame>(preview_session_id, preview_loader, "");
 

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -308,7 +308,7 @@ bool Session::FillExtendedFileInfo(CARTA::FileInfoExtended& extended_info, std::
     bool file_info_ok(false);
 
     try {
-        image_loader = std::shared_ptr<FileLoader>(FileLoader::GetLoader(image, filename));
+        image_loader = FileLoader::GetLoader(image, filename);
         FileExtInfoLoader ext_info_loader(image_loader);
         file_info_ok = ext_info_loader.FillFileExtInfo(extended_info, filename, "", message);
     } catch (casacore::AipsError& err) {

--- a/test/TestContour.cc
+++ b/test/TestContour.cc
@@ -36,7 +36,7 @@ public:
     }
 
     void GenerateContour(fs::path file_path, const CARTA::SmoothingMode& smoothing_mode) {
-        std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(file_path));
+        auto loader = carta::FileLoader::GetLoader(file_path);
         std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
 
         spdlog::info("The generated image contains random pixels values with mean = 0 and STD = 1.");

--- a/test/TestCursorSpatialProfiles.cc
+++ b/test/TestCursorSpatialProfiles.cc
@@ -110,7 +110,7 @@ public:
 
 TEST_F(CursorSpatialProfileTest, SmallFitsProfile) {
     auto path = FitsImages() / "10x10_nans.fits";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(path));
+    auto loader = carta::FileLoader::GetLoader(path);
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     FitsDataReader reader(path);
 
@@ -154,7 +154,7 @@ TEST_F(CursorSpatialProfileTest, SmallFitsProfile) {
 
 TEST_F(CursorSpatialProfileTest, SmallHdf5Profile) {
     auto path = Hdf5Images() / "10x10_nans.hdf5";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(path));
+    auto loader = carta::FileLoader::GetLoader(path);
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     Hdf5DataReader reader(path);
 
@@ -198,7 +198,7 @@ TEST_F(CursorSpatialProfileTest, SmallHdf5Profile) {
 
 TEST_F(CursorSpatialProfileTest, LowResFitsProfile) {
     auto path = FitsImages() / "130x100_nans.fits";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(path));
+    auto loader = carta::FileLoader::GetLoader(path);
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     FitsDataReader reader(path);
 
@@ -235,7 +235,7 @@ TEST_F(CursorSpatialProfileTest, LowResFitsProfile) {
 
 TEST_F(CursorSpatialProfileTest, LowResHdf5ProfileExactMipAvailable) {
     auto path = Hdf5Images() / "130x100_nans.hdf5";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(path));
+    auto loader = carta::FileLoader::GetLoader(path);
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     Hdf5DataReader reader(path);
 
@@ -272,7 +272,7 @@ TEST_F(CursorSpatialProfileTest, LowResHdf5ProfileExactMipAvailable) {
 
 TEST_F(CursorSpatialProfileTest, LowResHdf5ProfileLowerMipAvailable) {
     auto path = Hdf5Images() / "130x100_nans.hdf5";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(path));
+    auto loader = carta::FileLoader::GetLoader(path);
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     Hdf5DataReader reader(path);
 
@@ -311,7 +311,7 @@ TEST_F(CursorSpatialProfileTest, LowResHdf5ProfileLowerMipAvailable) {
 
 TEST_F(CursorSpatialProfileTest, LowResHdf5ProfileNoMipAvailable) {
     auto path = Hdf5Images() / "120x100_nans.hdf5";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(path));
+    auto loader = carta::FileLoader::GetLoader(path);
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     Hdf5DataReader reader(path);
 
@@ -350,7 +350,7 @@ TEST_F(CursorSpatialProfileTest, LowResHdf5ProfileNoMipAvailable) {
 
 TEST_F(CursorSpatialProfileTest, FullResFitsStartEnd) {
     auto path = FitsImages() / "400x300_nans.fits";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(path));
+    auto loader = carta::FileLoader::GetLoader(path);
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     FitsDataReader reader(path);
 
@@ -387,7 +387,7 @@ TEST_F(CursorSpatialProfileTest, FullResFitsStartEnd) {
 
 TEST_F(CursorSpatialProfileTest, FullResHdf5StartEnd) {
     auto path = Hdf5Images() / "400x300_nans.hdf5";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(path));
+    auto loader = carta::FileLoader::GetLoader(path);
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     Hdf5DataReader reader(path);
 
@@ -424,7 +424,7 @@ TEST_F(CursorSpatialProfileTest, FullResHdf5StartEnd) {
 
 TEST_F(CursorSpatialProfileTest, LowResFitsStartEnd) {
     auto path = FitsImages() / "400x300_nans.fits";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(path));
+    auto loader = carta::FileLoader::GetLoader(path);
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     FitsDataReader reader(path);
 
@@ -463,7 +463,7 @@ TEST_F(CursorSpatialProfileTest, LowResFitsStartEnd) {
 
 TEST_F(CursorSpatialProfileTest, LowResHdf5StartEnd) {
     auto path = Hdf5Images() / "400x300_nans.hdf5";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(path));
+    auto loader = carta::FileLoader::GetLoader(path);
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     Hdf5DataReader reader(path);
 
@@ -508,7 +508,7 @@ TEST_F(CursorSpatialProfileTest, LowResHdf5StartEnd) {
 
 TEST_F(CursorSpatialProfileTest, Hdf5MultipleChunkFullRes) {
     auto path = Hdf5Images() / "3000x2000_nans.hdf5";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(path));
+    auto loader = carta::FileLoader::GetLoader(path);
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     Hdf5DataReader reader(path);
 
@@ -545,7 +545,7 @@ TEST_F(CursorSpatialProfileTest, Hdf5MultipleChunkFullRes) {
 
 TEST_F(CursorSpatialProfileTest, Hdf5MultipleChunkFullResStartEnd) {
     auto path = Hdf5Images() / "3000x2000_nans.hdf5";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(path));
+    auto loader = carta::FileLoader::GetLoader(path);
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     Hdf5DataReader reader(path);
 
@@ -582,7 +582,7 @@ TEST_F(CursorSpatialProfileTest, Hdf5MultipleChunkFullResStartEnd) {
 
 TEST_F(CursorSpatialProfileTest, FitsChannelChange) {
     auto path = FitsImages() / "10x10x2_nans.fits";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(path));
+    auto loader = carta::FileLoader::GetLoader(path);
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     FitsDataReader reader(path);
 
@@ -628,7 +628,7 @@ TEST_F(CursorSpatialProfileTest, FitsChannelChange) {
 
 TEST_F(CursorSpatialProfileTest, FitsChannelStokesChange) {
     auto path = FitsImages() / "10x10x2x2_nans.fits";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(path));
+    auto loader = carta::FileLoader::GetLoader(path);
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     FitsDataReader reader(path);
 
@@ -680,7 +680,7 @@ TEST_F(CursorSpatialProfileTest, FitsChannelStokesChange) {
 
 TEST_F(CursorSpatialProfileTest, ContiguousHDF5ChannelChange) {
     auto path = Hdf5Images() / "10x10x2_nans.hdf5";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(path));
+    auto loader = carta::FileLoader::GetLoader(path);
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     Hdf5DataReader reader(path);
 
@@ -726,7 +726,7 @@ TEST_F(CursorSpatialProfileTest, ContiguousHDF5ChannelChange) {
 
 TEST_F(CursorSpatialProfileTest, ChunkedHDF5ChannelChange) {
     auto path = Hdf5Images() / "1000x1000x2_nans.hdf5";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(path));
+    auto loader = carta::FileLoader::GetLoader(path);
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     Hdf5DataReader reader(path);
 
@@ -772,7 +772,7 @@ TEST_F(CursorSpatialProfileTest, ChunkedHDF5ChannelChange) {
 
 TEST_F(CursorSpatialProfileTest, ChunkedHDF5ChannelStokesChange) {
     auto path = Hdf5Images() / "1000x1000x2x2_nans.hdf5";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(path));
+    auto loader = carta::FileLoader::GetLoader(path);
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     Hdf5DataReader reader(path);
 

--- a/test/TestExprImage.cc
+++ b/test/TestExprImage.cc
@@ -17,7 +17,7 @@ class ImageExprTest : public ::testing::Test {
 public:
     void GenerateImageExprTimesTwo(const fs::path file_path, const std::string& hdu, bool invalid = false) {
         // Image on disk
-        std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(file_path));
+        auto loader = carta::FileLoader::GetLoader(file_path);
         loader->OpenFile(hdu);
         casacore::IPosition image_shape(loader->GetShape());
 
@@ -43,7 +43,7 @@ public:
             expr = "'" + fs_path.filename().string() + "' * 2";
         }
 
-        std::shared_ptr<carta::FileLoader> expr_loader(carta::FileLoader::GetLoader(expr, directory));
+        auto expr_loader = carta::FileLoader::GetLoader(expr, directory);
         expr_loader->OpenFile(hdu);
         casacore::IPosition expr_shape(expr_loader->GetShape());
 
@@ -81,7 +81,7 @@ public:
         std::string expr = "\"" + fs_path.filename().string() + "\" * 2";
         std::string directory = fs_path.parent_path().string();
 
-        std::shared_ptr<carta::FileLoader> expr_loader(carta::FileLoader::GetLoader(expr, directory));
+        auto expr_loader = carta::FileLoader::GetLoader(expr, directory);
         expr_loader->OpenFile(hdu);
         casacore::IPosition expr_shape(expr_loader->GetShape());
 
@@ -91,7 +91,7 @@ public:
         ASSERT_TRUE(expr_loader->SaveFile(CARTA::FileType::CASA, save_path, message));
 
         // Load saved image
-        std::shared_ptr<carta::FileLoader> saved_expr_loader(carta::FileLoader::GetLoader(save_path));
+        auto saved_expr_loader = carta::FileLoader::GetLoader(save_path);
         saved_expr_loader->OpenFile(hdu);
         ASSERT_TRUE(expr_loader->GetImage().get() != nullptr);
         ASSERT_EQ(expr_loader->GetImage()->imageType(), "ImageExpr");
@@ -122,12 +122,12 @@ TEST_F(ImageExprTest, ImageExprTwoDirs) {
     // Add images in different directories
     std::string expr = "\"noise_10px_10px.fits\" + \"../casa/noise_10px_10px.im\"";
 
-    std::shared_ptr<carta::FileLoader> expr_loader(carta::FileLoader::GetLoader(expr, FitsImages()));
+    auto expr_loader = carta::FileLoader::GetLoader(expr, FitsImages());
     expr_loader->OpenFile("");
     casacore::IPosition expr_shape(expr_loader->GetShape());
 
     auto fits_path = FitsImages() / "noise_10px_10px.fits";
-    std::shared_ptr<carta::FileLoader> fits_loader(carta::FileLoader::GetLoader(fits_path));
+    auto fits_loader = carta::FileLoader::GetLoader(fits_path);
     fits_loader->OpenFile("");
     casacore::IPosition fits_shape(fits_loader->GetShape());
     ASSERT_EQ(fits_shape, expr_shape);

--- a/test/TestFileInfo.cc
+++ b/test/TestFileInfo.cc
@@ -53,7 +53,7 @@ public:
     static void CheckFileExtInfoLoader(
         const std::string& request_filename, const CARTA::FileType& request_file_type, const std::string& request_hdu = "") {
         std::string fullname = MixedImages() / request_filename;
-        auto loader = std::shared_ptr<carta::FileLoader>(carta::FileLoader::GetLoader(fullname));
+        auto loader = carta::FileLoader::GetLoader(fullname);
         FileExtInfoLoader ext_info_loader(loader);
         bool file_info_ok;
         std::string message;

--- a/test/TestFitsImage.cc
+++ b/test/TestFitsImage.cc
@@ -25,7 +25,7 @@ class FitsImageTest : public ::testing::Test {};
 
 TEST_F(FitsImageTest, BasicLoadingTest) {
     auto path = FitsImages() / "10x10.fits";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(path));
+    auto loader = carta::FileLoader::GetLoader(path);
     EXPECT_NE(loader.get(), nullptr);
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     EXPECT_NE(frame.get(), nullptr);
@@ -35,7 +35,7 @@ TEST_F(FitsImageTest, BasicLoadingTest) {
 TEST_F(FitsImageTest, ExampleFriendTest) {
     auto path = FitsImages() / "10x10.fits";
     // TestFrame used instead of Frame if access to protected values is required
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(path));
+    auto loader = carta::FileLoader::GetLoader(path);
     std::unique_ptr<TestFrame> frame(new TestFrame(0, loader, "0"));
     EXPECT_TRUE(frame->IsValid());
     EXPECT_TRUE(frame->_open_image_error.empty());
@@ -43,7 +43,7 @@ TEST_F(FitsImageTest, ExampleFriendTest) {
 
 TEST_F(FitsImageTest, CorrectShape2dImage) {
     auto path = FitsImages() / "10x10.fits";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(path));
+    auto loader = carta::FileLoader::GetLoader(path);
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     EXPECT_TRUE(frame->IsValid());
 
@@ -57,7 +57,7 @@ TEST_F(FitsImageTest, CorrectShape2dImage) {
 
 TEST_F(FitsImageTest, CorrectShape3dImage) {
     auto path = FitsImages() / "10x10x10.fits";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(path));
+    auto loader = carta::FileLoader::GetLoader(path);
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     EXPECT_TRUE(frame->IsValid());
 
@@ -73,7 +73,7 @@ TEST_F(FitsImageTest, CorrectShape3dImage) {
 
 TEST_F(FitsImageTest, CorrectShapeDegenerate3dImages) {
     auto path = FitsImages() / "10x10x10x1.fits";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(path));
+    auto loader = carta::FileLoader::GetLoader(path);
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     EXPECT_TRUE(frame->IsValid());
 
@@ -89,7 +89,7 @@ TEST_F(FitsImageTest, CorrectShapeDegenerate3dImages) {
 
     // CASA-generated images often have spectral and Stokes axes swapped
     path = FitsImages() / "10x10x1x10.fits";
-    loader.reset(carta::FileLoader::GetLoader(path));
+    loader = carta::FileLoader::GetLoader(path);
     frame.reset(new Frame(0, loader, "0"));
     EXPECT_TRUE(frame->IsValid());
 
@@ -106,7 +106,7 @@ TEST_F(FitsImageTest, CorrectShapeDegenerate3dImages) {
 
 TEST_F(FitsImageTest, CorrectShape4dImages) {
     auto path = FitsImages() / "10x10x5x2.fits";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(path));
+    auto loader = carta::FileLoader::GetLoader(path);
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     EXPECT_TRUE(frame->IsValid());
 
@@ -122,7 +122,7 @@ TEST_F(FitsImageTest, CorrectShape4dImages) {
 
     // CASA-generated images often have spectral and Stokes axes swapped
     path = FitsImages() / "10x10x2x5.fits";
-    loader.reset(carta::FileLoader::GetLoader(path));
+    loader = carta::FileLoader::GetLoader(path);
     frame.reset(new Frame(0, loader, "0"));
     EXPECT_TRUE(frame->IsValid());
 

--- a/test/TestHdf5Image.cc
+++ b/test/TestHdf5Image.cc
@@ -26,7 +26,7 @@ class Hdf5ImageTest : public ::testing::Test {};
 
 TEST_F(Hdf5ImageTest, BasicLoadingTest) {
     auto path = Hdf5Images() / "10x10.hdf5";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(path));
+    auto loader = carta::FileLoader::GetLoader(path);
     EXPECT_NE(loader.get(), nullptr);
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     EXPECT_NE(frame.get(), nullptr);
@@ -36,7 +36,7 @@ TEST_F(Hdf5ImageTest, BasicLoadingTest) {
 TEST_F(Hdf5ImageTest, ExampleFriendTest) {
     auto path = Hdf5Images() / "10x10.hdf5";
     // TestFrame used instead of Frame if access to protected values is required
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(path));
+    auto loader = carta::FileLoader::GetLoader(path);
     std::unique_ptr<TestFrame> frame(new TestFrame(0, loader, "0"));
     EXPECT_TRUE(frame->IsValid());
     EXPECT_TRUE(frame->_open_image_error.empty());
@@ -44,7 +44,7 @@ TEST_F(Hdf5ImageTest, ExampleFriendTest) {
 
 TEST_F(Hdf5ImageTest, CorrectShape2dImage) {
     auto path = Hdf5Images() / "10x10.hdf5";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(path));
+    auto loader = carta::FileLoader::GetLoader(path);
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     EXPECT_TRUE(frame->IsValid());
 
@@ -58,7 +58,7 @@ TEST_F(Hdf5ImageTest, CorrectShape2dImage) {
 
 TEST_F(Hdf5ImageTest, CorrectShape3dImage) {
     auto path = Hdf5Images() / "10x10x10.hdf5";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(path));
+    auto loader = carta::FileLoader::GetLoader(path);
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     EXPECT_TRUE(frame->IsValid());
 
@@ -74,7 +74,7 @@ TEST_F(Hdf5ImageTest, CorrectShape3dImage) {
 
 TEST_F(Hdf5ImageTest, CorrectShapeDegenerate3dImages) {
     auto path = Hdf5Images() / "10x10x10x1.hdf5";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(path));
+    auto loader = carta::FileLoader::GetLoader(path);
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     EXPECT_TRUE(frame->IsValid());
 
@@ -90,7 +90,7 @@ TEST_F(Hdf5ImageTest, CorrectShapeDegenerate3dImages) {
 
     // CASA-generated images often have spectral and Stokes axes swapped
     path = Hdf5Images() / "10x10x1x10.hdf5";
-    loader.reset(carta::FileLoader::GetLoader(path));
+    loader = carta::FileLoader::GetLoader(path);
     frame.reset(new Frame(0, loader, "0"));
     EXPECT_TRUE(frame->IsValid());
 
@@ -107,7 +107,7 @@ TEST_F(Hdf5ImageTest, CorrectShapeDegenerate3dImages) {
 
 TEST_F(Hdf5ImageTest, CorrectShape4dImages) {
     auto path = Hdf5Images() / "10x10x5x2.hdf5";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(path));
+    auto loader = carta::FileLoader::GetLoader(path);
     std::unique_ptr<Frame> frame(new Frame(0, loader, "0"));
     EXPECT_TRUE(frame->IsValid());
 
@@ -123,7 +123,7 @@ TEST_F(Hdf5ImageTest, CorrectShape4dImages) {
 
     // CASA-generated images often have spectral and Stokes axes swapped
     path = Hdf5Images() / "10x10x2x5.hdf5";
-    loader.reset(carta::FileLoader::GetLoader(path));
+    loader = carta::FileLoader::GetLoader(path);
     frame.reset(new Frame(0, loader, "0"));
     EXPECT_TRUE(frame->IsValid());
 

--- a/test/TestImageFitting.cc
+++ b/test/TestImageFitting.cc
@@ -57,7 +57,7 @@ public:
     }
 
     void FitImage(fs::path file_path, std::string failed_message = "") {
-        std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(file_path));
+        auto loader = carta::FileLoader::GetLoader(file_path);
         std::unique_ptr<TestFrame> frame(new TestFrame(0, loader, "0"));
 
         CARTA::FittingResponse fitting_response;
@@ -84,7 +84,7 @@ public:
     }
 
     void FitImageWithFov(fs::path file_path, int region_id, std::string failed_message = "") {
-        std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(file_path));
+        auto loader = carta::FileLoader::GetLoader(file_path);
         std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
 
         // TODO: avoid using higher level function region_handler.FitImage

--- a/test/TestPvGenerator.cc
+++ b/test/TestPvGenerator.cc
@@ -66,7 +66,7 @@ public:
 
     static void TestAveragingWidthRange(int width, bool expected_width_range) {
         auto image_path = FitsImages() / "noise_3d.fits"; // 10x10x10 image
-        std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
+        auto loader = carta::FileLoader::GetLoader(image_path);
         std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
         carta::RegionHandler region_handler;
         int file_id(0), region_id(-1);
@@ -96,7 +96,7 @@ public:
 
 TEST_F(PvGeneratorTest, FitsPvImage) {
     auto image_path = FitsImages() / "noise_3d.fits"; // 10x10x10 image with spectral coordinate axis
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
+    auto loader = carta::FileLoader::GetLoader(image_path);
     std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
 
     // Image coordinate system
@@ -166,7 +166,7 @@ TEST_F(PvGeneratorTest, FitsPvImage) {
 
 TEST_F(PvGeneratorTest, FitsPvImageHorizontalCut) {
     auto image_path = FitsImages() / "noise_3d.fits"; // 10x10x10 image with spectral coordinate axis
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
+    auto loader = carta::FileLoader::GetLoader(image_path);
     std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
 
     // Image coordinate system
@@ -243,7 +243,7 @@ TEST_F(PvGeneratorTest, FitsPvImageHorizontalCut) {
 
 TEST_F(PvGeneratorTest, FitsPvImageVerticalCut) {
     auto image_path = FitsImages() / "noise_3d.fits"; // 10x10x10 image
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
+    auto loader = carta::FileLoader::GetLoader(image_path);
     std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
 
     // Image coordinate system
@@ -320,7 +320,7 @@ TEST_F(PvGeneratorTest, FitsPvImageVerticalCut) {
 
 TEST_F(PvGeneratorTest, TestNoSpectralAxis) {
     auto path_string = Hdf5Images() / "10x10x10.hdf5";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(path_string));
+    auto loader = carta::FileLoader::GetLoader(path_string);
     std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
 
     // Set line region [0, 0] to [9, 9]
@@ -352,7 +352,7 @@ TEST_F(PvGeneratorTest, AveragingWidthRange) {
 
 TEST_F(PvGeneratorTest, PvImageSpectralRange) {
     auto image_path = FitsImages() / "noise_3d.fits"; // 10x10x10 image
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
+    auto loader = carta::FileLoader::GetLoader(image_path);
     std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
     auto csys = frame->CoordinateSystem();
 
@@ -382,7 +382,7 @@ TEST_F(PvGeneratorTest, PvImageSpectralRange) {
 
 TEST_F(PvGeneratorTest, PvImageReversedAxes) {
     auto image_path = FitsImages() / "noise_3d.fits"; // 10x10x10 image
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
+    auto loader = carta::FileLoader::GetLoader(image_path);
     std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
     auto csys = frame->CoordinateSystem();
 
@@ -422,7 +422,7 @@ TEST_F(PvGeneratorTest, PvImageReversedAxes) {
 
 TEST_F(PvGeneratorTest, PvImageKeep) {
     auto image_path = FitsImages() / "noise_3d.fits"; // 10x10x10 image
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
+    auto loader = carta::FileLoader::GetLoader(image_path);
     std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
     auto csys = frame->CoordinateSystem();
 
@@ -470,7 +470,7 @@ TEST_F(PvGeneratorTest, PvImageKeep) {
 
 TEST_F(PvGeneratorTest, FitsPvAnnotationLine) {
     auto image_path = FitsImages() / "noise_3d.fits"; // 10x10x10 image
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
+    auto loader = carta::FileLoader::GetLoader(image_path);
     std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
     carta::RegionHandler region_handler;
 
@@ -497,7 +497,7 @@ TEST_F(PvGeneratorTest, FitsPvAnnotationLine) {
 
 TEST_F(PvGeneratorTest, FitsPvPolyLine) {
     auto image_path = FitsImages() / "noise_3d.fits"; // 10x10x10 image
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
+    auto loader = carta::FileLoader::GetLoader(image_path);
     std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
     carta::RegionHandler region_handler;
 
@@ -542,7 +542,7 @@ TEST_F(PvGeneratorTest, FitsPvPolyLine) {
 
 TEST_F(PvGeneratorTest, PvPreview) {
     auto image_path = FitsImages() / "noise_3d.fits"; // 10x10x10 image
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
+    auto loader = carta::FileLoader::GetLoader(image_path);
     std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
     auto csys = frame->CoordinateSystem();
 

--- a/test/TestRegion.cc
+++ b/test/TestRegion.cc
@@ -32,7 +32,7 @@ public:
 
 TEST_F(RegionTest, TestSetUpdateRemoveRegion) {
     auto image_path = FitsImages() / "noise_3d.fits";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
+    auto loader = carta::FileLoader::GetLoader(image_path);
     std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
 
     // Set region
@@ -80,7 +80,7 @@ TEST_F(RegionTest, TestSetUpdateRemoveRegion) {
 
 TEST_F(RegionTest, TestReferenceImageRectangleLCRegion) {
     auto image_path = FitsImages() / "noise_3d.fits";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
+    auto loader = carta::FileLoader::GetLoader(image_path);
     std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
 
     // Set region
@@ -106,7 +106,7 @@ TEST_F(RegionTest, TestReferenceImageRectangleLCRegion) {
 
 TEST_F(RegionTest, TestReferenceImageRotboxLCRegion) {
     auto image_path = FitsImages() / "noise_3d.fits"; // 10x10x10
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
+    auto loader = carta::FileLoader::GetLoader(image_path);
     std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
 
     // Set region
@@ -133,7 +133,7 @@ TEST_F(RegionTest, TestReferenceImageRotboxLCRegion) {
 
 TEST_F(RegionTest, TestReferenceImageEllipseLCRegion) {
     auto image_path = FitsImages() / "noise_3d.fits";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
+    auto loader = carta::FileLoader::GetLoader(image_path);
     std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
 
     // Set region
@@ -160,7 +160,7 @@ TEST_F(RegionTest, TestReferenceImageEllipseLCRegion) {
 
 TEST_F(RegionTest, TestReferenceImagePolygonLCRegion) {
     auto image_path = FitsImages() / "noise_3d.fits";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
+    auto loader = carta::FileLoader::GetLoader(image_path);
     std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
 
     // Set region
@@ -187,7 +187,7 @@ TEST_F(RegionTest, TestReferenceImagePolygonLCRegion) {
 
 TEST_F(RegionTest, TestReferenceImagePointRecord) {
     auto image_path = FitsImages() / "noise_3d.fits";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
+    auto loader = carta::FileLoader::GetLoader(image_path);
     std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
 
     // Set region
@@ -223,7 +223,7 @@ TEST_F(RegionTest, TestReferenceImagePointRecord) {
 
 TEST_F(RegionTest, TestReferenceImageLineRecord) {
     auto image_path = FitsImages() / "noise_3d.fits";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
+    auto loader = carta::FileLoader::GetLoader(image_path);
     std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
 
     // Set region
@@ -257,7 +257,7 @@ TEST_F(RegionTest, TestReferenceImageLineRecord) {
 
 TEST_F(RegionTest, TestReferenceImageRectangleRecord) {
     auto image_path = FitsImages() / "noise_3d.fits";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
+    auto loader = carta::FileLoader::GetLoader(image_path);
     std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
 
     // Set region
@@ -303,7 +303,7 @@ TEST_F(RegionTest, TestReferenceImageRectangleRecord) {
 TEST_F(RegionTest, TestReferenceImageRotboxRecord) {
     // Record is for unrotated rectangle; RegionState used for angle in export
     auto image_path = FitsImages() / "noise_3d.fits"; // 10x10x10
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
+    auto loader = carta::FileLoader::GetLoader(image_path);
     std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
 
     // Set region
@@ -348,7 +348,7 @@ TEST_F(RegionTest, TestReferenceImageRotboxRecord) {
 
 TEST_F(RegionTest, TestReferenceImageEllipseRecord) {
     auto image_path = FitsImages() / "noise_3d.fits";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
+    auto loader = carta::FileLoader::GetLoader(image_path);
     std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
 
     // Set region
@@ -380,7 +380,7 @@ TEST_F(RegionTest, TestReferenceImageEllipseRecord) {
 
 TEST_F(RegionTest, TestReferenceImagePolygonRecord) {
     auto image_path = FitsImages() / "noise_3d.fits";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
+    auto loader = carta::FileLoader::GetLoader(image_path);
     std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
 
     // Set region

--- a/test/TestRegionHistogram.cc
+++ b/test/TestRegionHistogram.cc
@@ -49,7 +49,7 @@ public:
 
     static bool RegionHistogram(const std::string& image_path, const std::vector<float>& endpoints,
         CARTA::RegionHistogramData& region_histogram, const std::string& coordinate = "z", bool is_annotation = false) {
-        std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
+        auto loader = carta::FileLoader::GetLoader(image_path);
         std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
         carta::RegionHandler region_handler;
 
@@ -75,9 +75,9 @@ public:
 
     static bool RegionHistogramMatched(const std::string& image_path0, const std::string& image_path1, const std::vector<float>& endpoints,
         CARTA::RegionHistogramData& region_histogram) {
-        std::shared_ptr<carta::FileLoader> loader0(carta::FileLoader::GetLoader(image_path0));
+        auto loader0 = carta::FileLoader::GetLoader(image_path0);
         std::shared_ptr<Frame> frame0(new Frame(0, loader0, "0"));
-        std::shared_ptr<carta::FileLoader> loader1(carta::FileLoader::GetLoader(image_path1));
+        auto loader1 = carta::FileLoader::GetLoader(image_path1);
         std::shared_ptr<Frame> frame1(new Frame(0, loader1, "0"));
         carta::RegionHandler region_handler;
 

--- a/test/TestRegionImportExport.cc
+++ b/test/TestRegionImportExport.cc
@@ -175,11 +175,11 @@ public:
 TEST_F(RegionImportExportTest, TestCrtfPixExportImport) {
     // frame 0
     auto image_path0 = FitsImages() / "noise_10px_10px.fits";
-    std::shared_ptr<carta::FileLoader> loader0(carta::FileLoader::GetLoader(image_path0));
+    auto loader0 = carta::FileLoader::GetLoader(image_path0);
     std::shared_ptr<Frame> frame0(new Frame(0, loader0, "0"));
     // frame 1
     auto image_path1 = Hdf5Images() / "noise_10px_10px.hdf5";
-    std::shared_ptr<carta::FileLoader> loader1(carta::FileLoader::GetLoader(image_path1));
+    auto loader1 = carta::FileLoader::GetLoader(image_path1);
     std::shared_ptr<Frame> frame1(new Frame(0, loader1, "0"));
 
     // Set all region types in frame0
@@ -241,11 +241,11 @@ TEST_F(RegionImportExportTest, TestCrtfPixExportImport) {
 TEST_F(RegionImportExportTest, TestCrtfWorldExportImport) {
     // frame 0
     auto image_path0 = FitsImages() / "noise_10px_10px.fits";
-    std::shared_ptr<carta::FileLoader> loader0(carta::FileLoader::GetLoader(image_path0));
+    auto loader0 = carta::FileLoader::GetLoader(image_path0);
     std::shared_ptr<Frame> frame0(new Frame(0, loader0, "0"));
     // frame 1
     auto image_path1 = Hdf5Images() / "noise_10px_10px.hdf5";
-    std::shared_ptr<carta::FileLoader> loader1(carta::FileLoader::GetLoader(image_path1));
+    auto loader1 = carta::FileLoader::GetLoader(image_path1);
     std::shared_ptr<Frame> frame1(new Frame(0, loader1, "0"));
 
     // Set all region types in frame0
@@ -305,11 +305,11 @@ TEST_F(RegionImportExportTest, TestCrtfWorldExportImport) {
 TEST_F(RegionImportExportTest, TestDs9PixExportImport) {
     // frame 0
     auto image_path0 = FitsImages() / "noise_10px_10px.fits";
-    std::shared_ptr<carta::FileLoader> loader0(carta::FileLoader::GetLoader(image_path0));
+    auto loader0 = carta::FileLoader::GetLoader(image_path0);
     std::shared_ptr<Frame> frame0(new Frame(0, loader0, "0"));
     // frame 1
     auto image_path1 = Hdf5Images() / "noise_10px_10px.hdf5";
-    std::shared_ptr<carta::FileLoader> loader1(carta::FileLoader::GetLoader(image_path1));
+    auto loader1 = carta::FileLoader::GetLoader(image_path1);
     std::shared_ptr<Frame> frame1(new Frame(0, loader1, "0"));
 
     // Set all region types in frame0
@@ -369,11 +369,11 @@ TEST_F(RegionImportExportTest, TestDs9PixExportImport) {
 TEST_F(RegionImportExportTest, TestDs9WorldExportImport) {
     // frame 0
     auto image_path0 = FitsImages() / "noise_10px_10px.fits";
-    std::shared_ptr<carta::FileLoader> loader0(carta::FileLoader::GetLoader(image_path0));
+    auto loader0 = carta::FileLoader::GetLoader(image_path0);
     std::shared_ptr<Frame> frame0(new Frame(0, loader0, "0"));
     // frame 1
     auto image_path1 = Hdf5Images() / "noise_10px_10px.hdf5";
-    std::shared_ptr<carta::FileLoader> loader1(carta::FileLoader::GetLoader(image_path1));
+    auto loader1 = carta::FileLoader::GetLoader(image_path1);
     std::shared_ptr<Frame> frame1(new Frame(0, loader1, "0"));
 
     // Set all region types in frame0

--- a/test/TestRegionMatched.cc
+++ b/test/TestRegionMatched.cc
@@ -33,11 +33,11 @@ public:
 TEST_F(RegionMatchedTest, TestMatchedImageRectangleLCRegion) {
     // frame 0
     auto image_path0 = FitsImages() / "noise_10px_10px.fits";
-    std::shared_ptr<carta::FileLoader> loader0(carta::FileLoader::GetLoader(image_path0));
+    auto loader0 = carta::FileLoader::GetLoader(image_path0);
     std::shared_ptr<Frame> frame0(new Frame(0, loader0, "0"));
     // frame 1
     auto image_path1 = Hdf5Images() / "noise_10px_10px.hdf5";
-    std::shared_ptr<carta::FileLoader> loader1(carta::FileLoader::GetLoader(image_path1));
+    auto loader1 = carta::FileLoader::GetLoader(image_path1);
     std::shared_ptr<Frame> frame1(new Frame(0, loader1, "0"));
 
     // Set rectangle in frame 0
@@ -68,11 +68,11 @@ TEST_F(RegionMatchedTest, TestMatchedImageRectangleLCRegion) {
 TEST_F(RegionMatchedTest, TestMatchedImageRotboxLCRegion) {
     // frame 0
     auto image_path0 = FitsImages() / "noise_10px_10px.fits";
-    std::shared_ptr<carta::FileLoader> loader0(carta::FileLoader::GetLoader(image_path0));
+    auto loader0 = carta::FileLoader::GetLoader(image_path0);
     std::shared_ptr<Frame> frame0(new Frame(0, loader0, "0"));
     // frame 1
     auto image_path1 = Hdf5Images() / "noise_10px_10px.hdf5";
-    std::shared_ptr<carta::FileLoader> loader1(carta::FileLoader::GetLoader(image_path1));
+    auto loader1 = carta::FileLoader::GetLoader(image_path1);
     std::shared_ptr<Frame> frame1(new Frame(0, loader1, "0"));
 
     // Set rectangle in frame 0
@@ -103,11 +103,11 @@ TEST_F(RegionMatchedTest, TestMatchedImageRotboxLCRegion) {
 TEST_F(RegionMatchedTest, TestMatchedImageEllipseLCRegion) {
     // frame 0
     auto image_path0 = FitsImages() / "noise_10px_10px.fits";
-    std::shared_ptr<carta::FileLoader> loader0(carta::FileLoader::GetLoader(image_path0));
+    auto loader0 = carta::FileLoader::GetLoader(image_path0);
     std::shared_ptr<Frame> frame0(new Frame(0, loader0, "0"));
     // frame 1
     auto image_path1 = Hdf5Images() / "noise_10px_10px.hdf5";
-    std::shared_ptr<carta::FileLoader> loader1(carta::FileLoader::GetLoader(image_path1));
+    auto loader1 = carta::FileLoader::GetLoader(image_path1);
     std::shared_ptr<Frame> frame1(new Frame(0, loader1, "0"));
 
     // Set region in frame0
@@ -138,11 +138,11 @@ TEST_F(RegionMatchedTest, TestMatchedImageEllipseLCRegion) {
 TEST_F(RegionMatchedTest, TestMatchedImagePolygonLCRegion) {
     // frame 0
     auto image_path0 = FitsImages() / "noise_10px_10px.fits";
-    std::shared_ptr<carta::FileLoader> loader0(carta::FileLoader::GetLoader(image_path0));
+    auto loader0 = carta::FileLoader::GetLoader(image_path0);
     std::shared_ptr<Frame> frame0(new Frame(0, loader0, "0"));
     // frame 1
     auto image_path1 = Hdf5Images() / "noise_10px_10px.hdf5";
-    std::shared_ptr<carta::FileLoader> loader1(carta::FileLoader::GetLoader(image_path1));
+    auto loader1 = carta::FileLoader::GetLoader(image_path1);
     std::shared_ptr<Frame> frame1(new Frame(0, loader1, "0"));
 
     // Set region in frame0
@@ -184,11 +184,11 @@ TEST_F(RegionMatchedTest, TestMatchedImagePolygonLCRegion) {
 TEST_F(RegionMatchedTest, TestMatchedImagePointRecord) {
     // frame 0
     auto image_path0 = FitsImages() / "noise_10px_10px.fits";
-    std::shared_ptr<carta::FileLoader> loader0(carta::FileLoader::GetLoader(image_path0));
+    auto loader0 = carta::FileLoader::GetLoader(image_path0);
     std::shared_ptr<Frame> frame0(new Frame(0, loader0, "0"));
     // frame 1
     auto image_path1 = Hdf5Images() / "noise_10px_10px.hdf5";
-    std::shared_ptr<carta::FileLoader> loader1(carta::FileLoader::GetLoader(image_path1));
+    auto loader1 = carta::FileLoader::GetLoader(image_path1);
     std::shared_ptr<Frame> frame1(new Frame(0, loader1, "0"));
 
     // Set region in frame0
@@ -227,11 +227,11 @@ TEST_F(RegionMatchedTest, TestMatchedImagePointRecord) {
 TEST_F(RegionMatchedTest, TestMatchedImageLineRecord) {
     // frame 0
     auto image_path0 = FitsImages() / "noise_10px_10px.fits";
-    std::shared_ptr<carta::FileLoader> loader0(carta::FileLoader::GetLoader(image_path0));
+    auto loader0 = carta::FileLoader::GetLoader(image_path0);
     std::shared_ptr<Frame> frame0(new Frame(0, loader0, "0"));
     // frame 1
     auto image_path1 = Hdf5Images() / "noise_10px_10px.hdf5";
-    std::shared_ptr<carta::FileLoader> loader1(carta::FileLoader::GetLoader(image_path1));
+    auto loader1 = carta::FileLoader::GetLoader(image_path1);
     std::shared_ptr<Frame> frame1(new Frame(0, loader1, "0"));
 
     // Set region in frame0
@@ -270,11 +270,11 @@ TEST_F(RegionMatchedTest, TestMatchedImageLineRecord) {
 TEST_F(RegionMatchedTest, TestMatchedImageRectangleRecord) {
     // frame 0
     auto image_path0 = FitsImages() / "noise_10px_10px.fits";
-    std::shared_ptr<carta::FileLoader> loader0(carta::FileLoader::GetLoader(image_path0));
+    auto loader0 = carta::FileLoader::GetLoader(image_path0);
     std::shared_ptr<Frame> frame0(new Frame(0, loader0, "0"));
     // frame 1
     auto image_path1 = Hdf5Images() / "noise_10px_10px.hdf5";
-    std::shared_ptr<carta::FileLoader> loader1(carta::FileLoader::GetLoader(image_path1));
+    auto loader1 = carta::FileLoader::GetLoader(image_path1);
     std::shared_ptr<Frame> frame1(new Frame(0, loader1, "0"));
 
     // Set region in frame0
@@ -318,11 +318,11 @@ TEST_F(RegionMatchedTest, TestMatchedImageRectangleRecord) {
 TEST_F(RegionMatchedTest, TestMatchedImageRotboxRecord) {
     // frame 0
     auto image_path0 = FitsImages() / "noise_10px_10px.fits";
-    std::shared_ptr<carta::FileLoader> loader0(carta::FileLoader::GetLoader(image_path0));
+    auto loader0 = carta::FileLoader::GetLoader(image_path0);
     std::shared_ptr<Frame> frame0(new Frame(0, loader0, "0"));
     // frame 1
     auto image_path1 = Hdf5Images() / "noise_10px_10px.hdf5";
-    std::shared_ptr<carta::FileLoader> loader1(carta::FileLoader::GetLoader(image_path1));
+    auto loader1 = carta::FileLoader::GetLoader(image_path1);
     std::shared_ptr<Frame> frame1(new Frame(0, loader1, "0"));
 
     // Set region in frame0
@@ -371,11 +371,11 @@ TEST_F(RegionMatchedTest, TestMatchedImageRotboxRecord) {
 TEST_F(RegionMatchedTest, TestMatchedImageEllipseRecord) {
     // frame 0
     auto image_path0 = FitsImages() / "noise_10px_10px.fits";
-    std::shared_ptr<carta::FileLoader> loader0(carta::FileLoader::GetLoader(image_path0));
+    auto loader0 = carta::FileLoader::GetLoader(image_path0);
     std::shared_ptr<Frame> frame0(new Frame(0, loader0, "0"));
     // frame 1
     auto image_path1 = Hdf5Images() / "noise_10px_10px.hdf5";
-    std::shared_ptr<carta::FileLoader> loader1(carta::FileLoader::GetLoader(image_path1));
+    auto loader1 = carta::FileLoader::GetLoader(image_path1);
     std::shared_ptr<Frame> frame1(new Frame(0, loader1, "0"));
 
     // Set region in frame0
@@ -412,11 +412,11 @@ TEST_F(RegionMatchedTest, TestMatchedImageEllipseRecord) {
 TEST_F(RegionMatchedTest, TestMatchedImagePolygonRecord) {
     // frame 0
     auto image_path0 = FitsImages() / "noise_10px_10px.fits";
-    std::shared_ptr<carta::FileLoader> loader0(carta::FileLoader::GetLoader(image_path0));
+    auto loader0 = carta::FileLoader::GetLoader(image_path0);
     std::shared_ptr<Frame> frame0(new Frame(0, loader0, "0"));
     // frame 1
     auto image_path1 = Hdf5Images() / "noise_10px_10px.hdf5";
-    std::shared_ptr<carta::FileLoader> loader1(carta::FileLoader::GetLoader(image_path1));
+    auto loader1 = carta::FileLoader::GetLoader(image_path1);
     std::shared_ptr<Frame> frame1(new Frame(0, loader1, "0"));
 
     // Set region in frame0

--- a/test/TestRegionSpatialProfiles.cc
+++ b/test/TestRegionSpatialProfiles.cc
@@ -78,7 +78,7 @@ public:
     static bool RegionSpatialProfile(const std::string& image_path, const std::vector<float>& endpoints,
         const std::vector<CARTA::SetSpatialRequirements_SpatialConfig>& spatial_reqs, CARTA::SpatialProfileData& spatial_profile_message,
         bool is_annotation = false) {
-        std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
+        auto loader = carta::FileLoader::GetLoader(image_path);
         std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
         carta::RegionHandler region_handler;
 
@@ -131,7 +131,7 @@ public:
 
 TEST_F(RegionSpatialProfileTest, TestSpatialRequirements) {
     auto image_path = FitsImages() / "noise_3d.fits";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
+    auto loader = carta::FileLoader::GetLoader(image_path);
     std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
 
     // Set line region
@@ -370,7 +370,7 @@ TEST_F(RegionSpatialProfileTest, FitsAnnotationPointProfile) {
 
 TEST_F(RegionSpatialProfileTest, FitsMovePointProfile) {
     auto image_path = FitsImages() / "noise_3d.fits";
-    std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
+    auto loader = carta::FileLoader::GetLoader(image_path);
     std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
 
     // Set point region

--- a/test/TestRegionSpectralProfiles.cc
+++ b/test/TestRegionSpectralProfiles.cc
@@ -56,7 +56,7 @@ public:
 
     static bool SpectralProfile(const fs::path& image_path, const std::vector<float>& points, CARTA::SpectralProfileData& spectral_data,
         bool is_annotation = false) {
-        std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
+        auto loader = carta::FileLoader::GetLoader(image_path);
         std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
         carta::RegionHandler region_handler;
 

--- a/test/TestRegionStats.cc
+++ b/test/TestRegionStats.cc
@@ -52,7 +52,7 @@ public:
 
     static bool RegionStats(const std::string& image_path, const std::vector<float>& endpoints, CARTA::RegionStatsData& region_stats,
         bool is_annotation = false) {
-        std::shared_ptr<carta::FileLoader> loader(carta::FileLoader::GetLoader(image_path));
+        auto loader = carta::FileLoader::GetLoader(image_path);
         std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
         carta::RegionHandler region_handler;
 


### PR DESCRIPTION
**Description**

This is one of several small refactoring changes that I am splitting out of the [polarization PR](https://github.com/CARTAvis/carta-backend/pull/1525) to reduce its scope and make it simpler to complete and review.

This PR makes `FileLoader::GetLoader` return a shared pointer instead of a raw pointer, and updates the calling code.

**Checklist**

- [X] changelog updated
- [x] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [X] no protobuf update needed
- [X] protobuf version not bumped
- [X] added reviewers and assignee
- [ ] GitHub Project estimate added
