### PR TITLE
Fix duplication bug in spatial profile calculation for polyline region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * Fixed error opening HDF5 image with degenerate undefined Stokes axis ([#1594](https://github.com/CARTAvis/carta-backend/issues/1594)).
+* Fixed duplicate data appearing in wide field polyline spatial profiles ([#1604](https://github.com/CARTAvis/carta-backend/issues/1604)). 
 
 ## [6.0.0-beta.1]
 

--- a/src/Region/RegionAnalysis/LineBoxRegions.cc
+++ b/src/Region/RegionAnalysis/LineBoxRegions.cc
@@ -160,6 +160,7 @@ bool LineBoxRegions::GetFixedPixelRegions(const RegionState& line_region_state, 
                 increment = sqrt((xlength * xlength) + (ylength * ylength));
             } else if (!CheckLinearOffsets(box_centers, line_coord_sys, increment)) {
                 spdlog::debug("Fixed pixel offsets not linear");
+                region_states.clear();
                 return false;
             }
 


### PR DESCRIPTION
**Description**

Fixes #1604.

We calculate spatial profiles for lines and polylines by approximating them as a series of evenly spaced box regions. We first attempt to offset the box regions in pixel coordinates, but if this would result in non-linear spacing in world coordinates (because of distortion near the edges of the grid), they are instead offset in world coordinates.

The function that attempts to use pixel coordinates exits with an unsuccessful return status if it encounters a polyline segment with non-linear offsets. The function that uses world coordinates is then called. However, the first function appends region state objects to the shared in-out vector after it processes each segment of a polyline successfully. Therefore, if one or more initial segments can be processed and a subsequent segment cannot, the vector will contain a duplicate sequence.

This PR clears the vector before the early exit.

To reproduce the bug:
* Open an image (this is easiest to demonstrate with an image that covers a large area in world coordinates)
* Show the grid and zoom out
* Draw a polyline region with two horizontal segments. Position it so that the first segment starts outside the image and the second segment ends outside the image, so that there is a single contiguous interval of data in the profile plot.
* Move the endpoint of the polyline so that the second segment extends diagonally far towards the edge of the grid. You should now see two disjoint intervals of data in the plot, with the first repeating some or all of the second (depending on whether any of the second segment is inside the image). The distance axis in the plot will also be incorrect (if you maintain the length of the second segment while gradually changing the angle, you should see the distance becoming longer than the actual distance of the polyline when the duplicate interval appears).

In this branch, this should never be triggered, and you should always see the correct data in the plot.

**Checklist**

- [X] changelog updated
- [x] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [X] no protobuf update needed
- [X] protobuf version not bumped
- [X] added reviewers and assignee
- [ ] GitHub Project estimate added
