### PR TITLE
Handle complex return_path types in scripting requests

### DIFF
--- a/src/HttpServer/HttpServer.cc
+++ b/src/HttpServer/HttpServer.cc
@@ -864,7 +864,14 @@ std::string_view HttpServer::SendScriptingRequest(const std::string& buffer, int
 
         std::string return_path;
         if (req.contains("return_path")) {
-            return_path = req["return_path"].get<std::string>();
+            const auto& return_path_value = req["return_path"];
+            if (return_path_value.is_string()) {
+                return_path = return_path_value.get<std::string>();
+            } else if (return_path_value.is_array() || return_path_value.is_object()) {
+                return_path = return_path_value.dump();
+            } else {
+                return HTTP_400;
+            }
         }
 
         if (!request_handler(

--- a/src/HttpServer/HttpServer.cc
+++ b/src/HttpServer/HttpServer.cc
@@ -867,10 +867,8 @@ std::string_view HttpServer::SendScriptingRequest(const std::string& buffer, int
             const auto& return_path_value = req["return_path"];
             if (return_path_value.is_string()) {
                 return_path = return_path_value.get<std::string>();
-            } else if (return_path_value.is_array() || return_path_value.is_object()) {
-                return_path = return_path_value.dump();
             } else {
-                return HTTP_400;
+                return_path = return_path_value.dump();
             }
         }
 

--- a/test/TestRestApi.cc
+++ b/test/TestRestApi.cc
@@ -82,6 +82,7 @@ public:
     FRIEND_TEST(RestApiTest, SetWorkspaceReadOnly);
 
     FRIEND_TEST(RestApiTest, SendScriptingRequest);
+    FRIEND_TEST(RestApiTest, SendScriptingRequestInvalidReturnPath);
     FRIEND_TEST(RestApiTest, SendScriptingRequestSessionNotFound);
     FRIEND_TEST(RestApiTest, SendScriptingRequestBadJson);
     FRIEND_TEST(RestApiTest, SendScriptingRequestServerError);
@@ -715,26 +716,48 @@ TEST_F(RestApiTest, SendScriptingRequest) {
 
     int requested_session_id(1);
 
+    const std::vector<json> return_paths = {
+        "frameInfo.fileId",
+        json::array({"id", "type"}),
+        json({{"id", "frameInfo.fileId"}, {"label", "name"}}),
+    };
+
+    for (const auto& return_path : return_paths) {
+        body["return_path"] = return_path;
+        auto status = _frontend_server->SendScriptingRequest(
+            body.dump(), requested_session_id, [](const bool&, const std::string&, const std::string&) {}, []() {},
+            [&](int& session_id, uint32_t& scripting_request_id, std::string& target, std::string& action, std::string& parameters,
+                bool& async, std::string& parsed_return_path, ScriptingResponseCallback callback,
+                ScriptingSessionClosedCallback session_closed_callback) {
+                last_session_id = session_id;
+                last_target = target;
+                last_action = action;
+                last_parameters = parameters;
+                last_async = async;
+                last_return_path = parsed_return_path;
+
+                return true;
+            });
+        EXPECT_EQ(status, HTTP_200);
+        EXPECT_EQ(last_session_id, 1);
+        EXPECT_EQ(last_target, "");
+        EXPECT_EQ(last_action, "openFile");
+        EXPECT_EQ(last_parameters, body["parameters"].dump());
+        EXPECT_FALSE(last_async);
+        EXPECT_EQ(last_return_path, return_path.is_string() ? return_path.get<std::string>() : return_path.dump());
+    }
+}
+
+TEST_F(RestApiTest, SendScriptingRequestInvalidReturnPath) {
+    json body = {
+        {"session_id", 1}, {"path", ""}, {"action", "openFile"}, {"parameters", json::array()}, {"async", false}, {"return_path", true}};
+    int requested_session_id(1);
+
     auto status = _frontend_server->SendScriptingRequest(
         body.dump(), requested_session_id, [](const bool&, const std::string&, const std::string&) {}, []() {},
-        [&](int& session_id, uint32_t& scripting_request_id, std::string& target, std::string& action, std::string& parameters, bool& async,
-            std::string& return_path, ScriptingResponseCallback callback, ScriptingSessionClosedCallback session_closed_callback) {
-            last_session_id = session_id;
-            last_target = target;
-            last_action = action;
-            last_parameters = parameters;
-            last_async = async;
-            last_return_path = return_path;
-
-            return true;
-        });
-    EXPECT_EQ(status, HTTP_200);
-    EXPECT_EQ(last_session_id, 1);
-    EXPECT_EQ(last_target, "");
-    EXPECT_EQ(last_action, "openFile");
-    EXPECT_EQ(last_parameters, body["parameters"].dump());
-    EXPECT_EQ(last_async, false);
-    EXPECT_EQ(last_return_path, "frameInfo.fileId");
+        [&](int&, uint32_t&, std::string&, std::string&, std::string&, bool&, std::string&, ScriptingResponseCallback,
+            ScriptingSessionClosedCallback) { return true; });
+    EXPECT_EQ(status, HTTP_400);
 }
 
 TEST_F(RestApiTest, SendScriptingRequestSessionNotFound) {

--- a/test/TestRestApi.cc
+++ b/test/TestRestApi.cc
@@ -82,7 +82,6 @@ public:
     FRIEND_TEST(RestApiTest, SetWorkspaceReadOnly);
 
     FRIEND_TEST(RestApiTest, SendScriptingRequest);
-    FRIEND_TEST(RestApiTest, SendScriptingRequestInvalidReturnPath);
     FRIEND_TEST(RestApiTest, SendScriptingRequestSessionNotFound);
     FRIEND_TEST(RestApiTest, SendScriptingRequestBadJson);
     FRIEND_TEST(RestApiTest, SendScriptingRequestServerError);
@@ -720,6 +719,9 @@ TEST_F(RestApiTest, SendScriptingRequest) {
         "frameInfo.fileId",
         json::array({"id", "type"}),
         json({{"id", "frameInfo.fileId"}, {"label", "name"}}),
+        true,
+        nullptr,
+        42,
     };
 
     for (const auto& return_path : return_paths) {
@@ -746,18 +748,6 @@ TEST_F(RestApiTest, SendScriptingRequest) {
         EXPECT_FALSE(last_async);
         EXPECT_EQ(last_return_path, return_path.is_string() ? return_path.get<std::string>() : return_path.dump());
     }
-}
-
-TEST_F(RestApiTest, SendScriptingRequestInvalidReturnPath) {
-    json body = {
-        {"session_id", 1}, {"path", ""}, {"action", "openFile"}, {"parameters", json::array()}, {"async", false}, {"return_path", true}};
-    int requested_session_id(1);
-
-    auto status = _frontend_server->SendScriptingRequest(
-        body.dump(), requested_session_id, [](const bool&, const std::string&, const std::string&) {}, []() {},
-        [&](int&, uint32_t&, std::string&, std::string&, std::string&, bool&, std::string&, ScriptingResponseCallback,
-            ScriptingSessionClosedCallback) { return true; });
-    EXPECT_EQ(status, HTTP_400);
 }
 
 TEST_F(RestApiTest, SendScriptingRequestSessionNotFound) {


### PR DESCRIPTION
**Description**

* What is implemented or fixed? Mention the linked issue(s), if any.
  * Closes frontend issue https://github.com/CARTAvis/carta-frontend/issues/2903
* How does this PR solve the issue? Give a brief summary.
  * Updated `SendScriptingRequest` to support string, array, and object values for return_path. Arrays and objects are serialized as JSON strings, while unsupported types return HTTP 400.
* Are there any companion PRs (frontend, protobuf)?
  * https://github.com/CARTAvis/carta-frontend/pull/2924
  * https://github.com/CARTAvis/carta-python/pull/179
* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
  * No 

**Checklist**

- [ ] changelog updated / no changelog update needed
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [ ] ICD test passing / corresponding fix added / new ICD test created
- [x] ~~protobuf updated to the latest dev commit~~ / no protobuf update needed
- [x] ~~protobuf version bumped~~ / protobuf version not bumped
- [x] added reviewers and assignee
- [x] GitHub Project estimate added
