### PR TITLE
retry failed test if backend disconnection

### DIFF
--- a/.github/actions/run-macos/action.yml
+++ b/.github/actions/run-macos/action.yml
@@ -23,6 +23,8 @@ runs:
 
     - name: ICD tests
       run: |
+        SRC_DIR=$GITHUB_WORKSPACE/source
+        BUILD_DIR=$GITHUB_WORKSPACE/build
         ICD_DIR=$GITHUB_WORKSPACE/ICD-RxJS
         cd $ICD_DIR
         for test_file in $(cat ICD_test_stages/${{ inputs.test_stage_name }}.tests); do
@@ -30,7 +32,29 @@ runs:
             echo "$test_file 1st attempt: PASS"
           else
             echo "Failed: $test_file - retrying ..."
-            sleep 3
+            if ! pgrep carta_backend > /dev/null; then
+              echo "Backend has crashed, restarting before retry ..."
+              tail -50 ~/.carta/log/carta.log || true
+              cd $BUILD_DIR
+              ASAN_OPTIONS=suppressions=$SRC_DIR/debug/asan/myasan.supp \
+              LSAN_OPTIONS=suppressions=$SRC_DIR/debug/asan/myasan-leaks.supp \
+              ASAN_SYMBOLIZER_PATH=llvm-symbolizer \
+              ./carta_backend /images --top_level_folder /images \
+              --port 5555 \
+              --omp_threads=4 --debug_no_auth --no_frontend --no_database --verbosity=5 &
+              echo "CARTA_BACKEND_PID=$!" >> $GITHUB_ENV
+              PORT=5555
+              for i in {1..30}; do
+                if nc -z 127.0.0.1 "$PORT"; then
+                  echo "Backend restarted on port $PORT (attempt $i)"
+                  break
+                fi
+                sleep 1
+              done
+              cd $ICD_DIR
+            else
+              sleep 3
+            fi
             CI=true npm test "$test_file"
           fi
           sleep 3 && pgrep carta_backend

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: Clear hooks from workspace before checkout
         run: |
-          rm .git/hooks/*
+          if [ -d .git/hooks ]; then rm .git/hooks/*; fi
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -144,7 +144,7 @@ jobs:
     steps:
       - name: Clear hooks from workspace before checkout
         run: |
-          rm .git/hooks/*
+          if [ -d .git/hooks ]; then rm .git/hooks/*; fi
 
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
**Description**
 
* Improves the macOS ICD test action to handle cases where carta_backend crashes mid-run, which previously caused all remaining tests to fail with ECONNREFUSED.

* When carta_backend crashed during a test (e.g. OPEN_SWAPPED_IMAGES), the retry mechanism would attempt to re-run the failed test against a dead backend, resulting in cascading ECONNREFUSED failures for all subsequent tests in the stage.

**Checklist**

- [x] changelog updated / no changelog update needed
- [x] ICD test passing / corresponding fix added / new ICD test created
