### PR TITLE
Posh/macos26: CI/ICD: update macOS runners with macOS-26

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,5 +1,6 @@
 name: ci
 on:
+  workflow_dispatch:
   push:
     branches:
       - dev

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Install clang-format 14
         run: sudo apt-get install clang-format-14
       - name: Run format check
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: check out theme submodule
         run: git submodule update --init docs/doxygen-awesome-css
       - name: Install dependencies
@@ -41,7 +41,7 @@ jobs:
           if [ -d .git/hooks ]; then rm .git/hooks/*; fi
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
           lfs: true
@@ -138,8 +138,8 @@ jobs:
           git checkout stash@{0} -- badge-coverage.svg
           git diff --staged --quiet || { git commit -m "Updated coverage @ ${lastcommit}" && git push; }
           
-  macOS-15:
-    runs-on: [self-hosted, macOS-15-M1, CI]
+  macOS-26:
+    runs-on: [self-hosted, macOS-26-M1, CI]
     needs: format-check
     steps:
       - name: Clear hooks from workspace before checkout
@@ -147,7 +147,7 @@ jobs:
           if [ -d .git/hooks ]; then rm .git/hooks/*; fi
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
           lfs: true
@@ -161,6 +161,7 @@ jobs:
       - name: Build backend  
         shell: bash
         run: |
+          export Protobuf_ROOT="/opt/homebrew/opt/protobuf@21"
           cmake --version
           mkdir build && cd build
           cmake .. -Dtest=on -DCMAKE_BUILD_TYPE=Debug \
@@ -193,7 +194,7 @@ jobs:
         uses: dorny/test-reporter@v1
         if: success() || failure()
         with:
-          name: macOS-15 Unit Test results
+          name: macOS-26 Unit Test results
           path: build/test/macos_test_report.xml
           reporter: java-junit
 
@@ -207,7 +208,7 @@ jobs:
           rm .git/hooks/*
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
           lfs: true
@@ -257,7 +258,7 @@ jobs:
   Notify:
     name: Send notifications
     runs-on: ubuntu-latest
-    needs: [format-check, Ubuntu-Noble, macOS-15, AlmaLinux-9]
+    needs: [format-check, Ubuntu-Noble, macOS-26, AlmaLinux-9]
     if: always()
     steps:
       - name: Notify Slack
@@ -271,7 +272,7 @@ jobs:
   NotifyEmail:
     name: Send email on failure
     runs-on: ubuntu-latest
-    needs: [format-check, doxygen-check, Ubuntu-Noble, macOS-15, AlmaLinux-9]
+    needs: [format-check, doxygen-check, Ubuntu-Noble, macOS-26, AlmaLinux-9]
     if: failure()
     steps:
       - name: Send email notification
@@ -297,5 +298,5 @@ jobs:
             - format-check: ${{ needs.format-check.result }}
             - doxygen-check: ${{ needs.doxygen-check.result }}
             - Ubuntu-Noble: ${{ needs.Ubuntu-Noble.result }}
-            - macOS-15: ${{ needs.macOS-15.result }}
+            - macOS-26: ${{ needs.macOS-26.result }}
             - AlmaLinux-9: ${{ needs.AlmaLinux-9.result }}

--- a/.github/workflows/icd_tests.yml
+++ b/.github/workflows/icd_tests.yml
@@ -15,15 +15,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os_version: macOS-13
-            os: macos
-            runner: [macOS-13, ICD]
           - os_version: macOS-14
             os: macos
             runner: [macOS-14, ICD]
           - os_version: macOS-15
             os: macos
             runner: [macOS-15, ICD]
+          - os_version: macOS-26
+            os: macos
+            runner: [macOS-26, ICD]
           - os_version: ubuntu-22.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
@@ -46,7 +46,7 @@ jobs:
             port: 9005
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: source
 
@@ -85,6 +85,7 @@ jobs:
         if: matrix.os == 'macos' && matrix.os_version != 'macOS-14'
         shell: bash
         run: |
+          export Protobuf_ROOT="/opt/homebrew/opt/protobuf@21"
           SRC_DIR=$GITHUB_WORKSPACE/source
           BUILD_DIR=$GITHUB_WORKSPACE/build
           cd $SRC_DIR && git submodule update --init
@@ -149,15 +150,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os_version: macOS-13
-            os: macos
-            runner: [macOS-13, ICD]
           - os_version: macOS-14
             os: macos
             runner: [macOS-14, ICD]
           - os_version: macOS-15
             os: macos
             runner: [macOS-15, ICD]
+          - os_version: macOS-26
+            os: macos
+            runner: [macOS-26, ICD]
           - os_version: ubuntu-22.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
@@ -181,7 +182,7 @@ jobs:
     needs: Build
     steps:
       - name: Checkout ICD-RxJS repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: CARTAvis/ICD-RxJS
           ref: ${{ env.ICD_RXJS_BRANCH_NAME }}
@@ -222,15 +223,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os_version: macOS-13
-            os: macos
-            runner: [macOS-13, ICD]
           - os_version: macOS-14
             os: macos
             runner: [macOS-14, ICD]
           - os_version: macOS-15
             os: macos
             runner: [macOS-15, ICD]
+          - os_version: macOS-26
+            os: macos
+            runner: [macOS-26, ICD]
           - os_version: ubuntu-22.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
@@ -251,8 +252,8 @@ jobs:
             runner: [self-hosted, Linux, Apptainer, ICD5]
             image: /opt/apptainer/almalinux9-mar2026.sif
             port: 9005
-    needs: Prepare-ICD-RxJS
-    if: always()
+    needs: [Build, Prepare-ICD-RxJS]
+    if: ${{ github.event.inputs.file_browser_animator_icd_tests == 'true' }}
     steps:
       # macOS steps
       - name: File Browser ICD tests
@@ -278,15 +279,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os_version: macOS-13
-            os: macos
-            runner: [macOS-13, ICD]
           - os_version: macOS-14
             os: macos
             runner: [macOS-14, ICD]
           - os_version: macOS-15
             os: macos
             runner: [macOS-15, ICD]
+          - os_version: macOS-26
+            os: macos
+            runner: [macOS-26, ICD]
           - os_version: ubuntu-22.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
@@ -307,8 +308,8 @@ jobs:
             runner: [self-hosted, Linux, Apptainer, ICD5]
             image: /opt/apptainer/almalinux9-mar2026.sif
             port: 9005
-    needs: [File-Browser-ICD-Tests, Prepare-ICD-RxJS]
-    if: always()
+    needs: [Build, Prepare-ICD-RxJS]
+    if: ${{ github.event.inputs.file_browser_animator_icd_tests == 'true' }}
     steps:
       # macOS steps
       - name: Animator ICD tests
@@ -334,15 +335,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os_version: macOS-13
-            os: macos
-            runner: [macOS-13, ICD]
           - os_version: macOS-14
             os: macos
             runner: [macOS-14, ICD]
           - os_version: macOS-15
             os: macos
             runner: [macOS-15, ICD]
+          - os_version: macOS-26
+            os: macos
+            runner: [macOS-26, ICD]
           - os_version: ubuntu-22.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
@@ -363,8 +364,8 @@ jobs:
             runner: [self-hosted, Linux, Apptainer, ICD5]
             image: /opt/apptainer/almalinux9-mar2026.sif
             port: 9005
-    needs: [Animator-ICD-Tests, Prepare-ICD-RxJS]
-    if: always()
+    needs: [Build, Prepare-ICD-RxJS]
+    if: ${{ github.event.inputs.region_statistics_manipulation_icd_tests == 'true' }}
     steps:
       # macOS steps
       - name: Region-Statistics ICD tests
@@ -390,15 +391,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os_version: macOS-13
-            os: macos
-            runner: [macOS-13, ICD]
           - os_version: macOS-14
             os: macos
             runner: [macOS-14, ICD]
           - os_version: macOS-15
             os: macos
             runner: [macOS-15, ICD]
+          - os_version: macOS-26
+            os: macos
+            runner: [macOS-26, ICD]
           - os_version: ubuntu-22.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
@@ -419,8 +420,8 @@ jobs:
             runner: [self-hosted, Linux, Apptainer, ICD5]
             image: /opt/apptainer/almalinux9-mar2026.sif
             port: 9005
-    needs: [Region-Statistics-ICD-Tests, Prepare-ICD-RxJS]
-    if: always()
+    needs: [Build, Prepare-ICD-RxJS]
+    if: ${{ github.event.inputs.region_statistics_manipulation_icd_tests == 'true' }}
     steps:
       # macOS steps
       - name: Region Manipulation ICD tests
@@ -446,15 +447,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os_version: macOS-13
-            os: macos
-            runner: [macOS-13, ICD]
           - os_version: macOS-14
             os: macos
             runner: [macOS-14, ICD]
           - os_version: macOS-15
             os: macos
             runner: [macOS-15, ICD]
+          - os_version: macOS-26
+            os: macos
+            runner: [macOS-26, ICD]
           - os_version: ubuntu-22.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
@@ -475,8 +476,8 @@ jobs:
             runner: [self-hosted, Linux, Apptainer, ICD5]
             image: /opt/apptainer/almalinux9-mar2026.sif
             port: 9005
-    needs: [Region-Manipulation-ICD-Tests, Prepare-ICD-RxJS]
-    if: always()
+    needs: [Build, Prepare-ICD-RxJS]
+    if: ${{ github.event.inputs.cube_histogram_pv_generator_icd_tests == 'true' }}
     steps:
       # macOS steps
       - name: Cube Histogram ICD tests
@@ -502,15 +503,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os_version: macOS-13
-            os: macos
-            runner: [macOS-13, ICD]
           - os_version: macOS-14
             os: macos
             runner: [macOS-14, ICD]
           - os_version: macOS-15
             os: macos
             runner: [macOS-15, ICD]
+          - os_version: macOS-26
+            os: macos
+            runner: [macOS-26, ICD]
           - os_version: ubuntu-22.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
@@ -531,8 +532,8 @@ jobs:
             runner: [self-hosted, Linux, Apptainer, ICD5]
             image: /opt/apptainer/almalinux9-mar2026.sif
             port: 9005
-    needs: [Cube-Histogram-ICD-Tests, Prepare-ICD-RxJS]
-    if: always()
+    needs: [Build, Prepare-ICD-RxJS]
+    if: ${{ github.event.inputs.cube_histogram_pv_generator_icd_tests == 'true' }}
     steps:
       # macOS steps
       - name: PV Generator ICD tests
@@ -558,15 +559,15 @@ jobs:
       fail-fast: false
       matrix:  
         include:
-          - os_version: macOS-13
-            os: macos
-            runner: [macOS-13, ICD]
           - os_version: macOS-14
             os: macos
             runner: [macOS-14, ICD]
           - os_version: macOS-15
             os: macos
             runner: [macOS-15, ICD]
+          - os_version: macOS-26
+            os: macos
+            runner: [macOS-26, ICD]
           - os_version: ubuntu-22.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
@@ -587,8 +588,8 @@ jobs:
             runner: [self-hosted, Linux, Apptainer, ICD5]
             image: /opt/apptainer/almalinux9-mar2026.sif
             port: 9005
-    needs: [PV-Generator-ICD-Tests, Prepare-ICD-RxJS]
-    if: always()
+    needs: [Build, Prepare-ICD-RxJS]
+    if: ${{ github.event.inputs.raster_tiles_catalog_icd_tests == 'true' }}
     steps:
       # macOS steps
       - name: Raster Tiles ICD tests
@@ -614,15 +615,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os_version: macOS-13
-            os: macos
-            runner: [macOS-13, ICD]
           - os_version: macOS-14
             os: macos
             runner: [macOS-14, ICD]
           - os_version: macOS-15
             os: macos
             runner: [macOS-15, ICD]
+          - os_version: macOS-26
+            os: macos
+            runner: [macOS-26, ICD]
           - os_version: ubuntu-22.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
@@ -643,8 +644,8 @@ jobs:
             runner: [self-hosted, Linux, Apptainer, ICD5]
             image: /opt/apptainer/almalinux9-mar2026.sif
             port: 9005
-    needs: [Raster-Tiles-ICD-Tests, Prepare-ICD-RxJS]
-    if: always()
+    needs: [Build, Prepare-ICD-RxJS]
+    if: ${{ github.event.inputs.raster_tiles_catalog_icd_tests == 'true' }}
     steps:
       # macOS steps
       - name: Catalog ICD tests
@@ -670,15 +671,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os_version: macOS-13
-            os: macos
-            runner: [macOS-13, ICD]
           - os_version: macOS-14
             os: macos
             runner: [macOS-14, ICD]
           - os_version: macOS-15
             os: macos
             runner: [macOS-15, ICD]
+          - os_version: macOS-26
+            os: macos
+            runner: [macOS-26, ICD]
           - os_version: ubuntu-22.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
@@ -699,8 +700,8 @@ jobs:
             runner: [self-hosted, Linux, Apptainer, ICD5]
             image: /opt/apptainer/almalinux9-mar2026.sif
             port: 9005
-    needs: [Catalog-ICD-Tests, Prepare-ICD-RxJS]
-    if: always()
+    needs: [Build, Prepare-ICD-RxJS]
+    if: ${{ github.event.inputs.moment_match_icd_tests == 'true' }}
     steps:
       # macOS steps
       - name: Moment ICD tests
@@ -726,15 +727,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os_version: macOS-13
-            os: macos
-            runner: [macOS-13, ICD]
           - os_version: macOS-14
             os: macos
             runner: [macOS-14, ICD]
           - os_version: macOS-15
             os: macos
             runner: [macOS-15, ICD]
+          - os_version: macOS-26
+            os: macos
+            runner: [macOS-26, ICD]
           - os_version: ubuntu-22.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
@@ -755,8 +756,8 @@ jobs:
             runner: [self-hosted, Linux, Apptainer, ICD5]
             image: /opt/apptainer/almalinux9-mar2026.sif
             port: 9005
-    needs: [Moment-ICD-Tests, Prepare-ICD-RxJS]
-    if: always()
+    needs: [Build, Prepare-ICD-RxJS]
+    if: ${{ github.event.inputs.moment_match_icd_tests == 'true' }}
     steps:
       # macOS steps
       - name: Match ICD tests
@@ -782,15 +783,15 @@ jobs:
       fail-fast: false
       matrix:
         include:  
-          - os_version: macOS-13
-            os: macos
-            runner: [macOS-13, ICD]
           - os_version: macOS-14
             os: macos
             runner: [macOS-14, ICD]
           - os_version: macOS-15
             os: macos
             runner: [macOS-15, ICD]
+          - os_version: macOS-26
+            os: macos
+            runner: [macOS-26, ICD]
           - os_version: ubuntu-22.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
@@ -811,8 +812,8 @@ jobs:
             runner: [self-hosted, Linux, Apptainer, ICD5]
             image: /opt/apptainer/almalinux9-mar2026.sif
             port: 9005
-    needs: [Match-ICD-Tests, Prepare-ICD-RxJS]
-    if: always()
+    needs: [Build, Prepare-ICD-RxJS]
+    if: ${{ github.event.inputs.close_files_image_fitting_icd_tests == 'true' }}
     steps:
       # macOS steps
       - name: Close File ICD tests
@@ -838,15 +839,15 @@ jobs:
       fail-fast: false
       matrix:
         include:  
-          - os_version: macOS-13
-            os: macos
-            runner: [macOS-13, ICD]
           - os_version: macOS-14
             os: macos
             runner: [macOS-14, ICD]
           - os_version: macOS-15
             os: macos
             runner: [macOS-15, ICD]
+          - os_version: macOS-26
+            os: macos
+            runner: [macOS-26, ICD]
           - os_version: ubuntu-22.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
@@ -867,8 +868,8 @@ jobs:
             runner: [self-hosted, Linux, Apptainer, ICD5]
             image: /opt/apptainer/almalinux9-mar2026.sif
             port: 9005
-    needs: [Close-File-ICD-Tests, Prepare-ICD-RxJS]
-    if: always()
+    needs: [Build, Prepare-ICD-RxJS]
+    if: ${{ github.event.inputs.close_files_image_fitting_icd_tests == 'true' }}
     steps:
       # macOS steps
       - name: Image Fitting ICD tests
@@ -894,15 +895,15 @@ jobs:
       fail-fast: false
       matrix:
         include:  
-          - os_version: macOS-13
-            os: macos
-            runner: [macOS-13, ICD]
           - os_version: macOS-14
             os: macos
             runner: [macOS-14, ICD]
           - os_version: macOS-15
             os: macos
             runner: [macOS-15, ICD]
+          - os_version: macOS-26
+            os: macos
+            runner: [macOS-26, ICD]
           - os_version: ubuntu-22.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
@@ -923,8 +924,8 @@ jobs:
             runner: [self-hosted, Linux, Apptainer, ICD5]
             image: /opt/apptainer/almalinux9-mar2026.sif
             port: 9005
-    needs: [Image-Fitting-ICD-Tests, Prepare-ICD-RxJS]
-    if: always()
+    needs: [Build, Prepare-ICD-RxJS]
+    if: ${{ github.event.inputs.vector_overlay_resume_icd_tests == 'true' }}
     steps:
       # macOS steps
       - name: Vector Overlay ICD tests
@@ -950,15 +951,15 @@ jobs:
       fail-fast: false
       matrix:
         include:  
-          - os_version: macOS-13
-            os: macos
-            runner: [macOS-13, ICD]
           - os_version: macOS-14
             os: macos
             runner: [macOS-14, ICD]
           - os_version: macOS-15
             os: macos
             runner: [macOS-15, ICD]
+          - os_version: macOS-26
+            os: macos
+            runner: [macOS-26, ICD]
           - os_version: ubuntu-22.04
             os: linux
             runner: [self-hosted, Linux, Apptainer, ICD2]
@@ -979,8 +980,8 @@ jobs:
             runner: [self-hosted, Linux, Apptainer, ICD5]
             image: /opt/apptainer/almalinux9-mar2026.sif
             port: 9005
-    needs: [Vector-Overlay-ICD-Tests, Prepare-ICD-RxJS]
-    if: always()
+    needs: [Build, Prepare-ICD-RxJS]
+    if: ${{ github.event.inputs.vector_overlay_resume_icd_tests == 'true' }}
     steps:
       # macOS steps
       - name: Resume ICD tests

--- a/.github/workflows/icd_tests.yml
+++ b/.github/workflows/icd_tests.yml
@@ -1,5 +1,6 @@
 name: ICD tests
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * *' # UTC time
 env:


### PR DESCRIPTION
**Description**

CI: Replace macOS-15 → macOS-26: Renamed the CI job from macOS-15 (runner: macOS-15-M1) to macOS-26 (runner: macOS-26-M1).
ICD: Replace macOS-13 → macOS-26: Renamed the ICD job from macOS-13 (runner: macOS-13-M1) to macOS-26 (runner: macOS-26-M1).
Add Protobuf_ROOT export: Set Protobuf_ROOT=/opt/homebrew/opt/protobuf@21 in the macOS build step to fix protobuf discovery on macOS 26
Enable manual dispatch: Added workflow_dispatch: trigger so the workflow can be run manually from the Actions tab
Bump actions/checkout: Updated all usages from @v3/@v4 to @v6

**Checklist**

- [x] no changelog update needed
- [x] ICD test passing / corresponding fix added
- [x] no protobuf update needed
- [x] protobuf version not bumped
- [x] added reviewers and assignee
- [ ] GitHub Project estimate added
