### PR TITLE
Include all casa statistics type

### DIFF
--- a/src/Frame/Frame.cc
+++ b/src/Frame/Frame.cc
@@ -1046,9 +1046,14 @@ bool Frame::FillRegionStatsData(std::function<void(CARTA::RegionStatsData stats_
             required_stats.push_back(stats_config.stats_types(i));
         }
 
+        auto has_required_stats = [&required_stats](const std::map<CARTA::StatsType, double>& stats_map) {
+            return std::all_of(required_stats.begin(), required_stats.end(),
+                [&stats_map](CARTA::StatsType type) { return stats_map.find(type) != stats_map.end(); });
+        };
+
         // Use loader image stats
         auto& image_stats = _loader->GetImageStats(stokes, z);
-        if (image_stats.full) {
+        if (image_stats.full && has_required_stats(image_stats.basic_stats)) {
             FillStatistics(stats_data, required_stats, image_stats.basic_stats);
             stats_data_callback(stats_data);
             continue;
@@ -1056,8 +1061,8 @@ bool Frame::FillRegionStatsData(std::function<void(CARTA::RegionStatsData stats_
 
         // Use cached stats
         int cache_key(CacheKey(z, stokes));
-        if (_image_stats.count(cache_key)) {
-            auto stats_map = _image_stats[cache_key];
+        if (_image_stats.count(cache_key) && has_required_stats(_image_stats[cache_key])) {
+            auto& stats_map = _image_stats[cache_key];
             FillStatistics(stats_data, required_stats, stats_map);
             stats_data_callback(stats_data);
             continue;

--- a/src/ImageStats/StatsCalculator.h
+++ b/src/ImageStats/StatsCalculator.h
@@ -32,7 +32,11 @@ static std::unordered_map<CARTA::StatsType, casacore::LatticeStatsBase::Statisti
     {CARTA::StatsType::Sum, casacore::LatticeStatsBase::SUM}, {CARTA::StatsType::Mean, casacore::LatticeStatsBase::MEAN},
     {CARTA::StatsType::RMS, casacore::LatticeStatsBase::RMS}, {CARTA::StatsType::Sigma, casacore::LatticeStatsBase::SIGMA},
     {CARTA::StatsType::SumSq, casacore::LatticeStatsBase::SUMSQ}, {CARTA::StatsType::Min, casacore::LatticeStatsBase::MIN},
-    {CARTA::StatsType::Extrema, casacore::LatticeStatsBase::MIN}, {CARTA::StatsType::Max, casacore::LatticeStatsBase::MAX}};
+    {CARTA::StatsType::Extrema, casacore::LatticeStatsBase::MIN}, {CARTA::StatsType::Max, casacore::LatticeStatsBase::MAX},
+    {CARTA::StatsType::Median, casacore::LatticeStatsBase::MEDIAN},
+    {CARTA::StatsType::MedAbsDevMed, casacore::LatticeStatsBase::MEDABSDEVMED},
+    {CARTA::StatsType::Quartile, casacore::LatticeStatsBase::QUARTILE}, {CARTA::StatsType::Q1, casacore::LatticeStatsBase::Q1},
+    {CARTA::StatsType::Q3, casacore::LatticeStatsBase::Q3}};
 
 /** @brief Calculate basic stats from a float vector using BasicStatsCalculator
  *  @param stats The results returned in a BasicStats struct

--- a/src/Region/RegionAnalysis/RegionStatistics.cc
+++ b/src/Region/RegionAnalysis/RegionStatistics.cc
@@ -8,6 +8,8 @@
 
 #include "RegionStatistics.h"
 
+#include <algorithm>
+
 #include "Util/File.h"
 #include "Util/Message.h"
 
@@ -60,8 +62,12 @@ bool RegionStatistics::GetRegionStatsData(int file_id, std::shared_ptr<Frame> fr
     if (_cache.find(cache_id) != _cache.end()) {
         std::map<CARTA::StatsType, double> stats_results;
         if (_cache[cache_id].GetStats(stats_results)) {
-            FillStatistics(stats_data_message, required_stats, stats_results); // Message helper
-            return true;
+            bool all_stats_cached = std::all_of(required_stats.begin(), required_stats.end(),
+                [&stats_results](CARTA::StatsType type) { return stats_results.find(type) != stats_results.end(); });
+            if (all_stats_cached) {
+                FillStatistics(stats_data_message, required_stats, stats_results); // Message helper
+                return true;
+            }
         }
     }
 

--- a/test/TestRegionStats.cc
+++ b/test/TestRegionStats.cc
@@ -7,6 +7,8 @@
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
+#include <cmath>
+
 #include "CommonTestUtilities.h"
 #include "ImageData/FileLoader.h"
 #include "Region/Region.h"
@@ -30,6 +32,11 @@ public:
         stats_config->add_stats_types(CARTA::StatsType::SumSq);
         stats_config->add_stats_types(CARTA::StatsType::Min);
         stats_config->add_stats_types(CARTA::StatsType::Max);
+        stats_config->add_stats_types(CARTA::StatsType::Median);
+        stats_config->add_stats_types(CARTA::StatsType::MedAbsDevMed);
+        stats_config->add_stats_types(CARTA::StatsType::Quartile);
+        stats_config->add_stats_types(CARTA::StatsType::Q1);
+        stats_config->add_stats_types(CARTA::StatsType::Q3);
         return set_stats_requirements;
     }
 
@@ -98,6 +105,15 @@ TEST_F(RegionStatsTest, TestFitsRegionStats) {
     double expected_mean = expected_sum / image_data.size();
     double expected_min = *std::min_element(image_data.begin(), image_data.end());
     double expected_max = *std::max_element(image_data.begin(), image_data.end());
+    std::sort(image_data.begin(), image_data.end());
+    double expected_median = (image_data[7] + image_data[8]) / 2.0;
+    double expected_q1 = image_data[3];
+    double expected_q3 = image_data[11];
+    std::vector<double> absolute_deviations;
+    std::transform(image_data.begin(), image_data.end(), std::back_inserter(absolute_deviations),
+        [expected_median](double value) { return std::abs(value - expected_median); });
+    std::sort(absolute_deviations.begin(), absolute_deviations.end());
+    double expected_mad = (absolute_deviations[7] + absolute_deviations[8]) / 2.0;
 
     // Check some stats
     for (size_t i = 0; i < stats_data.statistics_size(); ++i) {
@@ -111,8 +127,90 @@ TEST_F(RegionStatsTest, TestFitsRegionStats) {
             ASSERT_DOUBLE_EQ(stats_data.statistics(i).value(), expected_min);
         } else if (stats_data.statistics(i).stats_type() == CARTA::StatsType::Max) {
             ASSERT_DOUBLE_EQ(stats_data.statistics(i).value(), expected_max);
+        } else if (stats_data.statistics(i).stats_type() == CARTA::StatsType::Median) {
+            ASSERT_NEAR(stats_data.statistics(i).value(), expected_median, 1e-7);
+        } else if (stats_data.statistics(i).stats_type() == CARTA::StatsType::MedAbsDevMed) {
+            ASSERT_NEAR(stats_data.statistics(i).value(), expected_mad, 1e-7);
+        } else if (stats_data.statistics(i).stats_type() == CARTA::StatsType::Quartile) {
+            ASSERT_NEAR(stats_data.statistics(i).value(), expected_q3 - expected_q1, 1e-7);
+        } else if (stats_data.statistics(i).stats_type() == CARTA::StatsType::Q1) {
+            ASSERT_NEAR(stats_data.statistics(i).value(), expected_q1, 1e-7);
+        } else if (stats_data.statistics(i).stats_type() == CARTA::StatsType::Q3) {
+            ASSERT_NEAR(stats_data.statistics(i).value(), expected_q3, 1e-7);
         }
     }
+}
+
+TEST_F(RegionStatsTest, TestFitsImageStatsRecalculateMissingStatistics) {
+    auto image_path = FitsImages() / "noise_3d.fits";
+    auto loader = carta::FileLoader::GetLoader(image_path);
+    std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
+
+    CARTA::SetStatsRequirements_StatsConfig basic_config;
+    basic_config.add_stats_types(CARTA::StatsType::Mean);
+    ASSERT_TRUE(frame->SetStatsRequirements(IMAGE_REGION_ID, {basic_config}));
+    ASSERT_TRUE(frame->FillRegionStatsData([](CARTA::RegionStatsData) {}, IMAGE_REGION_ID, 0));
+
+    auto stats_req_message = SetStatsRequirements(0, IMAGE_REGION_ID);
+    std::vector<CARTA::SetStatsRequirements_StatsConfig> stats_configs = {
+        stats_req_message.stats_configs().begin(), stats_req_message.stats_configs().end()};
+    ASSERT_TRUE(frame->SetStatsRequirements(IMAGE_REGION_ID, stats_configs));
+
+    CARTA::RegionStatsData stats_data;
+    ASSERT_TRUE(frame->FillRegionStatsData([&stats_data](CARTA::RegionStatsData data) { stats_data = data; }, IMAGE_REGION_ID, 0));
+
+    int robust_stats_count = 0;
+    for (const auto& statistic : stats_data.statistics()) {
+        switch (statistic.stats_type()) {
+            case CARTA::StatsType::Median:
+            case CARTA::StatsType::MedAbsDevMed:
+            case CARTA::StatsType::Quartile:
+            case CARTA::StatsType::Q1:
+            case CARTA::StatsType::Q3:
+                ASSERT_TRUE(std::isfinite(statistic.value()));
+                ++robust_stats_count;
+                break;
+            default:
+                break;
+        }
+    }
+    ASSERT_EQ(robust_stats_count, 5);
+}
+
+TEST_F(RegionStatsTest, TestHdf5ImageStatsRecalculateMissingStatistics) {
+    auto image_path = Hdf5Images() / "noise_10px_10px.hdf5";
+    auto loader = carta::FileLoader::GetLoader(image_path);
+    std::shared_ptr<Frame> frame(new Frame(0, loader, "0"));
+
+    CARTA::SetStatsRequirements_StatsConfig basic_config;
+    basic_config.add_stats_types(CARTA::StatsType::Mean);
+    ASSERT_TRUE(frame->SetStatsRequirements(IMAGE_REGION_ID, {basic_config}));
+    ASSERT_TRUE(frame->FillRegionStatsData([](CARTA::RegionStatsData) {}, IMAGE_REGION_ID, 0));
+
+    auto stats_req_message = SetStatsRequirements(0, IMAGE_REGION_ID);
+    std::vector<CARTA::SetStatsRequirements_StatsConfig> stats_configs = {
+        stats_req_message.stats_configs().begin(), stats_req_message.stats_configs().end()};
+    ASSERT_TRUE(frame->SetStatsRequirements(IMAGE_REGION_ID, stats_configs));
+
+    CARTA::RegionStatsData stats_data;
+    ASSERT_TRUE(frame->FillRegionStatsData([&stats_data](CARTA::RegionStatsData data) { stats_data = data; }, IMAGE_REGION_ID, 0));
+
+    int robust_stats_count = 0;
+    for (const auto& statistic : stats_data.statistics()) {
+        switch (statistic.stats_type()) {
+            case CARTA::StatsType::Median:
+            case CARTA::StatsType::MedAbsDevMed:
+            case CARTA::StatsType::Quartile:
+            case CARTA::StatsType::Q1:
+            case CARTA::StatsType::Q3:
+                ASSERT_TRUE(std::isfinite(statistic.value()));
+                ++robust_stats_count;
+                break;
+            default:
+                break;
+        }
+    }
+    ASSERT_EQ(robust_stats_count, 5);
 }
 
 TEST_F(RegionStatsTest, TestFitsAnnotationRegionStats) {


### PR DESCRIPTION
## Description

* What is implemented or fixed? Mention the linked issue(s), if any.
  * Adds casacore mappings for Median, MedAbsDevMed, Quartile, Q1, and Q3.
  * Recalculates image and region statistics when a cached result does not contain every requested quantity, preventing newly requested metrics from returning NaN.
  * Adds FITS/HDF5 regression coverage for recalculation and robust statistic values.
* How does this PR solve the issue? Give a brief summary.
  * Statistics requests now validate cached keys before returning cached data, and missing quantities are computed and returned.
* Are there any companion PRs (frontend, protobuf)?
  * Protobuf: https://github.com/CARTAvis/carta-protobuf/pull/114
  * Frontend: https://github.com/CARTAvis/carta-frontend/pull/2931
* Is there anything else that testers should know (e.g. exactly how to reproduce the issue)?
  * Request a basic statistic first, then add robust statistics for the same image or region; the second response should contain finite values rather than NaN.

Related frontend issues:
- https://github.com/CARTAvis/carta-frontend/issues/2501
- https://github.com/CARTAvis/carta-frontend/issues/1396

## Checklist

- [x] changelog updated / no changelog update needed
- [ ] e2e test passing / corresponding fix added / new e2e test created
- [x] ICD test passing / corresponding fix added / new ICD test created (BackendService unchanged)
- [x] protobuf updated to the companion commit / no protobuf update needed
- [x] protobuf version not bumped
- [ ] added reviewers and assignee
- [ ] GitHub Project estimate added