### PR TITLE
Refactoring: new polarization <--> index mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+* Refactored mapping of Stokes types to indices ([#1598](https://github.com/CARTAvis/carta-backend/pull/1598)).
+
 ## [6.0.0-beta.1]
 
 ### Fixed

--- a/src/FileList/FileExtInfoLoader.cc
+++ b/src/FileList/FileExtInfoLoader.cc
@@ -64,6 +64,7 @@ bool FileExtInfoLoader::FillFitsFileInfoMap(
         fits_hdu_list.GetHduList(hdu_list, message);
 
         if (hdu_list.empty()) {
+            spdlog::error(message);
             message = "No image HDUs found.";
             return map_ok;
         }
@@ -82,6 +83,7 @@ bool FileExtInfoLoader::FillFitsFileInfoMap(
 
     map_ok = !hdu_info_map.empty();
     if (!map_ok) {
+        spdlog::error(message);
         message = "Error loading headers or image.";
     }
 

--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -786,7 +786,7 @@ bool Frame::FillRegionHistogramData(std::function<void(CARTA::RegionHistogramDat
         int num_bins = histogram_config.num_bins;
 
         // Set stokes
-        if (!GetStokesTypeIndex(histogram_config.coordinate, stokes)) {
+        if (!GetCoordinateStokesIndex(histogram_config.coordinate, stokes)) {
             continue;
         }
 
@@ -1033,7 +1033,7 @@ bool Frame::FillRegionStatsData(std::function<void(CARTA::RegionStatsData stats_
     for (auto stats_config : _image_required_stats) {
         // Get stokes index
         int stokes;
-        if (!GetStokesTypeIndex(stats_config.coordinate(), stokes)) {
+        if (!GetCoordinateStokesIndex(stats_config.coordinate(), stokes)) {
             continue;
         }
 
@@ -1153,7 +1153,7 @@ bool Frame::FillSpatialProfileData(PointXy point, std::vector<CARTA::SetSpatialR
     for (auto& config : configs) {
         // Get stokes
         int stokes;
-        if (!GetStokesTypeIndex(config.coordinate(), stokes)) {
+        if (!GetCoordinateStokesIndex(config.coordinate(), stokes)) {
             continue;
         }
         stokes_configs[stokes].push_back(config);
@@ -1473,7 +1473,7 @@ bool Frame::FillSpectralProfileData(std::function<void(CARTA::SpectralProfileDat
         // Send spectral profile data if cursor inside image
         if (start_cursor.InImage(_dims.width, _dims.height)) {
             int stokes;
-            if (!GetStokesTypeIndex(coordinate, stokes)) {
+            if (!GetCoordinateStokesIndex(coordinate, stokes)) {
                 continue;
             }
 
@@ -1819,8 +1819,10 @@ bool Frame::CalculateMoments(int file_id, GeneratorProgressCallback progress_cal
         }
 
         std::unique_lock<std::mutex> ulock(_image_mutex); // Must lock the image while doing moment calculations
+        auto stokes_type = CARTA::PolarizationType::POLARIZATION_TYPE_NONE;
+        _loader->GetStokesType(CurrentStokes(), stokes_type);
         _moment_generator->CalculateMoments(file_id, stokes_region.image_region, _axes.z, _axes.stokes, name_index, progress_callback,
-            moment_request, moment_response, collapse_results, region_state, GetStokesType(CurrentStokes()));
+            moment_request, moment_response, collapse_results, region_state, Stokes::Description(stokes_type));
         ulock.unlock();
     }
 
@@ -2352,9 +2354,10 @@ casacore::Slicer Frame::GetExportRegionSlicer(const CARTA::SaveFile& save_file_m
     return casacore::Slicer(start, end, stride, casacore::Slicer::endIsLast);
 }
 
-bool Frame::GetStokesTypeIndex(const string& coordinate, int& stokes_index) {
-    // Coordinate could be profile (x, y, z), stokes string (I, Q, U), or combination (Ix, Qy).
+bool Frame::GetCoordinateStokesIndex(const string& coordinate, int& stokes_index) {
+    // Coordinate could be profile (x, y, z), stokes string (I, Q, U), or combination (Ix, Qy)
     // Returns stokes axis index for coordinate or computed stokes, and whether this index exists or can be computed.
+
     if (coordinate.empty() || coordinate == 'x' || coordinate == 'y' || coordinate == 'z') {
         // Profile only or blank; use current Stokes
         stokes_index = CurrentStokes();
@@ -2374,32 +2377,8 @@ bool Frame::GetStokesTypeIndex(const string& coordinate, int& stokes_index) {
 
     auto stokes_type = Stokes::Get(stokes_string);
     if (stokes_type) {
-        if (Stokes::IsComputed(stokes_type)) {
-            stokes_index = stokes_type;
-
-            // Recursively check if components exist for computed stokes.
-            std::unordered_map<CARTA::PolarizationType, std::vector<string>> computed_stokes_components{{CARTA::Ptotal, {"Q", "U", "V"}},
-                {CARTA::Plinear, {"Q", "U"}}, {CARTA::PFtotal, {"Ptotal", "I"}}, {CARTA::PFlinear, {"Plinear", "I"}},
-                {CARTA::Pangle, {"Q", "U"}}};
-            int test_stokes;
-            for (auto& component : computed_stokes_components[stokes_type]) {
-                stokes_ok = GetStokesTypeIndex(component, test_stokes);
-                if (!stokes_ok) {
-                    break;
-                }
-            }
-        } else {
-            if (!_loader->GetStokesIndices().empty()) {
-                // Stokes are defined in image
-                stokes_ok = _loader->GetStokesTypeIndex(stokes_type, stokes_index);
-            } else {
-                int assumed_stokes_index = (stokes_type - 1) % 4;
-                if (NumStokes() > assumed_stokes_index) {
-                    stokes_index = assumed_stokes_index;
-                    stokes_ok = true;
-                    spdlog::warn("Can not get stokes index from the header. Assuming stokes {} index is {}.", stokes_string, stokes_index);
-                }
-            }
+        if (_loader->GetStokesTypeIndex(stokes_type, stokes_index)) {
+            stokes_ok = true;
         }
     }
 
@@ -2409,20 +2388,6 @@ bool Frame::GetStokesTypeIndex(const string& coordinate, int& stokes_index) {
     }
 
     return true;
-}
-
-std::string Frame::GetStokesType(int stokes_index) {
-    auto stokes_type = CARTA::PolarizationType::POLARIZATION_TYPE_NONE;
-
-    // Computed stokes: stokes index is equal to numeric value
-    if (Stokes::IsComputed(stokes_index)) {
-        stokes_type = Stokes::Get(stokes_index);
-    }
-
-    // Otherwise try to map index to type with loader
-    _loader->GetStokesType(stokes_index, stokes_type);
-
-    return Stokes::Description(stokes_type);
 }
 
 std::shared_mutex& Frame::GetActiveTaskMutex() {
@@ -2524,9 +2489,9 @@ bool Frame::DoVectorFieldCalculation(const std::function<void(CARTA::VectorOverl
 
     // Set stokes flags and get their indices
     bool use_threshold_I = !std::isnan(threshold) && threshold_option == CARTA::PolarizationType::I;
-    stokes_flag["I"] = (fractional || use_threshold_I) && GetStokesTypeIndex("I", stokes_indices["I"]);
-    stokes_flag["Q"] = (calculate_pi || calculate_pa) && GetStokesTypeIndex("Q", stokes_indices["Q"]);
-    stokes_flag["U"] = (calculate_pi || calculate_pa) && GetStokesTypeIndex("U", stokes_indices["U"]);
+    stokes_flag["I"] = (fractional || use_threshold_I) && _loader->GetStokesTypeIndex(CARTA::PolarizationType::I, stokes_indices["I"]);
+    stokes_flag["Q"] = (calculate_pi || calculate_pa) && _loader->GetStokesTypeIndex(CARTA::PolarizationType::Q, stokes_indices["Q"]);
+    stokes_flag["U"] = (calculate_pi || calculate_pa) && _loader->GetStokesTypeIndex(CARTA::PolarizationType::U, stokes_indices["U"]);
 
     // Get image tiles data
     for (int i = 0; i < tiles.size(); ++i) {

--- a/src/Frame/Frame.h
+++ b/src/Frame/Frame.h
@@ -202,8 +202,7 @@ public:
     void SaveFile(const std::string& root_folder, const CARTA::SaveFile& save_file_msg, CARTA::SaveFileAck& save_file_ack,
         std::shared_ptr<Region> image_region);
 
-    bool GetStokesTypeIndex(const string& coordinate, int& stokes_index);
-    std::string GetStokesType(int stokes_index);
+    bool GetCoordinateStokesIndex(const string& coordinate, int& stokes_index);
 
     std::shared_mutex& GetActiveTaskMutex();
 

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -257,50 +257,54 @@ bool FileLoader::FindCoordinateAxes(std::string& message) {
         _axes = AxesInfo(render_axes, spatial_axes, spectral_axis);
         // Keep depth and num_stokes defaults of 1
         _dims = DimsInfo(_axes, _image_shape);
-        return true;
-    }
+    } else {
+        // Cope with incomplete/invalid headers for 3D, 4D images
+        bool no_spectral(spectral_axis < 0), no_stokes(stokes_axis < 0);
+        if ((no_spectral && no_stokes) && (_num_dims == 3)) {
+            // assume third is spectral with no stokes
+            spectral_axis = 2;
+        }
 
-    // Cope with incomplete/invalid headers for 3D, 4D images
-    bool no_spectral(spectral_axis < 0), no_stokes(stokes_axis < 0);
-    if ((no_spectral && no_stokes) && (_num_dims == 3)) {
-        // assume third is spectral with no stokes
-        spectral_axis = 2;
-    }
+        if ((no_spectral || no_stokes) && (_num_dims == 4)) {
+            if (no_spectral && !no_stokes) { // stokes is known
+                spectral_axis = (stokes_axis == 3 ? 2 : 3);
+            } else if (!no_spectral && no_stokes) { // spectral is known
+                stokes_axis = (spectral_axis == 3 ? 2 : 3);
+            } else { // neither is known
+                // guess by shape (max 4 stokes)
+                if (_image_shape(2) > 4) {
+                    spectral_axis = 2;
+                    stokes_axis = 3;
+                } else if (_image_shape(3) > 4) {
+                    spectral_axis = 3;
+                    stokes_axis = 2;
+                }
 
-    if ((no_spectral || no_stokes) && (_num_dims == 4)) {
-        if (no_spectral && !no_stokes) { // stokes is known
-            spectral_axis = (stokes_axis == 3 ? 2 : 3);
-        } else if (!no_spectral && no_stokes) { // spectral is known
-            stokes_axis = (spectral_axis == 3 ? 2 : 3);
-        } else { // neither is known
-            // guess by shape (max 4 stokes)
-            if (_image_shape(2) > 4) {
-                spectral_axis = 2;
-                stokes_axis = 3;
-            } else if (_image_shape(3) > 4) {
-                spectral_axis = 3;
-                stokes_axis = 2;
-            }
-
-            if ((spectral_axis < 0) && (stokes_axis < 0)) {
-                // could not guess, assume [spectral, stokes]
-                spectral_axis = 2;
-                stokes_axis = 3;
+                if ((spectral_axis < 0) && (stokes_axis < 0)) {
+                    // could not guess, assume [spectral, stokes]
+                    spectral_axis = 2;
+                    stokes_axis = 3;
+                }
             }
         }
-    }
 
-    // Z axis is non-render axis that is not stokes (if any)
-    for (size_t i = 0; i < _num_dims; ++i) {
-        if ((i != render_axes[0]) && (i != render_axes[1]) && (i != stokes_axis)) {
-            z_axis = i;
-            break;
+        // Z axis is non-render axis that is not stokes (if any)
+        for (size_t i = 0; i < _num_dims; ++i) {
+            if ((i != render_axes[0]) && (i != render_axes[1]) && (i != stokes_axis)) {
+                z_axis = i;
+                break;
+            }
         }
+
+        _axes = AxesInfo(render_axes, spatial_axes, spectral_axis, z_axis, stokes_axis);
+        _dims = DimsInfo(_axes, _image_shape);
     }
 
     size_t num_stokes = DimsInfo::FromAxis(stokes_axis, _image_shape);
 
-    // save stokes types with respect to the stokes index
+    std::vector<CARTA::PolarizationType> available_stokes;
+
+    // map polarization types to indices and vice versa
     if (_stokes_cdelt != 0) {
         for (int i = 0; i < num_stokes; ++i) {
             int stokes_fits_value = _stokes_crval + (i + 1 - _stokes_crpix) * _stokes_cdelt;
@@ -309,12 +313,22 @@ bool FileLoader::FindCoordinateAxes(std::string& message) {
                 auto stokes_type = static_cast<CARTA::PolarizationType>(stokes_value);
                 _stokes_indices[stokes_type] = i;
                 _stokes_types[i] = stokes_type;
+                available_stokes.push_back(stokes_type);
             }
+        }
+    } else {
+        for (int i = 0; i < num_stokes; ++i) {
+            auto stokes_type = static_cast<CARTA::PolarizationType>(i + 1);
+            _deduced_stokes_indices[stokes_type] = i;
+            _deduced_stokes_types[i] = stokes_type;
+            available_stokes.push_back(stokes_type);
         }
     }
 
-    _axes = AxesInfo(render_axes, spatial_axes, spectral_axis, z_axis, stokes_axis);
-    _dims = DimsInfo(_axes, _image_shape);
+    // Determine computable polarizations
+    for (auto& computed_type : Stokes::Computable(available_stokes)) {
+        _available_polarizations.insert(computed_type);
+    }
 
     return true;
 }
@@ -914,20 +928,61 @@ double FileLoader::CalculateBeamArea() {
 }
 
 bool FileLoader::GetStokesTypeIndex(const CARTA::PolarizationType& stokes_type, int& stokes_index) {
+    // Computed type which is available for this image
+    if (_available_polarizations.count(stokes_type)) {
+        stokes_index = stokes_type;
+        return true;
+    }
+
+    // Invalid computed type
+    if (Stokes::IsComputed(stokes_type)) {
+        spdlog::warn("Computed polarization {} is not available in this image.", Stokes::Name(stokes_type));
+        return false;
+    }
+
+    // Basic type
     try {
         stokes_index = _stokes_indices.at(stokes_type);
         return true;
     } catch (const std::out_of_range& e) {
-        return false;
+        try {
+            stokes_index = _deduced_stokes_indices.at(stokes_type);
+            spdlog::warn("Could not get polarization index from header. Assuming {} index is {}.", Stokes::Name(stokes_type), stokes_index);
+            return true;
+        } catch (const std::out_of_range& e) {
+            spdlog::warn("Could not get or deduce index for polarization {}.", Stokes::Name(stokes_type));
+            return false;
+        }
     }
 }
 
 bool FileLoader::GetStokesType(const int& stokes_index, CARTA::PolarizationType& stokes_type) {
+    if (Stokes::IsComputed(stokes_index)) {
+        // Computed type which is available for this image
+        if (_available_polarizations.count((CARTA::PolarizationType)stokes_index)) {
+            stokes_type = Stokes::Get(stokes_index);
+            return true;
+        }
+
+        // Invalid computed type
+        spdlog::warn("Computed polarization {} is not available in this image.", Stokes::Name(Stokes::Get(stokes_index)));
+        return false;
+    }
+
+    // Basic type
     try {
         stokes_type = _stokes_types.at(stokes_index);
         return true;
     } catch (const std::out_of_range& e) {
-        return false;
+        try {
+            stokes_type = _deduced_stokes_types.at(stokes_index);
+            spdlog::warn(
+                "Could not get polarization type from header. Assuming type of index {} is {}.", stokes_index, Stokes::Name(stokes_type));
+            return true;
+        } catch (const std::out_of_range& e) {
+            spdlog::warn("Could not get or deduce polarization type for index {}.", stokes_index);
+            return false;
+        }
     }
 }
 

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -302,8 +302,6 @@ bool FileLoader::FindCoordinateAxes(std::string& message) {
 
     size_t num_stokes = DimsInfo::FromAxis(stokes_axis, _image_shape);
 
-    std::vector<CARTA::PolarizationType> available_stokes;
-
     // map polarization types to indices and vice versa
     if (_stokes_cdelt != 0) {
         for (int i = 0; i < num_stokes; ++i) {
@@ -313,20 +311,23 @@ bool FileLoader::FindCoordinateAxes(std::string& message) {
                 auto stokes_type = static_cast<CARTA::PolarizationType>(stokes_value);
                 _stokes_indices[stokes_type] = i;
                 _stokes_types[i] = stokes_type;
-                available_stokes.push_back(stokes_type);
             }
         }
     } else {
         for (int i = 0; i < num_stokes; ++i) {
             auto stokes_type = static_cast<CARTA::PolarizationType>(i + 1);
-            _deduced_stokes_indices[stokes_type] = i;
-            _deduced_stokes_types[i] = stokes_type;
-            available_stokes.push_back(stokes_type);
+            _stokes_indices[stokes_type] = i;
+            _stokes_types[i] = stokes_type;
         }
     }
 
     // Determine computable polarizations
-    for (auto& computed_type : Stokes::Computable(available_stokes)) {
+    std::vector<CARTA::PolarizationType> available_stokes;
+    for (const auto& [stokes_type, _] : _stokes_indices) {
+        available_stokes.push_back(stokes_type);
+    }
+
+    for (const auto& computed_type : Stokes::Computable(available_stokes)) {
         _computable_polarizations.insert(computed_type);
     }
 
@@ -945,14 +946,8 @@ bool FileLoader::GetStokesTypeIndex(const CARTA::PolarizationType& stokes_type, 
         stokes_index = _stokes_indices.at(stokes_type);
         return true;
     } catch (const std::out_of_range& e) {
-        try {
-            stokes_index = _deduced_stokes_indices.at(stokes_type);
-            spdlog::warn("Could not get polarization index from header. Assuming {} index is {}.", Stokes::Name(stokes_type), stokes_index);
-            return true;
-        } catch (const std::out_of_range& e) {
-            spdlog::warn("Could not get or deduce index for polarization {}.", Stokes::Name(stokes_type));
-            return false;
-        }
+        spdlog::warn("Could not get or deduce index for polarization {}.", Stokes::Name(stokes_type));
+        return false;
     }
 }
 
@@ -974,15 +969,8 @@ bool FileLoader::GetStokesType(const int& stokes_index, CARTA::PolarizationType&
         stokes_type = _stokes_types.at(stokes_index);
         return true;
     } catch (const std::out_of_range& e) {
-        try {
-            stokes_type = _deduced_stokes_types.at(stokes_index);
-            spdlog::warn(
-                "Could not get polarization type from header. Assuming type of index {} is {}.", stokes_index, Stokes::Name(stokes_type));
-            return true;
-        } catch (const std::out_of_range& e) {
-            spdlog::warn("Could not get or deduce polarization type for index {}.", stokes_index);
-            return false;
-        }
+        spdlog::warn("Could not get or deduce polarization type for index {}.", stokes_index);
+        return false;
     }
 }
 

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -327,7 +327,7 @@ bool FileLoader::FindCoordinateAxes(std::string& message) {
 
     // Determine computable polarizations
     for (auto& computed_type : Stokes::Computable(available_stokes)) {
-        _available_polarizations.insert(computed_type);
+        _computable_polarizations.insert(computed_type);
     }
 
     return true;
@@ -929,7 +929,7 @@ double FileLoader::CalculateBeamArea() {
 
 bool FileLoader::GetStokesTypeIndex(const CARTA::PolarizationType& stokes_type, int& stokes_index) {
     // Computed type which is available for this image
-    if (_available_polarizations.count(stokes_type)) {
+    if (_computable_polarizations.count(stokes_type)) {
         stokes_index = stokes_type;
         return true;
     }
@@ -959,7 +959,7 @@ bool FileLoader::GetStokesTypeIndex(const CARTA::PolarizationType& stokes_type, 
 bool FileLoader::GetStokesType(const int& stokes_index, CARTA::PolarizationType& stokes_type) {
     if (Stokes::IsComputed(stokes_index)) {
         // Computed type which is available for this image
-        if (_available_polarizations.count((CARTA::PolarizationType)stokes_index)) {
+        if (_computable_polarizations.count((CARTA::PolarizationType)stokes_index)) {
             stokes_type = Stokes::Get(stokes_index);
             return true;
         }

--- a/src/ImageData/FileLoader.cc
+++ b/src/ImageData/FileLoader.cc
@@ -306,12 +306,17 @@ bool FileLoader::FindCoordinateAxes(std::string& message) {
     if (_stokes_cdelt != 0) {
         for (int i = 0; i < num_stokes; ++i) {
             int stokes_fits_value = _stokes_crval + (i + 1 - _stokes_crpix) * _stokes_cdelt;
-            int stokes_value;
-            if (Stokes::ConvertFits(stokes_fits_value, stokes_value)) {
-                auto stokes_type = static_cast<CARTA::PolarizationType>(stokes_value);
-                _stokes_indices[stokes_type] = i;
-                _stokes_types[i] = stokes_type;
+            CARTA::PolarizationType stokes_type(CARTA::PolarizationType::POLARIZATION_TYPE_NONE);
+            try {
+                stokes_type = Stokes::FromFits(stokes_fits_value);
+            } catch (const std::out_of_range& e) {
+                if (num_stokes > 1) {
+                    message = "Non-standard polarizations are currently unsupported in images with multiple polarizations.";
+                    return false;
+                }
             }
+            _stokes_indices[stokes_type] = i;
+            _stokes_types[i] = stokes_type;
         }
     } else {
         for (int i = 0; i < num_stokes; ++i) {

--- a/src/ImageData/FileLoader.h
+++ b/src/ImageData/FileLoader.h
@@ -123,9 +123,6 @@ public:
     virtual void SetStokesCdelt(int stokes_cdelt);
     virtual bool GetStokesTypeIndex(const CARTA::PolarizationType& stokes_type, int& stokes_index);
     virtual bool GetStokesType(const int& stokes_index, CARTA::PolarizationType& stokes_type);
-    std::unordered_map<CARTA::PolarizationType, int> GetStokesIndices() {
-        return _stokes_indices;
-    };
 
     // Modify time changed
     bool ImageUpdated();
@@ -181,8 +178,14 @@ protected:
     FileInfo::ImageStats _empty_stats;
 
     // Storage for the stokes type vs. stokes index
-    std::unordered_map<CARTA::PolarizationType, int> _stokes_indices;
-    std::unordered_map<int, CARTA::PolarizationType> _stokes_types;
+    std::map<CARTA::PolarizationType, int> _stokes_indices;
+    std::map<CARTA::PolarizationType, int> _deduced_stokes_indices;
+    std::map<int, CARTA::PolarizationType> _stokes_types;
+    std::map<int, CARTA::PolarizationType> _deduced_stokes_types;
+
+    // To be moved into refactored polarization calculator
+    std::unordered_set<CARTA::PolarizationType> _available_polarizations;
+
     float _stokes_crval;
     float _stokes_crpix;
     int _stokes_cdelt;

--- a/src/ImageData/FileLoader.h
+++ b/src/ImageData/FileLoader.h
@@ -179,9 +179,7 @@ protected:
 
     // Storage for the stokes type vs. stokes index
     std::map<CARTA::PolarizationType, int> _stokes_indices;
-    std::map<CARTA::PolarizationType, int> _deduced_stokes_indices;
     std::map<int, CARTA::PolarizationType> _stokes_types;
-    std::map<int, CARTA::PolarizationType> _deduced_stokes_types;
 
     // To be moved into refactored polarization calculator
     std::unordered_set<CARTA::PolarizationType> _computable_polarizations;

--- a/src/ImageData/FileLoader.h
+++ b/src/ImageData/FileLoader.h
@@ -184,7 +184,7 @@ protected:
     std::map<int, CARTA::PolarizationType> _deduced_stokes_types;
 
     // To be moved into refactored polarization calculator
-    std::unordered_set<CARTA::PolarizationType> _available_polarizations;
+    std::unordered_set<CARTA::PolarizationType> _computable_polarizations;
 
     float _stokes_crval;
     float _stokes_crpix;

--- a/src/ImageData/StokesFilesConnector.cc
+++ b/src/ImageData/StokesFilesConnector.cc
@@ -250,19 +250,23 @@ bool StokesFilesConnector::OpenStokesFiles(const CARTA::ConcatStokesFiles& messa
         int delt = 0;
         int stokes_fits_value = 0;
         for (int i = 0; i < message.stokes_files_size(); ++i) {
-            int new_stokes_value = message.stokes_files(i).polarization_type();
+            auto new_stokes_value = message.stokes_files(i).polarization_type();
             int new_stokes_fits_value;
-            if (Stokes::ConvertFits(new_stokes_value, new_stokes_fits_value)) {
-                if (stokes_fits_value != 0) {
-                    if (delt == 0) {
-                        delt = new_stokes_fits_value - stokes_fits_value;
-                    } else if (new_stokes_fits_value - stokes_fits_value != delt) {
-                        err = fmt::format("Hypercube {} is not allowed!", _concatenated_name);
-                        return false;
-                    }
-                }
-                stokes_fits_value = new_stokes_fits_value;
+            try {
+                new_stokes_fits_value = Stokes::ToFits(new_stokes_value);
+            } catch (const std::out_of_range& e) {
+                err = fmt::format("Cannot convert unsupported polarization {} to FITS.", Stokes::Name(new_stokes_value));
+                return false;
             }
+            if (stokes_fits_value != 0) {
+                if (delt == 0) {
+                    delt = new_stokes_fits_value - stokes_fits_value;
+                } else if (new_stokes_fits_value - stokes_fits_value != delt) {
+                    err = fmt::format("Hypercube {} is not allowed!", _concatenated_name);
+                    return false;
+                }
+            }
+            stokes_fits_value = new_stokes_fits_value;
         }
     }
 

--- a/src/Region/RegionHandler.cc
+++ b/src/Region/RegionHandler.cc
@@ -1604,8 +1604,8 @@ bool RegionHandler::GetRegionSpectralData(int region_id, int file_id, const Axis
 
             auto get_profiles_data = [&](ProfilesMap& tmp_results, std::string tmp_coordinate) {
                 int tmp_stokes_index;
-                return (
-                    frame->GetCoordinateStokesIndex(tmp_coordinate, tmp_stokes_index) && get_stokes_profiles_data(tmp_results, tmp_stokes_index));
+                return (frame->GetCoordinateStokesIndex(tmp_coordinate, tmp_stokes_index) &&
+                        get_stokes_profiles_data(tmp_results, tmp_stokes_index));
             };
 
             if (Stokes::IsComputed(stokes_index)) { // For computed stokes

--- a/src/Region/RegionHandler.cc
+++ b/src/Region/RegionHandler.cc
@@ -382,7 +382,7 @@ bool RegionHandler::SetSpectralRequirements(int region_id, int file_id, std::sha
         // check stokes coordinate
         std::string profile_coordinate(profile.coordinate());
         int stokes_index;
-        if (!frame->GetStokesTypeIndex(profile_coordinate, stokes_index)) {
+        if (!frame->GetCoordinateStokesIndex(profile_coordinate, stokes_index)) {
             continue;
         }
 
@@ -1414,7 +1414,7 @@ bool RegionHandler::FillRegionHistogramData(std::function<void(CARTA::RegionHist
             for (auto& histogram_config : histogram_configs) {
                 // Create data message for each configuration
                 int stokes_index(0);
-                if (!frame->GetStokesTypeIndex(histogram_config.coordinate, stokes_index)) {
+                if (!frame->GetCoordinateStokesIndex(histogram_config.coordinate, stokes_index)) {
                     continue;
                 }
 
@@ -1502,7 +1502,7 @@ bool RegionHandler::FillSpectralProfileData(
                 }
 
                 int stokes_index;
-                if (!_frames.at(config_file_id)->GetStokesTypeIndex(coordinate, stokes_index)) {
+                if (!_frames.at(config_file_id)->GetCoordinateStokesIndex(coordinate, stokes_index)) {
                     continue;
                 }
 
@@ -1605,7 +1605,7 @@ bool RegionHandler::GetRegionSpectralData(int region_id, int file_id, const Axis
             auto get_profiles_data = [&](ProfilesMap& tmp_results, std::string tmp_coordinate) {
                 int tmp_stokes_index;
                 return (
-                    frame->GetStokesTypeIndex(tmp_coordinate, tmp_stokes_index) && get_stokes_profiles_data(tmp_results, tmp_stokes_index));
+                    frame->GetCoordinateStokesIndex(tmp_coordinate, tmp_stokes_index) && get_stokes_profiles_data(tmp_results, tmp_stokes_index));
             };
 
             if (Stokes::IsComputed(stokes_index)) { // For computed stokes
@@ -1654,7 +1654,7 @@ bool RegionHandler::GetRegionSpectralData(int region_id, int file_id, const Axis
                 // Get partial profile
                 auto get_profiles_data = [&](ProfilesMap& tmp_results, std::string tmp_coordinate) {
                     int tmp_stokes_index;
-                    return (frame->GetStokesTypeIndex(tmp_coordinate, tmp_stokes_index) &&
+                    return (frame->GetCoordinateStokesIndex(tmp_coordinate, tmp_stokes_index) &&
                             frame->GetLoaderSpectralData(region_id, z_range, tmp_stokes_index, mask, xy_origin, tmp_results, progress));
                 };
 
@@ -1735,7 +1735,7 @@ bool RegionHandler::GetRegionSpectralData(int region_id, int file_id, const Axis
 
         auto get_profiles_data = [&](ProfilesMap& tmp_partial_profiles, std::string tmp_coordinate) {
             int tmp_stokes_index;
-            return (frame->GetStokesTypeIndex(tmp_coordinate, tmp_stokes_index) &&
+            return (frame->GetCoordinateStokesIndex(tmp_coordinate, tmp_stokes_index) &&
                     get_stokes_profiles_data(tmp_partial_profiles, tmp_stokes_index));
         };
 
@@ -1851,7 +1851,7 @@ bool RegionHandler::FillRegionStatsData(std::function<void(CARTA::RegionStatsDat
             for (auto& stats_config : stats_configs) {
                 // Get stokes and channel from config
                 int stokes_index(0);
-                if (!frame->GetStokesTypeIndex(stats_config.coordinate(), stokes_index)) {
+                if (!frame->GetCoordinateStokesIndex(stats_config.coordinate(), stokes_index)) {
                     continue; // invalid image/computed Stokes
                 }
 
@@ -1958,7 +1958,7 @@ bool RegionHandler::FillSpatialProfileData(std::function<void(CARTA::SpatialProf
                     }
 
                     int stokes_index(0);
-                    if (!frame->GetStokesTypeIndex(spatial_config.coordinate(), stokes_index)) {
+                    if (!frame->GetCoordinateStokesIndex(spatial_config.coordinate(), stokes_index)) {
                         continue; // invalid image/computed Stokes
                     }
 

--- a/src/Session/Session.cc
+++ b/src/Session/Session.cc
@@ -1660,7 +1660,7 @@ bool Session::CalculateCubeHistogram(int file_id, CARTA::RegionHistogramData& cu
 
             // Get stokes index
             int stokes;
-            if (!_frames.at(file_id)->GetStokesTypeIndex(cube_histogram_config.coordinate, stokes)) {
+            if (!_frames.at(file_id)->GetCoordinateStokesIndex(cube_histogram_config.coordinate, stokes)) {
                 return calculated;
             }
 

--- a/src/Util/Collections.h
+++ b/src/Util/Collections.h
@@ -1,0 +1,15 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018- Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+#ifndef CARTA_SRC_UTIL_COLLECTIONS_H_
+#define CARTA_SRC_UTIL_COLLECTIONS_H_
+
+template <typename InMapType, typename OutMapType>
+OutMapType InvertedMap(const InMapType& in_map);
+
+#include "Collections.tcc"
+
+#endif // CARTA_SRC_UTIL_COLLECTIONS_H_

--- a/src/Util/Collections.tcc
+++ b/src/Util/Collections.tcc
@@ -1,0 +1,21 @@
+/* This file is part of the CARTA Image Viewer: https://github.com/CARTAvis/carta-backend
+   Copyright 2018- Academia Sinica Institute of Astronomy and Astrophysics (ASIAA),
+   Associated Universities, Inc. (AUI) and the Inter-University Institute for Data Intensive Astronomy (IDIA)
+   SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+#ifndef CARTA_SRC_UTIL_COLLECTIONS_TCC_
+#define CARTA_SRC_UTIL_COLLECTIONS_TCC_
+
+#include <map>
+#include <unordered_map>
+
+template <typename InMapType, typename OutMapType>
+OutMapType InvertedMap(const InMapType& in_map) {
+    OutMapType out_map;
+    for (const auto& [key, value] : in_map) {
+        out_map[value] = key;
+    }
+    return out_map;
+}
+#endif // CARTA_SRC_UTIL_COLLECTIONS_TCC_

--- a/src/Util/Stokes.cc
+++ b/src/Util/Stokes.cc
@@ -5,11 +5,14 @@
 */
 
 #include "Stokes.h"
+#include "Collections.h"
+
+#include <spdlog/fmt/fmt.h>
 
 using namespace carta;
 
 /** @details This map stores the component polarizations required to calculate each computed polarization type. It is used to determine
- * whether a polarization can be computed from the polarizations available in an image file. The map is ordered so that Stokes::Computable
+ * whether a polarization can be computed from the polarizations available in an image file. The map is ordered so that `Stokes::Computable`
  * does not have to sort its output.
  */
 std::map<Stokes::Pol, std::vector<Stokes::Pol>> Stokes::_components{{Pol::Ptotal, {Pol::Q, Pol::U, Pol::V}},
@@ -18,14 +21,28 @@ std::map<Stokes::Pol, std::vector<Stokes::Pol>> Stokes::_components{{Pol::Ptotal
 
 /**
  * @details This unordered map provides a conversion between the CARTA polarization type
- * enumeration and the corresponding CASA Stokes type enumeration.
- * It is used to translate polarization representations between the two frameworks.
+ * enumeration and the corresponding CASA polarization type enumeration. It is used by `Stokes::ToCasa`.
  */
 std::unordered_map<Stokes::Pol, Stokes::CasaPol> Stokes::_to_casa{{Pol::POLARIZATION_TYPE_NONE, CasaPol::Undefined}, {Pol::I, CasaPol::I},
     {Pol::Q, CasaPol::Q}, {Pol::U, CasaPol::U}, {Pol::V, CasaPol::V}, {Pol::RR, CasaPol::RR}, {Pol::LL, CasaPol::LL},
     {Pol::RL, CasaPol::RL}, {Pol::LR, CasaPol::LR}, {Pol::XX, CasaPol::XX}, {Pol::YY, CasaPol::YY}, {Pol::XY, CasaPol::XY},
     {Pol::YX, CasaPol::YX}, {Pol::Ptotal, CasaPol::Ptotal}, {Pol::Plinear, CasaPol::Plinear}, {Pol::PFtotal, CasaPol::PFtotal},
     {Pol::PFlinear, CasaPol::PFlinear}, {Pol::Pangle, CasaPol::Pangle}};
+
+/**
+ * @details This unordered map provides a conversion between the CARTA polarization type
+ * enumeration and the corresponding FITS polarization type enumeration. It is used by `Stokes::ToFits`.
+ */
+std::unordered_map<Stokes::Pol, Stokes::FitsPol> Stokes::_to_fits{{Pol::I, FitsPol::I}, {Pol::Q, FitsPol::Q}, {Pol::U, FitsPol::U},
+    {Pol::V, FitsPol::V}, {Pol::RR, FitsPol::RR}, {Pol::LL, FitsPol::LL}, {Pol::RL, FitsPol::RL}, {Pol::LR, FitsPol::LR},
+    {Pol::XX, FitsPol::XX}, {Pol::YY, FitsPol::YY}, {Pol::XY, FitsPol::XY}, {Pol::YX, FitsPol::YX}};
+
+/**
+ * @details This unordered map provides a conversion between the FITS polarization type
+ * enumeration and the corresponding CARTA polarization type enumeration. It is used by `Stokes::FromFits`.
+ */
+std::unordered_map<Stokes::FitsPol, Stokes::Pol> Stokes::_from_fits =
+    InvertedMap<std::unordered_map<Stokes::Pol, Stokes::FitsPol>, std::unordered_map<Stokes::FitsPol, Stokes::Pol>>(Stokes::_to_fits);
 
 /**
  * @details This unordered map associates each CARTA polarization type enumeration value
@@ -61,7 +78,7 @@ Stokes::Pol Stokes::Get(std::string name) {
 }
 
 /**
- * @details This function maps a CARTA polarization type to its equivalent CASA Stokes type
+ * @details This function maps a CARTA polarization type to its equivalent CASA polarization type
  * using a predefined lookup table. If the provided type is not found in the mapping,
  * an `std::out_of_range` exception may be thrown.
  */
@@ -70,24 +87,26 @@ Stokes::CasaPol Stokes::ToCasa(Pol type) {
 }
 
 /**
- * @details This function maps a FITS Stokes parameter to a valid internal Stokes value.
- * It supports conversion of standard Stokes parameters (1 to 4) and
- * circular/linear polarization parameters (5 to 12 and -1 to -8).
- *
- * @note Valid FITS Stokes values:
- *       - `1` to `4` (directly assigned)
- *       - `5` to `12` and `-1` to `-8` (converted using `out_stokes_value = -in_stokes_value + 4`)
+ * @details This function maps a CARTA polarization type to the corresponding FITS polarization type using a predefined lookup table. It
+ * currently only supports standard FITS polarizations (the Stokes parameters IQUV, the linear polarizations RR LL RL LR, and the circular
+ * polarizations XX YY XY YX).
+ * @todo In future this function should support all nonstandard polarizations supported by CASA.
  */
-bool Stokes::ConvertFits(const int& in_stokes_value, int& out_stokes_value) {
-    if (in_stokes_value >= 1 && in_stokes_value <= 4) {
-        out_stokes_value = in_stokes_value;
-        return true;
-    } else if ((in_stokes_value >= 4 && in_stokes_value <= 12) || (in_stokes_value <= -1 && in_stokes_value >= -8)) {
-        // convert between [5, 6, ..., 12] and [-1, -2, ..., -8]
-        out_stokes_value = -in_stokes_value + 4;
-        return true;
+Stokes::FitsPol Stokes::ToFits(Pol type) {
+    return _to_fits.at(type);
+}
+
+/**
+ * @details This function maps an integer representing a FITS polarization type to the corresponding CARTA polarization type. It currently
+ * only supports integer values of standard FITS polarizations (the Stokes parameters 1 to 4, the linear polarizations -1 to -4, and the
+ * circular polarizations -5 to -8).
+ * @todo In future this function should support all nonstandard polarizations supported by CASA.
+ */
+Stokes::Pol Stokes::FromFits(int type) {
+    if (type >= 1 && type <= 4 || type <= -1 && type >= -8) {
+        return _from_fits.at(static_cast<FitsPol>(type));
     }
-    return false;
+    throw std::out_of_range(fmt::format("Invalid or unsupported FITS polarization type: {}", type));
 }
 
 /**

--- a/src/Util/Stokes.cc
+++ b/src/Util/Stokes.cc
@@ -8,67 +8,64 @@
 
 using namespace carta;
 
-/**
- * @details This unordered map provides a conversion between the `CARTA::PolarizationType`
- * enumeration and the corresponding `casacore::Stokes::StokesTypes` enumeration.
- * It is used to translate polarization representations between the two frameworks.
+/** @details This map stores the component polarizations required to calculate each computed polarization type. It is used to determine
+ * whether a polarization can be computed from the polarizations available in an image file. The map is ordered so that Stokes::Computable
+ * does not have to sort its output.
  */
-std::unordered_map<CARTA::PolarizationType, casacore::Stokes::StokesTypes> Stokes::_to_casa{
-    {CARTA::PolarizationType::POLARIZATION_TYPE_NONE, casacore::Stokes::StokesTypes::Undefined},
-    {CARTA::PolarizationType::I, casacore::Stokes::StokesTypes::I}, {CARTA::PolarizationType::Q, casacore::Stokes::StokesTypes::Q},
-    {CARTA::PolarizationType::U, casacore::Stokes::StokesTypes::U}, {CARTA::PolarizationType::V, casacore::Stokes::StokesTypes::V},
-    {CARTA::PolarizationType::RR, casacore::Stokes::StokesTypes::RR}, {CARTA::PolarizationType::LL, casacore::Stokes::StokesTypes::LL},
-    {CARTA::PolarizationType::RL, casacore::Stokes::StokesTypes::RL}, {CARTA::PolarizationType::LR, casacore::Stokes::StokesTypes::LR},
-    {CARTA::PolarizationType::XX, casacore::Stokes::StokesTypes::XX}, {CARTA::PolarizationType::YY, casacore::Stokes::StokesTypes::YY},
-    {CARTA::PolarizationType::XY, casacore::Stokes::StokesTypes::XY}, {CARTA::PolarizationType::YX, casacore::Stokes::StokesTypes::YX},
-    {CARTA::PolarizationType::Ptotal, casacore::Stokes::StokesTypes::Ptotal},
-    {CARTA::PolarizationType::Plinear, casacore::Stokes::StokesTypes::Plinear},
-    {CARTA::PolarizationType::PFtotal, casacore::Stokes::StokesTypes::PFtotal},
-    {CARTA::PolarizationType::PFlinear, casacore::Stokes::StokesTypes::PFlinear},
-    {CARTA::PolarizationType::Pangle, casacore::Stokes::StokesTypes::Pangle}};
+std::map<Stokes::Pol, std::vector<Stokes::Pol>> Stokes::_components{{Pol::Ptotal, {Pol::Q, Pol::U, Pol::V}},
+    {Pol::Plinear, {Pol::Q, Pol::U}}, {Pol::PFtotal, {Pol::I, Pol::Q, Pol::U, Pol::V}}, {Pol::PFlinear, {Pol::I, Pol::Q, Pol::U}},
+    {Pol::Pangle, {Pol::Q, Pol::U}}};
 
 /**
- * @details This unordered map associates each `CARTA::PolarizationType` enumeration value
+ * @details This unordered map provides a conversion between the CARTA polarization type
+ * enumeration and the corresponding CASA Stokes type enumeration.
+ * It is used to translate polarization representations between the two frameworks.
+ */
+std::unordered_map<Stokes::Pol, Stokes::CasaPol> Stokes::_to_casa{{Pol::POLARIZATION_TYPE_NONE, CasaPol::Undefined}, {Pol::I, CasaPol::I},
+    {Pol::Q, CasaPol::Q}, {Pol::U, CasaPol::U}, {Pol::V, CasaPol::V}, {Pol::RR, CasaPol::RR}, {Pol::LL, CasaPol::LL},
+    {Pol::RL, CasaPol::RL}, {Pol::LR, CasaPol::LR}, {Pol::XX, CasaPol::XX}, {Pol::YY, CasaPol::YY}, {Pol::XY, CasaPol::XY},
+    {Pol::YX, CasaPol::YX}, {Pol::Ptotal, CasaPol::Ptotal}, {Pol::Plinear, CasaPol::Plinear}, {Pol::PFtotal, CasaPol::PFtotal},
+    {Pol::PFlinear, CasaPol::PFlinear}, {Pol::Pangle, CasaPol::Pangle}};
+
+/**
+ * @details This unordered map associates each CARTA polarization type enumeration value
  * with a corresponding descriptive string. It is used to provide user-friendly
  * labels for polarization types in logs, UI displays, or reports.
  */
-std::unordered_map<CARTA::PolarizationType, std::string> Stokes::_description{{CARTA::PolarizationType::POLARIZATION_TYPE_NONE, "Unknown"},
-    {CARTA::PolarizationType::I, "Stokes I"}, {CARTA::PolarizationType::Q, "Stokes Q"}, {CARTA::PolarizationType::U, "Stokes U"},
-    {CARTA::PolarizationType::V, "Stokes V"}, {CARTA::PolarizationType::Ptotal, "Total polarization intensity"},
-    {CARTA::PolarizationType::Plinear, "Linear polarization intensity"},
-    {CARTA::PolarizationType::PFtotal, "Fractional total polarization intensity"},
-    {CARTA::PolarizationType::PFlinear, "Fractional linear polarization intensity"},
-    {CARTA::PolarizationType::Pangle, "Polarization angle"}};
+std::unordered_map<Stokes::Pol, std::string> Stokes::_description{{Pol::POLARIZATION_TYPE_NONE, "Unknown"}, {Pol::I, "Stokes I"},
+    {Pol::Q, "Stokes Q"}, {Pol::U, "Stokes U"}, {Pol::V, "Stokes V"}, {Pol::Ptotal, "Total polarization intensity"},
+    {Pol::Plinear, "Linear polarization intensity"}, {Pol::PFtotal, "Fractional total polarization intensity"},
+    {Pol::PFlinear, "Fractional linear polarization intensity"}, {Pol::Pangle, "Polarization angle"}};
 
 /**
- * @details This function checks if the provided integer value is a valid `CARTA::PolarizationType`.
+ * @details This function checks if the provided integer value is a valid CARTA polarization type.
  * If valid, it returns the corresponding enumeration value. Otherwise, it returns
  * `CARTA::PolarizationType::POLARIZATION_TYPE_NONE` as a fallback.
  */
-CARTA::PolarizationType Stokes::Get(int value) {
+Stokes::Pol Stokes::Get(int value) {
     if (CARTA::PolarizationType_IsValid(value)) {
-        return static_cast<CARTA::PolarizationType>(value);
+        return static_cast<Pol>(value);
     }
-    return CARTA::PolarizationType::POLARIZATION_TYPE_NONE;
+    return Pol::POLARIZATION_TYPE_NONE;
 }
 
 /**
- * @details This function attempts to parse a given string into a `CARTA::PolarizationType`.
+ * @details This function attempts to parse a given string into a CARTA polarization type.
  * If parsing is successful, it returns the corresponding enumeration value.
  * If the name is invalid, it returns `CARTA::PolarizationType::POLARIZATION_TYPE_NONE`.
  */
-CARTA::PolarizationType Stokes::Get(std::string name) {
-    auto type = CARTA::PolarizationType::POLARIZATION_TYPE_NONE;
+Stokes::Pol Stokes::Get(std::string name) {
+    auto type = Pol::POLARIZATION_TYPE_NONE;
     CARTA::PolarizationType_Parse(name, &type);
     return type;
 }
 
 /**
- * @details This function maps a `CARTA::PolarizationType` to its equivalent `casacore::Stokes::StokesTypes`
+ * @details This function maps a CARTA polarization type to its equivalent CASA Stokes type
  * using a predefined lookup table. If the provided type is not found in the mapping,
  * an `std::out_of_range` exception may be thrown.
  */
-casacore::Stokes::StokesTypes Stokes::ToCasa(CARTA::PolarizationType type) {
+Stokes::CasaPol Stokes::ToCasa(Pol type) {
     return _to_casa.at(type);
 }
 
@@ -94,19 +91,19 @@ bool Stokes::ConvertFits(const int& in_stokes_value, int& out_stokes_value) {
 }
 
 /**
- * @details This function returns the string representation of a `CARTA::PolarizationType`
+ * @details This function returns the string representation of a CARTA polarization type
  * using the `CARTA::PolarizationType_Name` function.
  */
-std::string Stokes::Name(CARTA::PolarizationType type) {
+std::string Stokes::Name(Pol type) {
     return CARTA::PolarizationType_Name(type);
 }
 
 /**
- * @details This function returns a human-readable description of a `CARTA::PolarizationType`
+ * @details This function returns a human-readable description of a CARTA polarization type
  * from the `_description` map. If the type is not found in the map, it falls back
  * to returning the string representation of the polarization type.
  */
-std::string Stokes::Description(CARTA::PolarizationType type) {
+std::string Stokes::Description(Pol type) {
     try {
         return _description.at(type);
     } catch (const std::out_of_range& e) {
@@ -119,5 +116,39 @@ std::string Stokes::Description(CARTA::PolarizationType type) {
  * a computed polarization type (e.g., `Ptotal`, `Plinear`, `PFtotal`, `PFlinear`, `Pangle`).
  */
 bool Stokes::IsComputed(int value) {
-    return (value >= CARTA::PolarizationType::Ptotal) && (value <= CARTA::PolarizationType::Pangle);
+    return (value >= Pol::Ptotal) && (value <= Pol::Pangle);
+}
+
+/** @details This function returns a vector containing the polarization types required to calculate the given computed polarization type,
+ * using the `_components` map. For example, for `Ptotal` it returns `Q`, `U`, and `V`. If the input value is not found in the map, an empty
+ * vector is returned.
+ */
+std::vector<Stokes::Pol> Stokes::Components(const Pol type) {
+    try {
+        return _components.at(type);
+    } catch (const std::out_of_range& e) {
+        return std::vector<Pol>();
+    }
+}
+
+/** @details This function retrieves the polarizations which may be computed from the given component polarizations, using the `_components`
+ * map. The components may be given in any order. The returned polarizations are sorted by numeric value. If no polarizations are computable
+ * from the components provided, an empty vector is returned.
+ */
+std::vector<Stokes::Pol> Stokes::Computable(const std::vector<Pol>& components) {
+    // Ensure that components are sorted and deduplicated
+    std::vector<Pol> available(components);
+    std::sort(available.begin(), available.end());
+    auto last = std::unique(available.begin(), available.end());
+    available.erase(last, available.end());
+
+    std::vector<Pol> computable;
+
+    for (auto& [computed, required] : _components) {
+        if (std::includes(available.begin(), available.end(), required.begin(), required.end())) {
+            computable.push_back(computed);
+        }
+    }
+
+    return computable;
 }

--- a/src/Util/Stokes.h
+++ b/src/Util/Stokes.h
@@ -17,10 +17,18 @@
 
 namespace carta {
 
+/**
+ * @brief An enumeration of FITS polarizations that we support.
+ * @details In future we may extend this to all nonstandard types supported by CASA.
+ *
+ */
+enum FitsPolarizationType : int { I = 1, Q = 2, U = 3, V = 4, RR = -1, LL = -2, RL = -3, LR = -4, XX = -5, YY = -6, XY = -7, YX = -8 };
+
 class Stokes {
 public:
     using Pol = CARTA::PolarizationType;
     using CasaPol = casacore::Stokes::StokesTypes;
+    using FitsPol = FitsPolarizationType;
 
     /**
      * @brief Retrieves the corresponding CARTA polarization type from an integer value.
@@ -39,22 +47,31 @@ public:
     static Pol Get(std::string name);
 
     /**
-     * @brief Converts a CARTA polarization type to the corresponding CASA Stokes type.
+     * @brief Converts a CARTA polarization type to the corresponding CASA polarization type.
      *
      * @param type The CARTA polarization type to convert.
-     * @return The corresponding CASA Stokes type.
+     * @return The corresponding CASA polarization type.
      * @throws std::out_of_range If the provided type is not found in the mapping.
      */
     static CasaPol ToCasa(Pol type);
 
     /**
-     * @brief Converts a FITS Stokes parameter value to its corresponding internal representation.
+     * @brief Converts a CARTA polarization type to the corresponding FITS polarization type.
      *
-     * @param[in] in_stokes_value The input FITS Stokes parameter value.
-     * @param[out] out_stokes_value The converted Stokes parameter value.
-     * @return `true` if the conversion was successful, `false` if the input value is invalid.
+     * @param type The CARTA polarization type to convert.
+     * @return The corresponding FITS polarization type.
+     * @throws std::out_of_range If the provided type is not found in the mapping.
      */
-    static bool ConvertFits(const int& in_stokes_value, int& out_stokes_value);
+    static FitsPol ToFits(Pol type);
+
+    /**
+     * @brief Converts an integer representing a FITS polarization type to the corresponding CARTA polarization type.
+     *
+     * @param type The input type to convert. This is an integer because we cannot guarantee that the input type is supported or valid.
+     * @return The corresponding CARTA polarization type.
+     * @throws std::out_of_range If the provided type is invalid.
+     */
+    static Pol FromFits(int type);
 
     /**
      * @brief Retrieves the name of a given CARTA polarization type.
@@ -101,9 +118,19 @@ protected:
     static std::map<Pol, std::vector<Pol>> _components;
 
     /**
-     * @brief Maps CARTA polarization types to CASA Stokes types.
+     * @brief Maps CARTA polarization types to CASA polarization types.
      */
     static std::unordered_map<Pol, CasaPol> _to_casa;
+
+    /**
+     * @brief Maps CARTA polarization types to FITS polarization types.
+     */
+    static std::unordered_map<Pol, FitsPol> _to_fits;
+
+    /**
+     * @brief Maps FITS polarization types to CARTA polarization types.
+     */
+    static std::unordered_map<FitsPol, Pol> _from_fits;
 
     /**
      * @brief Provides human-readable descriptions for CARTA polarization types.

--- a/src/Util/Stokes.h
+++ b/src/Util/Stokes.h
@@ -19,30 +19,33 @@ namespace carta {
 
 class Stokes {
 public:
+    using Pol = CARTA::PolarizationType;
+    using CasaPol = casacore::Stokes::StokesTypes;
+
     /**
      * @brief Retrieves the corresponding CARTA polarization type from an integer value.
      *
-     * @param value The integer representation of a `CARTA::PolarizationType`.
-     * @return The corresponding `CARTA::PolarizationType` if valid, otherwise `POLARIZATION_TYPE_NONE`.
+     * @param value The integer representation of a CARTA polarization type.
+     * @return The corresponding CARTA polarization type if valid, otherwise `POLARIZATION_TYPE_NONE`.
      */
-    static CARTA::PolarizationType Get(int value);
+    static Pol Get(int value);
 
     /**
      * @brief Retrieves the corresponding CARTA polarization type from a string name.
      *
-     * @param name The string representation of a `CARTA::PolarizationType`.
-     * @return The corresponding `CARTA::PolarizationType` if parsing is successful, otherwise `POLARIZATION_TYPE_NONE`.
+     * @param name The string representation of a CARTA polarization type.
+     * @return The corresponding CARTA polarization type if parsing is successful, otherwise `POLARIZATION_TYPE_NONE`.
      */
-    static CARTA::PolarizationType Get(std::string name);
+    static Pol Get(std::string name);
 
     /**
      * @brief Converts a CARTA polarization type to the corresponding CASA Stokes type.
      *
-     * @param type The `CARTA::PolarizationType` to convert.
-     * @return The corresponding `casacore::Stokes::StokesTypes` value.
+     * @param type The CARTA polarization type to convert.
+     * @return The corresponding CASA Stokes type.
      * @throws std::out_of_range If the provided type is not found in the mapping.
      */
-    static casacore::Stokes::StokesTypes ToCasa(CARTA::PolarizationType type);
+    static CasaPol ToCasa(Pol type);
 
     /**
      * @brief Converts a FITS Stokes parameter value to its corresponding internal representation.
@@ -59,7 +62,7 @@ public:
      * @param[in] type The polarization type to retrieve the name for.
      * @return The string representation of the given polarization type.
      */
-    static std::string Name(CARTA::PolarizationType type);
+    static std::string Name(Pol type);
 
     /**
      * @brief Retrieves a descriptive string for a given CARTA polarization type.
@@ -67,27 +70,45 @@ public:
      * @param[in] type The polarization type for which to retrieve a description.
      * @return A descriptive string for the given polarization type.
      */
-    static std::string Description(CARTA::PolarizationType type);
+    static std::string Description(Pol type);
 
     /**
      * @brief Determines if a given polarization type is a computed polarization.
      *
-     * @param[in] value The integer representation of a `CARTA::PolarizationType`.
+     * @param[in] value The integer representation of a CARTA polarization type.
      * @return `true` if the value corresponds to a computed polarization type, otherwise `false`.
      */
     static bool IsComputed(int value);
 
-    // TODO move FITS mappings here too
+    /** @brief Retrieves the component polarizations required to calculate the given computed polarization.
+     *
+     * @param[in] type The computed polarization type.
+     * @return A vector of the required component polarizations.
+     */
+    static std::vector<Pol> Components(const Pol type);
+
+    /** @brief Retrieves the polarizations which may be computed from the given component polarizations.
+     *
+     * @param[in] components A vector of the available component polarizations.
+     * @return A sorted vector of the computable polarizations.
+     */
+    static std::vector<Pol> Computable(const std::vector<Pol>& components);
+
 protected:
+    /**
+     * @brief Maps computed polarization types to the component polarizations required to calculate them.
+     */
+    static std::map<Pol, std::vector<Pol>> _components;
+
     /**
      * @brief Maps CARTA polarization types to CASA Stokes types.
      */
-    static std::unordered_map<CARTA::PolarizationType, casacore::Stokes::StokesTypes> _to_casa;
+    static std::unordered_map<Pol, CasaPol> _to_casa;
 
     /**
      * @brief Provides human-readable descriptions for CARTA polarization types.
      */
-    static std::unordered_map<CARTA::PolarizationType, std::string> _description;
+    static std::unordered_map<Pol, std::string> _description;
 };
 
 // The struct StokesSource is used to tell the file loader to get the original image interface, or get the computed stokes image interface.


### PR DESCRIPTION
**Description**

This is another set of changes that I pulled out of the [polarization calculator PR](https://github.com/CARTAvis/carta-backend/pull/1525). It cleans up the mapping of Stokes types to Stokes indices, and vice versa. This is mostly used to parse coordinate strings from various config structs. @pford implemented some of this in parallel in a different way during the region code refactoring. This solution pre-calculates information about computable Stokes, and eliminates the need to check for available components every time.

* `Util/Stokes` now has a fixed mapping of computed Stokes to required components, and a function that calculates all Stokes computable from a given set of available Stokes.
* The file loader now handles deducing of Stokes types internally (the frame no longer does this). ~~The deduced mappings are stored separately.~~ _I have removed this, since we don't make this distinction for any other guesses._
* The file loader pre-populates a set of computable Stokes for the file.
* Mapping functions in the file loader use the "real" mappings, the deduced mappings, and the computable Stokes to map polarization types to indices and vice versa.
* The frame handles only the other coordinate string logic, and uses the loader's function to map the polarization type parsed from the coordinate to an index.
* In cases where the mapping is only needed for a polarization, not a coordinate, the loader's function is used directly.
* The frame's function for mapping indices to types has been eliminated, and the loader's function is used directly.

Updated information about non-standard polarizations in files: following some investigation and discussion, we will no longer open files with multiple polarizations if any of them are unsupported (because this breaks functionality such as the polarization animator). We will open a separate issue for supporting all the polarizations that CASA currently supports.

New TODOs:

- [X] Replace the bidirectional `ConvertFits` function with two functions with an unambiguous direction. Currently a non-standard FITS value that falls within a valid range for *our* enum will be converted in the wrong direction and lead to unpredictable behaviour later.
- [X] Add sensible error messages and fallbacks for polarizations that we don't support.
- [ ] Add documentation to the main mapping functions to make it clear what they do and do not support.
- [ ] Add unit tests for the polarization conversion functions.
- [ ] Add or extend tests for the FileLoader's coordinate and mapping functions.

**Checklist**

- [X] changelog updated / no changelog update needed
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [X] no protobuf update needed
- [X] protobuf version not bumped
- [X] added reviewers and assignee
- [ ] GitHub Project estimate added
